### PR TITLE
Reject header injection and fuse redundant header walks

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -254,6 +254,22 @@ the only mode on h2.
 
 **Scope:** small-medium when needed. No present caller is blocked.
 
+### Strict grammars for Set-Cookie attributes
+
+**What:** `roadrunner_cookie:serialize/3` validates the cookie
+`Name` and `Value` against RFC 6265 §4.1.1 (and rejects header-injection
+bytes in `Domain`, `Path`, `Expires`), but it does not enforce the full
+attribute grammars — e.g. `Domain` is not checked against RFC 1035 §3.5
+hostname rules, `Expires` is not parsed as IMF-fixdate, `Path` accepts
+any non-CTL non-`;` byte (RFC 6265 §4.1.1 allows that, but stricter
+checks could catch caller bugs earlier).
+
+**Why deferred:** the present check covers the header-injection /
+attribute-smuggling surface (the cowlib CVE-2026-43969 class). Strict
+grammar enforcement is callers-write-bugs ergonomics, not security.
+
+**Scope:** small per attribute. Add when a real caller hits the gap.
+
 ## Out of scope
 
 These are deliberately out of scope, not "deferred":

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1015,8 +1015,10 @@ encode_and_send_headers(
 ) ->
     StatusBin = integer_to_binary(Status),
     %% Handler-supplied header names MUST already be lowercase per RFC 9113
-    %% §8.1.2 (see `roadrunner_handler:response/0`). h1 emits names verbatim;
-    %% h2 follows the same contract here, skipping a redundant pass.
+    %% §8.1.2 (see `roadrunner_handler:response/0`). Bytes outside the
+    %% RFC 9110 §5.5 field-value charset (CR/LF/NUL) crash here so the
+    %% h2 path matches h1's `encode_headers/1` discipline.
+    ok = validate_headers(Headers),
     AllHeaders = [{~":status", StatusBin} | Headers],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     %% `frame:encode` accepts iodata for the header block — skip
@@ -1047,7 +1049,10 @@ encode_and_send_response_atomic(
 ) ->
     #{StreamId := Stream} = Streams,
     StatusBin = integer_to_binary(Status),
-    %% Names already lowercase per `roadrunner_handler:response/0` contract.
+    %% Names already lowercase per `roadrunner_handler:response/0` contract;
+    %% reject CR/LF/NUL anywhere in the pair so they cannot reach the peer
+    %% or split at an h2->h1 reverse proxy.
+    ok = validate_headers(Headers),
     AllHeaders = [{~":status", StatusBin} | Headers],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     HFrame = roadrunner_http2_frame:encode(
@@ -1060,7 +1065,9 @@ encode_and_send_response_atomic(
     close_stream_send_side(State2, StreamId).
 
 encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
-    %% Trailer names already lowercase per `roadrunner_handler:response/0`.
+    %% Trailer names already lowercase per `roadrunner_handler:response/0`;
+    %% h1 trailers run the same check in `roadrunner_stream_response`.
+    ok = validate_headers(Trailers),
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(Trailers, Enc),
     Frame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04 bor 16#01, undefined, HpackBlock}
@@ -1068,6 +1075,20 @@ encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
     _ = send(State, Frame),
     State1 = State#loop{hpack_enc = Enc1},
     close_stream_send_side(State1, StreamId).
+
+%% RFC 9110 §5.5 / RFC 9113 §8.2.1: field values are VCHAR / SP /
+%% HTAB only; no CTLs. HPACK is length-framed so CR/LF cannot smuggle
+%% a new h2 frame, but malformed bytes still reach the peer (and any
+%% downstream h2->h1 reverse proxy where they would split). Crash
+%% hard so a handler echoing user input into a header turns into a
+%% 500, matching `roadrunner_http1:encode_headers/1`.
+-spec validate_headers([{binary(), binary()}]) -> ok.
+validate_headers([]) ->
+    ok;
+validate_headers([{Name, Value} | Rest]) ->
+    ok = roadrunner_http1:check_header_safe(Name, name),
+    ok = roadrunner_http1:check_header_safe(Value, value),
+    validate_headers(Rest).
 
 %% Mark the send side closed. Future worker writes on this stream
 %% get `{h2_stream_reset, _}` so they unwind cleanly.

--- a/src/roadrunner_cookie.erl
+++ b/src/roadrunner_cookie.erl
@@ -2,8 +2,8 @@
 -moduledoc """
 HTTP cookie codec (RFC 6265).
 
-Currently provides `parse/1` for the request-side `Cookie` header.
-The response-side `Set-Cookie` builder will arrive in a later feature.
+Provides `parse/1` for the request-side `Cookie` header and
+`serialize/3` for the response-side `Set-Cookie` header.
 """.
 
 -on_load(init_patterns/0).
@@ -68,11 +68,28 @@ Attributes are appended in this fixed order: `Domain`, `Path`,
 `Max-Age`, `Expires`, `Secure`, `HttpOnly`, `SameSite`. Boolean flags
 (`secure`, `http_only`) appear only when set to `true`; setting them
 to `false` is equivalent to omitting them. `same_site` accepts
-`strict`, `lax`, or `none`. Caller is responsible for any encoding
-or quoting of `Value`.
+`strict`, `lax`, or `none`.
+
+Each user-supplied binary is validated against the RFC 6265 §4.1.1
+grammar before any iodata is produced; on a violation the call crashes
+with one of:
+
+- `{invalid_cookie_name, Bin}` — `Name` is empty or has a byte outside
+  RFC 7230 §3.2.6 `token`
+- `{invalid_cookie_value, Bin}` — `Value` has a byte outside
+  `cookie-octet` (CTL, SP, DQUOTE, `,`, `;`, `\\`)
+- `{invalid_cookie_attr, AttrName, Bin}` — `Domain`, `Path`, or
+  `Expires` contains a CTL or `;` (the bytes that would let a
+  malicious caller smuggle attributes or split the header line)
+
+Crashing matches the discipline of `roadrunner_http1:check_header_safe/2`:
+a programmer bug echoing user input into a cookie turns into a 500, not
+a wire-level vulnerability.
 """.
 -spec serialize(Name :: binary(), Value :: binary(), serialize_opts()) -> iodata().
 serialize(Name, Value, Opts) when is_binary(Name), is_binary(Value), is_map(Opts) ->
+    ok = valid_name(Name),
+    ok = valid_value(Value, Value),
     [
         Name,
         $=,
@@ -87,12 +104,18 @@ serialize(Name, Value, Opts) when is_binary(Name), is_binary(Value), is_map(Opts
     ].
 
 -spec attr_domain(serialize_opts()) -> iodata().
-attr_domain(#{domain := D}) -> [~"; Domain=", D];
-attr_domain(_) -> [].
+attr_domain(#{domain := D}) when is_binary(D) ->
+    ok = valid_attr_domain(D, D),
+    [~"; Domain=", D];
+attr_domain(_) ->
+    [].
 
 -spec attr_path(serialize_opts()) -> iodata().
-attr_path(#{path := P}) -> [~"; Path=", P];
-attr_path(_) -> [].
+attr_path(#{path := P}) when is_binary(P) ->
+    ok = valid_attr_path(P, P),
+    [~"; Path=", P];
+attr_path(_) ->
+    [].
 
 -spec attr_max_age(serialize_opts()) -> iodata().
 attr_max_age(#{max_age := N}) when is_integer(N), N >= 0 ->
@@ -101,8 +124,11 @@ attr_max_age(_) ->
     [].
 
 -spec attr_expires(serialize_opts()) -> iodata().
-attr_expires(#{expires := E}) -> [~"; Expires=", E];
-attr_expires(_) -> [].
+attr_expires(#{expires := E}) when is_binary(E) ->
+    ok = valid_attr_expires(E, E),
+    [~"; Expires=", E];
+attr_expires(_) ->
+    [].
 
 -spec attr_secure(serialize_opts()) -> binary() | [].
 attr_secure(#{secure := true}) -> ~"; Secure";
@@ -117,6 +143,93 @@ attr_same_site(#{same_site := strict}) -> ~"; SameSite=Strict";
 attr_same_site(#{same_site := lax}) -> ~"; SameSite=Lax";
 attr_same_site(#{same_site := none}) -> ~"; SameSite=None";
 attr_same_site(_) -> [].
+
+%% RFC 6265 §4.1.1: cookie-name = token (RFC 7230 §3.2.6). Empty
+%% rejected. The recursion splits into a separate "tail" walker so
+%% the bottoming-out `<<>>` clause means "consumed every byte" rather
+%% than "empty input".
+-spec valid_name(binary()) -> ok.
+valid_name(<<>>) ->
+    error({invalid_cookie_name, <<>>});
+valid_name(Bin) ->
+    valid_name_chars(Bin, Bin).
+
+-spec valid_name_chars(binary(), binary()) -> ok.
+valid_name_chars(<<>>, _Orig) ->
+    ok;
+valid_name_chars(<<C, R/binary>>, Orig) when C >= $a, C =< $z ->
+    valid_name_chars(R, Orig);
+valid_name_chars(<<C, R/binary>>, Orig) when C >= $A, C =< $Z ->
+    valid_name_chars(R, Orig);
+valid_name_chars(<<C, R/binary>>, Orig) when C >= $0, C =< $9 ->
+    valid_name_chars(R, Orig);
+valid_name_chars(<<C, R/binary>>, Orig) when
+    %% Token punctuation (RFC 7230 §3.2.6): `!#$%&'*+-.^_`|~`
+    C =:= $!;
+    C =:= $#;
+    C =:= $$;
+    C =:= $%;
+    C =:= $&;
+    C =:= $';
+    C =:= $*;
+    C =:= $+;
+    C =:= $-;
+    C =:= $.;
+    C =:= $^;
+    C =:= $_;
+    C =:= $`;
+    C =:= $|;
+    C =:= $~
+->
+    valid_name_chars(R, Orig);
+valid_name_chars(<<_, _/binary>>, Orig) ->
+    error({invalid_cookie_name, Orig}).
+
+%% RFC 6265 §4.1.1: cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B /
+%% %x5D-7E. Excludes CTL (0-31, 127), SP (32), DQUOTE (34), `,` (44),
+%% `;` (59), `\` (92). Empty value is allowed (cookie-value = *cookie-octet).
+-spec valid_value(binary(), binary()) -> ok.
+valid_value(<<>>, _Orig) ->
+    ok;
+valid_value(<<C, R/binary>>, Orig) when
+    C > 32, C < 127, C =/= $", C =/= $,, C =/= $;, C =/= $\\
+->
+    valid_value(R, Orig);
+valid_value(<<_, _/binary>>, Orig) ->
+    error({invalid_cookie_value, Orig}).
+
+%% RFC 6265 §5.1.3 — domain-value is a `<subdomain>` per RFC 1034
+%% §3.5. For header-injection defence we reject CTLs, SP, and `;`;
+%% strict hostname-grammar enforcement is deferred (see
+%% `docs/roadmap.md`).
+-spec valid_attr_domain(binary(), binary()) -> ok.
+valid_attr_domain(<<>>, _Orig) ->
+    ok;
+valid_attr_domain(<<C, R/binary>>, Orig) when C > 32, C < 127, C =/= $; ->
+    valid_attr_domain(R, Orig);
+valid_attr_domain(<<_, _/binary>>, Orig) ->
+    error({invalid_cookie_attr, domain, Orig}).
+
+%% RFC 6265 §4.1.1: path-value = <any CHAR except CTLs or ";">.
+-spec valid_attr_path(binary(), binary()) -> ok.
+valid_attr_path(<<>>, _Orig) ->
+    ok;
+valid_attr_path(<<C, R/binary>>, Orig) when C > 31, C =/= 127, C =/= $; ->
+    valid_attr_path(R, Orig);
+valid_attr_path(<<_, _/binary>>, Orig) ->
+    error({invalid_cookie_attr, path, Orig}).
+
+%% RFC 6265 §5.1.1 expects an IMF-fixdate; we only enforce header-injection
+%% safety (no CR/LF/NUL/`;`) and leave date-grammar validation to the caller.
+-spec valid_attr_expires(binary(), binary()) -> ok.
+valid_attr_expires(<<>>, _Orig) ->
+    ok;
+valid_attr_expires(<<C, R/binary>>, Orig) when
+    C =/= $\r, C =/= $\n, C =/= 0, C =/= $;
+->
+    valid_attr_expires(R, Orig);
+valid_attr_expires(<<_, _/binary>>, Orig) ->
+    error({invalid_cookie_attr, expires, Orig}).
 
 %% `-on_load` callback. See `feedback_compile_pattern_convention` —
 %% binary:match/split patterns belong in `persistent_term` so the

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -75,7 +75,11 @@ response (`400`, `414`, `431`, etc.).
     %% malformed. `roadrunner_conn:body_framing/1` consumes this directly
     %% on the cached path, avoiding a `roadrunner_req:header/2` lookup
     %% (which lowercases the lookup name) plus a `binary_to_integer/1`.
-    content_length := none | {ok, non_neg_integer()} | {error, bad_content_length}
+    content_length := none | {ok, non_neg_integer()} | {error, bad_content_length},
+    %% True iff a `Host` header is present. Drives the RFC 7230 §5.4
+    %% missing-host rejection for HTTP/1.1 without a per-request
+    %% keymember walk.
+    has_host := boolean()
 }.
 -type request() :: #{
     method := binary(),
@@ -561,7 +565,8 @@ compute_cached_decisions(Headers) ->
         has_transfer_encoding => false,
         expects_continue => false,
         connection_lower => ~"",
-        content_length => none
+        content_length => none,
+        has_host => false
     }).
 
 -spec compute_cached_decisions_loop(headers(), cached_decisions()) -> cached_decisions().
@@ -588,6 +593,8 @@ compute_cached_decisions_loop([{~"connection", V} | Rest], Acc) ->
     );
 compute_cached_decisions_loop([{~"content-length", V} | Rest], Acc) ->
     compute_cached_decisions_loop(Rest, Acc#{content_length := parse_content_length(V)});
+compute_cached_decisions_loop([{~"host", _} | Rest], Acc) ->
+    compute_cached_decisions_loop(Rest, Acc#{has_host := true});
 compute_cached_decisions_loop([_ | Rest], Acc) ->
     compute_cached_decisions_loop(Rest, Acc).
 
@@ -632,13 +639,14 @@ parse_request(Bin) when is_binary(Bin) ->
     maybe
         {ok, Method, Target, Version, Rest} ?= parse_request_line(Bin),
         {ok, Headers, Rest2} ?= parse_headers(Rest),
-        ok ?= validate_host(Version, Headers),
+        Decisions = compute_cached_decisions(Headers),
+        ok ?= validate_host(Version, Decisions),
         Req = #{
             method => Method,
             target => Target,
             version => Version,
             headers => Headers,
-            cached_decisions => compute_cached_decisions(Headers)
+            cached_decisions => Decisions
         },
         {ok, Req, Rest2}
     end.
@@ -647,14 +655,10 @@ parse_request(Bin) when is_binary(Bin) ->
 %% header. Absence is a 400 Bad Request, also a request-smuggling
 %% mitigation when proxies forward to backends that disagree on the
 %% target host. HTTP/1.0 didn't require it.
--spec validate_host(version(), headers()) -> ok | {error, missing_host}.
-validate_host({1, 1}, Headers) ->
-    case lists:keymember(~"host", 1, Headers) of
-        true -> ok;
-        false -> {error, missing_host}
-    end;
-validate_host({1, 0}, _Headers) ->
-    ok.
+-spec validate_host(version(), cached_decisions()) -> ok | {error, missing_host}.
+validate_host({1, 1}, #{has_host := true}) -> ok;
+validate_host({1, 1}, #{has_host := false}) -> {error, missing_host};
+validate_host({1, 0}, _Decisions) -> ok.
 
 -doc """
 Parse a single chunk from a chunked transfer-encoded body.

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -512,17 +512,30 @@ parse_headers_loop(Bin, Count, Consumed, LfCp, ColonCp) ->
 %% Reject the two classic smuggling shapes:
 %% 1. Transfer-Encoding present alongside any Content-Length.
 %% 2. Multiple Content-Length headers with differing values.
+%% One pass over the header list collects the TE-present flag and every
+%% Content-Length value; `decide_framing/2` then drives the verdict from
+%% those two summaries.
 -spec check_framing(headers()) -> ok | error.
 check_framing(Headers) ->
-    HasTE = lists:keymember(~"transfer-encoding", 1, Headers),
-    Cls = [V || {N, V} <- Headers, N =:= ~"content-length"],
-    check_framing(HasTE, Cls).
+    scan_framing(Headers, false, []).
 
--spec check_framing(boolean(), [binary()]) -> ok | error.
-check_framing(true, []) -> ok;
-check_framing(false, []) -> ok;
-check_framing(false, [V | Rest]) -> check_cls_consistent(V, Rest);
-check_framing(true, [_ | _]) -> error.
+-spec scan_framing(headers(), boolean(), [binary()]) -> ok | error.
+scan_framing([], HasTE, Cls) ->
+    decide_framing(HasTE, Cls);
+scan_framing([{~"transfer-encoding", _} | Rest], _HasTE, Cls) ->
+    scan_framing(Rest, true, Cls);
+scan_framing([{~"content-length", V} | Rest], HasTE, Cls) ->
+    scan_framing(Rest, HasTE, [V | Cls]);
+scan_framing([_ | Rest], HasTE, Cls) ->
+    scan_framing(Rest, HasTE, Cls).
+
+%% `Cls` order is irrelevant — `check_cls_consistent/2` does a pairwise
+%% pivot-vs-rest compare, so the reversed-by-cons accumulator is fine.
+-spec decide_framing(boolean(), [binary()]) -> ok | error.
+decide_framing(true, []) -> ok;
+decide_framing(false, []) -> ok;
+decide_framing(false, [V | Rest]) -> check_cls_consistent(V, Rest);
+decide_framing(true, [_ | _]) -> error.
 
 -spec check_cls_consistent(binary(), [binary()]) -> ok | error.
 check_cls_consistent(_, []) -> ok;

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -166,17 +166,19 @@ build_handshake_headers(Accept, {permessage_deflate, _, ResponseValue}) ->
 validate_upgrade(Headers) ->
     %% RFC 9110 §7.8 — upgrade tokens are case-insensitive. Browsers
     %% send `websocket` (lowercase) but other clients may send
-    %% `WebSocket` or `WEBSOCKET`; accept any case.
-    case is_websocket_upgrade(header_lookup(~"upgrade", Headers)) of
+    %% `WebSocket` or `WEBSOCKET`; accept any case. One pass over
+    %% Headers extracts all four handshake-relevant values; the
+    %% dispatch below is map lookups, not list walks.
+    {Upgrade, Connection, Version, Key} = collect_upgrade_headers(Headers),
+    case is_websocket_upgrade(Upgrade) of
         true ->
-            case has_upgrade_token(header_lookup(~"connection", Headers)) of
+            case has_upgrade_token(Connection) of
                 true ->
-                    case validate_version(header_lookup(~"sec-websocket-version", Headers)) of
+                    case validate_version(Version) of
+                        ok when Key =:= undefined ->
+                            {error, missing_websocket_key};
                         ok ->
-                            case header_lookup(~"sec-websocket-key", Headers) of
-                                undefined -> {error, missing_websocket_key};
-                                Key -> {ok, Key}
-                            end;
+                            {ok, Key};
                         {error, _} = VErr ->
                             VErr
                     end;
@@ -186,6 +188,28 @@ validate_upgrade(Headers) ->
         false ->
             {error, missing_websocket_upgrade}
     end.
+
+%% Single-pass extraction. Missing headers come back as `undefined`,
+%% matching `header_lookup/2`'s contract so the validators above stay
+%% untouched.
+-spec collect_upgrade_headers(roadrunner_req:headers()) ->
+    {binary() | undefined, binary() | undefined, binary() | undefined, binary() | undefined}.
+collect_upgrade_headers([]) ->
+    {undefined, undefined, undefined, undefined};
+collect_upgrade_headers([{~"upgrade", V} | Rest]) ->
+    {_, C, Ver, K} = collect_upgrade_headers(Rest),
+    {V, C, Ver, K};
+collect_upgrade_headers([{~"connection", V} | Rest]) ->
+    {U, _, Ver, K} = collect_upgrade_headers(Rest),
+    {U, V, Ver, K};
+collect_upgrade_headers([{~"sec-websocket-version", V} | Rest]) ->
+    {U, C, _, K} = collect_upgrade_headers(Rest),
+    {U, C, V, K};
+collect_upgrade_headers([{~"sec-websocket-key", V} | Rest]) ->
+    {U, C, Ver, _} = collect_upgrade_headers(Rest),
+    {U, C, Ver, V};
+collect_upgrade_headers([_ | Rest]) ->
+    collect_upgrade_headers(Rest).
 
 %% RFC 6455 §4.1 / §4.2.2: server MUST accept only `Sec-WebSocket-
 %% Version: 13`. Other versions (or missing) → 400. Older drafts

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -959,22 +959,21 @@ send_ws_frame(#data{socket = Socket, ctx = Ctx} = Data, Opcode, Payload) ->
     ok.
 
 %% Batched outbound frames from a handler `{reply, [...]}` return —
-%% emit telemetry per frame (so subscribers can count by opcode), then
-%% write all frames in a single TCP send to avoid partial-write
-%% fragmentation.
+%% emit telemetry per frame (so subscribers can count by opcode) and
+%% encode them in one walk, then write the whole batch in a single
+%% TCP send to avoid partial-write fragmentation.
 -spec send_ws_frames(#data{}, [{roadrunner_ws:opcode(), iodata()}]) ->
     ok | {error, term()}.
 send_ws_frames(#data{socket = Socket, ctx = Ctx} = Data, OutFrames) ->
-    lists:foreach(
-        fun({Op, Payload}) ->
-            ok = roadrunner_telemetry:ws_frame_out(
-                Ctx#{opcode => Op}, iolist_size(Payload)
-            )
-        end,
-        OutFrames
-    ),
-    Iodata = [encode_outbound(Data, Op, Payload) || {Op, Payload} <- OutFrames],
+    Iodata = encode_frames(Data, Ctx, OutFrames),
     roadrunner_transport:send(Socket, Iodata).
+
+-spec encode_frames(#data{}, map(), [{roadrunner_ws:opcode(), iodata()}]) -> iodata().
+encode_frames(_Data, _Ctx, []) ->
+    [];
+encode_frames(Data, Ctx, [{Op, Payload} | Rest]) ->
+    ok = roadrunner_telemetry:ws_frame_out(Ctx#{opcode => Op}, iolist_size(Payload)),
+    [encode_outbound(Data, Op, Payload) | encode_frames(Data, Ctx, Rest)].
 
 -spec encode_outbound(#data{}, roadrunner_ws:opcode(), iodata()) -> iodata().
 encode_outbound(#data{pmd_params = undefined}, Opcode, Payload) ->

--- a/test/roadrunner_cookie_tests.erl
+++ b/test/roadrunner_cookie_tests.erl
@@ -253,3 +253,142 @@ serialize_with_all_attrs_test() ->
         Expected,
         iolist_to_binary(roadrunner_cookie:serialize(~"sid", ~"abc", Opts))
     ).
+
+%% --- serialize/3 input validation ---
+
+serialize_rejects_empty_name_test() ->
+    ?assertError(
+        {invalid_cookie_name, ~""},
+        roadrunner_cookie:serialize(~"", ~"abc", #{})
+    ).
+
+serialize_rejects_separator_in_name_test() ->
+    %% `;` is a token separator per RFC 7230 §3.2.6 — must not appear in
+    %% a cookie-name or it would smuggle a new pair on the wire.
+    ?assertError(
+        {invalid_cookie_name, ~"foo;bar"},
+        roadrunner_cookie:serialize(~"foo;bar", ~"abc", #{})
+    ).
+
+serialize_rejects_equals_in_name_test() ->
+    ?assertError(
+        {invalid_cookie_name, ~"foo=bar"},
+        roadrunner_cookie:serialize(~"foo=bar", ~"abc", #{})
+    ).
+
+serialize_rejects_space_in_name_test() ->
+    ?assertError(
+        {invalid_cookie_name, ~"foo bar"},
+        roadrunner_cookie:serialize(~"foo bar", ~"abc", #{})
+    ).
+
+serialize_rejects_crlf_in_name_test() ->
+    ?assertError(
+        {invalid_cookie_name, ~"foo\r\nbar"},
+        roadrunner_cookie:serialize(~"foo\r\nbar", ~"abc", #{})
+    ).
+
+serialize_rejects_semicolon_in_value_test() ->
+    %% Cookie-smuggling: `abc; admin=1` would surface as a phantom
+    %% attribute on the client. Reject at the encoder.
+    ?assertError(
+        {invalid_cookie_value, ~"abc; admin=1"},
+        roadrunner_cookie:serialize(~"sid", ~"abc; admin=1", #{})
+    ).
+
+serialize_rejects_comma_in_value_test() ->
+    ?assertError(
+        {invalid_cookie_value, ~"a,b"},
+        roadrunner_cookie:serialize(~"sid", ~"a,b", #{})
+    ).
+
+serialize_rejects_dquote_in_value_test() ->
+    ?assertError(
+        {invalid_cookie_value, ~"a\"b"},
+        roadrunner_cookie:serialize(~"sid", ~"a\"b", #{})
+    ).
+
+serialize_rejects_backslash_in_value_test() ->
+    ?assertError(
+        {invalid_cookie_value, ~"a\\b"},
+        roadrunner_cookie:serialize(~"sid", ~"a\\b", #{})
+    ).
+
+serialize_rejects_crlf_in_value_test() ->
+    ?assertError(
+        {invalid_cookie_value, ~"a\r\nb"},
+        roadrunner_cookie:serialize(~"sid", ~"a\r\nb", #{})
+    ).
+
+serialize_rejects_nul_in_value_test() ->
+    ?assertError(
+        {invalid_cookie_value, <<"a", 0, "b">>},
+        roadrunner_cookie:serialize(~"sid", <<"a", 0, "b">>, #{})
+    ).
+
+serialize_accepts_empty_value_test() ->
+    %% RFC 6265 §4.1.1: cookie-value = *cookie-octet, so empty is legal.
+    ?assertEqual(
+        ~"sid=",
+        iolist_to_binary(roadrunner_cookie:serialize(~"sid", ~"", #{}))
+    ).
+
+serialize_rejects_semicolon_in_domain_test() ->
+    ?assertError(
+        {invalid_cookie_attr, domain, ~"ex;ample.com"},
+        roadrunner_cookie:serialize(~"sid", ~"abc", #{domain => ~"ex;ample.com"})
+    ).
+
+serialize_rejects_space_in_domain_test() ->
+    ?assertError(
+        {invalid_cookie_attr, domain, ~"example .com"},
+        roadrunner_cookie:serialize(~"sid", ~"abc", #{domain => ~"example .com"})
+    ).
+
+serialize_rejects_crlf_in_domain_test() ->
+    ?assertError(
+        {invalid_cookie_attr, domain, ~"example.com\r\nX-Evil: 1"},
+        roadrunner_cookie:serialize(~"sid", ~"abc", #{
+            domain => ~"example.com\r\nX-Evil: 1"
+        })
+    ).
+
+serialize_rejects_semicolon_in_path_test() ->
+    ?assertError(
+        {invalid_cookie_attr, path, ~"/a;b"},
+        roadrunner_cookie:serialize(~"sid", ~"abc", #{path => ~"/a;b"})
+    ).
+
+serialize_rejects_crlf_in_path_test() ->
+    ?assertError(
+        {invalid_cookie_attr, path, ~"/a\r\nb"},
+        roadrunner_cookie:serialize(~"sid", ~"abc", #{path => ~"/a\r\nb"})
+    ).
+
+serialize_rejects_crlf_in_expires_test() ->
+    ?assertError(
+        {invalid_cookie_attr, expires, ~"Wed\r\nX-Evil: 1"},
+        roadrunner_cookie:serialize(~"sid", ~"abc", #{expires => ~"Wed\r\nX-Evil: 1"})
+    ).
+
+serialize_rejects_semicolon_in_expires_test() ->
+    ?assertError(
+        {invalid_cookie_attr, expires, ~"Wed; admin=1"},
+        roadrunner_cookie:serialize(~"sid", ~"abc", #{expires => ~"Wed; admin=1"})
+    ).
+
+serialize_accepts_token_punctuation_in_name_test() ->
+    %% Token punctuation (RFC 7230 §3.2.6): `!#$%&'*+-.^_`|~`. Pin so an
+    %% over-eager validator doesn't reject legal cookie names.
+    ?assertEqual(
+        ~"_a.b-c=v",
+        iolist_to_binary(roadrunner_cookie:serialize(~"_a.b-c", ~"v", #{}))
+    ).
+
+serialize_accepts_alnum_in_name_test() ->
+    %% RFC 7230 §3.2.6 token covers ALPHA and DIGIT; exercise both
+    %% uppercase and digit branches of the validator.
+    ?assertEqual(
+        ~"Foo42=v",
+        iolist_to_binary(roadrunner_cookie:serialize(~"Foo42", ~"v", #{}))
+    ).

--- a/test/roadrunner_http1_tests.erl
+++ b/test/roadrunner_http1_tests.erl
@@ -483,7 +483,8 @@ request_full_test() ->
                     has_transfer_encoding => false,
                     expects_continue => false,
                     connection_lower => ~"",
-                    content_length => none
+                    content_length => none,
+                    has_host => true
                 }
             },
             ~"body"},
@@ -514,7 +515,8 @@ request_http10_no_host_accepted_test() ->
                     has_transfer_encoding => false,
                     expects_continue => false,
                     connection_lower => ~"",
-                    content_length => none
+                    content_length => none,
+                    has_host => false
                 }
             },
             ~""},
@@ -537,7 +539,8 @@ cached_decisions_empty_for_empty_headers_test() ->
             has_transfer_encoding => false,
             expects_continue => false,
             connection_lower => ~"",
-            content_length => none
+            content_length => none,
+            has_host => false
         },
         roadrunner_http1:compute_cached_decisions([])
     ).
@@ -625,15 +628,18 @@ cached_decisions_connection_lowercased_test() ->
     ).
 
 cached_decisions_ignores_unrelated_headers_test() ->
-    %% Only the cached case-insensitive headers feed the cache;
-    %% unrelated headers (Host, Content-Type, etc.) leave defaults intact.
+    %% Only cached headers feed the cache; everything else
+    %% (Content-Type, X-*, etc.) leaves defaults intact. `Host` is
+    %% cached too — flips `has_host` — so it stays in the input here
+    %% and the assertion expects `has_host => true`.
     ?assertEqual(
         #{
             is_chunked => false,
             has_transfer_encoding => false,
             expects_continue => false,
             connection_lower => ~"",
-            content_length => none
+            content_length => none,
+            has_host => true
         },
         roadrunner_http1:compute_cached_decisions([
             {~"host", ~"x"}, {~"content-type", ~"text/plain"}


### PR DESCRIPTION
# Description

Audit response to GHSA-g2wm-735q-3f56 (CVE-2026-43969, cowlib cookie encoder) plus a perf-clarity pass on adjacent header-processing code. `roadrunner_cookie:serialize/3` now validates cookie name, value, and attributes against RFC 6265 §4.1.1 before any iodata is produced, catching the `; admin=1` smuggling vector that cowlib also missed, and the HTTP/2 encoder mirrors h1's `check_header_safe` on the three header-send sites so CR/LF/NUL in handler-supplied headers crash hard on both wire paths. Same branch fuses four spots that walked the same list twice or four times: `check_framing/1`, `validate_host/2` (folded into `compute_cached_decisions`), `roadrunner_ws:validate_upgrade/1`, and `roadrunner_ws_session:send_ws_frames/2`. Fuses ship for clarity, not measured for throughput.

```
serialize(~"sid", ~"abc; admin=1", #{})    error({invalid_cookie_value, _})    (was: phantom attribute on wire)
h2 handler returns [{~"x-evil", ~"a\r\nb"}] error({header_injection, value, _}) (was: bytes shipped over h2)
parse_request/1 walks of Headers           4 → 2
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
