### PR TITLE
Cover HTTP/2 response shapes and rework body buffering

### DIFF
--- a/docs/bench_internals.md
+++ b/docs/bench_internals.md
@@ -243,3 +243,42 @@ SLA sizing and exposing tail-hiding effects.
 substitutes. The peak in `bench_results.md` feeds the rate sweep in
 `wrk2_results.md`; the tail in `wrk2_results.md` tells you how
 close to that peak you can actually run in production.
+
+## HttpArena-shape workloads
+
+For profile-driven optimization against the
+[HttpArena](https://github.com/MDA2AV/HttpArena) leaderboard, the
+bench includes scenarios that mirror HttpArena profiles directly,
+so improvements can be measured reproducibly inside this repo
+rather than only via the external harness:
+
+- `httparena_baseline`: `GET /baseline11?a=I&b=I` returns plaintext
+  `A + B`. Mirrors HttpArena's `baseline` profile.
+- `httparena_json`: `GET /httparena_json/50?m=1` returns a 50-item
+  JSON list with `total = price * quantity * m`. The dataset is
+  cached in `persistent_term` at module load. Mirrors HttpArena's
+  `json` profile.
+- `httparena_upload_20mb_auto` and `httparena_upload_20mb_manual`:
+  `POST /upload` with a 20 MB body, under `body_buffering => auto`
+  vs `body_buffering => manual` respectively. The handler returns
+  the plaintext byte count. Mirrors HttpArena's `upload` profile;
+  the pair is the in-tree reproduction of HttpArena's auto-mode
+  memory peak on the 20 MB validator.
+
+All four are roadrunner-only fixtures (no cowboy / elli parity
+handler); the bench filters the other servers out at preflight.
+
+Run with `--with-resources` to capture peak RSS / BEAM memory
+alongside throughput:
+
+```bash
+./scripts/bench.escript --scenario httparena_upload_20mb_auto \
+    --with-resources --clients 8 --duration 5
+./scripts/bench.escript --scenario httparena_upload_20mb_manual \
+    --with-resources --clients 8 --duration 5
+```
+
+For hot-path analysis, add `--profile --profile-tool eprof` (or
+`fprof`); the workflow established in
+[`conn_lifecycle_investigation.md`](conn_lifecycle_investigation.md)
+applies directly.

--- a/docs/bench_results.md
+++ b/docs/bench_results.md
@@ -1,5 +1,16 @@
 # Benchmark results
 
+> ⚠️ **Out of date.** The full matrix below is from 2026-05-05
+> (SHA `020b440`) and has NOT been re-run after the
+> `feat/http-arena` branch's perf rounds (concat fix, iodata body,
+> h2 lowercase contract). Several scenarios moved by 5-20 % on
+> roadrunner since this matrix was captured.
+>
+> For up-to-date side-by-side numbers on the representative
+> scenarios, see [`comparison.md`](comparison.md). Re-run the full
+> matrix locally with `./scripts/bench_matrix.sh` (~25-40 min) to
+> refresh this file end-to-end.
+
 Captured by `scripts/bench_matrix.sh` on 2026-05-05 at `020b440`.
 
 **Hardware / runtime**

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -87,12 +87,12 @@ honestly in
 p50 / p99 numbers per scenario × server are in the full results
 file. Spot-checks from the same run:
 
-| scenario               | rr p50 / p99    | elli p50 / p99   | cowboy p50 / p99 |
-|------------------------|----------------:|-----------------:|-----------------:|
-| `hello`                | 119 µs / 1.65 ms| 117 µs / 1.53 ms | 196 µs / 1.87 ms |
-| `echo`                 | 126 µs / 1.77 ms| 119 µs / 1.70 ms | 261 µs / 2.75 ms |
-| `cookies_heavy`        | 120 µs / 1.56 ms|         —        | 235 µs / 2.62 ms |
-| `pipelined_h1`         |  74 µs / 0.71 ms| 10.35 ms / 10.67 ms| 117 µs / 0.82 ms |
+| scenario               |     rr p50 / p99 |        elli p50 / p99 | cowboy p50 / p99 |
+|------------------------|-----------------:|----------------------:|-----------------:|
+| `hello`                | 119 µs / 1.65 ms |      117 µs / 1.53 ms | 196 µs / 1.87 ms |
+| `echo`                 | 126 µs / 1.77 ms |      119 µs / 1.70 ms | 261 µs / 2.75 ms |
+| `cookies_heavy`        | 120 µs / 1.56 ms |           —           | 235 µs / 2.62 ms |
+| `pipelined_h1`         |  74 µs / 0.71 ms |   10.35 ms / 10.67 ms | 117 µs / 0.82 ms |
 
 ## Open-loop tail latency (wrk2)
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -49,16 +49,16 @@ inside variance and shouldn't be read as a win.
 
 | scenario                  | roadrunner    | elli          | cowboy        |
 |---------------------------|--------------:|--------------:|--------------:|
-| `hello`                   |       298 k   |       278 k   |       179 k   |
-| `json`                    |       264 k   |       269 k   |       163 k   |
-| `echo`                    |       256 k   |       251 k   |       133 k   |
-| `large_response`          |       104 k   |       111 k   |        85 k   |
-| `headers_heavy`           |       235 k   |       211 k   |       118 k   |
-| `cookies_heavy`           |   **247 k**   |          —    |       154 k   |
-| `pipelined_h1`            |   **501 k**   |       4.9 k   |       329 k   |
-| `varied_paths_router`     |   **257 k**   |          —    |       149 k   |
-| `gzip_response`           |   **127 k**   |          —    |       100 k   |
-| `websocket_msg_throughput`|   **199 k**   |          —    |       155 k   |
+| `hello`                   |       285 k   |       289 k   |       196 k   |
+| `json`                    |       292 k   |       301 k   |       182 k   |
+| `echo`                    |       270 k   |       281 k   |       148 k   |
+| `large_response`          |       124 k   |       125 k   |        94 k   |
+| `headers_heavy`           |       267 k   |       241 k   |       134 k   |
+| `cookies_heavy`           |   **287 k**   |          —    |       163 k   |
+| `pipelined_h1`            |   **526 k**   |       4.9 k   |       357 k   |
+| `varied_paths_router`     |   **294 k**   |          —    |       170 k   |
+| `gzip_response`           |   **136 k**   |          —    |       108 k   |
+| `websocket_msg_throughput`|   **230 k**   |          —    |       167 k   |
 
 `—` means the elli test fixture doesn't support that scenario shape
 (no h2, no WebSocket, no gzip middleware, no router, no native qs
@@ -69,12 +69,12 @@ needs any of these, elli isn't on the table.
 
 | scenario                   | roadrunner    | cowboy        |
 |----------------------------|--------------:|--------------:|
-| `hello`                    |       162 k   |       157 k   |
-| `json`                     |       159 k   |       141 k   |
-| `echo`                     |   **151 k**   |       104 k   |
-| `headers_heavy`            |   **148 k**   |        84 k   |
-| `multi_stream_h2`          |       334 k   |       307 k   |
-| `tls_handshake_throughput` |       2.5 k   |     **3.0 k** |
+| `hello`                    |       178 k   |       169 k   |
+| `json`                     |       170 k   |       151 k   |
+| `echo`                     |   **163 k**   |       118 k   |
+| `headers_heavy`            |   **162 k**   |        89 k   |
+| `multi_stream_h2`          |       351 k   |       331 k   |
+| `tls_handshake_throughput` |       2.7 k   |     **3.2 k** |
 
 Multi-stream and basic-req h2 line up with the h1 picture — large
 wins on bigger headers/bodies, smaller wins on the simple paths.
@@ -89,10 +89,10 @@ file. Spot-checks from the same run:
 
 | scenario               | rr p50 / p99    | elli p50 / p99   | cowboy p50 / p99 |
 |------------------------|----------------:|-----------------:|-----------------:|
-| `hello`                | 117 µs / 1.45 ms| 124 µs / 1.69 ms | 211 µs / 2.36 ms |
-| `echo`                 | 139 µs / 1.51 ms| 138 µs / 1.77 ms | 301 µs / 2.65 ms |
-| `cookies_heavy`        | 142 µs / 1.67 ms|         —        | 251 µs / 2.52 ms |
-| `pipelined_h1`         |  83 µs / 0.57 ms| 10.3 ms / 10.6 ms| 129 µs / 0.84 ms |
+| `hello`                | 119 µs / 1.65 ms| 117 µs / 1.53 ms | 196 µs / 1.87 ms |
+| `echo`                 | 126 µs / 1.77 ms| 119 µs / 1.70 ms | 261 µs / 2.75 ms |
+| `cookies_heavy`        | 120 µs / 1.56 ms|         —        | 235 µs / 2.62 ms |
+| `pipelined_h1`         |  74 µs / 0.71 ms| 10.35 ms / 10.67 ms| 117 µs / 0.82 ms |
 
 ## Open-loop tail latency (wrk2)
 

--- a/docs/conn_lifecycle_investigation.md
+++ b/docs/conn_lifecycle_investigation.md
@@ -236,12 +236,15 @@ A/B (3×5 s):
 Variance band on baseline was <1 % (11.67–11.77K), so the +15 % is
 unambiguously real.
 
-Same fix shape applies to `roadrunner_conn:read_body_until/3` (auto-
-mode body read) — same `<<Acc/binary, Data/binary>>` pattern.
-Tested but reverted: at the 4 KB body sizes our scenarios use, only
-~3 recv chunks per request, not enough to surface the O(N²) at
-bench scale. Kept as a known follow-up if a future scenario stresses
-larger auto-mode bodies.
+Same fix shape later applied to `roadrunner_conn:read_body_until/3`
+(auto-mode body read), same `<<Acc/binary, Data/binary>>` pattern.
+At 4 KB body sizes (~3 recv chunks per request) the O(N²) was
+invisible. The `httparena_upload_20mb_auto` scenario (20 MB body,
+~320 recv chunks per request) surfaced it unambiguously: eprof
+showed `read_body_until/3` at 49 % of CPU. Shipped the body-
+recursive iolist fix in `b507415` "Avoid quadratic binary concat
+in conn body buffer"; pre→post on that scenario: 381 → 430 r/s,
+peak RSS 3.4 GB → 1.95 GB, p99 44 → 31 ms.
 
 ### Null results (reverted)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,32 +6,9 @@ rough effort estimate so you know what's on deck and what's
 
 ## HTTP/2 response-shape coverage
 
-Today, two of the five handler return shapes return `501 Not
+Today, one of the five handler return shapes still returns `501 Not
 Implemented` when served over HTTP/2 (`src/roadrunner_conn_loop_http2.erl`
-moduledoc has the matrix). Both are tracked here.
-
-### `{loop, _}` over h2 — medium effort
-
-**What:** Allow a handler to return `{loop, Status, Headers,
-State}` and run a long-lived handler with `handle_info/3` callbacks
-(SSE-style push) over h2.
-
-**Why deferred:** the h2 stream worker today does request → response
-→ exit. Implementing `{loop, _}` means teaching the worker to enter
-a selective-receive loop, dispatch process messages to
-`Handler:handle_info/3`, and emit DATA frames per push (with the
-conn process mediating socket writes for ordering + flow control).
-It also has to cooperate with peer `RST_STREAM` cancellation and h2
-flow-control windows. Not protocol-hard — just code we haven't
-written.
-
-**Workaround today:** `{stream, _}` works on both h1 and h2 and is
-a better cross-protocol primitive for most push workloads.
-
-**Scope:** medium. Tests cover happy path, server-initiated close,
-peer-initiated `RST_STREAM`, mid-loop flow-control bursts,
-`handle_info/3` returning `{ok, NewState}` / `{stop, _}` /
-`{reply, NewState}`.
+moduledoc has the matrix). It's tracked here.
 
 ### `{websocket, _, _}` over h2 — RFC 8441 Extended CONNECT — large effort
 
@@ -240,6 +217,29 @@ needs full regeneration. Automating earns its keep once we're
 chasing a regression that needs frequent refresh.
 
 **Scope:** small.
+
+### Proper OTP citizenship in loop responses
+
+**What:** Both `roadrunner_loop_response:info_loop/4` (h1) and
+`roadrunner_http2_loop_response:info_loop/5` (h2) silently drop
+`{system, _, _}`, `{'$gen_call', _, _}`, and `{'$gen_cast', _}`
+messages. A more polite implementation would call
+`sys:handle_system_msg/6` on the system message, reply to gen-calls
+with `gen:reply(From, {error, not_supported})`, and so on.
+
+**Why deferred:** the conn (h1) and worker (h2) are plain
+`proc_lib`-spawned loops, not `gen_*` behaviours, so the only path
+for these shapes to reach them is misuse (`gen_server:call(ConnPid, _)`
+or `sys:get_state(ConnPid)`). The current contract is "those calls
+appear to hang; the caller should expect to time out", documented
+in the `roadrunner_loop_response` moduledoc. Proper handling would
+make these calls observable (e.g. `sys:get_state/1` would return the
+loop state), which has debugging value but no functional fix.
+
+**Scope:** small. New helper `roadrunner_loop_sys` exporting a
+single `handle/3` (sys message, From, ProcessState) used from both
+h1 and h2 info_loops. Tests covering sys/get_state, sys/replace_state,
+gen_call rejection, gen_cast no-op.
 
 ### h2 manual-mode body reading
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,6 +108,75 @@ route h3 traffic to a new `roadrunner_conn_loop_http3` that adapts
 telemetry surface. Most of the protocol-heavy work is already done
 by the dep.
 
+## HttpArena coverage gaps
+
+The HttpArena Erlang submission (`frameworks/roadrunner/` in
+`MDA2AV/HttpArena`) covers 16 of HttpArena's 28 profiles: baseline,
+pipelined, limited-conn, json, json-comp, json-tls, upload,
+async-db, api-4, api-16, static, fortunes, crud, baseline-h2,
+echo-ws, echo-ws-pipeline. Validator passes 57/57 on those. The
+remaining 12 profiles need roadrunner-side features; listed in
+roughly the order a follow-up PR would tackle them.
+
+### `static` gzip-sibling serving — small (roadrunner-side)
+
+**What:** When `Accept-Encoding: gzip` is present and `<file>.gz`
+exists, serve the pre-compressed sibling with
+`Content-Encoding: gzip`. nginx's `gzip_static on`.
+
+**Why:** The HttpArena `static` fixture ships `.gz` siblings.
+Without sibling-serving, every static response either passes the
+raw bytes (uncompressed wire) or runs through the on-the-fly
+compress middleware (CPU per request). Sibling-serving sends the
+pre-encoded bytes verbatim. The validator marks this as SKIP today
+(compression is optional for correctness); the benchmark numbers
+would improve with it.
+
+**Scope:** small. One file existence check on the request path,
+swap the file plus add headers.
+
+### `static-h2` — covered by `{sendfile, _}` over h2 above
+
+### h2c (HTTP/2 cleartext) — small/medium (roadrunner-side)
+
+**What:** Accept HTTP/2 on a plaintext listener, either via
+prior-knowledge (client opens with the h2 connection preface
+directly on a dedicated port) or RFC 7540 §3.2 `Upgrade: h2c`.
+
+**Why deferred:** The current h2 path is gated by TLS ALPN
+negotiation in `roadrunner_listener`. h2c needs either a listener
+opt that forces every accepted connection through the h2 state
+machine without TLS, or first-byte sniffing for the HTTP/2 preface
+(`PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n`) on a shared port.
+
+**HttpArena impact:** `baseline-h2c` and `json-h2c`.
+
+**Scope:** small for prior-knowledge on a dedicated listener,
+medium with preface sniffing.
+
+### HTTP/3 — see above
+
+Unlocks `baseline-h3` and `static-h3`.
+
+### gRPC — large (roadrunner-side)
+
+**What:** A gRPC layer on top of the h2 stack: `application/grpc`
+content-type dispatch, length-prefixed framing inside h2 DATA,
+`grpc-status` trailers, server-streaming generators, plus a
+codegen story (rebar3 plugin or grpcbox-style runtime descriptors).
+
+**HttpArena impact:** `unary-grpc`, `stream-grpc`, and their TLS
+variants.
+
+**Scope:** large. None of the bits are exotic, but there are a
+lot of them.
+
+### `gateway-64`, `gateway-h3`, `production-stack` — out of scope
+
+Reverse-proxy multi-container setups (nginx, caddy, or envoy in
+front of the framework). Bench-app docker-compose work, not a
+roadrunner gap.
+
 ## Other
 
 ### h2 receive-window defaults

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,24 +6,9 @@ rough effort estimate so you know what's on deck and what's
 
 ## HTTP/2 response-shape coverage
 
-Today, three of the five handler return shapes return `501 Not
+Today, two of the five handler return shapes return `501 Not
 Implemented` when served over HTTP/2 (`src/roadrunner_conn_loop_http2.erl`
-moduledoc has the matrix). All three are tracked here.
-
-### `{sendfile, _}` over h2 — small effort
-
-**What:** Allow a handler to return `{sendfile, Status, Headers,
-{File, Offset, Length}}` and have it work over h2.
-
-**Why deferred:** h2 has no kernel sendfile path — every byte must
-go through HPACK (for headers) and DATA framing. The implementation
-is a chunked-read-and-frame loop honoring per-stream and conn-level
-flow control. Doable; just lower priority than other items because
-the perf upside vs. a buffered response is smaller on h2 than on h1.
-
-**Scope:** small. Tests cover happy path, large file (>64 KB so
-multiple DATA frames), small initial window (flow-control split),
-file-open errors.
+moduledoc has the matrix). Both are tracked here.
 
 ### `{loop, _}` over h2 — medium effort
 
@@ -117,8 +102,6 @@ async-db, api-4, api-16, static, fortunes, crud, baseline-h2,
 echo-ws, echo-ws-pipeline. Validator passes 57/57 on those. The
 remaining 12 profiles need roadrunner-side features; listed in
 roughly the order a follow-up PR would tackle them.
-
-### `static-h2` — covered by `{sendfile, _}` over h2 above
 
 ### h2c (HTTP/2 cleartext) — small/medium (roadrunner-side)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -118,23 +118,6 @@ echo-ws, echo-ws-pipeline. Validator passes 57/57 on those. The
 remaining 12 profiles need roadrunner-side features; listed in
 roughly the order a follow-up PR would tackle them.
 
-### `static` gzip-sibling serving — small (roadrunner-side)
-
-**What:** When `Accept-Encoding: gzip` is present and `<file>.gz`
-exists, serve the pre-compressed sibling with
-`Content-Encoding: gzip`. nginx's `gzip_static on`.
-
-**Why:** The HttpArena `static` fixture ships `.gz` siblings.
-Without sibling-serving, every static response either passes the
-raw bytes (uncompressed wire) or runs through the on-the-fly
-compress middleware (CPU per request). Sibling-serving sends the
-pre-encoded bytes verbatim. The validator marks this as SKIP today
-(compression is optional for correctness); the benchmark numbers
-would improve with it.
-
-**Scope:** small. One file existence check on the request path,
-swap the file plus add headers.
-
 ### `static-h2` — covered by `{sendfile, _}` over h2 above
 
 ### h2c (HTTP/2 cleartext) — small/medium (roadrunner-side)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -180,6 +180,35 @@ workloads (server-side, large-POST upload patterns) before shipping.
 have to drain the new SETTINGS entry + early WINDOW_UPDATE in
 their handshake fixture).
 
+### Sendfile chunk size tracks the peer's negotiated MAX_FRAME_SIZE
+
+**What:** Today `?SENDFILE_CHUNK_SIZE` in
+`src/roadrunner_http2_stream_worker.erl` is pinned at 16384, the
+RFC 9113 §6.5.2 default for `SETTINGS_MAX_FRAME_SIZE`. Peers can
+advertise up to `16777215` in their SETTINGS frame; gun, h2o, and
+other clients routinely raise it. Reading the peer's actual
+negotiated value (already tracked at
+`roadrunner_http2_settings:settings.max_frame_size`,
+`src/roadrunner_http2_settings.erl:47`) and using it as the cap in
+`sendfile_loop/3` would let large sendfile responses ship fewer,
+larger DATA frames.
+
+**Why deferred:** Per-DATA-frame overhead is 9 bytes of header vs
+payloads typically thousands of bytes long, so the bandwidth win is
+sub-1%. Plumbing the peer's settings into the stream worker also
+isn't trivial: the worker is handed `(ConnPid, StreamId, ...)` at
+spawn time, not the conn's per-stream peer-settings view, so the
+handoff path needs a new field. No measured case yet where the
+framing overhead matters.
+
+**Scope:** small once measured. Add the peer `max_frame_size` to
+the stream worker's spawn args (or a fetch-on-demand call into the
+conn); replace `min(Remaining, ?SENDFILE_CHUNK_SIZE)` with
+`min(Remaining, PeerMaxFrameSize)` in `sendfile_loop/3`. One new
+test in `roadrunner_conn_loop_http2_tests` that advertises a higher
+`MAX_FRAME_SIZE` in the client SETTINGS and asserts the resulting
+DATA frames scale up accordingly.
+
 ### Investigate small-body POST RSS gap
 
 **What:** A `--with-resources` survey (see `docs/resource_results.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,25 +100,33 @@ The HttpArena Erlang submission (`frameworks/roadrunner/` in
 pipelined, limited-conn, json, json-comp, json-tls, upload,
 async-db, api-4, api-16, static, fortunes, crud, baseline-h2,
 echo-ws, echo-ws-pipeline. Validator passes 57/57 on those. The
-remaining 12 profiles need roadrunner-side features; listed in
-roughly the order a follow-up PR would tackle them.
+remaining 10 profiles need roadrunner-side features; listed in
+roughly the order a follow-up PR would tackle them. (`baseline-h2c`
+and `json-h2c` are reachable once the HttpArena SHA pin bumps and
+the bench app subscribes; the underlying h2c prior-knowledge
+support shipped in `roadrunner_listener`'s `h2c => enabled` opt.)
 
-### h2c (HTTP/2 cleartext) — small/medium (roadrunner-side)
+### h2c Upgrade-mode on a shared port — medium (roadrunner-side)
 
-**What:** Accept HTTP/2 on a plaintext listener, either via
-prior-knowledge (client opens with the h2 connection preface
-directly on a dedicated port) or RFC 7540 §3.2 `Upgrade: h2c`.
+**What:** RFC 7540 §3.2 `Upgrade: h2c` negotiation: an HTTP/1.1
+request with `Upgrade: h2c, HTTP2-Settings: <base64>` headers,
+answered with `101 Switching Protocols`, after which the
+connection upstreams h2 frames. The same listener accepts h1 and
+h2c on the same port.
 
-**Why deferred:** The current h2 path is gated by TLS ALPN
-negotiation in `roadrunner_listener`. h2c needs either a listener
-opt that forces every accepted connection through the h2 state
-machine without TLS, or first-byte sniffing for the HTTP/2 preface
-(`PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n`) on a shared port.
+**Why deferred:** The prior-knowledge variant (`h2c => enabled` on
+a dedicated plaintext listener) ships and covers the common case
+(benchmarks, internal clients with prior knowledge). Upgrade-mode
+adds preface sniffing or h1-parse-then-switch logic to the conn
+loop — a real expansion of the connection state machine that
+isn't on the critical path.
 
-**HttpArena impact:** `baseline-h2c` and `json-h2c`.
+**HttpArena impact:** none (its `baseline-h2c` / `json-h2c` profiles
+use prior-knowledge).
 
-**Scope:** small for prior-knowledge on a dedicated listener,
-medium with preface sniffing.
+**Scope:** medium. Decide on shared-port sniff vs h1-parse-Upgrade;
+implement the chosen path; tests for both successful upgrade and
+`Upgrade: h2c` rejection on TLS sockets (the spec forbids it).
 
 ### HTTP/3 — see above
 

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -50,6 +50,7 @@
 -define(ECHO_BODY_SIZE, 256).
 -define(LARGE_BODY_SIZE, 65536).
 -define(LARGE_POST_BODY_SIZE, 1048576).
+-define(HTTPARENA_UPLOAD_BODY_SIZE, 20 * 1024 * 1024).
 
 %% Servers known to the bench, in default-run order. Adding a new
 %% server is two steps: append it here and add a clause for it in
@@ -149,6 +150,18 @@ preflight_scenario(#{scenario := chunked_request_body, servers := Servers} = Opt
 preflight_scenario(#{scenario := cookies_heavy, servers := Servers} = Opts) ->
     filter_servers(cookies_heavy, [elli], Servers, Opts,
         ~"no /cookies handler in elli test fixture");
+preflight_scenario(#{scenario := httparena_baseline, servers := Servers} = Opts) ->
+    filter_servers(httparena_baseline, [cowboy, elli], Servers, Opts,
+        ~"roadrunner-only fixture; mirrors HttpArena's `baseline` profile");
+preflight_scenario(#{scenario := httparena_json, servers := Servers} = Opts) ->
+    filter_servers(httparena_json, [cowboy, elli], Servers, Opts,
+        ~"roadrunner-only fixture; mirrors HttpArena's `json` profile");
+preflight_scenario(#{scenario := httparena_upload_20mb_auto, servers := Servers} = Opts) ->
+    filter_servers(httparena_upload_20mb_auto, [cowboy, elli], Servers, Opts,
+        ~"roadrunner-only fixture; mirrors HttpArena's `upload` profile (auto-buffering)");
+preflight_scenario(#{scenario := httparena_upload_20mb_manual, servers := Servers} = Opts) ->
+    filter_servers(httparena_upload_20mb_manual, [cowboy, elli], Servers, Opts,
+        ~"roadrunner-only fixture; mirrors HttpArena's `upload` profile (manual streaming)");
 preflight_scenario(Opts) ->
     Opts.
 
@@ -255,7 +268,11 @@ cli() ->
                         cors_preflight,
                         chunked_request_body,
                         redirect_response,
-                        compressed_request_body
+                        compressed_request_body,
+                        httparena_baseline,
+                        httparena_json,
+                        httparena_upload_20mb_auto,
+                        httparena_upload_20mb_manual
                     ]},
                 default => ?DEFAULT_SCENARIO,
                 help =>
@@ -544,6 +561,49 @@ cli() ->
                                     the framework). Distinct on
                                     the wire from echo via the
                                     Content-Encoding header.
+                    httparena_baseline:
+                                    h1-only, roadrunner-only.
+                                    GET /baseline11?a=123&b=456
+                                    returns plaintext A+B. Mirrors
+                                    HttpArena's `baseline` profile:
+                                    query-string parse + integer
+                                    arithmetic + small plaintext
+                                    response. cowboy / elli
+                                    filtered out (no parity
+                                    fixture).
+                    httparena_json: h1-only, roadrunner-only.
+                                    GET /httparena_json/50?m=1
+                                    returns a JSON list of 50
+                                    items projected with
+                                    total=price*qty*m. Mirrors
+                                    HttpArena's `json` profile:
+                                    path-binding + qs parse +
+                                    dataset projection + JSON
+                                    encode. Dataset cached in
+                                    persistent_term.
+                    httparena_upload_20mb_auto:
+                                    h1-only, roadrunner-only.
+                                    POST /upload with a 20 MB body
+                                    under default
+                                    `body_buffering => auto`.
+                                    Handler reads from
+                                    #{body := Body} and returns
+                                    plaintext byte count. Mirrors
+                                    HttpArena's `upload` profile
+                                    on the buffered path; pair
+                                    with `_manual` to expose the
+                                    body_buffering memory delta.
+                    httparena_upload_20mb_manual:
+                                    h1-only, roadrunner-only.
+                                    POST /upload with a 20 MB body
+                                    under `body_buffering =>
+                                    manual`. Handler drains via
+                                    `roadrunner_req:read_body/2`
+                                    in 64 KB chunks. Expected
+                                    peak memory bounded by the
+                                    chunk size; auto-mode peer
+                                    pays the full-body buffering
+                                    cost.
                     """
             },
             #{
@@ -1251,7 +1311,36 @@ scenario_roadrunner_opts(router_404_storm, BaseOpts) ->
         {~"/large", roadrunner_bench_large_handler, undefined}
     ]};
 scenario_roadrunner_opts(varied_paths_router, BaseOpts) ->
-    BaseOpts#{routes => varied_paths_roadrunner_routes()}.
+    BaseOpts#{routes => varied_paths_roadrunner_routes()};
+scenario_roadrunner_opts(httparena_baseline, BaseOpts) ->
+    BaseOpts#{routes => [
+        {~"/baseline11", roadrunner_bench_httparena_baseline_handler, undefined}
+    ]};
+scenario_roadrunner_opts(httparena_json, BaseOpts) ->
+    BaseOpts#{routes => [
+        {~"/httparena_json/:count", roadrunner_bench_httparena_json_handler, undefined}
+    ]};
+scenario_roadrunner_opts(httparena_upload_20mb_auto, BaseOpts) ->
+    %% Default `body_buffering => auto`: the conn pre-buffers the
+    %% 20 MB body into the request map before dispatch. Pair with
+    %% `_manual` to surface the body_buffering memory delta.
+    BaseOpts#{
+        max_content_length => ?HTTPARENA_UPLOAD_BODY_SIZE + 1024,
+        routes => [
+            {~"/upload", roadrunner_bench_httparena_upload_handler, undefined}
+        ]
+    };
+scenario_roadrunner_opts(httparena_upload_20mb_manual, BaseOpts) ->
+    %% Manual buffering: the handler drains the body in 64 KB chunks
+    %% via `roadrunner_req:read_body/2`. Peak memory bounded by chunk
+    %% size, not full body size.
+    BaseOpts#{
+        body_buffering => manual,
+        max_content_length => ?HTTPARENA_UPLOAD_BODY_SIZE + 1024,
+        routes => [
+            {~"/upload", roadrunner_bench_httparena_upload_handler, undefined}
+        ]
+    }.
 
 scenario_cowboy_routes(hello) ->
     [{'_', [{"/", roadrunner_bench_cowboy_handler, []}]}];
@@ -2494,7 +2583,11 @@ scenario_method(chunked_request_body) -> ~"POST";
 scenario_method(redirect_response) -> ~"GET";
 scenario_method(compressed_request_body) -> ~"POST";
 scenario_method(post_4kb_form) -> ~"POST";
-scenario_method(headers_heavy) -> ~"GET".
+scenario_method(headers_heavy) -> ~"GET";
+scenario_method(httparena_baseline) -> ~"GET";
+scenario_method(httparena_json) -> ~"GET";
+scenario_method(httparena_upload_20mb_auto) -> ~"POST";
+scenario_method(httparena_upload_20mb_manual) -> ~"POST".
 
 scenario_path(hello) -> ~"/";
 scenario_path(echo) -> ~"/echo";
@@ -2517,7 +2610,11 @@ scenario_path(chunked_request_body) -> ~"/echo";
 scenario_path(redirect_response) -> ~"/redirect";
 scenario_path(compressed_request_body) -> ~"/echo";
 scenario_path(post_4kb_form) -> ~"/form";
-scenario_path(headers_heavy) -> ~"/".
+scenario_path(headers_heavy) -> ~"/";
+scenario_path(httparena_baseline) -> ~"/baseline11?a=123&b=456";
+scenario_path(httparena_json) -> ~"/httparena_json/50?m=1";
+scenario_path(httparena_upload_20mb_auto) -> ~"/upload";
+scenario_path(httparena_upload_20mb_manual) -> ~"/upload".
 
 %% Pre-built per-iteration request bytes so the worker hot loop doesn't
 %% allocate. Both scenarios assume the same handler returns
@@ -2685,7 +2782,26 @@ build_request(headers_heavy) ->
         "x-bench-15: fffffffffffffff\r\n"
         "x-bench-16: gggggggggggggggg\r\n"
         "\r\n"
-    >>.
+    >>;
+build_request(httparena_baseline) ->
+    ~"GET /baseline11?a=123&b=456 HTTP/1.1\r\nHost: x\r\n\r\n";
+build_request(httparena_json) ->
+    ~"GET /httparena_json/50?m=1 HTTP/1.1\r\nHost: x\r\nAccept: application/json\r\n\r\n";
+build_request(httparena_upload_20mb_auto) ->
+    httparena_upload_request();
+build_request(httparena_upload_20mb_manual) ->
+    httparena_upload_request().
+
+httparena_upload_request() ->
+    Body = binary:copy(~"x", ?HTTPARENA_UPLOAD_BODY_SIZE),
+    BodyLenBin = integer_to_binary(?HTTPARENA_UPLOAD_BODY_SIZE),
+    <<"POST /upload HTTP/1.1\r\n",
+        "Host: x\r\n",
+        "Content-Type: application/octet-stream\r\n",
+        "Content-Length: ",
+        BodyLenBin/binary,
+        "\r\n\r\n",
+        Body/binary>>.
 
 %% Body byte count the recv loop should wait for before claiming the
 %% response is complete.
@@ -2728,7 +2844,19 @@ expected_body_len(compressed_request_body) ->
     %% Server echoes the gzipped bytes back unchanged. zlib:gzip
     %% of `abc`*350 produces 32 B; pin recv to a lower bound (20)
     %% so it stops as soon as the body shows up.
-    20.
+    20;
+expected_body_len(httparena_baseline) ->
+    %% Response is `integer_to_binary(123 + 456)` = "579" (3 bytes).
+    byte_size(integer_to_binary(123 + 456));
+expected_body_len(httparena_json) ->
+    %% Variable JSON body for count=50, m=1; the handler module
+    %% precomputes it at -on_load via `bench_body/0`.
+    byte_size(roadrunner_bench_httparena_json_handler:bench_body());
+expected_body_len(httparena_upload_20mb_auto) ->
+    %% Response is `integer_to_binary(20*1024*1024)` = "20971520" (8 B).
+    byte_size(integer_to_binary(?HTTPARENA_UPLOAD_BODY_SIZE));
+expected_body_len(httparena_upload_20mb_manual) ->
+    byte_size(integer_to_binary(?HTTPARENA_UPLOAD_BODY_SIZE)).
 
 %% 128 pairs of `kNNN=` + 27-char value, joined by `&`. Each
 %% pair = 32 bytes; 128 × 32 - 1 (trailing `&` dropped) = 4095
@@ -3170,7 +3298,34 @@ h2_request_shape(headers_heavy) ->
         {<<"x-bench-", (integer_to_binary(N))/binary>>, binary:copy(~"a", N)}
      || N <- lists:seq(1, 16)
     ],
-    {~"GET", ~"/", Hdrs, <<>>}.
+    {~"GET", ~"/", Hdrs, <<>>};
+h2_request_shape(httparena_baseline) ->
+    %% h2 variant is meaningful but out of scope for the first round;
+    %% this scenario mirrors HttpArena's h1 baseline profile.
+    io:format(standard_error,
+        "error: --scenario httparena_baseline is h1-only "
+        "(use --protocol h1)~n", []),
+    halt(2);
+h2_request_shape(httparena_json) ->
+    %% h2 variant is meaningful but out of scope for the first round;
+    %% this scenario mirrors HttpArena's h1 json profile.
+    io:format(standard_error,
+        "error: --scenario httparena_json is h1-only "
+        "(use --protocol h1)~n", []),
+    halt(2);
+h2_request_shape(httparena_upload_20mb_auto) ->
+    %% h2 has its own body-delivery model (DATA frames with per-stream
+    %% flow control); a 20 MB POST over h2 is a separate scenario worth
+    %% adding later. h1-only here.
+    io:format(standard_error,
+        "error: --scenario httparena_upload_20mb_auto is h1-only "
+        "(use --protocol h1)~n", []),
+    halt(2);
+h2_request_shape(httparena_upload_20mb_manual) ->
+    io:format(standard_error,
+        "error: --scenario httparena_upload_20mb_manual is h1-only "
+        "(use --protocol h1)~n", []),
+    halt(2).
 
 h2_worker_loop(Host, Port, Method, Path, ReqHeaders, ReqBody, Deadline, Acc) ->
     case roadrunner_bench_client:open(Host, Port, h2) of
@@ -3384,7 +3539,15 @@ scenario_request_summary(chunked_request_body) ->
 scenario_request_summary(redirect_response) ->
     "GET /redirect HTTP/1.1, server returns 302 + Location (router)";
 scenario_request_summary(compressed_request_body) ->
-    "POST /echo HTTP/1.1 + Content-Encoding: gzip, ~50 B compressed body (router)".
+    "POST /echo HTTP/1.1 + Content-Encoding: gzip, ~50 B compressed body (router)";
+scenario_request_summary(httparena_baseline) ->
+    "GET /baseline11?a=123&b=456 HTTP/1.1, plaintext A+B response (router, roadrunner-only)";
+scenario_request_summary(httparena_json) ->
+    "GET /httparena_json/50?m=1 HTTP/1.1, 50-item projected JSON response (router, roadrunner-only)";
+scenario_request_summary(httparena_upload_20mb_auto) ->
+    "POST /upload HTTP/1.1, 20 MB body, body_buffering=auto (router, roadrunner-only)";
+scenario_request_summary(httparena_upload_20mb_manual) ->
+    "POST /upload HTTP/1.1, 20 MB body, body_buffering=manual 64 KB chunks (router, roadrunner-only)".
 
 result_to_row(Side, #{
     total := Total,

--- a/scripts/bench_matrix.sh
+++ b/scripts/bench_matrix.sh
@@ -86,6 +86,8 @@ declare -A PROTOS=(
   [compressed_request_body]="h1"
   [router_404_storm]="h1"
   [varied_paths_router]="h1"
+  [httparena_baseline]="h1"
+  [httparena_json]="h1"
 )
 
 # Stable iteration order — groups roughly by category for the
@@ -102,6 +104,7 @@ SCENARIOS=(
   slow_client accept_storm_burst partial_body_drop
   server_sent_events gzip_response backpressure_sustained
   websocket_msg_throughput
+  httparena_baseline httparena_json
   streaming_response multi_stream_h2 small_chunked_response
   tls_handshake_throughput
 )

--- a/scripts/wrk2_bench.sh
+++ b/scripts/wrk2_bench.sh
@@ -91,7 +91,6 @@ SCENARIOS_ALL=(
     cookies_heavy etag_304 large_keepalive_session
     gzip_response backpressure_sustained
     httparena_baseline httparena_json
-    httparena_upload_20mb_auto httparena_upload_20mb_manual
 )
 
 # Scenarios elli doesn't support (mirrors `preflight_scenario/1` in
@@ -103,7 +102,6 @@ ELLI_UNSUPPORTED=(
     large_post_streaming cookies_heavy etag_304
     gzip_response backpressure_sustained
     httparena_baseline httparena_json
-    httparena_upload_20mb_auto httparena_upload_20mb_manual
 )
 
 # Scenarios cowboy doesn't run here either (roadrunner-only fixtures).
@@ -111,7 +109,6 @@ ELLI_UNSUPPORTED=(
 # PEAK entries below, but listing here makes the intent explicit.
 COWBOY_UNSUPPORTED=(
     httparena_baseline httparena_json
-    httparena_upload_20mb_auto httparena_upload_20mb_manual
 )
 
 # Lua scripts for non-GET scenarios. Run via Docker volume mount.
@@ -124,8 +121,6 @@ declare -A LUA_FILE=(
     [cors_preflight]=cors_preflight.lua
     [chunked_request_body]=chunked_request_body.lua
     [head_method]=head_method.lua
-    [httparena_upload_20mb_auto]=httparena_upload.lua
-    [httparena_upload_20mb_manual]=httparena_upload.lua
 )
 
 # Custom request headers for GET-with-headers scenarios. Multiple
@@ -143,34 +138,32 @@ declare -A EXTRA_HEADERS=(
 # 75%, 95% of these. Estimates can drift with code changes; the
 # achieved-rate column makes the gap visible.
 declare -A PEAK=(
-    [roadrunner.hello]=254000           [cowboy.hello]=181000           [elli.hello]=272000
-    [roadrunner.json]=255000            [cowboy.json]=178000            [elli.json]=270000
-    [roadrunner.echo]=225000            [cowboy.echo]=146000            [elli.echo]=269000
-    [roadrunner.headers_heavy]=210000   [cowboy.headers_heavy]=125000   [elli.headers_heavy]=240000
-    [roadrunner.large_response]=103000  [cowboy.large_response]=90000   [elli.large_response]=114000
+    [roadrunner.hello]=285000           [cowboy.hello]=196000           [elli.hello]=289000
+    [roadrunner.json]=292000            [cowboy.json]=182000            [elli.json]=301000
+    [roadrunner.echo]=270000            [cowboy.echo]=148000            [elli.echo]=281000
+    [roadrunner.headers_heavy]=267000   [cowboy.headers_heavy]=134000   [elli.headers_heavy]=241000
+    [roadrunner.large_response]=124000  [cowboy.large_response]=94000   [elli.large_response]=125000
     [roadrunner.url_with_qs]=247000     [cowboy.url_with_qs]=167000
     [roadrunner.path_with_unicode]=235000 [cowboy.path_with_unicode]=167000
     [roadrunner.cors_preflight]=242000  [cowboy.cors_preflight]=162000
     [roadrunner.redirect_response]=258000 [cowboy.redirect_response]=176000
     [roadrunner.head_method]=251000     [cowboy.head_method]=176000
-    [roadrunner.post_4kb_form]=122000   [cowboy.post_4kb_form]=92000
-    [roadrunner.chunked_request_body]=210000 [cowboy.chunked_request_body]=129000
-    [roadrunner.compressed_request_body]=233000 [cowboy.compressed_request_body]=149000 [elli.compressed_request_body]=278000
-    [roadrunner.multi_request_body]=225000 [cowboy.multi_request_body]=111000 [elli.multi_request_body]=245000
-    [roadrunner.large_post_streaming]=15000 [cowboy.large_post_streaming]=6600
-    [roadrunner.cookies_heavy]=234000   [cowboy.cookies_heavy]=160000
+    [roadrunner.post_4kb_form]=193000   [cowboy.post_4kb_form]=92500
+    [roadrunner.chunked_request_body]=266000 [cowboy.chunked_request_body]=137000
+    [roadrunner.compressed_request_body]=289000 [cowboy.compressed_request_body]=154000 [elli.compressed_request_body]=298000
+    [roadrunner.multi_request_body]=257000 [cowboy.multi_request_body]=121000 [elli.multi_request_body]=272000
+    [roadrunner.large_post_streaming]=18900 [cowboy.large_post_streaming]=6800
+    [roadrunner.cookies_heavy]=287000   [cowboy.cookies_heavy]=163000
     [roadrunner.etag_304]=234000        [cowboy.etag_304]=169000
     [roadrunner.large_keepalive_session]=227000 [cowboy.large_keepalive_session]=175000 [elli.large_keepalive_session]=279000
-    [roadrunner.gzip_response]=105000   [cowboy.gzip_response]=96000
+    [roadrunner.gzip_response]=136000   [cowboy.gzip_response]=108000
     [roadrunner.backpressure_sustained]=249000 [cowboy.backpressure_sustained]=182000
-    # roadrunner-only HttpArena-shape scenarios. Placeholders captured
-    # on the first standalone smoke run; refresh from
-    # `docs/bench_results.md` once measured under the same harness as
-    # the other scenarios.
-    [roadrunner.httparena_baseline]=200000
-    [roadrunner.httparena_json]=80000
-    [roadrunner.httparena_upload_20mb_auto]=500
-    [roadrunner.httparena_upload_20mb_manual]=2000
+    # roadrunner-only HttpArena-shape scenarios. The upload scenarios
+    # are intentionally absent: at 50 concurrent 20 MB POSTs they
+    # don't fit the matrix's memory budget; profile them via
+    # bench.escript at 8 clients (see `docs/bench_internals.md`).
+    [roadrunner.httparena_baseline]=275000
+    [roadrunner.httparena_json]=81000
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/wrk2_bench.sh
+++ b/scripts/wrk2_bench.sh
@@ -90,6 +90,8 @@ SCENARIOS_ALL=(
     compressed_request_body multi_request_body large_post_streaming
     cookies_heavy etag_304 large_keepalive_session
     gzip_response backpressure_sustained
+    httparena_baseline httparena_json
+    httparena_upload_20mb_auto httparena_upload_20mb_manual
 )
 
 # Scenarios elli doesn't support (mirrors `preflight_scenario/1` in
@@ -100,6 +102,16 @@ ELLI_UNSUPPORTED=(
     head_method post_4kb_form chunked_request_body
     large_post_streaming cookies_heavy etag_304
     gzip_response backpressure_sustained
+    httparena_baseline httparena_json
+    httparena_upload_20mb_auto httparena_upload_20mb_manual
+)
+
+# Scenarios cowboy doesn't run here either (roadrunner-only fixtures).
+# The matrix only emits roadrunner rows; cowboy is skipped via missing
+# PEAK entries below, but listing here makes the intent explicit.
+COWBOY_UNSUPPORTED=(
+    httparena_baseline httparena_json
+    httparena_upload_20mb_auto httparena_upload_20mb_manual
 )
 
 # Lua scripts for non-GET scenarios. Run via Docker volume mount.
@@ -112,6 +124,8 @@ declare -A LUA_FILE=(
     [cors_preflight]=cors_preflight.lua
     [chunked_request_body]=chunked_request_body.lua
     [head_method]=head_method.lua
+    [httparena_upload_20mb_auto]=httparena_upload.lua
+    [httparena_upload_20mb_manual]=httparena_upload.lua
 )
 
 # Custom request headers for GET-with-headers scenarios. Multiple
@@ -121,6 +135,7 @@ declare -A EXTRA_HEADERS=(
     [gzip_response]="Accept-Encoding: gzip"
     [etag_304]='If-None-Match: "v1"'
     [headers_heavy]="x-bench-1: 1|x-bench-2: 22|x-bench-3: 333|x-bench-4: 4444|x-bench-5: 55555|x-bench-6: 666666|x-bench-7: 7777777|x-bench-8: 88888888|x-bench-9: 999999999|x-bench-10: aaaaaaaaaa|x-bench-11: bbbbbbbbbbb|x-bench-12: cccccccccccc|x-bench-13: ddddddddddddd|x-bench-14: eeeeeeeeeeeeee|x-bench-15: fffffffffffffff|x-bench-16: gggggggggggggggg"
+    [httparena_json]="Accept: application/json"
 )
 
 # Per-(server, scenario) PEAK ESTIMATE in req/s. Pulled from
@@ -148,6 +163,14 @@ declare -A PEAK=(
     [roadrunner.large_keepalive_session]=227000 [cowboy.large_keepalive_session]=175000 [elli.large_keepalive_session]=279000
     [roadrunner.gzip_response]=105000   [cowboy.gzip_response]=96000
     [roadrunner.backpressure_sustained]=249000 [cowboy.backpressure_sustained]=182000
+    # roadrunner-only HttpArena-shape scenarios. Placeholders captured
+    # on the first standalone smoke run; refresh from
+    # `docs/bench_results.md` once measured under the same harness as
+    # the other scenarios.
+    [roadrunner.httparena_baseline]=200000
+    [roadrunner.httparena_json]=80000
+    [roadrunner.httparena_upload_20mb_auto]=500
+    [roadrunner.httparena_upload_20mb_manual]=2000
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/wrk2_lua/httparena_upload.lua
+++ b/scripts/wrk2_lua/httparena_upload.lua
@@ -1,6 +1,0 @@
--- POST /upload with 20 MB of 'x' body.
--- Mirrors `build_request(httparena_upload_20mb_*)` in scripts/bench.escript;
--- shared between the `_auto` and `_manual` scenarios.
-wrk.method = "POST"
-wrk.headers["Content-Type"] = "application/octet-stream"
-wrk.body = string.rep("x", 20 * 1024 * 1024)

--- a/scripts/wrk2_lua/httparena_upload.lua
+++ b/scripts/wrk2_lua/httparena_upload.lua
@@ -1,0 +1,6 @@
+-- POST /upload with 20 MB of 'x' body.
+-- Mirrors `build_request(httparena_upload_20mb_*)` in scripts/bench.escript;
+-- shared between the `_auto` and `_manual` scenarios.
+wrk.method = "POST"
+wrk.headers["Content-Type"] = "application/octet-stream"
+wrk.body = string.rep("x", 20 * 1024 * 1024)

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -451,13 +451,46 @@ body_framing(Req) ->
     fun(() -> {ok, binary()} | {error, term()})
 ) ->
     {ok, binary(), binary()} | {error, term()}.
-read_body_until(N, Acc, _RecvFun) when byte_size(Acc) >= N ->
-    <<Body:N/binary, Leftover/binary>> = Acc,
+read_body_until(N, Buffered, _RecvFun) when byte_size(Buffered) >= N ->
+    <<Body:N/binary, Leftover/binary>> = Buffered,
     {ok, Body, Leftover};
-read_body_until(N, Acc, RecvFun) ->
+read_body_until(N, Buffered, RecvFun) ->
+    %% Body recursion: each level reads one recv-chunk and prepends it
+    %% to the iolist returned from below on the way out, then a single
+    %% `iolist_to_binary` flattens at the public boundary. The previous
+    %% shape (`<<Acc/binary, Data/binary>>` per iteration) was O(N²) on
+    %% the body size: the parser's leftover seed is a sub-binary view
+    %% (non-writable), so the binary-builder slack-allocation
+    %% optimisation never engaged and every iteration copied the full
+    %% accumulator.
+    case read_body_until_io(N - byte_size(Buffered), RecvFun) of
+        {ok, MoreIo, Leftover} ->
+            {ok, iolist_to_binary([Buffered | MoreIo]), Leftover};
+        {error, _} = E ->
+            E
+    end.
+
+-spec read_body_until_io(
+    non_neg_integer(),
+    fun(() -> {ok, binary()} | {error, term()})
+) ->
+    {ok, iolist(), binary()} | {error, term()}.
+read_body_until_io(N, RecvFun) ->
     case RecvFun() of
-        {ok, Data} -> read_body_until(N, <<Acc/binary, Data/binary>>, RecvFun);
-        {error, _} = E -> E
+        {ok, Data} ->
+            DataSz = byte_size(Data),
+            if
+                DataSz >= N ->
+                    <<Chunk:N/binary, Leftover/binary>> = Data,
+                    {ok, [Chunk], Leftover};
+                true ->
+                    case read_body_until_io(N - DataSz, RecvFun) of
+                        {ok, More, Leftover} -> {ok, [Data | More], Leftover};
+                        {error, _} = E -> E
+                    end
+            end;
+        {error, _} = E ->
+            E
     end.
 
 %% Read chunks until the size-0 last-chunk, concatenating decoded data

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -97,6 +97,12 @@ read it anyway.
     %% SSE / WebSocket handlers depend on it. Short-lived h1
     %% workloads can opt out for ~10% lower per-conn overhead.
     drain_group => enabled | disabled,
+    %% RFC 7540 §3.4 prior-knowledge HTTP/2 cleartext. When `enabled`,
+    %% `roadrunner_conn_loop:awaiting_shoot/3` routes the connection
+    %% straight to the h2 conn loop without consulting TLS ALPN.
+    %% Plain TCP only: `roadrunner_listener` rejects the combo with
+    %% `tls` at `init/1`. Default `disabled`.
+    h2c => enabled | disabled,
     %% h2 receive-window tuning. See `roadrunner_listener:opts()` for
     %% prose. Defaults match the RFC 9113 baseline.
     h2_initial_conn_window => 1..16#7FFFFFFF,

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -333,7 +333,7 @@ resolve_handler({router, ListenerName}, Req) ->
     fun(() -> {ok, binary()} | {error, term()}),
     non_neg_integer()
 ) ->
-    {ok, Body :: binary(), Leftover :: binary()}
+    {ok, Body :: iodata(), Leftover :: binary()}
     | {error,
         content_length_too_large
         | bad_content_length
@@ -450,22 +450,21 @@ body_framing(Req) ->
     binary(),
     fun(() -> {ok, binary()} | {error, term()})
 ) ->
-    {ok, binary(), binary()} | {error, term()}.
+    {ok, iodata(), binary()} | {error, term()}.
 read_body_until(N, Buffered, _RecvFun) when byte_size(Buffered) >= N ->
     <<Body:N/binary, Leftover/binary>> = Buffered,
     {ok, Body, Leftover};
 read_body_until(N, Buffered, RecvFun) ->
     %% Body recursion: each level reads one recv-chunk and prepends it
-    %% to the iolist returned from below on the way out, then a single
-    %% `iolist_to_binary` flattens at the public boundary. The previous
-    %% shape (`<<Acc/binary, Data/binary>>` per iteration) was O(N²) on
-    %% the body size: the parser's leftover seed is a sub-binary view
-    %% (non-writable), so the binary-builder slack-allocation
-    %% optimisation never engaged and every iteration copied the full
-    %% accumulator.
+    %% to the iolist returned from below on the way out. The auto-path
+    %% body field is `iodata()` so handlers that only need
+    %% `iolist_size/1` or want to forward the body via `gen_tcp:send/2`
+    %% never pay the flatten cost. Handlers requiring a flat binary
+    %% (e.g. pattern matching, `roadrunner_qs:parse/1`) call
+    %% `iolist_to_binary/1` themselves.
     case read_body_until_io(N - byte_size(Buffered), RecvFun) of
         {ok, MoreIo, Leftover} ->
-            {ok, iolist_to_binary([Buffered | MoreIo]), Leftover};
+            {ok, [Buffered | MoreIo], Leftover};
         {error, _} = E ->
             E
     end.
@@ -561,8 +560,8 @@ bytes — content-length framing only; chunked falls through to a
 full read).
 """.
 -spec consume_body_state(body_state(), all | next_chunk | {length, non_neg_integer()}) ->
-    {ok, binary(), body_state()}
-    | {more, binary(), body_state()}
+    {ok, iodata(), body_state()}
+    | {more, iodata(), body_state()}
     | {error, term()}.
 consume_body_state(#{framing := none} = BS, _Mode) ->
     %% Per RFC 9112 §6.3: no framing means the body is empty.
@@ -598,7 +597,7 @@ consume_body_state(
         false ->
             case fill_n(Want, Buf, Recv) of
                 {ok, Bytes, NewBuf} ->
-                    NewRead = Read + byte_size(Bytes),
+                    NewRead = Read + iolist_size(Bytes),
                     NewState = BS#{buffered := NewBuf, bytes_read := NewRead},
                     case NewRead >= N of
                         true -> {ok, Bytes, NewState};
@@ -610,34 +609,24 @@ consume_body_state(
     end;
 consume_body_state(#{framing := chunked} = BS, all) ->
     %% Drain everything left: any pending decoded bytes plus all
-    %% remaining chunks, accumulated in one return.
-    finalize_chunked(chunked_collect(BS, infinity));
+    %% remaining chunks, accumulated in one return. Iodata stays unflattened
+    %% so callers that only need `iolist_size/1` or want to forward via
+    %% `gen_tcp:send/2` skip a flatten.
+    chunked_collect(BS, infinity);
 consume_body_state(#{framing := chunked} = BS, {length, N}) ->
-    finalize_chunked(chunked_collect(BS, N));
+    chunked_collect(BS, N);
 consume_body_state(#{framing := chunked} = BS, next_chunk) ->
     next_chunk(BS).
 %% Non-chunked framing (none, content_length) is handled by the
 %% earlier clauses above — `next_chunk` is treated as a full drain
 %% inside those, since there are no chunk boundaries to honor.
 
--spec finalize_chunked(
-    {ok, iodata(), body_state()}
-    | {more, iodata(), body_state()}
-    | {error, term()}
-) ->
-    {ok, binary(), body_state()}
-    | {more, binary(), body_state()}
-    | {error, term()}.
-finalize_chunked({ok, Iodata, BS}) -> {ok, iolist_to_binary(Iodata), BS};
-finalize_chunked({more, Iodata, BS}) -> {more, iolist_to_binary(Iodata), BS};
-finalize_chunked({error, _} = E) -> E.
-
 %% Pull decoded chunked-body bytes out of `BS` until either `Want`
 %% bytes are collected or the body is fully drained. `Want` is either
 %% `infinity` (drain to end — caller asked for `all`) or a positive
 %% integer (caller asked for `{length, N}`). Returns
-%% `{ok | more, Bytes, BS2}` (Bytes as iodata so each frame conses
-%% in front on the way out — caller flattens) or `{error, Reason}`.
+%% `{ok | more, Bytes, BS2}` with Bytes as iodata (propagated through
+%% `consume_body_state` to the public API unflattened).
 -spec chunked_collect(body_state(), infinity | non_neg_integer()) ->
     {ok, iodata(), body_state()}
     | {more, iodata(), body_state()}
@@ -727,22 +716,20 @@ next_chunk(#{buffered := Buf, recv := Recv, max := Max, bytes_read := Read} = BS
     end.
 
 -spec fill_n(non_neg_integer(), binary(), fun(() -> {ok, binary()} | {error, term()})) ->
-    {ok, binary(), binary()} | {error, term()}.
+    {ok, iodata(), binary()} | {error, term()}.
 fill_n(N, Buf, _Recv) when byte_size(Buf) >= N ->
     <<Bytes:N/binary, Rest/binary>> = Buf,
     {ok, Bytes, Rest};
 fill_n(N, Buf, Recv) ->
     %% Body recursion that conses each recv chunk onto the iolist on
-    %% the way OUT. Avoids the original `<<Buf/binary, More/binary>>`
-    %% per-step concat (O(N²) total copy across all chunks); the
-    %% single `iolist_to_binary` at the bottom is O(N).
+    %% the way OUT. The iolist propagates through `consume_body_state`
+    %% to the caller unflattened so callers that only need
+    %% `iolist_size/1` (or want to forward via `gen_tcp:send/2`) avoid
+    %% an O(total-body) copy.
     Need = N - byte_size(Buf),
     case fill_iolist(Need, Recv) of
         {ok, Iolist, Leftover} ->
-            %% Iolist has Need bytes, Buf has byte_size(Buf), so
-            %% [Buf | Iolist] flattens to exactly N bytes.
-            Bytes = iolist_to_binary([Buf | Iolist]),
-            {ok, Bytes, Leftover};
+            {ok, [Buf | Iolist], Leftover};
         {error, _} = E ->
             E
     end.

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -142,11 +142,13 @@ awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
             StartMono = roadrunner_telemetry:listener_accept(#{
                 listener_name => ListenerName, peer => Peer
             }),
-            case http2_negotiated(Socket) of
+            case http2_negotiated(Socket) orelse h2c_enabled(ProtoOpts) of
                 true ->
-                    %% ALPN landed on `h2` and the listener allows it —
-                    %% the HTTP/2 path takes over. Slot release and
-                    %% `listener_conn_close` happen inside the h2 module.
+                    %% Either ALPN landed on `h2` (TLS listener) or the
+                    %% listener is in prior-knowledge h2c mode (plain TCP
+                    %% with `h2c => enabled`). The HTTP/2 path takes over;
+                    %% slot release and `listener_conn_close` happen
+                    %% inside the h2 module.
                     roadrunner_conn_loop_http2:enter(
                         Socket, ProtoOpts, ListenerName, Peer, StartMono
                     );
@@ -190,6 +192,15 @@ http2_negotiated(Socket) ->
         {ok, ~"h2"} -> true;
         _ -> false
     end.
+
+%% True iff this listener is configured for HTTP/2 cleartext
+%% (RFC 7540 §3.4 prior-knowledge). Plain TCP only: listener init
+%% rejects `h2c => enabled` combined with `tls`, so by the time this
+%% function runs the socket is `{gen_tcp, _}` (or `{fake, _}` in
+%% tests).
+-spec h2c_enabled(roadrunner_conn:proto_opts()) -> boolean().
+h2c_enabled(#{h2c := enabled}) -> true;
+h2c_enabled(_) -> false.
 
 %% --- read_request phase ---
 %%

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -823,10 +823,9 @@ dispatch_stream(
     } = Streams,
     case content_length_matches(Headers, BodyLen) of
         true ->
-            %% iolist → binary once here; downstream code (worker
-            %% Req map, content-length comparator, etc.) all want
-            %% a flat binary.
-            Body = iolist_to_binary(BodyIolist),
+            %% Pass the iolist body straight through to the worker's
+            %% Req map. The body field is typed `iodata()`; handlers
+            %% that need a flat binary call `iolist_to_binary/1`.
             {RequestId, NewBuf} = roadrunner_conn:generate_request_id(
                 State#loop.req_id_buffer
             ),
@@ -836,7 +835,7 @@ dispatch_stream(
                 listener_name => ListenerName,
                 request_id => RequestId
             },
-            case roadrunner_http2_request:from_headers(Headers, Body, ConnInfo) of
+            case roadrunner_http2_request:from_headers(Headers, BodyIolist, ConnInfo) of
                 {ok, Req} ->
                     {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
                         self(), StreamId, Req, ProtoOpts

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -42,7 +42,7 @@ Response shapes supported:
 | `{Status, Headers, Body}` (buffered) | yes |
 | `{stream, _, _, Fun}` | yes |
 | `{loop, _}` | 501 |
-| `{sendfile, _}` | 501 |
+| `{sendfile, _}` | yes (chunked DATA via the stream-response engine) |
 | `{websocket, _, _}` | 501 (Phase H13) |
 """.
 

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -47,7 +47,7 @@ Response shapes supported:
 |---|---|
 | `{Status, Headers, Body}` (buffered) | yes |
 | `{stream, _, _, Fun}` | yes |
-| `{loop, _}` | 501 |
+| `{loop, _}` | yes (worker enters handle_info loop) |
 | `{sendfile, _}` | yes (chunked DATA via the stream-response engine) |
 | `{websocket, _, _}` | 501 (Phase H13) |
 """.

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1014,8 +1014,10 @@ encode_and_send_headers(
     #loop{hpack_enc = Enc} = State, StreamId, Status, Headers, EndStream
 ) ->
     StatusBin = integer_to_binary(Status),
-    LowerHeaders = [{roadrunner_bin:ascii_lowercase(N), V} || {N, V} <- Headers],
-    AllHeaders = [{~":status", StatusBin} | LowerHeaders],
+    %% Handler-supplied header names MUST already be lowercase per RFC 9113
+    %% §8.1.2 (see `roadrunner_handler:response/0`). h1 emits names verbatim;
+    %% h2 follows the same contract here, skipping a redundant pass.
+    AllHeaders = [{~":status", StatusBin} | Headers],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     %% `frame:encode` accepts iodata for the header block — skip
     %% the upfront flatten; ssl:send walks the iolist anyway.
@@ -1045,8 +1047,8 @@ encode_and_send_response_atomic(
 ) ->
     #{StreamId := Stream} = Streams,
     StatusBin = integer_to_binary(Status),
-    LowerHeaders = [{roadrunner_bin:ascii_lowercase(N), V} || {N, V} <- Headers],
-    AllHeaders = [{~":status", StatusBin} | LowerHeaders],
+    %% Names already lowercase per `roadrunner_handler:response/0` contract.
+    AllHeaders = [{~":status", StatusBin} | Headers],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     HFrame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04, undefined, HpackBlock}
@@ -1058,8 +1060,8 @@ encode_and_send_response_atomic(
     close_stream_send_side(State2, StreamId).
 
 encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
-    LowerTrailers = [{roadrunner_bin:ascii_lowercase(N), V} || {N, V} <- Trailers],
-    {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(LowerTrailers, Enc),
+    %% Trailer names already lowercase per `roadrunner_handler:response/0`.
+    {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(Trailers, Enc),
     Frame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04 bor 16#01, undefined, HpackBlock}
     ),

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -2,6 +2,12 @@
 -moduledoc """
 HTTP/2 (RFC 9113) connection process.
 
+Driven by either TLS ALPN-negotiated `h2` or a plaintext listener
+configured with `h2c => enabled` (RFC 7540 §3.4 prior-knowledge).
+The dispatch decision lives in `roadrunner_conn_loop:awaiting_shoot/3`;
+this module is transport-agnostic and reads frames via
+`roadrunner_transport:recv/3` either way.
+
 Phase H8b — true multiplexing with per-stream workers. The conn
 process owns:
 

--- a/src/roadrunner_handler.erl
+++ b/src/roadrunner_handler.erl
@@ -63,6 +63,17 @@ handle(Req) ->
     Offset :: non_neg_integer(),
     Length :: non_neg_integer()
 }.
+
+-doc """
+Handler response shape returned alongside the (mutated) request map.
+
+Response header names MUST be ASCII lowercase. HTTP/2 requires this on the
+wire per RFC 9113 §8.1.2 (clients reject responses with uppercase names);
+the HTTP/1.1 path emits names verbatim, so the requirement is uniform
+across protocols. Framework helpers (`roadrunner_resp:*`,
+`roadrunner_compress`, the auto-injected `~"date"` header) all emit
+lowercase names; handler-supplied tuples must follow suit.
+""".
 -type response() ::
     {StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), Body :: iodata()}
     | {stream, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), stream_fun()}

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -89,10 +89,14 @@ response (`400`, `414`, `431`, etc.).
     %% manually-built request maps — consumers fall back to the raw
     %% `headers` list when missing.
     cached_decisions => cached_decisions(),
-    %% Body is set by `roadrunner_conn` before the handler is invoked. The parser
-    %% itself never populates this field — it leaves the buffered body in the
+    %% Body is set by `roadrunner_conn` before the handler is invoked. Auto
+    %% mode delivers the full body here as `iodata()` (an iolist of recv
+    %% chunks for multi-chunk bodies, a single binary otherwise) so the conn
+    %% can skip a flatten that many handlers do not need. Handlers that
+    %% require a flat binary call `iolist_to_binary/1` themselves. The parser
+    %% never populates this field; it leaves the buffered body in the
     %% `Rest` element of `parse_request/1` instead.
-    body => binary(),
+    body => iodata(),
     %% Bindings captured from `:param` segments by `roadrunner_router`, also set
     %% by `roadrunner_conn` before dispatch. Empty map when the dispatch is a
     %% single-handler one (no routing) or the route has no params.

--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -81,21 +81,26 @@ make_push(ConnPid, StreamId) ->
 %% factoring them out into `roadrunner_http2_worker_sync`.
 
 -spec sync_send_headers(
-    pid(), pos_integer(), roadrunner_req:status(),
-    roadrunner_req:headers(), boolean()
+    pid(),
+    pos_integer(),
+    roadrunner_req:status(),
+    roadrunner_req:headers(),
+    boolean()
 ) -> ok.
 sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->
     sync(fun(Ref) ->
-        _ = (ConnPid !
-            {h2_send_headers, self(), Ref, StreamId, Status, Headers, EndStream}),
+        _ =
+            (ConnPid !
+                {h2_send_headers, self(), Ref, StreamId, Status, Headers, EndStream}),
         ok
     end).
 
 -spec sync_send_data(pid(), pos_integer(), binary(), boolean()) -> ok.
 sync_send_data(ConnPid, StreamId, Bin, EndStream) ->
     sync(fun(Ref) ->
-        _ = (ConnPid !
-            {h2_send_data, self(), Ref, StreamId, Bin, EndStream}),
+        _ =
+            (ConnPid !
+                {h2_send_data, self(), Ref, StreamId, Bin, EndStream}),
         ok
     end).
 

--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -1,0 +1,109 @@
+-module(roadrunner_http2_loop_response).
+-moduledoc """
+HTTP/2 `{loop, _}` response: message-driven streaming over h2 DATA frames.
+
+Mirrors `roadrunner_loop_response` (the h1 path) but runs in the
+per-stream worker process and emits DATA frames via the conn's
+`{h2_send_data, ...}` message protocol. Same mailbox contract as
+h1: a handler's `self() ! Msg` and `register/2` calls from
+`handle/1` work because the worker IS the dispatch process. OTP
+shapes (`{system, _, _}`, `{'$gen_call', _, _}`, `{'$gen_cast', _}`)
+are silently dropped via dedicated receive clauses; we're a plain
+spawn, not a `gen_*`, so `gen_server:call/2,3` against the worker
+will time out instead of surfacing in `handle_info/3`.
+
+On `{stop, _NewState}` the worker emits an empty DATA frame with
+END_STREAM and returns; the conn cleans up the stream slot via the
+worker's `'DOWN'` signal.
+""".
+
+-export([run/5]).
+
+-doc """
+Send the response HEADERS, then enter the message-receive loop.
+Returns when the handler's `handle_info/3` returns `{stop, _}`.
+""".
+-spec run(
+    pid(),
+    pos_integer(),
+    roadrunner_req:status(),
+    roadrunner_req:headers(),
+    {module(), term()}
+) -> ok.
+run(ConnPid, StreamId, Status, Headers, {Handler, State}) ->
+    sync_send_headers(ConnPid, StreamId, Status, Headers, false),
+    Push = make_push(ConnPid, StreamId),
+    info_loop(ConnPid, StreamId, Handler, Push, State).
+
+-spec info_loop(
+    pid(), pos_integer(), module(), roadrunner_handler:push_fun(), term()
+) -> ok.
+info_loop(ConnPid, StreamId, Handler, Push, State) ->
+    receive
+        {system, _, _} ->
+            info_loop(ConnPid, StreamId, Handler, Push, State);
+        {'$gen_call', _, _} ->
+            info_loop(ConnPid, StreamId, Handler, Push, State);
+        {'$gen_cast', _} ->
+            info_loop(ConnPid, StreamId, Handler, Push, State);
+        Info ->
+            case Handler:handle_info(Info, Push, State) of
+                {ok, NewState} ->
+                    info_loop(ConnPid, StreamId, Handler, Push, NewState);
+                {stop, _NewState} ->
+                    sync_send_data(ConnPid, StreamId, <<>>, true),
+                    ok
+            end
+    end.
+
+%% Push fun handed to the user handler. Empty data is a no-op: an
+%% empty DATA frame would be legal on the wire but doesn't advance
+%% the response, and matching h1's behaviour (which skips empty
+%% chunks to avoid emitting the chunked terminator prematurely)
+%% keeps the two paths symmetric.
+-spec make_push(pid(), pos_integer()) -> roadrunner_handler:push_fun().
+make_push(ConnPid, StreamId) ->
+    fun(Data) ->
+        Bin = iolist_to_binary(Data),
+        case byte_size(Bin) of
+            0 ->
+                ok;
+            _ ->
+                sync_send_data(ConnPid, StreamId, Bin, false),
+                ok
+        end
+    end.
+
+%% Sync helpers: send a frame request to the conn and block on its
+%% ack. Duplicated from `roadrunner_http2_stream_response`. Two
+%% callers is the threshold for extracting a shared module; a third
+%% caller (e.g. a future `{loop, _}` middleware path) would justify
+%% factoring them out into `roadrunner_http2_worker_sync`.
+
+-spec sync_send_headers(
+    pid(), pos_integer(), roadrunner_req:status(),
+    roadrunner_req:headers(), boolean()
+) -> ok.
+sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->
+    sync(fun(Ref) ->
+        _ = (ConnPid !
+            {h2_send_headers, self(), Ref, StreamId, Status, Headers, EndStream}),
+        ok
+    end).
+
+-spec sync_send_data(pid(), pos_integer(), binary(), boolean()) -> ok.
+sync_send_data(ConnPid, StreamId, Bin, EndStream) ->
+    sync(fun(Ref) ->
+        _ = (ConnPid !
+            {h2_send_data, self(), Ref, StreamId, Bin, EndStream}),
+        ok
+    end).
+
+-spec sync(fun((reference()) -> ok)) -> ok.
+sync(SendFun) ->
+    Ref = make_ref(),
+    ok = SendFun(Ref),
+    receive
+        {h2_send_ack, Ref} -> ok;
+        {h2_stream_reset, _StreamId} -> exit(stream_reset)
+    end.

--- a/src/roadrunner_http2_request.erl
+++ b/src/roadrunner_http2_request.erl
@@ -58,10 +58,11 @@ value, and `method` set to `:method`. The `:authority`
 pseudo-header is forwarded as a `host` header so handlers that
 read it via `roadrunner_req:header/2` still work.
 
-`Body` is the concatenated DATA-frame payload bytes (or `<<>>`
-for header-only requests).
+`Body` is the iolist of accumulated DATA-frame payload chunks (or `<<>>`
+for header-only requests). Stored on the request map as `iodata()`;
+handlers requiring a flat binary call `iolist_to_binary/1` themselves.
 """.
--spec from_headers([roadrunner_http2_hpack:header()], binary(), conn_info()) ->
+-spec from_headers([roadrunner_http2_hpack:header()], iodata(), conn_info()) ->
     {ok, roadrunner_http1:request()} | {error, build_error()}.
 from_headers(Headers, Body, ConnInfo) ->
     maybe

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -154,10 +154,44 @@ emit_handler_response(ConnPid, StreamId, {stream, Status, Headers, Fun}) when
     roadrunner_http2_stream_response:run(ConnPid, StreamId, Status, Headers, Fun);
 emit_handler_response(ConnPid, StreamId, {loop, _, _, _}) ->
     emit_501(ConnPid, StreamId);
-emit_handler_response(ConnPid, StreamId, {sendfile, _, _, _}) ->
-    emit_501(ConnPid, StreamId);
+emit_handler_response(
+    ConnPid, StreamId, {sendfile, Status, Headers, {File, Offset, Length}}
+) when is_integer(Status, 100, 599) ->
+    %% h2 has no kernel sendfile path. Wrap the file-read loop in a
+    %% stream_fun so the existing streaming machinery handles
+    %% HEADERS, DATA framing, MAX_FRAME_SIZE chunking, and per-stream
+    %% / conn-level flow control. File-open failures crash the worker;
+    %% the conn process RST_STREAM-s the stream, matching h1.
+    Fun = fun(Send) ->
+        {ok, IoDev} = file:open(File, [read, raw, binary]),
+        try
+            {ok, _} = file:position(IoDev, Offset),
+            sendfile_loop(IoDev, Length, Send)
+        after
+            _ = file:close(IoDev)
+        end
+    end,
+    roadrunner_http2_stream_response:run(ConnPid, StreamId, Status, Headers, Fun);
 emit_handler_response(ConnPid, StreamId, {websocket, _, _}) ->
     emit_501(ConnPid, StreamId).
+
+%% h2 DATA frame payload cap. The default SETTINGS_MAX_FRAME_SIZE is
+%% 16384 (RFC 9113 §6.5.2); larger reads just force the framer to
+%% split, so cap at the floor.
+-define(SENDFILE_CHUNK_SIZE, 16384).
+
+sendfile_loop(_IoDev, 0, Send) ->
+    Send(<<>>, fin);
+sendfile_loop(IoDev, Remaining, Send) ->
+    Want = min(Remaining, ?SENDFILE_CHUNK_SIZE),
+    {ok, Bin} = file:read(IoDev, Want),
+    case Remaining - byte_size(Bin) of
+        0 ->
+            Send(Bin, fin);
+        NextRemaining ->
+            Send(Bin, nofin),
+            sendfile_loop(IoDev, NextRemaining, Send)
+    end.
 
 emit_501(ConnPid, StreamId) ->
     send_buffered(

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -97,7 +97,7 @@ invoke(ConnPid, StreamId, Handler, ListenerMws, Req, Metadata, ReqStart) ->
     Pipeline = roadrunner_middleware:build_pipeline(ListenerMws, Req, Handler),
     try Pipeline(Req) of
         {Response, _Req2} ->
-            emit_handler_response(ConnPid, StreamId, Response),
+            emit_handler_response(ConnPid, StreamId, Handler, Response),
             ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
                 status => roadrunner_conn:response_status(Response),
                 response_kind => roadrunner_conn:response_kind(Response)
@@ -144,18 +144,27 @@ telemetry_metadata(#{
         listener_name => ListenerName
     }.
 
-emit_handler_response(ConnPid, StreamId, {Status, Headers, Body}) when
+emit_handler_response(ConnPid, StreamId, _Handler, {Status, Headers, Body}) when
     is_integer(Status, 100, 599)
 ->
     send_buffered(ConnPid, StreamId, Status, Headers, Body);
-emit_handler_response(ConnPid, StreamId, {stream, Status, Headers, Fun}) when
+emit_handler_response(ConnPid, StreamId, _Handler, {stream, Status, Headers, Fun}) when
     is_integer(Status, 100, 599), is_function(Fun, 1)
 ->
     roadrunner_http2_stream_response:run(ConnPid, StreamId, Status, Headers, Fun);
-emit_handler_response(ConnPid, StreamId, {loop, _, _, _}) ->
-    emit_501(ConnPid, StreamId);
+emit_handler_response(ConnPid, StreamId, Handler, {loop, Status, Headers, State}) when
+    is_integer(Status, 100, 599)
+->
+    %% Mirrors h1's `{loop, _}` path: enter a selective-receive loop
+    %% in the worker (sharing the handler's mailbox), dispatch each
+    %% non-OTP message through `Handler:handle_info/3`, emit DATA
+    %% frames via Push. On `{stop, _}` the worker emits an empty
+    %% DATA + END_STREAM and exits.
+    roadrunner_http2_loop_response:run(
+        ConnPid, StreamId, Status, Headers, {Handler, State}
+    );
 emit_handler_response(
-    ConnPid, StreamId, {sendfile, Status, Headers, {File, Offset, Length}}
+    ConnPid, StreamId, _Handler, {sendfile, Status, Headers, {File, Offset, Length}}
 ) when is_integer(Status, 100, 599) ->
     %% h2 has no kernel sendfile path. Wrap the file-read loop in a
     %% stream_fun so the existing streaming machinery handles
@@ -172,7 +181,7 @@ emit_handler_response(
         end
     end,
     roadrunner_http2_stream_response:run(ConnPid, StreamId, Status, Headers, Fun);
-emit_handler_response(ConnPid, StreamId, {websocket, _, _}) ->
+emit_handler_response(ConnPid, StreamId, _Handler, {websocket, _, _}) ->
     emit_501(ConnPid, StreamId).
 
 %% h2 DATA frame payload cap. The default SETTINGS_MAX_FRAME_SIZE is

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -76,8 +76,15 @@ connection crash doesn't take the pool down.
     %% `~"h2"`, clients that ALPN-negotiate `h2` are dispatched to
     %% `roadrunner_conn_loop_http2`; everything else (including no-ALPN
     %% and `~"http/1.1"`) goes to the HTTP/1.1 path. Default ALPN is
-    %% `[~"http/1.1"]` only. Plain TCP listeners are h1-only.
+    %% `[~"http/1.1"]` only. For HTTP/2 on plain TCP set `h2c => enabled`.
     tls => [ssl:tls_server_option()],
+    %% Force every accepted connection on a plaintext listener through
+    %% the HTTP/2 state machine via the RFC 7540 §3.4 prior-knowledge
+    %% variant. Client opens TCP and sends the h2 connection preface
+    %% (`PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n`) directly, no Upgrade
+    %% negotiation. Plain TCP only: combining `h2c => enabled` with
+    %% `tls` is rejected at `init/1`. Default `disabled`.
+    h2c => enabled | disabled,
     %% h2 connection-level recv window peak (bytes). The RFC default is
     %% 65535 — the only window reachable without explicit
     %% `WINDOW_UPDATE` per RFC 9113 §6.5.2 (SETTINGS doesn't carry the
@@ -367,6 +374,7 @@ build_proto_opts(Opts, ListenerName) ->
     ok = validate_h2_window_opt(h2_initial_conn_window, Opts, 16#7FFFFFFF),
     ok = validate_h2_window_opt(h2_initial_stream_window, Opts, 16#7FFFFFFF),
     ok = validate_h2_window_opt(h2_window_refill_threshold, Opts, 16#7FFFFFFF),
+    ok = validate_h2c_opt(Opts),
     %% Per-listener atomics: live-connection counter (acceptors bump on
     %% accept; conns decrement on exit) and a cumulative requests-served
     %% counter (conn bumps on each handler dispatch). Lock-free, ~1ns
@@ -389,6 +397,7 @@ build_proto_opts(Opts, ListenerName) ->
         body_buffering => maps:get(body_buffering, Opts, auto),
         listener_name => ListenerName,
         drain_group => maps:get(drain_group, Opts, enabled),
+        h2c => maps:get(h2c, Opts, disabled),
         h2_initial_conn_window => maps:get(h2_initial_conn_window, Opts, 65535),
         h2_initial_stream_window => maps:get(h2_initial_stream_window, Opts, 65535),
         h2_window_refill_threshold => maps:get(h2_window_refill_threshold, Opts, 32768)
@@ -431,6 +440,28 @@ validate_h2_window_opt(Key, Opts, Max) ->
             ok;
         {ok, V} ->
             error({invalid_listener_opt, Key, V})
+    end.
+
+%% `h2c => enabled` is a plaintext-only mode: TLS listeners use ALPN
+%% to negotiate h2 instead. Reject the combo at `init/1` so the
+%% misconfiguration surfaces immediately rather than as a silent
+%% no-op (the dispatch wouldn't honour h2c on a TLS socket anyway).
+%%
+%% Two error shapes:
+%%
+%% - `{invalid_listener_opt, h2c, V}` for a bad value (anything other
+%%   than `enabled` / `disabled`). Matches `validate_h2_window_opt/3`.
+%% - `{listener_opt_conflict, h2c, tls}` when both opts are present
+%%   together. The value `enabled` is valid in isolation; the
+%%   misconfiguration is the combination, so a distinct class makes
+%%   the error message say what's actually wrong.
+-spec validate_h2c_opt(opts()) -> ok.
+validate_h2c_opt(Opts) ->
+    case {maps:get(h2c, Opts, disabled), maps:is_key(tls, Opts)} of
+        {disabled, _} -> ok;
+        {enabled, false} -> ok;
+        {enabled, true} -> error({listener_opt_conflict, h2c, tls});
+        {Other, _} -> error({invalid_listener_opt, h2c, Other})
     end.
 
 build_dispatch(#{routes := _}, ListenerName) ->

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -60,9 +60,10 @@ run(Socket, Status, UserHeaders, Handler, State) ->
 %% gen_server/gen_statem requests). Those would only reach the conn
 %% via misuse (the conn is a plain proc_lib loop, not a gen_*) and
 %% delivering them to the user handler would surface a confusing
-%% shape it has no reason to pattern-match on. Skipping leaves them
-%% in the mailbox; they're dropped when the conn exits. On
-%% `{stop, _}` we emit the size-0 chunked terminator and return.
+%% shape it has no reason to pattern-match on. Each OTP shape gets
+%% its own no-op clause that re-enters the loop; non-OTP messages
+%% fall through to the catch-all `Info` clause. On `{stop, _}` we
+%% emit the size-0 chunked terminator and return.
 %%
 %% **No `after` clause:** the loop blocks indefinitely until the
 %% handler returns `{stop, _}` from `handle_info/3`. A handler that
@@ -73,12 +74,13 @@ run(Socket, Status, UserHeaders, Handler, State) ->
     ok.
 info_loop(Socket, Handler, Push, State) ->
     receive
-        Info when
-            not (is_tuple(Info) andalso
-                (element(1, Info) =:= system orelse
-                    element(1, Info) =:= '$gen_call' orelse
-                    element(1, Info) =:= '$gen_cast'))
-        ->
+        {system, _, _} ->
+            info_loop(Socket, Handler, Push, State);
+        {'$gen_call', _, _} ->
+            info_loop(Socket, Handler, Push, State);
+        {'$gen_cast', _} ->
+            info_loop(Socket, Handler, Push, State);
+        Info ->
             case Handler:handle_info(Info, Push, State) of
                 {ok, NewState} ->
                     info_loop(Socket, Handler, Push, NewState);

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -159,26 +159,29 @@ parse_cookies(Req) ->
 Return the buffered request body bytes as seen by the handler.
 
 The connection process embeds whatever bytes followed the header block
-under the `body` map key before invoking the handler. Body framing
-(Content-Length / chunked) is not yet applied — this exposes the raw
-buffer the parser carried over.
+under the `body` map key before invoking the handler. Auto-mode delivers
+the full body as `iodata()` (an iolist of recv chunks for multi-chunk
+bodies, a single binary otherwise) so handlers that only need
+`iolist_size/1` or `gen_tcp:send/2` skip a flatten. Handlers requiring
+a flat binary call `iolist_to_binary/1` themselves.
 
 Returns `<<>>` when the request has no body field (e.g. when a request
 map is constructed manually outside the connection pipeline).
 """.
--spec body(request()) -> binary().
+-spec body(request()) -> iodata().
 body(#{body := B}) -> B;
 body(_) -> <<>>.
 
 -doc """
 Return whether the request carries a non-empty body.
 
-Returns `false` for both an absent `body` field and an empty body
-binary — handlers can use this as a short-circuit before doing any
-body-aware work.
+Returns `false` for both an absent `body` field and an empty body.
+Handlers can use this as a short-circuit before doing any body-aware
+work. Uses `iolist_size/1` so the check is O(length of iolist), not
+O(total bytes).
 """.
 -spec has_body(request()) -> boolean().
-has_body(#{body := B}) -> B =/= <<>>;
+has_body(#{body := B}) -> iolist_size(B) > 0;
 has_body(_) -> false.
 
 -doc """
@@ -196,7 +199,7 @@ body-buffering modes:
   handler skipped.
 """.
 -spec read_body(request()) ->
-    {ok, binary(), request()} | {error, term()}.
+    {ok, iodata(), request()} | {error, term()}.
 read_body(Req) ->
     read_body(Req, #{}).
 
@@ -218,8 +221,8 @@ In `auto` mode the body is already buffered, so `length` has no
 effect — the buffered bytes are returned in one shot.
 """.
 -spec read_body(request(), #{length => non_neg_integer()}) ->
-    {ok, binary(), request()}
-    | {more, binary(), request()}
+    {ok, iodata(), request()}
+    | {more, iodata(), request()}
     | {error, term()}.
 read_body(#{body_state := BS} = Req, Opts) ->
     Mode =
@@ -258,8 +261,8 @@ conn via the `{Response, Req2}` handler return shape so any unread
 chunks get drained for keep-alive.
 """.
 -spec read_body_chunked(request()) ->
-    {ok, binary(), request()}
-    | {more, binary(), request()}
+    {ok, iodata(), request()}
+    | {more, iodata(), request()}
     | {error, term()}.
 read_body_chunked(#{body_state := BS} = Req) ->
     case roadrunner_conn:consume_body_state(BS, next_chunk) of
@@ -319,14 +322,18 @@ content_type_kind(ContentType) ->
     | {error, term()}.
 dispatch_form(urlencoded, _ContentType, Req) ->
     case read_body(Req) of
-        {ok, Body, Req2} -> {ok, urlencoded, roadrunner_qs:parse(Body), Req2};
-        {error, _} = E -> E
+        {ok, Body, Req2} ->
+            %% Parser requires a flat binary; flatten only here, not at
+            %% every body read.
+            {ok, urlencoded, roadrunner_qs:parse(iolist_to_binary(Body)), Req2};
+        {error, _} = E ->
+            E
     end;
 dispatch_form(multipart, ContentType, Req) ->
     maybe
         {ok, Boundary} ?= roadrunner_multipart:boundary(ContentType),
         {ok, Body, Req2} ?= read_body(Req),
-        {ok, Parts} ?= roadrunner_multipart:parse(Body, Boundary),
+        {ok, Parts} ?= roadrunner_multipart:parse(iolist_to_binary(Body), Boundary),
         {ok, multipart, Parts, Req2}
     end;
 dispatch_form(unsupported, _ContentType, _Req) ->

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -12,6 +12,28 @@ Configure via a 3-tuple route with `#{dir => Path}` opts and a
 Reads the file from disk, sets `Content-Type` from the extension,
 returns 404 on a missing file or any path that contains `..`.
 
+## Gzip-sibling serving
+
+When a request carries `Accept-Encoding: gzip` and the requested
+file has a `<file>.gz` sibling on disk, the sibling is served
+verbatim with `Content-Encoding: gzip` plus `Vary: Accept-Encoding`.
+This matches nginx's `gzip_static on` behaviour and lets operators
+pre-compress build assets once instead of paying the deflate cost
+per request.
+
+`Accept-Encoding` is matched via plain substring (`gzip`) rather
+than full RFC 9110 §12.5.3 qvalue ranking. The static path is
+typically hit by browsers and benchmark clients that always
+include `gzip` plainly. Brotli (`.br`) siblings are not served —
+gzip is the universally supported encoding.
+
+The original file's ETag is reused for the gzip variant, so a
+follow-up `If-None-Match` returns 304 regardless of which variant
+was first served. A `Range` request disables the gzip path on that
+request — byte offsets over a compressed representation have
+subtle semantics and the simple "Range wins" rule matches what
+nginx does.
+
 ## Symlink policy
 
 `#{symlink_policy => Policy}` (default `refuse_escapes`) controls
@@ -114,8 +136,55 @@ serve_regular_file(FilePath, Size, Mtime, Req) ->
                 ],
                 ~""};
         false ->
-            serve_with_range(FilePath, Size, ETag, LastMod, Req)
+            case maybe_serve_gzip(FilePath, ETag, LastMod, Req) of
+                {ok, Resp} -> Resp;
+                none -> serve_with_range(FilePath, Size, ETag, LastMod, Req)
+            end
     end.
+
+%% When the client opted into gzip and a `<file>.gz` sibling is on
+%% disk, serve the sibling with `Content-Encoding: gzip`. `Range`
+%% requests skip this path — byte offsets over a compressed
+%% representation have subtle semantics, so we let Range win and
+%% serve the raw file.
+-spec maybe_serve_gzip(file:filename_all(), binary(), binary(), roadrunner_req:request()) ->
+    {ok, roadrunner_handler:response()} | none.
+maybe_serve_gzip(FilePath, ETag, LastMod, Req) ->
+    case (roadrunner_req:header(~"range", Req) =:= undefined)
+         andalso accepts_gzip(Req) of
+        true ->
+            GzPath = iolist_to_binary([FilePath, ~".gz"]),
+            case file:read_file_info(GzPath, [{time, posix}]) of
+                {ok, #file_info{type = regular, size = GzSize}} ->
+                    {ok, gzip_response(FilePath, GzPath, GzSize, ETag, LastMod)};
+                _ ->
+                    none
+            end;
+        false ->
+            none
+    end.
+
+-spec accepts_gzip(roadrunner_req:request()) -> boolean().
+accepts_gzip(Req) ->
+    case roadrunner_req:header(~"accept-encoding", Req) of
+        undefined -> false;
+        Bin -> binary:match(Bin, ~"gzip") =/= nomatch
+    end.
+
+-spec gzip_response(
+    file:filename_all(), file:filename_all(), non_neg_integer(), binary(), binary()
+) -> roadrunner_handler:response().
+gzip_response(OrigPath, GzPath, GzSize, ETag, LastMod) ->
+    {sendfile, 200,
+        [
+            {~"content-type", content_type_for(OrigPath)},
+            {~"content-encoding", ~"gzip"},
+            {~"content-length", integer_to_binary(GzSize)},
+            {~"etag", ETag},
+            {~"last-modified", LastMod},
+            {~"vary", ~"Accept-Encoding"}
+        ],
+        {GzPath, 0, GzSize}}.
 
 %% Cache hit when either:
 %% - `If-None-Match` matches the current ETag (strong validator), or

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -150,8 +150,10 @@ serve_regular_file(FilePath, Size, Mtime, Req) ->
 -spec maybe_serve_gzip(file:filename_all(), binary(), binary(), roadrunner_req:request()) ->
     {ok, roadrunner_handler:response()} | none.
 maybe_serve_gzip(FilePath, ETag, LastMod, Req) ->
-    case (roadrunner_req:header(~"range", Req) =:= undefined)
-         andalso accepts_gzip(Req) of
+    case
+        (roadrunner_req:header(~"range", Req) =:= undefined) andalso
+            accepts_gzip(Req)
+    of
         true ->
             GzPath = iolist_to_binary([FilePath, ~".gz"]),
             case file:read_file_info(GzPath, [{time, posix}]) of

--- a/test/roadrunner_bench_echo_handler.erl
+++ b/test/roadrunner_bench_echo_handler.erl
@@ -16,7 +16,7 @@ handle(#{body := Body} = Req) ->
         {200,
             [
                 {~"content-type", ~"application/octet-stream"},
-                {~"content-length", integer_to_binary(byte_size(Body))}
+                {~"content-length", integer_to_binary(iolist_size(Body))}
             ],
             Body},
     {Resp, Req};

--- a/test/roadrunner_bench_form_handler.erl
+++ b/test/roadrunner_bench_form_handler.erl
@@ -14,7 +14,8 @@ coverage but no bench coverage.
 
 -spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
 handle(#{body := Body} = Req) ->
-    Pairs = roadrunner_qs:parse(Body),
+    %% The auto-buffered body is `iodata()`; qs:parse requires a binary.
+    Pairs = roadrunner_qs:parse(iolist_to_binary(Body)),
     AckBody = integer_to_binary(length(Pairs)),
     Resp =
         {200,

--- a/test/roadrunner_bench_httparena_baseline_handler.erl
+++ b/test/roadrunner_bench_httparena_baseline_handler.erl
@@ -1,0 +1,37 @@
+-module(roadrunner_bench_httparena_baseline_handler).
+-moduledoc """
+Roadrunner handler for `scripts/bench.escript --scenario httparena_baseline`.
+
+Mirrors HttpArena's `baseline` profile: `GET /baseline11?a=I&b=I`
+returns plaintext `integer_to_binary(A + B)`. Exercises query-string
+parsing, integer parsing, and small plaintext response framing.
+""".
+
+-behaviour(roadrunner_handler).
+
+-export([handle/1]).
+
+-spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+handle(Req) ->
+    A = qs_int(~"a", Req, 0),
+    B = qs_int(~"b", Req, 0),
+    Body = integer_to_binary(A + B),
+    Resp =
+        {200,
+            [
+                {~"content-type", ~"text/plain"},
+                {~"content-length", integer_to_binary(byte_size(Body))}
+            ],
+            Body},
+    {Resp, Req}.
+
+qs_int(Key, Req, Default) ->
+    case lists:keyfind(Key, 1, roadrunner_req:parse_qs(Req)) of
+        {Key, V} when is_binary(V) ->
+            case string:to_integer(V) of
+                {N, _} when is_integer(N) -> N;
+                _ -> Default
+            end;
+        _ ->
+            Default
+    end.

--- a/test/roadrunner_bench_httparena_json_handler.erl
+++ b/test/roadrunner_bench_httparena_json_handler.erl
@@ -1,0 +1,111 @@
+-module(roadrunner_bench_httparena_json_handler).
+-moduledoc """
+Roadrunner handler for `scripts/bench.escript --scenario httparena_json`.
+
+Mirrors HttpArena's `json` profile: `GET /httparena_json/:count?m=M`
+returns a JSON list of `count` items, each projected with
+`total = price * quantity * M`. The 50-item dataset is precomputed
+at module load and stashed in `persistent_term` so the bench
+measures dispatch + projection + JSON encode, not dataset
+construction.
+
+Dataset shape (id, name, category, price, quantity, active, tags,
+rating) mirrors HttpArena's `data/dataset.json`. The canonical
+bench-fixture response (count=50, m=1) is also precomputed and
+exposed via `bench_body/0` so the loadgen knows the exact response
+size to expect.
+""".
+
+-behaviour(roadrunner_handler).
+
+-on_load(init_dataset/0).
+
+-export([handle/1]).
+-export([bench_body/0]).
+
+-define(DATASET_KEY, {?MODULE, dataset}).
+-define(BENCH_BODY_KEY, {?MODULE, bench_body}).
+-define(DATASET_SIZE, 50).
+-define(BENCH_COUNT, 50).
+-define(BENCH_MULTIPLIER, 1).
+
+-spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+handle(Req) ->
+    Count = binding_int(~"count", Req, 0),
+    M = qs_int(~"m", Req, 1),
+    Body = encode(Count, M),
+    Resp =
+        {200,
+            [
+                {~"content-type", ~"application/json"},
+                {~"content-length", integer_to_binary(byte_size(Body))}
+            ],
+            Body},
+    {Resp, Req}.
+
+-spec bench_body() -> binary().
+bench_body() ->
+    persistent_term:get(?BENCH_BODY_KEY).
+
+encode(Count, M) ->
+    Items = lists:sublist(persistent_term:get(?DATASET_KEY), max(0, Count)),
+    Projected = [project(I, M) || I <- Items],
+    iolist_to_binary(
+        json:encode(#{
+            ~"count" => length(Projected),
+            ~"items" => Projected
+        })
+    ).
+
+project(#{~"price" := P, ~"quantity" := Q} = Item, M) ->
+    Item#{~"total" => P * Q * M}.
+
+binding_int(Key, Req, Default) ->
+    case roadrunner_req:bindings(Req) of
+        #{Key := V} when is_binary(V) -> bin_int(V, Default);
+        _ -> Default
+    end.
+
+qs_int(Key, Req, Default) ->
+    case lists:keyfind(Key, 1, roadrunner_req:parse_qs(Req)) of
+        {Key, V} when is_binary(V) -> bin_int(V, Default);
+        _ -> Default
+    end.
+
+bin_int(<<>>, Default) ->
+    Default;
+bin_int(Bin, Default) ->
+    case string:to_integer(Bin) of
+        {N, _} when is_integer(N) -> N;
+        _ -> Default
+    end.
+
+-spec init_dataset() -> ok.
+init_dataset() ->
+    persistent_term:put(?DATASET_KEY, build_dataset(?DATASET_SIZE)),
+    persistent_term:put(?BENCH_BODY_KEY, encode(?BENCH_COUNT, ?BENCH_MULTIPLIER)),
+    ok.
+
+build_dataset(Size) ->
+    Categories = [~"electronics", ~"tools", ~"home", ~"outdoor", ~"office"],
+    TagPool = [~"sale", ~"new", ~"popular", ~"fast", ~"heavy-duty", ~"wireless"],
+    [build_item(N, Categories, TagPool) || N <- lists:seq(1, Size)].
+
+build_item(N, Categories, TagPool) ->
+    #{
+        ~"id" => N,
+        ~"name" => <<"Item-", (integer_to_binary(N))/binary>>,
+        ~"category" => lists:nth(((N - 1) rem length(Categories)) + 1, Categories),
+        ~"price" => 100 + (N * 7) rem 900,
+        ~"quantity" => 1 + (N * 3) rem 100,
+        ~"active" => (N rem 2) =:= 0,
+        ~"tags" => pick_tags(N, TagPool),
+        ~"rating" => #{
+            ~"score" => 30 + (N rem 70),
+            ~"count" => 1 + (N * 5) rem 200
+        }
+    }.
+
+pick_tags(N, TagPool) ->
+    Count = 2 + (N rem 3),
+    [lists:nth(((N + I - 1) rem length(TagPool)) + 1, TagPool) || I <- lists:seq(1, Count)].

--- a/test/roadrunner_bench_httparena_upload_handler.erl
+++ b/test/roadrunner_bench_httparena_upload_handler.erl
@@ -1,0 +1,51 @@
+-module(roadrunner_bench_httparena_upload_handler).
+-moduledoc """
+Roadrunner handler for `scripts/bench.escript --scenario
+httparena_upload_20mb_auto` and `--scenario
+httparena_upload_20mb_manual`.
+
+Mirrors HttpArena's `upload` profile: `POST /upload` returns the
+plaintext byte count of the request body. Two pattern-match
+clauses cover both buffering modes:
+
+- `body_buffering => auto` (default): the conn pre-buffers the body
+  into `#{body := Body}`; handler just reads the field.
+- `body_buffering => manual`: handler drains the body in 64 KB
+  chunks via `roadrunner_req:read_body/2`, counting bytes per
+  chunk without retaining them. Peak memory stays bounded even on
+  20 MB bodies.
+
+Same workload shape, two server-side paths. The pair is the
+empirical reproduction of HttpArena's auto-mode 4.1 GiB memory
+peak on the 20 MB upload validator.
+""".
+
+-behaviour(roadrunner_handler).
+
+-export([handle/1]).
+
+-define(CHUNK_LIMIT, 65536).
+
+-spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+handle(#{body := Body} = Req) ->
+    ack(byte_size(Body), Req);
+handle(Req) ->
+    {Count, Req2} = drain(Req, 0),
+    ack(Count, Req2).
+
+drain(Req, Acc) ->
+    case roadrunner_req:read_body(Req, #{length => ?CHUNK_LIMIT}) of
+        {ok, Bytes, Req2} -> {Acc + byte_size(Bytes), Req2};
+        {more, Bytes, Req2} -> drain(Req2, Acc + byte_size(Bytes))
+    end.
+
+ack(Count, Req) ->
+    Body = integer_to_binary(Count),
+    Resp =
+        {200,
+            [
+                {~"content-type", ~"text/plain"},
+                {~"content-length", integer_to_binary(byte_size(Body))}
+            ],
+            Body},
+    {Resp, Req}.

--- a/test/roadrunner_bench_httparena_upload_handler.erl
+++ b/test/roadrunner_bench_httparena_upload_handler.erl
@@ -9,7 +9,8 @@ plaintext byte count of the request body. Two pattern-match
 clauses cover both buffering modes:
 
 - `body_buffering => auto` (default): the conn pre-buffers the body
-  into `#{body := Body}`; handler just reads the field.
+  into `#{body := Body}` as `iodata()`; handler reads the field and
+  uses `iolist_size/1` to count bytes without flattening.
 - `body_buffering => manual`: handler drains the body in 64 KB
   chunks via `roadrunner_req:read_body/2`, counting bytes per
   chunk without retaining them. Peak memory stays bounded even on
@@ -28,15 +29,15 @@ peak on the 20 MB upload validator.
 
 -spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
 handle(#{body := Body} = Req) ->
-    ack(byte_size(Body), Req);
+    ack(iolist_size(Body), Req);
 handle(Req) ->
     {Count, Req2} = drain(Req, 0),
     ack(Count, Req2).
 
 drain(Req, Acc) ->
     case roadrunner_req:read_body(Req, #{length => ?CHUNK_LIMIT}) of
-        {ok, Bytes, Req2} -> {Acc + byte_size(Bytes), Req2};
-        {more, Bytes, Req2} -> drain(Req2, Acc + byte_size(Bytes))
+        {ok, Bytes, Req2} -> {Acc + iolist_size(Bytes), Req2};
+        {more, Bytes, Req2} -> drain(Req2, Acc + iolist_size(Bytes))
     end.
 
 ack(Count, Req) ->

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -42,7 +42,8 @@ all_test_() ->
         fun stream_response_with_trailers/0,
         fun stream_response_trailers_only/0,
         fun stream_response_skips_empty_nofin/0,
-        fun loop_response_returns_501/0,
+        fun loop_response_emits_data_then_closes_on_stop/0,
+        fun loop_response_filters_otp_messages/0,
         fun sendfile_empty_emits_empty_data/0,
         fun sendfile_small_file_emits_single_data_frame/0,
         fun sendfile_multi_frame_chunks_at_max_frame_size/0,
@@ -730,8 +731,50 @@ stream_response_skips_empty_nofin() ->
     ),
     cleanup(Pid, Ref).
 
-loop_response_returns_501() ->
-    {Pid, Ref} = run_h2_request_with_handler(roadrunner_h2_test_handler, ~"/loop"),
+loop_response_emits_data_then_closes_on_stop() ->
+    %% Drive the worker into the info_loop, push two messages, then
+    %% stop. The handler registers `roadrunner_h2_loop_test` so we
+    %% can address it from outside the worker. Expected wire frame
+    %% sequence: HEADERS (no END_STREAM), DATA(`data: hi\n\n`),
+    %% DATA(`data: bye(1)\n\n`), DATA(<<>>, END_STREAM).
+    {Pid, Ref} = run_stream_request(~"/loop"),
+    wait_for_register(roadrunner_h2_loop_test, 1000),
+    roadrunner_h2_loop_test ! {push, ~"hi"},
+    roadrunner_h2_loop_test ! stop,
+    Frames = collect_response_frames(),
+    ?assertMatch(
+        [
+            {headers, 1, false},
+            {data, 1, false, ~"data: hi\n\n"},
+            {data, 1, false, ~"data: bye(1)\n\n"},
+            {data, 1, true, ~""}
+        ],
+        Frames
+    ),
+    cleanup(Pid, Ref).
+
+loop_response_filters_otp_messages() ->
+    %% sys / gen_call / gen_cast shapes must NOT reach `handle_info/3`.
+    %% The handler increments `N` only on `{push, _}`; if any OTP
+    %% message slipped through to handle_info the `bye(N)` chunk
+    %% would show a larger counter.
+    {Pid, Ref} = run_stream_request(~"/loop"),
+    wait_for_register(roadrunner_h2_loop_test, 1000),
+    roadrunner_h2_loop_test ! {system, make_ref(), get_state},
+    roadrunner_h2_loop_test ! {'$gen_call', {self(), make_ref()}, ping},
+    roadrunner_h2_loop_test ! {'$gen_cast', whatever},
+    roadrunner_h2_loop_test ! {push, ~"real"},
+    roadrunner_h2_loop_test ! stop,
+    Frames = collect_response_frames(),
+    ?assertMatch(
+        [
+            {headers, 1, false},
+            {data, 1, false, ~"data: real\n\n"},
+            {data, 1, false, ~"data: bye(1)\n\n"},
+            {data, 1, true, ~""}
+        ],
+        Frames
+    ),
     cleanup(Pid, Ref).
 
 sendfile_empty_emits_empty_data() ->
@@ -2756,6 +2799,22 @@ drain_setopts() ->
     receive
         {roadrunner_fake_setopts, _, _} -> drain_setopts()
     after 0 -> ok
+    end.
+
+%% Spin-wait for a registered name to appear. Used by tests where
+%% the handler registers itself inside `handle/1`; without the wait,
+%% the test races with the worker's spawn and `Name ! Msg` crashes
+%% with `badarg`.
+wait_for_register(_Name, RemainingMs) when RemainingMs =< 0 ->
+    error({wait_for_register_timeout, _Name});
+wait_for_register(Name, RemainingMs) ->
+    case whereis(Name) of
+        undefined ->
+            Step = 10,
+            timer:sleep(Step),
+            wait_for_register(Name, RemainingMs - Step);
+        Pid ->
+            Pid
     end.
 
 drain_mailbox() ->

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -41,7 +41,11 @@ all_test_() ->
         fun stream_response_trailers_only/0,
         fun stream_response_skips_empty_nofin/0,
         fun loop_response_returns_501/0,
-        fun sendfile_response_returns_501/0,
+        fun sendfile_empty_emits_empty_data/0,
+        fun sendfile_small_file_emits_single_data_frame/0,
+        fun sendfile_multi_frame_chunks_at_max_frame_size/0,
+        fun sendfile_offset_and_length_window/0,
+        fun sendfile_missing_file_resets_stream/0,
         fun websocket_response_returns_501/0,
         fun handler_crash_returns_500/0,
         fun middleware_chain_runs/0,
@@ -630,8 +634,94 @@ loop_response_returns_501() ->
     {Pid, Ref} = run_h2_request_with_handler(roadrunner_h2_test_handler, ~"/loop"),
     cleanup(Pid, Ref).
 
-sendfile_response_returns_501() ->
-    {Pid, Ref} = run_h2_request_with_handler(roadrunner_h2_test_handler, ~"/sendfile"),
+sendfile_empty_emits_empty_data() ->
+    %% Length=0: file is opened but never read. The base clause of
+    %% sendfile_loop emits Send(<<>>, fin) → empty DATA with END_STREAM.
+    {Pid, Ref} = run_stream_request(~"/sendfile"),
+    Frames = collect_response_frames(),
+    ?assertEqual([{headers, 1, false}, {data, 1, true, ~""}], Frames),
+    cleanup(Pid, Ref).
+
+sendfile_small_file_emits_single_data_frame() ->
+    %% 100-byte file fits in a single DATA frame.
+    Path = "/tmp/rr_h2_sf_small.bin",
+    Body = binary:copy(<<"x">>, 100),
+    ok = file:write_file(Path, Body),
+    try
+        {Pid, Ref} = run_stream_request(~"/sendfile/small"),
+        Frames = collect_response_frames(),
+        ?assertEqual(
+            [{headers, 1, false}, {data, 1, true, Body}],
+            Frames
+        ),
+        cleanup(Pid, Ref)
+    after
+        _ = file:delete(Path)
+    end.
+
+sendfile_multi_frame_chunks_at_max_frame_size() ->
+    %% 40000-byte file splits into 3 DATA frames: 16384, 16384, 7232.
+    %% Only the last carries END_STREAM. The wire body re-assembled
+    %% from all three DATA payloads must equal the original file.
+    Path = "/tmp/rr_h2_sf_multi.bin",
+    Body = iolist_to_binary([
+        binary:copy(<<"a">>, 16384),
+        binary:copy(<<"b">>, 16384),
+        binary:copy(<<"c">>, 7232)
+    ]),
+    ok = file:write_file(Path, Body),
+    try
+        {Pid, Ref} = run_stream_request(~"/sendfile/multi"),
+        Frames = collect_response_frames(),
+        ?assertMatch(
+            [
+                {headers, 1, false},
+                {data, 1, false, _},
+                {data, 1, false, _},
+                {data, 1, true, _}
+            ],
+            Frames
+        ),
+        [_H, {data, 1, false, D1}, {data, 1, false, D2}, {data, 1, true, D3}] =
+            Frames,
+        ?assertEqual(16384, byte_size(D1)),
+        ?assertEqual(16384, byte_size(D2)),
+        ?assertEqual(7232, byte_size(D3)),
+        ?assertEqual(Body, <<D1/binary, D2/binary, D3/binary>>),
+        cleanup(Pid, Ref)
+    after
+        _ = file:delete(Path)
+    end.
+
+sendfile_offset_and_length_window() ->
+    %% 1000-byte file, sendfile (Offset=200, Length=500). Wire body
+    %% must equal bytes [200, 700) of the file.
+    Path = "/tmp/rr_h2_sf_window.bin",
+    Body = list_to_binary([X rem 256 || X <- lists:seq(0, 999)]),
+    ok = file:write_file(Path, Body),
+    try
+        {Pid, Ref} = run_stream_request(~"/sendfile/window"),
+        Frames = collect_response_frames(),
+        ?assertMatch(
+            [{headers, 1, false}, {data, 1, true, _}],
+            Frames
+        ),
+        [_H, {data, 1, true, Slice}] = Frames,
+        ?assertEqual(binary:part(Body, 200, 500), Slice),
+        cleanup(Pid, Ref)
+    after
+        _ = file:delete(Path)
+    end.
+
+sendfile_missing_file_resets_stream() ->
+    %% File open fails inside the StreamFun before any HEADERS are
+    %% sent. The worker crashes; the conn RST_STREAMs the stream and
+    %% the loop continues. The conn process must still be alive
+    %% afterwards.
+    _ = file:delete("/tmp/rr_h2_sf_does_not_exist.bin"),
+    {Pid, Ref} = run_h2_request_with_handler(
+        roadrunner_h2_test_handler, ~"/sendfile/missing"
+    ),
     cleanup(Pid, Ref).
 
 websocket_response_returns_501() ->

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -25,6 +25,8 @@ all_test_() ->
         fun all_frame_types_handled/0,
         fun goaway_received_closes_connection/0,
         fun concurrent_streams_both_dispatch/0,
+        fun h2c_dispatch_routes_plaintext_to_http2_loop/0,
+        fun plaintext_listener_without_h2c_stays_h1/0,
         fun post_with_body_via_data_frame/0,
         fun continuation_assembles_header_block/0,
         fun push_promise_from_client_triggers_goaway/0,
@@ -351,6 +353,104 @@ concurrent_streams_both_dispatch() ->
     StreamIds = lists:usort([SId || {headers, SId, _} <- Frames]),
     ?assert(lists:member(1, StreamIds)),
     ?assert(lists:member(3, StreamIds)),
+    cleanup(Pid, Ref).
+
+h2c_dispatch_routes_plaintext_to_http2_loop() ->
+    %% Drive the dispatch decision through `roadrunner_conn_loop:start/2`
+    %% with a `{fake, _}` socket and `h2c => enabled`. Without the h2c
+    %% opt the plain TCP path stays h1 and the conn waits for a request
+    %% line; the h2 path proactively emits SETTINGS right after `shoot`.
+    %% Receiving an h2 SETTINGS frame here proves the new dispatch
+    %% (`http2_negotiated/1 orelse h2c_enabled/1`) routed to the h2 loop.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    Self = self(),
+    Counter = atomics:new(1, [{signed, false}]),
+    ok = atomics:add(Counter, 1, 1),
+    RequestsCounter = atomics:new(1, [{signed, false}]),
+    ProtoOpts = #{
+        client_counter => Counter,
+        requests_counter => RequestsCounter,
+        listener_name => h2c_dispatch_test,
+        dispatch => {handler, roadrunner_hello_handler},
+        middlewares => [],
+        max_content_length => 1_048_576,
+        request_timeout => 30000,
+        keep_alive_timeout => 60000,
+        max_keep_alive_request => 1000,
+        max_clients => 100,
+        minimum_bytes_per_second => 0,
+        body_buffering => auto,
+        drain_group => disabled,
+        h2c => enabled,
+        h2_initial_conn_window => 65535,
+        h2_initial_stream_window => 65535,
+        h2_window_refill_threshold => 32768
+    },
+    Sock = {fake, Self},
+    {ok, Pid} = roadrunner_conn_loop:start(Sock, ProtoOpts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    %% h2 SETTINGS frame: 24-bit length, type=4, 8-bit flags, 31-bit
+    %% reserved+stream-id (zero for conn-level). Length is non-negative
+    %% (server SETTINGS is at least zero bytes). The exact value
+    %% depends on which SETTINGS entries roadrunner advertises; we
+    %% match the frame shape rather than pin the bytes.
+    Out = expect_send(),
+    ?assertMatch(<<_Len:24, 4, _Flags, _Reserved:1, _StreamId:31, _/binary>>, Out),
+    cleanup(Pid, Ref).
+
+plaintext_listener_without_h2c_stays_h1() ->
+    %% Regression guard for the dispatch's false branch. Without
+    %% `h2c => enabled` and without TLS ALPN, `awaiting_shoot/3`
+    %% must fall through to the HTTP/1.1 path. Discriminator:
+    %%
+    %% - The h2 path proactively sends a SETTINGS frame on the wire
+    %%   right after `shoot` (`{roadrunner_fake_send, _, _}`).
+    %% - The h1 path enters passive recv and asks the fake transport
+    %%   for bytes (`{roadrunner_fake_recv, _, _, _}`).
+    %%
+    %% Receiving the recv message (and no send) proves we routed to h1.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    Self = self(),
+    Counter = atomics:new(1, [{signed, false}]),
+    ok = atomics:add(Counter, 1, 1),
+    RequestsCounter = atomics:new(1, [{signed, false}]),
+    ProtoOpts = #{
+        client_counter => Counter,
+        requests_counter => RequestsCounter,
+        listener_name => h1_dispatch_test,
+        dispatch => {handler, roadrunner_hello_handler},
+        middlewares => [],
+        max_content_length => 1_048_576,
+        request_timeout => 30000,
+        keep_alive_timeout => 60000,
+        max_keep_alive_request => 1000,
+        max_clients => 100,
+        minimum_bytes_per_second => 0,
+        body_buffering => auto,
+        drain_group => disabled,
+        h2c => disabled,
+        h2_initial_conn_window => 65535,
+        h2_initial_stream_window => 65535,
+        h2_window_refill_threshold => 32768
+    },
+    Sock = {fake, Self},
+    {ok, Pid} = roadrunner_conn_loop:start(Sock, ProtoOpts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    %% h1 issues a passive recv on the socket; on a fake socket that
+    %% surfaces as a `{roadrunner_fake_recv, ConnPid, Len, Timeout}`
+    %% message to our process. h2 would never do this — it goes
+    %% active-once via setopts and proactively writes SETTINGS first.
+    receive
+        {roadrunner_fake_recv, _, _, _} -> ok;
+        {roadrunner_fake_send, _, _} -> error(unexpected_h2_send)
+    after 500 ->
+        error(no_recv_call)
+    end,
+    ?assert(is_process_alive(Pid)),
     cleanup(Pid, Ref).
 
 post_with_body_via_data_frame() ->

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -59,10 +59,9 @@ read_body_cl_within_buffer_test() ->
 read_body_cl_needs_more_recv_test() ->
     Req = req_with_headers([{~"content-length", ~"11"}]),
     Recv = fun() -> {ok, ~" world"} end,
-    ?assertEqual(
-        {ok, ~"hello world", <<>>},
-        roadrunner_conn:read_body(Req, ~"hello", Recv, 1000)
-    ).
+    {ok, Body, Leftover} = roadrunner_conn:read_body(Req, ~"hello", Recv, 1000),
+    ?assertEqual(~"hello world", iolist_to_binary(Body)),
+    ?assertEqual(<<>>, Leftover).
 
 read_body_cl_multi_chunk_recv_test() ->
     %% Body arrives in three separate recv chunks, none individually
@@ -70,10 +69,9 @@ read_body_cl_multi_chunk_recv_test() ->
     %% iolist accumulator in `read_body_until_io/2`.
     Req = req_with_headers([{~"content-length", ~"15"}]),
     Recv = chunked_recv([~"abc", ~"defgh", ~"ijklmnop"]),
-    ?assertEqual(
-        {ok, ~"abcdefghijklmno", ~"p"},
-        roadrunner_conn:read_body(Req, <<>>, Recv, 1000)
-    ).
+    {ok, Body, Leftover} = roadrunner_conn:read_body(Req, <<>>, Recv, 1000),
+    ?assertEqual(~"abcdefghijklmno", iolist_to_binary(Body)),
+    ?assertEqual(~"p", Leftover).
 
 read_body_cl_recv_error_test() ->
     %% First recv returns an error before any body bytes arrive.
@@ -1242,7 +1240,7 @@ consume_state_length_multi_recv_test() ->
         max => 1000
     },
     {more, Bytes, State1} = roadrunner_conn:consume_body_state(State0, {length, 8}),
-    ?assertEqual(~"abcdefgh", Bytes),
+    ?assertEqual(~"abcdefgh", iolist_to_binary(Bytes)),
     %% State1's buffered should now hold the leftover "ij".
     ?assertMatch(#{buffered := ~"ij"}, State1).
 
@@ -1286,7 +1284,8 @@ consume_state_request_too_large_test() ->
 
 consume_state_chunked_full_drain_test() ->
     State = chunked_state(~"5\r\nhello\r\n0\r\n\r\n", fun() -> error(unused) end),
-    ?assertMatch({ok, ~"hello", _}, roadrunner_conn:consume_body_state(State, all)).
+    {ok, Bytes, _} = roadrunner_conn:consume_body_state(State, all),
+    ?assertEqual(~"hello", iolist_to_binary(Bytes)).
 
 consume_state_chunked_error_propagates_test() ->
     State = chunked_state(~"xyz\r\nhello\r\n", fun() -> error(unused) end),
@@ -1296,11 +1295,11 @@ consume_state_chunked_length_streams_within_chunk_test() ->
     %% Chunk decodes to "hello"; reading with length=2 yields he/ll/o.
     State = chunked_state(~"5\r\nhello\r\n0\r\n\r\n", fun() -> error(unused) end),
     {more, B1, S1} = roadrunner_conn:consume_body_state(State, {length, 2}),
-    ?assertEqual(~"he", B1),
+    ?assertEqual(~"he", iolist_to_binary(B1)),
     {more, B2, S2} = roadrunner_conn:consume_body_state(S1, {length, 2}),
-    ?assertEqual(~"ll", B2),
+    ?assertEqual(~"ll", iolist_to_binary(B2)),
     {ok, B3, _S3} = roadrunner_conn:consume_body_state(S2, {length, 2}),
-    ?assertEqual(~"o", B3).
+    ?assertEqual(~"o", iolist_to_binary(B3)).
 
 consume_state_chunked_length_crosses_chunk_boundary_test() ->
     %% Two chunks "hel" + "lo world"; read length=4 yields "hell", "o wo", "rld".
@@ -1309,11 +1308,11 @@ consume_state_chunked_length_crosses_chunk_boundary_test() ->
         fun() -> error(unused) end
     ),
     {more, B1, S1} = roadrunner_conn:consume_body_state(State, {length, 4}),
-    ?assertEqual(~"hell", B1),
+    ?assertEqual(~"hell", iolist_to_binary(B1)),
     {more, B2, S2} = roadrunner_conn:consume_body_state(S1, {length, 4}),
-    ?assertEqual(~"o wo", B2),
+    ?assertEqual(~"o wo", iolist_to_binary(B2)),
     {ok, B3, _S3} = roadrunner_conn:consume_body_state(S2, {length, 4}),
-    ?assertEqual(~"rld", B3).
+    ?assertEqual(~"rld", iolist_to_binary(B3)).
 
 consume_state_chunked_length_recvs_more_test() ->
     %% Buffer has the size line but the chunk body arrives via recv.
@@ -1323,7 +1322,7 @@ consume_state_chunked_length_recvs_more_test() ->
         {ok, ~"llo\r\n0\r\n\r\n"}
     end),
     {ok, Bytes, _S2} = roadrunner_conn:consume_body_state(State, {length, 100}),
-    ?assertEqual(~"hello", Bytes),
+    ?assertEqual(~"hello", iolist_to_binary(Bytes)),
     receive
         recv_called -> ok
     after 100 -> error(recv_was_not_called)
@@ -1336,8 +1335,10 @@ consume_state_chunked_length_recv_error_test() ->
 consume_state_chunked_length_after_done_returns_empty_test() ->
     %% Drain the body fully via the all path, then try to read more.
     State0 = chunked_state(~"3\r\nhel\r\n0\r\n\r\n", fun() -> error(unused) end),
-    {ok, ~"hel", State1} = roadrunner_conn:consume_body_state(State0, all),
-    ?assertMatch({ok, <<>>, _}, roadrunner_conn:consume_body_state(State1, {length, 4})).
+    {ok, Drained, State1} = roadrunner_conn:consume_body_state(State0, all),
+    ?assertEqual(~"hel", iolist_to_binary(Drained)),
+    {ok, MoreBytes, _} = roadrunner_conn:consume_body_state(State1, {length, 4}),
+    ?assertEqual(<<>>, iolist_to_binary(MoreBytes)).
 
 consume_state_next_chunk_returns_one_chunk_test() ->
     %% Two chunks "hel" and "lo"; next_chunk yields each one in turn.
@@ -1457,7 +1458,8 @@ consume_state_recvs_more_when_buffer_short_test() ->
         end,
         max => 1000
     },
-    ?assertMatch({ok, ~"hello", _}, roadrunner_conn:consume_body_state(State, all)),
+    {ok, Bytes, _} = roadrunner_conn:consume_body_state(State, all),
+    ?assertEqual(~"hello", iolist_to_binary(Bytes)),
     receive
         recv_called -> ok
     after 100 -> error(recv_was_not_called)

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -64,6 +64,26 @@ read_body_cl_needs_more_recv_test() ->
         roadrunner_conn:read_body(Req, ~"hello", Recv, 1000)
     ).
 
+read_body_cl_multi_chunk_recv_test() ->
+    %% Body arrives in three separate recv chunks, none individually
+    %% enough to satisfy Content-Length. Exercises the body-recursive
+    %% iolist accumulator in `read_body_until_io/2`.
+    Req = req_with_headers([{~"content-length", ~"15"}]),
+    Recv = chunked_recv([~"abc", ~"defgh", ~"ijklmnop"]),
+    ?assertEqual(
+        {ok, ~"abcdefghijklmno", ~"p"},
+        roadrunner_conn:read_body(Req, <<>>, Recv, 1000)
+    ).
+
+read_body_cl_recv_error_test() ->
+    %% First recv returns an error before any body bytes arrive.
+    Req = req_with_headers([{~"content-length", ~"5"}]),
+    Recv = fun() -> {error, closed} end,
+    ?assertEqual(
+        {error, closed},
+        roadrunner_conn:read_body(Req, <<>>, Recv, 1000)
+    ).
+
 read_body_cl_too_large_test() ->
     Req = req_with_headers([{~"content-length", ~"99999999"}]),
     NoRecv = fun() -> error(should_not_be_called) end,
@@ -318,6 +338,22 @@ req_with_headers(Headers) ->
         version => {1, 1},
         headers => Headers
     }.
+
+%% Recv closure that yields the given chunks one per call, then
+%% `{error, closed}` once exhausted. Backed by the process dictionary
+%% so the same fun can drive multiple recv invocations.
+chunked_recv(Chunks) ->
+    Key = {?MODULE, chunked_recv, make_ref()},
+    erlang:put(Key, Chunks),
+    fun() ->
+        case erlang:get(Key) of
+            [Chunk | Rest] ->
+                erlang:put(Key, Rest),
+                {ok, Chunk};
+            _ ->
+                {error, closed}
+        end
+    end.
 
 %% =============================================================================
 %% End-to-end integration over a real TCP socket

--- a/test/roadrunner_echo_body_handler.erl
+++ b/test/roadrunner_echo_body_handler.erl
@@ -16,7 +16,7 @@ handle(Req) ->
         {200,
             [
                 {~"content-type", ~"text/plain"},
-                {~"content-length", integer_to_binary(byte_size(Body))},
+                {~"content-length", integer_to_binary(iolist_size(Body))},
                 {~"connection", ~"close"}
             ],
             Body},

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -74,7 +74,27 @@ handle(#{target := ~"/stream/large"} = Req) ->
 handle(#{target := ~"/loop"} = Req) ->
     {{loop, 200, [], state}, Req};
 handle(#{target := ~"/sendfile"} = Req) ->
+    %% Empty-length: file is opened but never read. Exercises the
+    %% sendfile_loop/3 base case (`Send(<<>>, fin)`).
     {{sendfile, 200, [], {"/dev/null", 0, 0}}, Req};
+handle(#{target := ~"/sendfile/small"} = Req) ->
+    %% 100-byte body, single DATA frame with END_STREAM.
+    {{sendfile, 200, [], {"/tmp/rr_h2_sf_small.bin", 0, 100}}, Req};
+handle(#{target := ~"/sendfile/multi"} = Req) ->
+    %% 40000-byte body, splits into 3 DATA frames (16384 + 16384 + 7232).
+    {{sendfile, 200, [], {"/tmp/rr_h2_sf_multi.bin", 0, 40000}}, Req};
+handle(#{target := ~"/sendfile/window"} = Req) ->
+    %% Offset + Length: serve bytes [200, 700) from a 1000-byte file.
+    {{sendfile, 200, [], {"/tmp/rr_h2_sf_window.bin", 200, 500}}, Req};
+handle(#{target := ~"/sendfile/missing"} = Req) ->
+    %% File-open failure: worker crashes, conn RST_STREAMs.
+    {{sendfile, 200, [], {"/tmp/rr_h2_sf_does_not_exist.bin", 0, 100}}, Req};
+handle(#{target := ~"/sendfile/large"} = Req) ->
+    %% 100 KB body via sendfile — exceeds the default 65535-byte
+    %% conn-level window, so the server stalls and resumes after
+    %% WINDOW_UPDATE. Used by the flow-control SUITE to verify
+    %% sendfile-over-h2 reuses the streaming backpressure path.
+    {{sendfile, 200, [], {"/tmp/rr_h2_sf_large.bin", 0, 100_000}}, Req};
 handle(#{target := ~"/websocket"} = Req) ->
     {{websocket, some_module, state}, Req};
 handle(#{target := ~"/crash"} = _Req) ->

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -9,6 +9,8 @@ shape.
 
 -export([handle/1]).
 
+-export([handle_info/3]).
+
 -spec handle(roadrunner_http1:request()) ->
     {roadrunner_handler:response(), roadrunner_http1:request()}.
 handle(#{target := ~"/empty"} = Req) ->
@@ -72,7 +74,13 @@ handle(#{target := ~"/stream/large"} = Req) ->
         Req
     };
 handle(#{target := ~"/loop"} = Req) ->
-    {{loop, 200, [], state}, Req};
+    %% Register the worker so the test can address it from outside.
+    %% Unregister first in case a prior test's worker leaked the name
+    %% (eunit `_test/0` crashes skip the test's cleanup; the conn is
+    %% spawned not spawn_linked, so it can outlive a failed test).
+    try unregister(roadrunner_h2_loop_test) catch _:_ -> ok end,
+    true = register(roadrunner_h2_loop_test, self()),
+    {{loop, 200, [{~"content-type", ~"text/event-stream"}], 0}, Req};
 handle(#{target := ~"/sendfile"} = Req) ->
     %% Empty-length: file is opened but never read. Exercises the
     %% sendfile_loop/3 base case (`Send(<<>>, fin)`).
@@ -118,3 +126,13 @@ handle(#{target := ~"/large100k"} = Req) ->
     {{200, [], binary:copy(<<"x">>, 100_000)}, Req};
 handle(Req) ->
     {{200, [{~"content-type", ~"text/plain"}], ~"ok"}, Req}.
+
+%% `handle_info/3` is consulted only by `{loop, _}` responses. The
+%% `/loop` clause above registers the worker; the test then sends
+%% `{push, _}` to add an SSE-style chunk and `stop` to terminate.
+handle_info({push, Data}, Push, N) ->
+    _ = Push([~"data: ", Data, ~"\n\n"]),
+    {ok, N + 1};
+handle_info(stop, Push, N) ->
+    _ = Push([~"data: bye(", integer_to_binary(N), ~")\n\n"]),
+    {stop, N}.

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -78,7 +78,11 @@ handle(#{target := ~"/loop"} = Req) ->
     %% Unregister first in case a prior test's worker leaked the name
     %% (eunit `_test/0` crashes skip the test's cleanup; the conn is
     %% spawned not spawn_linked, so it can outlive a failed test).
-    try unregister(roadrunner_h2_loop_test) catch _:_ -> ok end,
+    try
+        unregister(roadrunner_h2_loop_test)
+    catch
+        _:_ -> ok
+    end,
     true = register(roadrunner_h2_loop_test, self()),
     {{loop, 200, [{~"content-type", ~"text/event-stream"}], 0}, Req};
 handle(#{target := ~"/sendfile"} = Req) ->

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -26,6 +26,7 @@ reuse / scheduling races.
     stream_window_update_grows_send_window/1,
     large_response_chunks_through_send_window/1,
     large_response_blocked_resumes_on_window_update/1,
+    sendfile_large_response_blocked_resumes_on_window_update/1,
     large_inbound_body_refills_recv_windows/1,
     rst_stream_during_blocked_send_drops_body/1,
     ping_during_blocked_send_is_acked/1,
@@ -53,6 +54,7 @@ all() ->
         stream_window_update_grows_send_window,
         large_response_chunks_through_send_window,
         large_response_blocked_resumes_on_window_update,
+        sendfile_large_response_blocked_resumes_on_window_update,
         large_inbound_body_refills_recv_windows,
         rst_stream_during_blocked_send_drops_body,
         ping_during_blocked_send_is_acked,
@@ -157,6 +159,31 @@ large_response_blocked_resumes_on_window_update(_Config) ->
     serve_recv(ConnPid, Wu2),
     drain_until_n_bytes(40_000),
     cleanup(Pid, Ref).
+
+sendfile_large_response_blocked_resumes_on_window_update(_Config) ->
+    %% Sendfile-over-h2 delegates to the same stream_response runner
+    %% as `{stream, _}`, so window-blocking behaviour must match the
+    %% streaming variant above. 100 KB file exceeds the default
+    %% conn-level window; the server stalls until WINDOW_UPDATE
+    %% refills both windows.
+    Path = "/tmp/rr_h2_sf_large.bin",
+    ok = file:write_file(Path, binary:copy(<<"x">>, 100_000)),
+    try
+        {Pid, Ref, ConnPid} = start_conn(roadrunner_h2_test_handler),
+        handshake(ConnPid),
+        HpackBin = encode_request_headers(~"GET", ~"/sendfile/large"),
+        Hf = encode_frame({headers, 1, 16#04 bor 16#01, undefined, HpackBin}),
+        serve_recv(ConnPid, Hf),
+        drain_until_n_bytes(60_000),
+        Wu = encode_frame({window_update, 0, 200_000}),
+        serve_recv(ConnPid, Wu),
+        Wu2 = encode_frame({window_update, 1, 200_000}),
+        serve_recv(ConnPid, Wu2),
+        drain_until_n_bytes(40_000),
+        cleanup(Pid, Ref)
+    after
+        _ = file:delete(Path)
+    end.
 
 large_inbound_body_refills_recv_windows(_Config) ->
     %% Sending 4 × 10 KB DATA frames drops both recv windows below

--- a/test/roadrunner_http2_loop_response_tests.erl
+++ b/test/roadrunner_http2_loop_response_tests.erl
@@ -1,0 +1,124 @@
+-module(roadrunner_http2_loop_response_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-behaviour(roadrunner_handler).
+-export([handle/1, handle_info/3]).
+
+%% Test handler. State is a list of `{push, IoData} | stop` directives;
+%% each handle_info pops one directive and acts on it.
+handle(Req) ->
+    {{200, [], ~""}, Req}.
+
+handle_info(go, Push, [{push, Data} | Rest]) ->
+    ok = Push(Data),
+    self() ! go,
+    {ok, Rest};
+handle_info(go, _Push, [stop | _]) ->
+    {stop, undefined}.
+
+%% --- empty push is a no-op ---
+
+empty_push_skips_data_frame_test() ->
+    %% `make_push(_, _)/1` short-circuits on empty data: pushing <<>>
+    %% must not trigger an `h2_send_data` request to the conn.
+    %% Sequence: handler pushes <<>>, then non-empty ~"x", then stops.
+    %% The fake conn logs send events; we expect:
+    %%   - 1 send_headers (run/5 prelude)
+    %%   - 1 send_data carrying ~"x" (the non-empty push)
+    %%   - 1 send_data carrying <<>> with END_STREAM (the stop)
+    {FakeConn, Worker} = spawn_loop([{push, <<>>}, {push, ~"x"}, stop]),
+    Worker ! go,
+    ok = wait_for_exit(Worker, 1000),
+    Sends = collect_sends(FakeConn),
+    ?assertEqual(
+        [
+            {send_headers, 1, 200, [], false},
+            {send_data, 1, ~"x", false},
+            {send_data, 1, <<>>, true}
+        ],
+        Sends
+    ),
+    FakeConn ! stop.
+
+%% --- sync exits on h2_stream_reset ---
+
+sync_exits_on_stream_reset_test() ->
+    %% When the conn replies `{h2_stream_reset, StreamId}` instead of
+    %% `{h2_send_ack, Ref}`, `sync/1` raises `exit(stream_reset)`. The
+    %% conn drives this when the peer has cancelled the stream.
+    {FakeConn, Worker} = spawn_loop([{push, ~"hi"}, stop]),
+    %% Tell the fake conn to RST_STREAM the next send_data instead of
+    %% acking.
+    FakeConn ! {reset_next, 1},
+    MRef = erlang:monitor(process, Worker),
+    Worker ! go,
+    receive
+        {'DOWN', MRef, process, Worker, Reason} ->
+            ?assertEqual(stream_reset, Reason)
+    after 1000 ->
+        error(worker_did_not_exit)
+    end,
+    FakeConn ! stop.
+
+%% --- helpers ---
+
+spawn_loop(Directives) ->
+    Self = self(),
+    FakeConn = spawn(fun() -> fake_conn_loop(Self, []) end),
+    Worker = spawn(fun() ->
+        roadrunner_http2_loop_response:run(FakeConn, 1, 200, [], {?MODULE, Directives})
+    end),
+    {FakeConn, Worker}.
+
+fake_conn_loop(Reporter, Sends) ->
+    fake_conn_loop(Reporter, Sends, undefined).
+
+%% ResetStreamId = undefined means ack every h2_send_data normally;
+%% set to a stream id by `{reset_next, _}` to make the next matching
+%% h2_send_data reply with `{h2_stream_reset, StreamId}` instead.
+fake_conn_loop(Reporter, Sends, ResetStreamId) ->
+    receive
+        stop ->
+            Reporter ! {sends, lists:reverse(Sends)};
+        {dump, From} ->
+            From ! {sends, lists:reverse(Sends)},
+            fake_conn_loop(Reporter, Sends, ResetStreamId);
+        {reset_next, StreamId} ->
+            fake_conn_loop(Reporter, Sends, StreamId);
+        {h2_send_headers, From, Ref, StreamId, Status, Headers, EndStream} ->
+            From ! {h2_send_ack, Ref},
+            fake_conn_loop(
+                Reporter,
+                [{send_headers, StreamId, Status, Headers, EndStream} | Sends],
+                ResetStreamId
+            );
+        {h2_send_data, From, _Ref, StreamId, _Bin, _EndStream} when
+            StreamId =:= ResetStreamId
+        ->
+            From ! {h2_stream_reset, StreamId},
+            %% Worker exits via sync/1; revert to normal mode in case
+            %% more messages arrive (they should not).
+            fake_conn_loop(Reporter, Sends, undefined);
+        {h2_send_data, From, Ref, StreamId, Bin, EndStream} ->
+            From ! {h2_send_ack, Ref},
+            fake_conn_loop(
+                Reporter, [{send_data, StreamId, Bin, EndStream} | Sends], ResetStreamId
+            )
+    end.
+
+wait_for_exit(Pid, Timeout) ->
+    MRef = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', MRef, process, Pid, _} -> ok
+    after Timeout ->
+        error(worker_did_not_finish)
+    end.
+
+collect_sends(FakeConn) ->
+    FakeConn ! {dump, self()},
+    receive
+        {sends, Sends} -> Sends
+    after 1000 ->
+        error(no_sends_received)
+    end.

--- a/test/roadrunner_http_tests.erl
+++ b/test/roadrunner_http_tests.erl
@@ -33,3 +33,10 @@ http_date_now_format_matches_imf_fixdate_test() ->
             ~"Dec"
         ])
     ).
+
+format_http_date_pads_single_digits_test() ->
+    %% Pick a timestamp whose calendar fields all need two-digit padding
+    %% (1970-01-01 00:00:00 UTC = Posix 0) so the `pad2/1` single-digit
+    %% clause is exercised regardless of wall-clock at test run time.
+    Date = roadrunner_http:format_http_date(0),
+    ?assertEqual(~"Thu, 01 Jan 1970 00:00:00 GMT", Date).

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -226,6 +226,63 @@ listener_threads_hibernate_after_into_proto_opts_test() ->
     ?assertEqual(5000, maps:get(hibernate_after, ProtoOpts)),
     ok = roadrunner_listener:stop(Name).
 
+listener_threads_h2c_into_proto_opts_test() ->
+    %% `h2c => enabled` listener opt threads into proto_opts so the
+    %% dispatch helper `roadrunner_conn_loop:h2c_enabled/1` can read
+    %% it and route plaintext connections to the h2 conn loop without
+    %% an ALPN check.
+    Name = listener_test_h2c_enabled,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        h2c => enabled,
+        handler => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual(enabled, maps:get(h2c, ProtoOpts)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_h2c_default_disabled_test() ->
+    %% Default for `h2c` is `disabled`; plaintext listeners stay
+    %% h1-only unless explicitly opted in.
+    Name = listener_test_h2c_default,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        handler => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual(disabled, maps:get(h2c, ProtoOpts)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_rejects_h2c_with_tls_test() ->
+    %% `h2c => enabled` is plaintext-only. Combining it with `tls`
+    %% must crash `init/1` so the misconfiguration surfaces at
+    %% startup, not as a silent no-op on the dispatch path.
+    Name = listener_test_h2c_with_tls,
+    process_flag(trap_exit, true),
+    Result = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        tls => [
+            {certfile, "/nonexistent/cert.pem"},
+            {keyfile, "/nonexistent/key.pem"}
+        ],
+        h2c => enabled,
+        handler => roadrunner_hello_handler
+    }),
+    ?assertMatch({error, {{listener_opt_conflict, h2c, tls}, _Stack}}, Result).
+
+listener_rejects_invalid_h2c_value_test() ->
+    %% Any atom other than `enabled` / `disabled` is rejected at init.
+    Name = listener_test_h2c_bad_atom,
+    process_flag(trap_exit, true),
+    Result = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        h2c => yes,
+        handler => roadrunner_hello_handler
+    }),
+    ?assertMatch({error, {{invalid_listener_opt, h2c, yes}, _Stack}}, Result).
+
 slot_reconciliation_disabled_drops_reconcile_slots_message_test() ->
     %% A `reconcile_slots` arriving at a listener with reconciliation
     %% disabled (race after a hypothetical config change) is just

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -324,6 +324,77 @@ static_test_() ->
                 %% `type = directory` — non-regular → 404.
                 Reply = http_get(Port, ~"/static/subdir_link"),
                 ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
+            end},
+            {"Accept-Encoding gzip serves .gz sibling with Content-Encoding", fun() ->
+                Reply = http_get_with(
+                    Port,
+                    ~"/static/compressible.css",
+                    [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                {match, _} = re:run(Reply, ~"content-encoding: gzip", [caseless]),
+                {match, _} = re:run(Reply, ~"vary: Accept-Encoding", [caseless]),
+                %% Content-Type still reflects the original file's extension.
+                {match, _} = re:run(Reply, ~"content-type: text/css", [caseless]),
+                %% Body is the exact bytes of `<file>.gz` on disk.
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                Expected = zlib:gzip(
+                    <<"body { background: white; padding: 1em; }">>
+                ),
+                ?assertEqual(Expected, Body)
+            end},
+            {"Accept-Encoding gzip with no .gz sibling falls back to plain", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/main.css", [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                nomatch = re:run(Reply, ~"content-encoding:", [caseless]),
+                {match, _} = re:run(Reply, ~"color: red")
+            end},
+            {"no Accept-Encoding serves plain file even when .gz exists", fun() ->
+                Reply = http_get(Port, ~"/static/compressible.css"),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                nomatch = re:run(Reply, ~"content-encoding:", [caseless]),
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(
+                    <<"body { background: white; padding: 1em; }">>, Body
+                )
+            end},
+            {"Range header disables gzip-sibling and serves raw bytes", fun() ->
+                Reply = http_get_with(
+                    Port,
+                    ~"/static/compressible.css",
+                    [
+                        {~"Accept-Encoding", ~"gzip"},
+                        {~"Range", ~"bytes=0-3"}
+                    ]
+                ),
+                ?assertMatch(<<"HTTP/1.1 206 ", _/binary>>, Reply),
+                nomatch = re:run(Reply, ~"content-encoding:", [caseless]),
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(~"body", Body)
+            end},
+            {"If-None-Match from a gzip-served response still 304s", fun() ->
+                %% ETag is the original file's, so cache validation
+                %% works regardless of which variant the client first
+                %% received.
+                Reply = http_get_with(
+                    Port,
+                    ~"/static/compressible.css",
+                    [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                {match, [_, ETag]} = re:run(
+                    Reply, ~"etag: (\"[^\"]+\")", [caseless, {capture, all, binary}]
+                ),
+                Reply2 = http_get_with(
+                    Port,
+                    ~"/static/compressible.css",
+                    [
+                        {~"Accept-Encoding", ~"gzip"},
+                        {~"If-None-Match", ETag}
+                    ]
+                ),
+                ?assertMatch(<<"HTTP/1.1 304 ", _/binary>>, Reply2)
             end}
         ]
     end}.
@@ -396,6 +467,13 @@ setup() ->
     ok = file:write_file(filename:join(Dir, "hello.html"), <<"<h1>Hello</h1>">>),
     ok = file:write_file(filename:join(Dir, "main.css"), <<"body { color: red; }">>),
     ok = file:write_file(filename:join(Dir, "blob.bin"), <<1, 2, 3, 4>>),
+    %% Gzip-sibling fixtures: a CSS file alongside its pre-compressed
+    %% sibling. The .gz body intentionally differs from a fresh
+    %% `zlib:gzip/1` of the original (different mtime/level) so tests
+    %% that read the served bytes verify which file was opened.
+    GzOriginal = <<"body { background: white; padding: 1em; }">>,
+    ok = file:write_file(filename:join(Dir, "compressible.css"), GzOriginal),
+    ok = file:write_file(filename:join(Dir, "compressible.css.gz"), zlib:gzip(GzOriginal)),
     ok = file:write_file(filename:join(Dir, "empty.txt"), <<>>),
     ok = file:write_file(filename:join(Dir, "notes.txt"), ~"hello via link"),
     %% Safe in-docroot symlink (relative target, no `..`).

--- a/test/roadrunner_stream_body_handler.erl
+++ b/test/roadrunner_stream_body_handler.erl
@@ -64,7 +64,7 @@ reply(Status, Body) ->
     {Status,
         [
             {~"content-type", ~"text/plain"},
-            {~"content-length", integer_to_binary(byte_size(Body))},
+            {~"content-length", integer_to_binary(iolist_size(Body))},
             {~"connection", ~"close"}
         ],
         Body}.
@@ -73,6 +73,6 @@ reply_keepalive(Status, Body) ->
     {Status,
         [
             {~"content-type", ~"text/plain"},
-            {~"content-length", integer_to_binary(byte_size(Body))}
+            {~"content-length", integer_to_binary(iolist_size(Body))}
         ],
         Body}.


### PR DESCRIPTION
# Description

Branch was scoped to ready roadrunner for [HttpArena](https://github.com/MDA2AV/HttpArena) and grew into two general framework wins. Rounds out h2 response coverage (`{sendfile, _}`, `{loop, _}`, `.gz`-sibling static, `h2c => enabled` listener), reworks the auto-mode body buffer to avoid quadratic allocation on large POSTs, and adds HttpArena-shape scenarios to `scripts/bench.escript` so future profile-driven work runs reproducibly in-tree. Two pre-v0.1 contract changes: request body in `#{body := _}` and `read_body/{1,2}` is now `iodata()` (was `binary()`), and response header names handed to the framework must be ASCII lowercase (RFC 9113 §8.1.2; h1 and h2 share the same contract now).

```
httparena_upload_20mb_auto   381 r/s → 685 r/s,  3.4 GB → 870 MB RSS
post_4kb_form (h1)           122 K   → 193 K
large_response (h1)          103 K   → 124 K
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)