### PR TITLE
Add bench workflow and accept --scenarios / --protocols as lists

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,9 +17,14 @@ name: Bench
   workflow_dispatch:
     inputs:
       scenarios:
-        description: "bench.escript scenarios, comma-separated (e.g. hello | hello,echo | hello,echo,large_response)"
+        description: "comma-separated scenarios (e.g. hello,echo); leave empty to run all known"
         required: false
-        default: hello
+        default: ""
+        type: string
+      protocols:
+        description: "comma-separated protocols (h1 | h2 | h1,h2); leave empty to run all known"
+        required: false
+        default: ""
         type: string
       duration:
         description: "bench duration in seconds (warmup is +2s on top)"
@@ -40,7 +45,10 @@ jobs:
 
     runs-on: ubuntu-24.04
 
-    timeout-minutes: 5
+    # Empty inputs run every scenario on every protocol (~30 cells
+    # × ~25 s × 3 servers ≈ tens of minutes). Bump if you trip the
+    # cap; default values fit in <2 min.
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -93,13 +101,20 @@ jobs:
 
       # Inputs threaded through env, not direct template substitution,
       # so a caller can't slip shell metacharacters into the run script.
+      # An empty input omits the flag so bench.escript's own default
+      # (`all`) kicks in — the workflow surface mirrors the CLI's
+      # "omitted = all" convention exactly.
       - name: Run bench.escript
         env:
           SCENARIOS: ${{ inputs.scenarios }}
+          PROTOCOLS: ${{ inputs.protocols }}
           DURATION: ${{ inputs.duration }}
         run: |
+          args=()
+          [[ -n "$SCENARIOS" ]] && args+=(--scenarios "$SCENARIOS")
+          [[ -n "$PROTOCOLS" ]] && args+=(--protocols "$PROTOCOLS")
           ./scripts/bench.escript \
-            --scenarios "$SCENARIOS" \
+            "${args[@]}" \
             --duration "$DURATION" \
             --warmup 2 \
             2>&1 | tee /tmp/bench.log
@@ -108,14 +123,18 @@ jobs:
         if: always()
         env:
           SCENARIOS: ${{ inputs.scenarios }}
+          PROTOCOLS: ${{ inputs.protocols }}
           DURATION: ${{ inputs.duration }}
           BRANCH: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
         run: |
+          scenarios_label="${SCENARIOS:-all}"
+          protocols_label="${PROTOCOLS:-all}"
           {
             echo "## bench on-demand"
             echo ""
-            echo "scenarios \`$SCENARIOS\`, duration \`${DURATION}s\`, warmup \`2s\`"
+            echo "scenarios \`$scenarios_label\`, protocols \`$protocols_label\`,"
+            echo "duration \`${DURATION}s\`, warmup \`2s\`"
             echo ""
             echo "branch \`$BRANCH\`, sha \`$SHA\`"
             echo ""

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ name: Bench
   workflow_dispatch:
     inputs:
       scenario:
-        description: "bench.escript scenario (e.g. hello, echo, large_post_streaming)"
+        description: "bench.escript scenario, comma-separated for multi-run (e.g. hello | hello,echo | hello,echo,large_response)"
         required: false
         default: hello
         type: string

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,8 +16,8 @@ name: Bench
 "on":
   workflow_dispatch:
     inputs:
-      scenario:
-        description: "bench.escript scenario, comma-separated for multi-run (e.g. hello | hello,echo | hello,echo,large_response)"
+      scenarios:
+        description: "bench.escript scenarios, comma-separated (e.g. hello | hello,echo | hello,echo,large_response)"
         required: false
         default: hello
         type: string
@@ -95,11 +95,11 @@ jobs:
       # so a caller can't slip shell metacharacters into the run script.
       - name: Run bench.escript
         env:
-          SCENARIO: ${{ inputs.scenario }}
+          SCENARIOS: ${{ inputs.scenarios }}
           DURATION: ${{ inputs.duration }}
         run: |
           ./scripts/bench.escript \
-            --scenario "$SCENARIO" \
+            --scenarios "$SCENARIOS" \
             --duration "$DURATION" \
             --warmup 2 \
             2>&1 | tee /tmp/bench.log
@@ -107,7 +107,7 @@ jobs:
       - name: Publish to step summary
         if: always()
         env:
-          SCENARIO: ${{ inputs.scenario }}
+          SCENARIOS: ${{ inputs.scenarios }}
           DURATION: ${{ inputs.duration }}
           BRANCH: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
@@ -115,7 +115,7 @@ jobs:
           {
             echo "## bench on-demand"
             echo ""
-            echo "scenario \`$SCENARIO\`, duration \`${DURATION}s\`, warmup \`2s\`"
+            echo "scenarios \`$SCENARIOS\`, duration \`${DURATION}s\`, warmup \`2s\`"
             echo ""
             echo "branch \`$BRANCH\`, sha \`$SHA\`"
             echo ""

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,130 @@
+---
+# Manual perf check — runs `scripts/bench.escript` on demand and pins
+# the output to the workflow step summary so a reviewer sees the
+# table without opening logs. Lives in its own workflow file so a
+# manual dispatch doesn't also fire precommit / h2spec / wrk2-smoke /
+# autobahn from `erlang.yml` (manual dispatch wall time stays ~45 s
+# instead of ~5 min dominated by autobahn).
+#
+# NOT a gate: GH free runners share CPU and variance is well above any
+# change we'd plausibly make in one PR. The variance caveat is printed
+# alongside the table so a reader doesn't mistake a 5 % bump for a real
+# win. Closed-loop (not wrk2) so the job stays in the ~1 min budget;
+# wrk2-smoke in erlang.yml already proves the open-loop pipeline.
+name: Bench
+
+"on":
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: "bench.escript scenario (e.g. hello, echo, large_post_streaming)"
+        required: false
+        default: hello
+        type: string
+      duration:
+        description: "bench duration in seconds (warmup is +2s on top)"
+        required: false
+        default: "10"
+        type: string
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bench-on-demand:
+    name: bench on-demand
+
+    runs-on: ubuntu-24.04
+
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24
+        id: setup-beam
+        with:
+          version-type: strict
+          version-file: .tool-versions
+
+      # Mirror the cache key shape used by erlang.yml so this workflow
+      # rides any cache that the regular suite seeded recently.
+      - name: Set build cache key
+        id: set-build-key
+        run: |
+          os="${{ runner.os }}"
+          otp="${{ steps.setup-beam.outputs.otp-version }}"
+          cfg_hash="${{ hashFiles('rebar.config') }}"
+          lock_hash="${{ hashFiles('rebar.lock') }}"
+          prefix="_build-${os}-otp-${otp}-cfg-${cfg_hash}-"
+          echo "prefix=${prefix}" >> "${GITHUB_OUTPUT}"
+          echo "key=${prefix}lock-${lock_hash}" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore _build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: _build
+          key: ${{ steps.set-build-key.outputs.key }}
+          restore-keys: ${{ steps.set-build-key.outputs.prefix }}
+
+      - name: Restore rebar3 cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-${{ runner.os }}-otp-${{ steps.setup-beam.outputs.otp-version }}-config-${{ hashFiles('rebar.config') }}
+          restore-keys: |
+            rebar3-${{ runner.os }}-otp-${{ steps.setup-beam.outputs.otp-version }}-
+            rebar3-${{ runner.os }}-
+
+      # bench.escript needs the test profile compiled (cowboy / elli /
+      # bench fixtures live under `_build/test/lib/`). On a cache hit
+      # this is a fast no-op.
+      - name: Compile test profile
+        env:
+          # OTP 29 RC3 + Fastly TLS workaround. Same rationale as in
+          # erlang.yml — pin TLS 1.2 + middlebox_comp_mode off for the
+          # rebar3 BEAM only. Drop after OTP 29 RC4.
+          ERL_FLAGS: "-config ${{ github.workspace }}/config/rebar3_ssl"
+        run: rebar3 as test compile
+
+      # Inputs threaded through env, not direct template substitution,
+      # so a caller can't slip shell metacharacters into the run script.
+      - name: Run bench.escript
+        env:
+          SCENARIO: ${{ inputs.scenario }}
+          DURATION: ${{ inputs.duration }}
+        run: |
+          ./scripts/bench.escript \
+            --scenario "$SCENARIO" \
+            --duration "$DURATION" \
+            --warmup 2 \
+            2>&1 | tee /tmp/bench.log
+
+      - name: Publish to step summary
+        if: always()
+        env:
+          SCENARIO: ${{ inputs.scenario }}
+          DURATION: ${{ inputs.duration }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          {
+            echo "## bench on-demand"
+            echo ""
+            echo "scenario \`$SCENARIO\`, duration \`${DURATION}s\`, warmup \`2s\`"
+            echo ""
+            echo "branch \`$BRANCH\`, sha \`$SHA\`"
+            echo ""
+            echo "> GH runners share CPU; deltas under ~15 % sit inside variance"
+            echo "> (see \`scripts/bench.escript\`'s own NOTE). Re-run a few times"
+            echo "> on the same ref before drawing conclusions, and never put"
+            echo "> CI-runner numbers in README or docs."
+            echo ""
+            echo "\`\`\`"
+            cat /tmp/bench.log
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -128,3 +128,15 @@ jobs:
             cat /tmp/bench.log
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Raw log archived alongside the run so a reviewer can grab it via
+      # `gh run download <run-id>` and pipe it through local tools. Same
+      # content as the step summary, just downloadable rather than
+      # copy-paste. 90-day default retention is fine.
+      - name: Upload bench.log artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/bench.log
+          if-no-files-found: error

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Run wrk2 smoke (hello + echo, --quick, 10s)
         run: |
-          ./scripts/wrk2_bench.sh --quick --scenario hello,echo \
+          ./scripts/wrk2_bench.sh --quick --scenarios hello,echo \
               --duration 10 --server roadrunner \
               --out /tmp/wrk2_smoke.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Two complementary load drivers ship in this repo:
 Run a quick wrk2 sanity check:
 
 ```bash
-./scripts/wrk2_bench.sh --quick --scenario hello
+./scripts/wrk2_bench.sh --quick --scenarios hello
 ```
 
 The full matrix takes ~2 hours at `--runs 1 --duration 30s` and

--- a/docs/bench_internals.md
+++ b/docs/bench_internals.md
@@ -272,9 +272,9 @@ Run with `--with-resources` to capture peak RSS / BEAM memory
 alongside throughput:
 
 ```bash
-./scripts/bench.escript --scenario httparena_upload_20mb_auto \
+./scripts/bench.escript --scenarios httparena_upload_20mb_auto \
     --with-resources --clients 8 --duration 5
-./scripts/bench.escript --scenario httparena_upload_20mb_manual \
+./scripts/bench.escript --scenarios httparena_upload_20mb_manual \
     --with-resources --clients 8 --duration 5
 ```
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -196,7 +196,7 @@ Full matrix (regenerates `bench_results.md`):
 
 Override defaults via env: `RUNS=5 DURATION=10 ./scripts/bench_matrix.sh`.
 
-`scripts/bench.escript --protocol h2` drives the same scenarios
+`scripts/bench.escript --protocols h2` drives the same scenarios
 over HTTP/2. The h2 loadgen is the in-tree pure-Erlang
 `roadrunner_bench_client` (lives in `test/` because it's only used
 by dev tools); no external h2 client / loadgen needs to be

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -119,7 +119,7 @@ Run it locally:
 ```
 ./scripts/wrk2_bench.sh                       # full matrix
 ./scripts/wrk2_bench.sh --quick                # --runs 1, dev iteration
-./scripts/wrk2_bench.sh --scenario hello,echo  # subset
+./scripts/wrk2_bench.sh --scenarios hello,echo  # subset
 ```
 
 Requires Docker and a compiled test profile. See
@@ -180,7 +180,7 @@ Single scenario:
 
 ```
 mise exec -- ./scripts/bench.escript --servers roadrunner,elli,cowboy \
-  --scenario hello --clients 50 --duration 5 --warmup 2
+  --scenarios hello --clients 50 --duration 5 --warmup 2
 ```
 
 Run several times and take the median — the bench script's banner

--- a/docs/resource_results.md
+++ b/docs/resource_results.md
@@ -141,7 +141,7 @@ Single scenario:
 
 ```
 mise exec -- ./scripts/bench.escript --servers roadrunner,elli,cowboy \
-  --scenario hello --clients 50 --duration 5 --warmup 2 --with-resources
+  --scenarios hello --clients 50 --duration 5 --warmup 2 --with-resources
 ```
 
 To regenerate this whole doc with fresh numbers, loop the kept

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,7 +61,7 @@ production options are imperfect:
   GitHub's license API pick it up automatically; the README
   declaration is unambiguous but unconventional.
 
-`--protocol h3` in `scripts/bench.escript` is currently a stub;
+`--protocols h3` in `scripts/bench.escript` is currently a stub;
 ALPN advertisement does not include `h3`.
 
 **Scope:** medium-large. Wiring is mostly: ALPN advertise `h3`,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -218,6 +218,24 @@ chasing a regression that needs frequent refresh.
 
 **Scope:** small.
 
+### CI bench-vs-baseline comparison
+
+**What:** The `Bench` workflow (`.github/workflows/bench.yml`) writes
+its result to the workflow step summary only. A follow-up would upload
+the bench output as an artifact and add a comparison step (or
+dashboard) that diffs a PR run against a baseline (e.g. `main` HEAD)
+and surfaces the delta.
+
+**Why deferred:** GH free runners are too noisy for automated
+regression gating (deltas under ~15 % are inside variance per
+`scripts/bench.escript`'s own NOTE). A useful comparison needs a
+baseline-collection strategy that filters noise (multi-sample on
+both sides, distribution stats, alerting only on shifts well outside
+variance). Eyeball-from-summary covers the v1 use case.
+
+**Scope:** medium. The artifact upload is a few lines; the parser,
+distribution stats, baseline storage, and presentation are the bulk.
+
 ### Proper OTP citizenship in loop responses
 
 **What:** Both `roadrunner_loop_response:info_loop/4` (h1) and

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -10,9 +10,9 @@
 %%%
 %%% Two protocols are supported, both via the same pure-Erlang
 %%% `roadrunner_bench_client` worker pool:
-%%%   --protocol h1 (default): plain TCP, one keep-alive connection
+%%%   --protocols h1 (default): plain TCP, one keep-alive connection
 %%%       per worker.
-%%%   --protocol h2: TLS + ALPN h2, one keep-alive connection per
+%%%   --protocols h2: TLS + ALPN h2, one keep-alive connection per
 %%%       worker, in-tree codec via `roadrunner_http2_frame` +
 %%%       `roadrunner_http2_hpack`. elli is filtered automatically
 %%%       — no h2 support there.
@@ -55,6 +55,13 @@
 %% server is two steps: append it here and add a clause for it in
 %% `start_server/2` (plus any `scenario_*` config helpers below).
 -define(KNOWN_SERVERS, [roadrunner, cowboy, elli]).
+
+%% Wire protocols the bench can drive. `--protocols` accepts a
+%% comma-separated subset; omitting the flag iterates every protocol.
+%% Adding a new protocol (e.g. h3) requires appending it here, wiring
+%% `preflight_protocol/1`, and tagging incompatible scenarios in the
+%% `?H?_ONLY_SCENARIOS` macros below.
+-define(KNOWN_PROTOCOLS, [h1, h2]).
 
 %% Scenarios are partitioned by protocol compatibility. Each scenario
 %% name lives in exactly one of these three macros; adding a new
@@ -132,21 +139,71 @@ main(Args) ->
     Opts0 = parse_args(Args),
     ProjectDir = project_dir(),
     ok = setup_code_paths(ProjectDir),
-    Scenarios = expand_scenarios(
-        maps:get(scenarios, Opts0), maps:get(protocol, Opts0)
+    Protocols = expand_protocols(maps:get(protocols, Opts0)),
+    Scenarios0 = maps:get(scenarios, Opts0),
+    case maps:get(standalone, Opts0, false) of
+        true ->
+            run_standalone_one(Opts0, Protocols, Scenarios0);
+        false ->
+            run_each_protocol(Opts0, Protocols, Scenarios0)
+    end.
+
+%% Standalone mode brings up ONE listener for an out-of-process wrk2
+%% driver, so exactly one protocol AND exactly one scenario must be
+%% selected. Each failure mode gets its own clear error.
+run_standalone_one(_Opts, Protocols, _Scenarios0) when length(Protocols) =/= 1 ->
+    io:format(
+        standard_error,
+        "error: --standalone takes exactly one protocol (got: ~p)~n",
+        [Protocols]
     ),
-    Opts1 = Opts0#{scenarios := Scenarios},
-    case maps:get(standalone, Opts1, false) of
-        true when length(Scenarios) > 1 ->
+    halt(2);
+run_standalone_one(Opts0, [Protocol], Scenarios0) ->
+    Scenarios = expand_scenarios(Scenarios0, Protocol),
+    case Scenarios of
+        [Scenario] ->
+            Opts1 = Opts0#{
+                protocols := [Protocol],
+                protocol => Protocol,
+                scenarios := Scenarios,
+                scenario => Scenario
+            },
+            run_standalone(Opts1);
+        _ ->
             io:format(
                 standard_error,
                 "error: --standalone takes exactly one scenario (got: ~p)~n",
                 [Scenarios]
             ),
-            halt(2);
-        _ ->
-            run_each_scenario(Opts1, Scenarios)
+            halt(2)
     end.
+
+run_each_protocol(_Opts, [], _Scenarios0) ->
+    ok;
+run_each_protocol(Opts0, [Protocol | Rest], Scenarios0) ->
+    Scenarios = expand_scenarios(Scenarios0, Protocol),
+    Opts1 = Opts0#{
+        protocol => Protocol,
+        scenarios := Scenarios
+    },
+    maybe_print_protocol_divider(Opts0, Protocol),
+    run_each_scenario(Opts1, Scenarios),
+    run_each_protocol(Opts0, Rest, Scenarios0).
+
+%% Single-protocol invocations keep the original output verbatim.
+%% Multi-protocol runs prefix each protocol block with a heavier
+%% divider so the nested scenario blocks underneath stay scannable.
+maybe_print_protocol_divider(#{protocols := [_]}, _Protocol) ->
+    ok;
+maybe_print_protocol_divider(_Opts, Protocol) ->
+    io:format("~n======== protocol: ~s ========~n", [Protocol]).
+
+%% Resolve the `--protocol` sentinel `all` (default when the flag is
+%% omitted) to `?KNOWN_PROTOCOLS`. Explicit picks pass through.
+expand_protocols(all) ->
+    ?KNOWN_PROTOCOLS;
+expand_protocols(Protocols) when is_list(Protocols) ->
+    Protocols.
 
 %% Resolve the `--scenarios all` sentinel to the protocol-compatible
 %% subset of `?KNOWN_SCENARIOS`. Other shapes (already a list of
@@ -166,7 +223,7 @@ expand_scenarios(all, Protocol) ->
             ok;
         _ ->
             io:format(
-                "note: --scenarios all + --protocol ~s, dropped: ~p~n",
+                "note: --protocols ~s, dropped ~p as incompatible~n",
                 [Protocol, Dropped]
             )
     end,
@@ -321,7 +378,7 @@ preflight_protocol(#{protocol := h2, servers := Servers} = Opts) ->
     case Filtered =/= Servers of
         true ->
             io:format(
-                "note: --protocol h2 — elli filtered out (no HTTP/2 support)~n",
+                "note: --protocols h2 — elli filtered out (no HTTP/2 support)~n",
                 []
             );
         false ->
@@ -383,8 +440,8 @@ cli() ->
                     invocations (e.g. `--scenarios hello`) keep the
                     existing one-shot output shape. Omitting the flag
                     runs every known scenario compatible with
-                    `--protocol`, dropping h1-only entries under
-                    `--protocol h2` and vice versa with a one-line
+                    `--protocols`, dropping h1-only entries under
+                    `--protocols h2` and vice versa with a one-line
                     note. Explicit comma-separated picks
                     (`--scenarios X,Y`) still halt loudly on protocol
                     mismatch — only the omitted-default auto-filters.
@@ -816,10 +873,16 @@ cli() ->
                     """
             },
             #{
-                name => protocol,
+                name => protocols,
                 long => "-protocol",
-                type => {atom, [h1, h2]},
-                default => h1,
+                type => {custom, fun parse_protocols/1},
+                %% Omitting `--protocols` defaults to the `all` sentinel,
+                %% which `main/1` expands to `?KNOWN_PROTOCOLS`. Explicit
+                %% picks (`--protocols h1` or `--protocols h1,h2`) are
+                %% passed through as a list. Both forms iterate in
+                %% sequence with per-protocol output dividers when
+                %% length > 1.
+                default => all,
                 help =>
                     """
                     Wire protocol to drive the load over. Both paths
@@ -843,7 +906,7 @@ cli() ->
                     out-of-process load drivers (e.g. wrk2) target
                     the listener without re-implementing the per-
                     server launcher logic. Requires `--port-file`,
-                    `--servers <one>`, `--protocol h1` (h1-only).
+                    `--servers <one>`, `--protocols h1` (h1-only).
                     """
             },
             #{
@@ -896,6 +959,13 @@ parse_servers(Str) ->
 %% of `?KNOWN_SCENARIOS`.
 parse_scenarios(Str) ->
     parse_known_atoms(Str, ?KNOWN_SCENARIOS, "scenarios").
+
+%% Same shape for `--protocols` — comma-separated list validated
+%% against `?KNOWN_PROTOCOLS`. Omitting the flag entirely uses the
+%% atom default `all` (set in `cli/0`) which `main/1`'s
+%% `expand_protocols/1` widens to `?KNOWN_PROTOCOLS`.
+parse_protocols(Str) ->
+    parse_known_atoms(Str, ?KNOWN_PROTOCOLS, "protocols").
 
 %% Shared comma-list parser for the two enum-valued options. Splits on
 %% comma, trims OWS, validates each token against `Known`, and either
@@ -956,7 +1026,7 @@ run_standalone(Opts) ->
         end,
     Protocol = maps:get(protocol, Opts),
     Protocol =:= h1 orelse standalone_error(
-        "--standalone is h1-only (received --protocol ~s)", [Protocol]
+        "--standalone is h1-only (received --protocols ~s)", [Protocol]
     ),
     Scenario = maps:get(scenario, Opts),
     ok = validate_standalone_scenario(Scenario),
@@ -2777,12 +2847,12 @@ build_request(streaming_response) ->
     %% can't reuse — limit this scenario to h2.
     io:format(standard_error,
         "error: --scenarios streaming_response is h2-only "
-        "(use --protocol h2)~n", []),
+        "(use --protocols h2)~n", []),
     halt(2);
 build_request(multi_stream_h2) ->
     io:format(standard_error,
         "error: --scenarios multi_stream_h2 is h2-only "
-        "(use --protocol h2)~n", []),
+        "(use --protocols h2)~n", []),
     halt(2);
 build_request(large_post_streaming) ->
     %% 1 MB body — `x` repeated. Cached at module load via
@@ -2815,7 +2885,7 @@ build_request(small_chunked_response) ->
     %% loop. h2-only.
     io:format(standard_error,
         "error: --scenarios small_chunked_response is h2-only "
-        "(use --protocol h2)~n", []),
+        "(use --protocols h2)~n", []),
     halt(2);
 build_request(head_method) ->
     ~"HEAD /large HTTP/1.1\r\nHost: x\r\n\r\n";
@@ -2827,7 +2897,7 @@ build_request(tls_handshake_throughput) ->
     %% h2-only scenario — handshake dominates, only meaningful over TLS.
     io:format(standard_error,
         "error: --scenarios tls_handshake_throughput is h2-only "
-        "(use --protocol h2)~n", []),
+        "(use --protocols h2)~n", []),
     halt(2);
 build_request(multi_request_body) ->
     Body = binary:copy(~"x", 4096),
@@ -3239,7 +3309,7 @@ h2_request_shape(pipelined_h1) ->
     %% with no analogue in h2 (use `multi_stream_h2` instead).
     io:format(standard_error,
         "error: --scenarios pipelined_h1 is h1-only "
-        "(use --protocol h1; for h2 multiplexing see multi_stream_h2)~n", []),
+        "(use --protocols h1; for h2 multiplexing see multi_stream_h2)~n", []),
     halt(2);
 h2_request_shape(slow_client) ->
     %% Drip-feed semantics target the h1 byte-stream parser; h2's
@@ -3247,7 +3317,7 @@ h2_request_shape(slow_client) ->
     %% (and less interesting) test.
     io:format(standard_error,
         "error: --scenarios slow_client is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(connection_storm) ->
     %% Per-request TLS handshake would dominate the measurement
@@ -3256,7 +3326,7 @@ h2_request_shape(connection_storm) ->
     %% conns is anti-h2 and not a real-world workload.
     io:format(standard_error,
         "error: --scenarios connection_storm is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(mixed_workload) ->
     %% h2 mixed-path workload is a separate (and meaningful) test
@@ -3265,7 +3335,7 @@ h2_request_shape(mixed_workload) ->
     %% h1 router under varied dispatch.
     io:format(standard_error,
         "error: --scenarios mixed_workload is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(post_4kb_form) ->
     %% h2 form-decode is a meaningful follow-up but out of scope
@@ -3273,7 +3343,7 @@ h2_request_shape(post_4kb_form) ->
     %% qs:parse path under realistic body sizes.
     io:format(standard_error,
         "error: --scenarios post_4kb_form is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(large_post_streaming) ->
     %% h2 has a different body-delivery model (DATA frames with
@@ -3282,7 +3352,7 @@ h2_request_shape(large_post_streaming) ->
     %% current focus is the h1 body-state machine.
     io:format(standard_error,
         "error: --scenarios large_post_streaming is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(router_404_storm) ->
     %% Connection lifecycle is the dominant cost on this scenario;
@@ -3290,7 +3360,7 @@ h2_request_shape(router_404_storm) ->
     %% router-miss cost we're trying to surface. h1-only.
     io:format(standard_error,
         "error: --scenarios router_404_storm is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(varied_paths_router) ->
     %% h2 varied paths is meaningful but needs varying per-request
@@ -3298,7 +3368,7 @@ h2_request_shape(varied_paths_router) ->
     %% scenario.
     io:format(standard_error,
         "error: --scenarios varied_paths_router is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(gzip_response) ->
     %% h2 has its own header compression (HPACK) and per-stream
@@ -3307,7 +3377,7 @@ h2_request_shape(gzip_response) ->
     %% path specifically.
     io:format(standard_error,
         "error: --scenarios gzip_response is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(backpressure_sustained) ->
     %% Connection limits over h2 are per-stream not per-conn; the
@@ -3315,7 +3385,7 @@ h2_request_shape(backpressure_sustained) ->
     %% is a different scenario worth its own design. h1-only here.
     io:format(standard_error,
         "error: --scenarios backpressure_sustained is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(server_sent_events) ->
     %% h2 SSE works (RFC 8441 + chunked-frame DATA) but the
@@ -3323,28 +3393,28 @@ h2_request_shape(server_sent_events) ->
     %% reads. Out of scope for now.
     io:format(standard_error,
         "error: --scenarios server_sent_events is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(expect_100_continue) ->
     %% h2 has no Expect: 100-continue equivalent (see RFC 9113 §8.5).
     %% h1-only scenario.
     io:format(standard_error,
         "error: --scenarios expect_100_continue is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(large_keepalive_session) ->
     %% h2 has no per-conn-request count limit at the protocol layer
     %% (per-stream limits are different); h1-only scenario.
     io:format(standard_error,
         "error: --scenarios large_keepalive_session is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(websocket_msg_throughput) ->
     %% RFC 8441 (h2 + WS) is out of scope for this scenario;
     %% bench-client side hasn't been wired for h2 WS frames.
     io:format(standard_error,
         "error: --scenarios websocket_msg_throughput is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(url_with_qs) ->
     %% h2 path encodes the query string in the `:path` pseudo-
@@ -3353,7 +3423,7 @@ h2_request_shape(url_with_qs) ->
     %% the h1 URL-side qs:parse path specifically.
     io:format(standard_error,
         "error: --scenarios url_with_qs is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(small_chunked_response) ->
     {~"GET", ~"/small", [], <<>>};
@@ -3362,7 +3432,7 @@ h2_request_shape(accept_storm_burst) ->
     %% backlog under burst is an h1-flavored question.
     io:format(standard_error,
         "error: --scenarios accept_storm_burst is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(head_method) ->
     {~"HEAD", ~"/large", [], <<>>};
@@ -3373,14 +3443,14 @@ h2_request_shape(etag_304) ->
     %% scope here.
     io:format(standard_error,
         "error: --scenarios etag_304 is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(partial_body_drop) ->
     %% h2 has its own truncation semantics (RST_STREAM); the h1
     %% Content-Length-mismatch path is what this scenario targets.
     io:format(standard_error,
         "error: --scenarios partial_body_drop is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(cookies_heavy) ->
     {~"GET", ~"/cookies",
@@ -3395,32 +3465,32 @@ h2_request_shape(multi_request_body) ->
 h2_request_shape(path_with_unicode) ->
     io:format(standard_error,
         "error: --scenarios path_with_unicode is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(cors_preflight) ->
     %% h2 client doesn't support OPTIONS preflight (it bypasses
     %% CORS via origin negotiation); h1-only.
     io:format(standard_error,
         "error: --scenarios cors_preflight is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(chunked_request_body) ->
     %% h2 has its own framing (DATA frames); chunked is h1-specific.
     io:format(standard_error,
         "error: --scenarios chunked_request_body is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(redirect_response) ->
     %% Bench h2 client only accepts :status = 200; 302 would
     %% short-circuit to bad_status. h2 follow-up.
     io:format(standard_error,
         "error: --scenarios redirect_response is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(compressed_request_body) ->
     io:format(standard_error,
         "error: --scenarios compressed_request_body is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(headers_heavy) ->
     %% 16 small custom headers — exercises HPACK encode's
@@ -3437,14 +3507,14 @@ h2_request_shape(httparena_baseline) ->
     %% this scenario mirrors HttpArena's h1 baseline profile.
     io:format(standard_error,
         "error: --scenarios httparena_baseline is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(httparena_json) ->
     %% h2 variant is meaningful but out of scope for the first round;
     %% this scenario mirrors HttpArena's h1 json profile.
     io:format(standard_error,
         "error: --scenarios httparena_json is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(httparena_upload_20mb_auto) ->
     %% h2 has its own body-delivery model (DATA frames with per-stream
@@ -3452,12 +3522,12 @@ h2_request_shape(httparena_upload_20mb_auto) ->
     %% adding later. h1-only here.
     io:format(standard_error,
         "error: --scenarios httparena_upload_20mb_auto is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2);
 h2_request_shape(httparena_upload_20mb_manual) ->
     io:format(standard_error,
         "error: --scenarios httparena_upload_20mb_manual is h1-only "
-        "(use --protocol h1)~n", []),
+        "(use --protocols h1)~n", []),
     halt(2).
 
 h2_worker_loop(Host, Port, Method, Path, ReqHeaders, ReqBody, Deadline, Acc) ->

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -57,22 +57,87 @@
 %% `start_server/2` (plus any `scenario_*` config helpers below).
 -define(KNOWN_SERVERS, [roadrunner, cowboy, elli]).
 
+%% Scenarios known to the bench. `--scenario` accepts a comma-separated
+%% list (mirroring `--servers`), so each value in the user's input
+%% must validate against this set. Adding a new scenario requires
+%% appending it here, adding a `preflight_scenario/1` clause if any
+%% servers should be filtered, and wiring `scenario_path/1` /
+%% `build_request/N` / `start_server/2` for it.
+-define(KNOWN_SCENARIOS, [
+    hello,
+    echo,
+    large_response,
+    json,
+    headers_heavy,
+    streaming_response,
+    multi_stream_h2,
+    pipelined_h1,
+    slow_client,
+    connection_storm,
+    mixed_workload,
+    post_4kb_form,
+    large_post_streaming,
+    router_404_storm,
+    varied_paths_router,
+    gzip_response,
+    backpressure_sustained,
+    server_sent_events,
+    expect_100_continue,
+    large_keepalive_session,
+    websocket_msg_throughput,
+    url_with_qs,
+    small_chunked_response,
+    accept_storm_burst,
+    head_method,
+    etag_304,
+    partial_body_drop,
+    cookies_heavy,
+    tls_handshake_throughput,
+    multi_request_body,
+    path_with_unicode,
+    cors_preflight,
+    chunked_request_body,
+    redirect_response,
+    compressed_request_body,
+    httparena_baseline,
+    httparena_json,
+    httparena_upload_20mb_auto,
+    httparena_upload_20mb_manual
+]).
+
 main(Args) ->
     Opts0 = parse_args(Args),
     ProjectDir = project_dir(),
     ok = setup_code_paths(ProjectDir),
+    Scenarios = maps:get(scenarios, Opts0),
+    case maps:get(standalone, Opts0, false) of
+        true when length(Scenarios) > 1 ->
+            io:format(
+                standard_error,
+                "error: --standalone takes exactly one scenario (got: ~p)~n",
+                [Scenarios]
+            ),
+            halt(2);
+        _ ->
+            run_each_scenario(Opts0, Scenarios)
+    end.
+
+run_each_scenario(_Opts, []) ->
+    ok;
+run_each_scenario(Opts0, [Scenario | Rest]) ->
     %% preflight runs for both `--standalone` and the regular bench
     %% flow: it filters incompatible servers (e.g. elli for scenarios
     %% the elli fixture can't serve) and produces clear console
     %% notes. `run_standalone/1`'s "exactly one server" check then
     %% catches the case where the user-requested server got filtered
     %% out, instead of starting a listener that 404s every request.
-    Opts1 = preflight_protocol(Opts0),
+    Opts1 = preflight_protocol(Opts0#{scenario := Scenario}),
     Opts = preflight_scenario(Opts1),
     case maps:get(standalone, Opts, false) of
         true ->
             run_standalone(Opts);
         false ->
+            maybe_print_scenario_divider(Opts0, Scenario),
             print_header(Opts),
             %% Each side runs in isolation: bring the server up, drive load,
             %% bring it down, then do the next. Order matches the user's
@@ -80,7 +145,16 @@ main(Args) ->
             Servers = maps:get(servers, Opts),
             Results = [{S, element(2, run_side(S, Opts))} || S <- Servers],
             print_summary(Results)
-    end.
+    end,
+    run_each_scenario(Opts0, Rest).
+
+%% Single-scenario invocations keep the existing one-shot output
+%% verbatim. Multi-scenario runs prefix each iteration with a divider so
+%% the stacked tables are scannable.
+maybe_print_scenario_divider(#{scenarios := [_]}, _Scenario) ->
+    ok;
+maybe_print_scenario_divider(_Opts, Scenario) ->
+    io:format("~n==== scenario: ~s ====~n", [Scenario]).
 
 %% Validate environment for the chosen protocol and drop
 %% incompatible servers. The h2 path needs a TLS cert (auto-
@@ -232,51 +306,17 @@ cli() ->
             #{
                 name => scenario,
                 long => "-scenario",
-                type =>
-                    {atom, [
-                        hello,
-                        echo,
-                        large_response,
-                        json,
-                        headers_heavy,
-                        streaming_response,
-                        multi_stream_h2,
-                        pipelined_h1,
-                        slow_client,
-                        connection_storm,
-                        mixed_workload,
-                        post_4kb_form,
-                        large_post_streaming,
-                        router_404_storm,
-                        varied_paths_router,
-                        gzip_response,
-                        backpressure_sustained,
-                        server_sent_events,
-                        expect_100_continue,
-                        large_keepalive_session,
-                        websocket_msg_throughput,
-                        url_with_qs,
-                        small_chunked_response,
-                        accept_storm_burst,
-                        head_method,
-                        etag_304,
-                        partial_body_drop,
-                        cookies_heavy,
-                        tls_handshake_throughput,
-                        multi_request_body,
-                        path_with_unicode,
-                        cors_preflight,
-                        chunked_request_body,
-                        redirect_response,
-                        compressed_request_body,
-                        httparena_baseline,
-                        httparena_json,
-                        httparena_upload_20mb_auto,
-                        httparena_upload_20mb_manual
-                    ]},
-                default => ?DEFAULT_SCENARIO,
+                type => string,
+                default => atom_to_list(?DEFAULT_SCENARIO),
                 help =>
                     """
+                    Comma-separated list of scenarios to run sequentially
+                    (e.g. `--scenario hello,echo,large_response`). Each is
+                    run in its own server-up / load / server-down cycle, in
+                    the order given. Single-scenario invocations (e.g.
+                    `--scenario hello`) keep the existing one-shot output
+                    shape.
+
                     hello:          GET / with 1 header, 7-byte body. Bare-minimum
                                     HTTP cost.
                     echo:           POST /echo with 256-byte body and 5 request
@@ -756,7 +796,10 @@ parse_args(Argv) ->
     ProgOpts = #{progname => "bench.escript"},
     case argparse:parse(Argv, Cli, ProgOpts) of
         {ok, Parsed, _Path, _Cmd} ->
-            Parsed#{servers => parse_servers(maps:get(servers, Parsed))};
+            Parsed#{
+                servers => parse_servers(maps:get(servers, Parsed)),
+                scenarios => parse_scenarios(maps:get(scenario, Parsed))
+            };
         {error, Reason} ->
             io:format(standard_error, "~s~n~n", [argparse:format_error(Reason)]),
             io:format(standard_error, "~s~n", [argparse:help(Cli, ProgOpts)]),
@@ -768,11 +811,24 @@ parse_args(Argv) ->
 %% bench runs in the order they typed (e.g. `--servers elli,roadrunner`
 %% runs elli first).
 parse_servers(Str) ->
+    parse_known_atoms(Str, ?KNOWN_SERVERS, "servers").
+
+%% Same shape for `--scenario` — comma-separated list validated against
+%% `?KNOWN_SCENARIOS`. Single-value input (e.g. `--scenario hello`)
+%% returns a 1-element list and runs the existing single-scenario flow
+%% unchanged.
+parse_scenarios(Str) ->
+    parse_known_atoms(Str, ?KNOWN_SCENARIOS, "scenarios").
+
+%% Shared comma-list parser for the two enum-valued options. Splits on
+%% comma, trims OWS, validates each token against `Known`, and either
+%% returns the resolved atoms in user-typed order or halts with a clean
+%% error listing the unknown names.
+parse_known_atoms(Str, Known, Label) ->
     Names = [string:trim(P) || P <- string:split(Str, ",", all), P =/= ""],
     %% `list_to_existing_atom` blows up on names that aren't already
     %% atoms — convert via the safe membership check instead so a
     %% typo produces a clean error message, not a crash.
-    Known = ?KNOWN_SERVERS,
     KnownStrs = [atom_to_list(A) || A <- Known],
     Lookup = lists:zip(KnownStrs, Known),
     {Resolved, Unknown} = lists:foldr(
@@ -791,8 +847,8 @@ parse_servers(Str) ->
         _ ->
             io:format(
                 standard_error,
-                "error: unknown servers: ~p (known: ~p)~n",
-                [Unknown, Known]
+                "error: unknown ~s: ~p (known: ~p)~n",
+                [Label, Unknown, Known]
             ),
             halt(2)
     end.

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -874,7 +874,7 @@ cli() ->
             },
             #{
                 name => protocols,
-                long => "-protocol",
+                long => "-protocols",
                 type => {custom, fun parse_protocols/1},
                 %% Omitting `--protocols` defaults to the `all` sentinel,
                 %% which `main/1` expands to `?KNOWN_PROTOCOLS`. Explicit
@@ -937,8 +937,14 @@ parse_args(Argv) ->
             %% pre-parsed (list of atoms). No post-process needed.
             Parsed;
         {error, Reason} ->
-            io:format(standard_error, "~s~n~n", [argparse:format_error(Reason)]),
-            io:format(standard_error, "~s~n", [argparse:help(Cli, ProgOpts)]),
+            %% Skip `argparse:help/2` on error: it renders every option's
+            %% default with `~ts`, and our `--servers` / `--scenarios` /
+            %% `--protocols` defaults are atom values (sentinel `all` or
+            %% atom lists like `?KNOWN_SERVERS`) that crash io_lib's
+            %% Unicode-chardata pass. The error message is still
+            %% actionable; users who want the full usage can pass no
+            %% arguments or read `cli/0`.
+            io:format(standard_error, "~s~n", [argparse:format_error(Reason)]),
             halt(2)
     end.
 

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -105,12 +105,62 @@
     httparena_upload_20mb_manual
 ]).
 
+%% Scenarios that only make sense over HTTP/1.1 — the listener fixture
+%% or the workload itself depends on h1-specific shape (pipelining,
+%% Connection: close storms, etc.). When `--scenarios all` is paired
+%% with `--protocol h2`, these get filtered out. Mirrors the
+%% `"error: --scenarios X is h1-only ..."` preflight checks at the
+%% per-scenario h2-workload sites — keep in sync when adding a new
+%% h1-only scenario.
+-define(H1_ONLY_SCENARIOS, [
+    pipelined_h1,
+    slow_client,
+    connection_storm,
+    mixed_workload,
+    post_4kb_form,
+    large_post_streaming,
+    router_404_storm,
+    varied_paths_router,
+    gzip_response,
+    backpressure_sustained,
+    server_sent_events,
+    expect_100_continue,
+    large_keepalive_session,
+    websocket_msg_throughput,
+    url_with_qs,
+    accept_storm_burst,
+    etag_304,
+    partial_body_drop,
+    path_with_unicode,
+    cors_preflight,
+    chunked_request_body,
+    redirect_response,
+    compressed_request_body,
+    httparena_baseline,
+    httparena_json,
+    httparena_upload_20mb_auto,
+    httparena_upload_20mb_manual
+]).
+
+%% Scenarios that only make sense over HTTP/2. Mirrors the
+%% `"error: --scenarios X is h2-only ..."` preflight checks at the
+%% per-scenario h1-workload sites.
+-define(H2_ONLY_SCENARIOS, [
+    streaming_response,
+    multi_stream_h2,
+    small_chunked_response,
+    tls_handshake_throughput
+]).
+
 main(Args) ->
     Opts0 = parse_args(Args),
     ProjectDir = project_dir(),
     ok = setup_code_paths(ProjectDir),
-    Scenarios = maps:get(scenarios, Opts0),
-    case maps:get(standalone, Opts0, false) of
+    Scenarios = expand_scenarios(
+        maps:get(scenarios, Opts0), maps:get(protocol, Opts0)
+    ),
+    Opts1 = Opts0#{scenarios := Scenarios},
+    case maps:get(standalone, Opts1, false) of
         true when length(Scenarios) > 1 ->
             io:format(
                 standard_error,
@@ -119,8 +169,34 @@ main(Args) ->
             ),
             halt(2);
         _ ->
-            run_each_scenario(Opts0, Scenarios)
+            run_each_scenario(Opts1, Scenarios)
     end.
+
+%% Resolve the `--scenarios all` sentinel to the protocol-compatible
+%% subset of `?KNOWN_SCENARIOS`. Other shapes (already a list of
+%% atoms) pass through unchanged so an explicit `--scenarios X,Y`
+%% picks still hit the existing loud preflight errors when the user
+%% asks for an incompatible combo.
+expand_scenarios(all, Protocol) ->
+    Drop =
+        case Protocol of
+            h1 -> ?H2_ONLY_SCENARIOS;
+            h2 -> ?H1_ONLY_SCENARIOS
+        end,
+    Kept = [S || S <- ?KNOWN_SCENARIOS, not lists:member(S, Drop)],
+    Dropped = [S || S <- ?KNOWN_SCENARIOS, lists:member(S, Drop)],
+    case Dropped of
+        [] ->
+            ok;
+        _ ->
+            io:format(
+                "note: --scenarios all + --protocol ~s, dropped: ~p~n",
+                [Protocol, Dropped]
+            )
+    end,
+    Kept;
+expand_scenarios(Scenarios, _Protocol) when is_list(Scenarios) ->
+    Scenarios.
 
 run_each_scenario(_Opts, []) ->
     ok;
@@ -324,7 +400,14 @@ cli() ->
                     is run in its own server-up / load / server-down
                     cycle, in the order given. Single-scenario
                     invocations (e.g. `--scenarios hello`) keep the
-                    existing one-shot output shape.
+                    existing one-shot output shape. The sentinel
+                    `--scenarios all` expands to every known scenario
+                    compatible with `--protocol`, dropping
+                    h1-only entries under `--protocol h2` and vice
+                    versa with a one-line note. Explicit
+                    comma-separated picks (`--scenarios X,Y`) still
+                    halt loudly on protocol mismatch — only the
+                    `all` sentinel auto-filters.
 
                     hello:          GET / with 1 header, 7-byte body. Bare-minimum
                                     HTTP cost.
@@ -826,7 +909,14 @@ parse_servers(Str) ->
 %% Same shape for `--scenarios` — comma-separated list validated
 %% against `?KNOWN_SCENARIOS`. Single-value input (e.g.
 %% `--scenarios hello`) returns a 1-element list and runs the existing
-%% single-scenario flow unchanged.
+%% single-scenario flow unchanged. The literal `all` returns the atom
+%% sentinel `all` which `main/1` expands to the protocol-compatible
+%% subset of `?KNOWN_SCENARIOS` (so `--scenarios all --protocol h1`
+%% drops h2-only scenarios and vice versa, with a one-line note). The
+%% sentinel must appear alone — mixing it into a comma list (`all,X`)
+%% fails the known-atom check, which is the intended UX.
+parse_scenarios("all") ->
+    all;
 parse_scenarios(Str) ->
     parse_known_atoms(Str, ?KNOWN_SCENARIOS, "scenarios").
 

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -109,7 +109,7 @@ main(Args) ->
     Opts0 = parse_args(Args),
     ProjectDir = project_dir(),
     ok = setup_code_paths(ProjectDir),
-    Scenarios = maps:get(scenarios, Opts0),
+    Scenarios = maps:get(scenario, Opts0),
     case maps:get(standalone, Opts0, false) of
         true when length(Scenarios) > 1 ->
             io:format(
@@ -150,8 +150,9 @@ run_each_scenario(Opts0, [Scenario | Rest]) ->
 
 %% Single-scenario invocations keep the existing one-shot output
 %% verbatim. Multi-scenario runs prefix each iteration with a divider so
-%% the stacked tables are scannable.
-maybe_print_scenario_divider(#{scenarios := [_]}, _Scenario) ->
+%% the stacked tables are scannable. The match looks at the original
+%% parsed `scenario` list (pre-iteration override) to decide.
+maybe_print_scenario_divider(#{scenario := [_]}, _Scenario) ->
     ok;
 maybe_print_scenario_divider(_Opts, Scenario) ->
     io:format("~n==== scenario: ~s ====~n", [Scenario]).
@@ -306,8 +307,8 @@ cli() ->
             #{
                 name => scenario,
                 long => "-scenario",
-                type => string,
-                default => atom_to_list(?DEFAULT_SCENARIO),
+                type => {custom, fun parse_scenarios/1},
+                default => [?DEFAULT_SCENARIO],
                 help =>
                     """
                     Comma-separated list of scenarios to run sequentially
@@ -649,8 +650,8 @@ cli() ->
             #{
                 name => servers,
                 long => "-servers",
-                type => string,
-                default => "roadrunner,cowboy,elli",
+                type => {custom, fun parse_servers/1},
+                default => ?KNOWN_SERVERS,
                 help =>
                     """
                     Comma-separated list of servers to run (run order is
@@ -796,10 +797,11 @@ parse_args(Argv) ->
     ProgOpts = #{progname => "bench.escript"},
     case argparse:parse(Argv, Cli, ProgOpts) of
         {ok, Parsed, _Path, _Cmd} ->
-            Parsed#{
-                servers => parse_servers(maps:get(servers, Parsed)),
-                scenarios => parse_scenarios(maps:get(scenario, Parsed))
-            };
+            %% `--scenario` and `--servers` use `{custom, fun}` types so
+            %% argparse has already run `parse_scenarios/1` /
+            %% `parse_servers/1` on user input; defaults are likewise
+            %% pre-parsed (list of atoms). No post-process needed here.
+            Parsed;
         {error, Reason} ->
             io:format(standard_error, "~s~n~n", [argparse:format_error(Reason)]),
             io:format(standard_error, "~s~n", [argparse:help(Cli, ProgOpts)]),

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -42,7 +42,6 @@
 
 -mode(compile).
 
--define(DEFAULT_SCENARIO, hello).
 -define(DEFAULT_CLIENTS, 50).
 -define(DEFAULT_DURATION_S, 5).
 -define(DEFAULT_WARMUP_S, 1).
@@ -369,7 +368,12 @@ cli() ->
                 name => scenarios,
                 long => "-scenarios",
                 type => {custom, fun parse_scenarios/1},
-                default => [?DEFAULT_SCENARIO],
+                %% Omitting `--scenarios` defaults to the `all` sentinel,
+                %% which `main/1` expands to the protocol-compatible
+                %% subset of `?KNOWN_SCENARIOS`. Explicit picks
+                %% (`--scenarios X,Y`) are passed through as a list and
+                %% still halt loudly on protocol mismatch.
+                default => all,
                 help =>
                     """
                     Comma-separated list of scenarios to run sequentially
@@ -377,14 +381,13 @@ cli() ->
                     is run in its own server-up / load / server-down
                     cycle, in the order given. Single-scenario
                     invocations (e.g. `--scenarios hello`) keep the
-                    existing one-shot output shape. The sentinel
-                    `--scenarios all` expands to every known scenario
-                    compatible with `--protocol`, dropping
-                    h1-only entries under `--protocol h2` and vice
-                    versa with a one-line note. Explicit
-                    comma-separated picks (`--scenarios X,Y`) still
-                    halt loudly on protocol mismatch — only the
-                    `all` sentinel auto-filters.
+                    existing one-shot output shape. Omitting the flag
+                    runs every known scenario compatible with
+                    `--protocol`, dropping h1-only entries under
+                    `--protocol h2` and vice versa with a one-line
+                    note. Explicit comma-separated picks
+                    (`--scenarios X,Y`) still halt loudly on protocol
+                    mismatch — only the omitted-default auto-filters.
 
                     hello:          GET / with 1 header, 7-byte body. Bare-minimum
                                     HTTP cost.
@@ -886,14 +889,11 @@ parse_servers(Str) ->
 %% Same shape for `--scenarios` — comma-separated list validated
 %% against `?KNOWN_SCENARIOS`. Single-value input (e.g.
 %% `--scenarios hello`) returns a 1-element list and runs the existing
-%% single-scenario flow unchanged. The literal `all` returns the atom
-%% sentinel `all` which `main/1` expands to the protocol-compatible
-%% subset of `?KNOWN_SCENARIOS` (so `--scenarios all --protocol h1`
-%% drops h2-only scenarios and vice versa, with a one-line note). The
-%% sentinel must appear alone — mixing it into a comma list (`all,X`)
-%% fails the known-atom check, which is the intended UX.
-parse_scenarios("all") ->
-    all;
+%% single-scenario flow unchanged. There is no user-facing `all`
+%% literal — when the user omits `--scenarios` entirely, argparse
+%% uses the atom default `all` (set in `cli/0`) and `main/1`'s
+%% `expand_scenarios/2` widens it to the protocol-compatible subset
+%% of `?KNOWN_SCENARIOS`.
 parse_scenarios(Str) ->
     parse_known_atoms(Str, ?KNOWN_SCENARIOS, "scenarios").
 

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -57,11 +57,11 @@
 %% `start_server/2` (plus any `scenario_*` config helpers below).
 -define(KNOWN_SERVERS, [roadrunner, cowboy, elli]).
 
-%% Scenarios known to the bench. `--scenario` accepts a comma-separated
-%% list (mirroring `--servers`), so each value in the user's input
-%% must validate against this set. Adding a new scenario requires
-%% appending it here, adding a `preflight_scenario/1` clause if any
-%% servers should be filtered, and wiring `scenario_path/1` /
+%% Scenarios known to the bench. `--scenarios` accepts a
+%% comma-separated list (mirroring `--servers`), so each value in the
+%% user's input must validate against this set. Adding a new scenario
+%% requires appending it here, adding a `preflight_scenario/1` clause
+%% if any servers should be filtered, and wiring `scenario_path/1` /
 %% `build_request/N` / `start_server/2` for it.
 -define(KNOWN_SCENARIOS, [
     hello,
@@ -109,7 +109,7 @@ main(Args) ->
     Opts0 = parse_args(Args),
     ProjectDir = project_dir(),
     ok = setup_code_paths(ProjectDir),
-    Scenarios = maps:get(scenario, Opts0),
+    Scenarios = maps:get(scenarios, Opts0),
     case maps:get(standalone, Opts0, false) of
         true when length(Scenarios) > 1 ->
             io:format(
@@ -131,7 +131,15 @@ run_each_scenario(Opts0, [Scenario | Rest]) ->
     %% notes. `run_standalone/1`'s "exactly one server" check then
     %% catches the case where the user-requested server got filtered
     %% out, instead of starting a listener that 404s every request.
-    Opts1 = preflight_protocol(Opts0#{scenario := Scenario}),
+    %%
+    %% `Opts0` keeps the parsed `scenarios :: [atom()]` input list
+    %% unchanged across iterations. Each iteration adds the singular
+    %% `scenario :: atom()` key — the current value — so downstream
+    %% pattern-matches (`preflight_scenario`, `start_server`,
+    %% `scenario_path`, `build_request`, etc.) keep reading a single
+    %% atom from `scenario` exactly as they did before multi-scenario
+    %% support landed.
+    Opts1 = preflight_protocol(Opts0#{scenario => Scenario}),
     Opts = preflight_scenario(Opts1),
     case maps:get(standalone, Opts, false) of
         true ->
@@ -150,9 +158,9 @@ run_each_scenario(Opts0, [Scenario | Rest]) ->
 
 %% Single-scenario invocations keep the existing one-shot output
 %% verbatim. Multi-scenario runs prefix each iteration with a divider so
-%% the stacked tables are scannable. The match looks at the original
-%% parsed `scenario` list (pre-iteration override) to decide.
-maybe_print_scenario_divider(#{scenario := [_]}, _Scenario) ->
+%% the stacked tables are scannable. The match looks at the parsed
+%% `scenarios` list, not the per-iteration `scenario` atom.
+maybe_print_scenario_divider(#{scenarios := [_]}, _Scenario) ->
     ok;
 maybe_print_scenario_divider(_Opts, Scenario) ->
     io:format("~n==== scenario: ~s ====~n", [Scenario]).
@@ -245,7 +253,7 @@ filter_servers(Scenario, Drop, Servers, Opts, Reason) ->
     case Filtered =/= Servers of
         true ->
             io:format(
-                "note: --scenario ~p — ~p filtered out (~s)~n",
+                "note: --scenarios ~p — ~p filtered out (~s)~n",
                 [Scenario, Drop, Reason]
             );
         false ->
@@ -305,18 +313,18 @@ cli() ->
             """,
         arguments => [
             #{
-                name => scenario,
-                long => "-scenario",
+                name => scenarios,
+                long => "-scenarios",
                 type => {custom, fun parse_scenarios/1},
                 default => [?DEFAULT_SCENARIO],
                 help =>
                     """
                     Comma-separated list of scenarios to run sequentially
-                    (e.g. `--scenario hello,echo,large_response`). Each is
-                    run in its own server-up / load / server-down cycle, in
-                    the order given. Single-scenario invocations (e.g.
-                    `--scenario hello`) keep the existing one-shot output
-                    shape.
+                    (e.g. `--scenarios hello,echo,large_response`). Each
+                    is run in its own server-up / load / server-down
+                    cycle, in the order given. Single-scenario
+                    invocations (e.g. `--scenarios hello`) keep the
+                    existing one-shot output shape.
 
                     hello:          GET / with 1 header, 7-byte body. Bare-minimum
                                     HTTP cost.
@@ -797,10 +805,10 @@ parse_args(Argv) ->
     ProgOpts = #{progname => "bench.escript"},
     case argparse:parse(Argv, Cli, ProgOpts) of
         {ok, Parsed, _Path, _Cmd} ->
-            %% `--scenario` and `--servers` use `{custom, fun}` types so
-            %% argparse has already run `parse_scenarios/1` /
+            %% `--scenarios` and `--servers` use `{custom, fun}` types
+            %% so argparse has already run `parse_scenarios/1` /
             %% `parse_servers/1` on user input; defaults are likewise
-            %% pre-parsed (list of atoms). No post-process needed here.
+            %% pre-parsed (list of atoms). No post-process needed.
             Parsed;
         {error, Reason} ->
             io:format(standard_error, "~s~n~n", [argparse:format_error(Reason)]),
@@ -815,10 +823,10 @@ parse_args(Argv) ->
 parse_servers(Str) ->
     parse_known_atoms(Str, ?KNOWN_SERVERS, "servers").
 
-%% Same shape for `--scenario` — comma-separated list validated against
-%% `?KNOWN_SCENARIOS`. Single-value input (e.g. `--scenario hello`)
-%% returns a 1-element list and runs the existing single-scenario flow
-%% unchanged.
+%% Same shape for `--scenarios` — comma-separated list validated
+%% against `?KNOWN_SCENARIOS`. Single-value input (e.g.
+%% `--scenarios hello`) returns a 1-element list and runs the existing
+%% single-scenario flow unchanged.
 parse_scenarios(Str) ->
     parse_known_atoms(Str, ?KNOWN_SCENARIOS, "scenarios").
 
@@ -2701,12 +2709,12 @@ build_request(streaming_response) ->
     %% keep-alive decision), which the bench's keep-alive loop
     %% can't reuse — limit this scenario to h2.
     io:format(standard_error,
-        "error: --scenario streaming_response is h2-only "
+        "error: --scenarios streaming_response is h2-only "
         "(use --protocol h2)~n", []),
     halt(2);
 build_request(multi_stream_h2) ->
     io:format(standard_error,
-        "error: --scenario multi_stream_h2 is h2-only "
+        "error: --scenarios multi_stream_h2 is h2-only "
         "(use --protocol h2)~n", []),
     halt(2);
 build_request(large_post_streaming) ->
@@ -2739,7 +2747,7 @@ build_request(small_chunked_response) ->
     %% close the conn per-request, breaking the bench's keep-alive
     %% loop. h2-only.
     io:format(standard_error,
-        "error: --scenario small_chunked_response is h2-only "
+        "error: --scenarios small_chunked_response is h2-only "
         "(use --protocol h2)~n", []),
     halt(2);
 build_request(head_method) ->
@@ -2751,7 +2759,7 @@ build_request(cookies_heavy) ->
 build_request(tls_handshake_throughput) ->
     %% h2-only scenario — handshake dominates, only meaningful over TLS.
     io:format(standard_error,
-        "error: --scenario tls_handshake_throughput is h2-only "
+        "error: --scenarios tls_handshake_throughput is h2-only "
         "(use --protocol h2)~n", []),
     halt(2);
 build_request(multi_request_body) ->
@@ -3163,7 +3171,7 @@ h2_request_shape(pipelined_h1) ->
     %% h2 already multiplexes — pipelining is an h1 wire concept
     %% with no analogue in h2 (use `multi_stream_h2` instead).
     io:format(standard_error,
-        "error: --scenario pipelined_h1 is h1-only "
+        "error: --scenarios pipelined_h1 is h1-only "
         "(use --protocol h1; for h2 multiplexing see multi_stream_h2)~n", []),
     halt(2);
 h2_request_shape(slow_client) ->
@@ -3171,7 +3179,7 @@ h2_request_shape(slow_client) ->
     %% framed wire format makes incremental delivery a different
     %% (and less interesting) test.
     io:format(standard_error,
-        "error: --scenario slow_client is h1-only "
+        "error: --scenarios slow_client is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(connection_storm) ->
@@ -3180,7 +3188,7 @@ h2_request_shape(connection_storm) ->
     %% point is keep-alive multiplexing — a "storm" of fresh h2
     %% conns is anti-h2 and not a real-world workload.
     io:format(standard_error,
-        "error: --scenario connection_storm is h1-only "
+        "error: --scenarios connection_storm is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(mixed_workload) ->
@@ -3189,7 +3197,7 @@ h2_request_shape(mixed_workload) ->
     %% client — out of scope for this scenario, which targets the
     %% h1 router under varied dispatch.
     io:format(standard_error,
-        "error: --scenario mixed_workload is h1-only "
+        "error: --scenarios mixed_workload is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(post_4kb_form) ->
@@ -3197,7 +3205,7 @@ h2_request_shape(post_4kb_form) ->
     %% for this scenario, which targets the h1 body-read +
     %% qs:parse path under realistic body sizes.
     io:format(standard_error,
-        "error: --scenario post_4kb_form is h1-only "
+        "error: --scenarios post_4kb_form is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(large_post_streaming) ->
@@ -3206,7 +3214,7 @@ h2_request_shape(large_post_streaming) ->
     %% h2 is a separate scenario worth adding later but the
     %% current focus is the h1 body-state machine.
     io:format(standard_error,
-        "error: --scenario large_post_streaming is h1-only "
+        "error: --scenarios large_post_streaming is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(router_404_storm) ->
@@ -3214,7 +3222,7 @@ h2_request_shape(router_404_storm) ->
     %% h2 conns + per-conn TLS handshake would obscure the
     %% router-miss cost we're trying to surface. h1-only.
     io:format(standard_error,
-        "error: --scenario router_404_storm is h1-only "
+        "error: --scenarios router_404_storm is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(varied_paths_router) ->
@@ -3222,7 +3230,7 @@ h2_request_shape(varied_paths_router) ->
     %% shapes through the bench client — out of scope for this
     %% scenario.
     io:format(standard_error,
-        "error: --scenario varied_paths_router is h1-only "
+        "error: --scenarios varied_paths_router is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(gzip_response) ->
@@ -3231,7 +3239,7 @@ h2_request_shape(gzip_response) ->
     %% for this scenario, which targets the h1 compress-middleware
     %% path specifically.
     io:format(standard_error,
-        "error: --scenario gzip_response is h1-only "
+        "error: --scenarios gzip_response is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(backpressure_sustained) ->
@@ -3239,7 +3247,7 @@ h2_request_shape(backpressure_sustained) ->
     %% h2 equivalent (multi_stream_h2 + low MAX_CONCURRENT_STREAMS)
     %% is a different scenario worth its own design. h1-only here.
     io:format(standard_error,
-        "error: --scenario backpressure_sustained is h1-only "
+        "error: --scenarios backpressure_sustained is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(server_sent_events) ->
@@ -3247,28 +3255,28 @@ h2_request_shape(server_sent_events) ->
     %% bench-client side hasn't been wired for streaming response
     %% reads. Out of scope for now.
     io:format(standard_error,
-        "error: --scenario server_sent_events is h1-only "
+        "error: --scenarios server_sent_events is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(expect_100_continue) ->
     %% h2 has no Expect: 100-continue equivalent (see RFC 9113 §8.5).
     %% h1-only scenario.
     io:format(standard_error,
-        "error: --scenario expect_100_continue is h1-only "
+        "error: --scenarios expect_100_continue is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(large_keepalive_session) ->
     %% h2 has no per-conn-request count limit at the protocol layer
     %% (per-stream limits are different); h1-only scenario.
     io:format(standard_error,
-        "error: --scenario large_keepalive_session is h1-only "
+        "error: --scenarios large_keepalive_session is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(websocket_msg_throughput) ->
     %% RFC 8441 (h2 + WS) is out of scope for this scenario;
     %% bench-client side hasn't been wired for h2 WS frames.
     io:format(standard_error,
-        "error: --scenario websocket_msg_throughput is h1-only "
+        "error: --scenarios websocket_msg_throughput is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(url_with_qs) ->
@@ -3277,7 +3285,7 @@ h2_request_shape(url_with_qs) ->
     %% follow-up scenario but out of scope here, which targets
     %% the h1 URL-side qs:parse path specifically.
     io:format(standard_error,
-        "error: --scenario url_with_qs is h1-only "
+        "error: --scenarios url_with_qs is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(small_chunked_response) ->
@@ -3286,7 +3294,7 @@ h2_request_shape(accept_storm_burst) ->
     %% h2 conns require TLS handshake which dominates burst cost;
     %% backlog under burst is an h1-flavored question.
     io:format(standard_error,
-        "error: --scenario accept_storm_burst is h1-only "
+        "error: --scenarios accept_storm_burst is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(head_method) ->
@@ -3297,14 +3305,14 @@ h2_request_shape(etag_304) ->
     %% intentionally. h2 support is a small follow-up but out of
     %% scope here.
     io:format(standard_error,
-        "error: --scenario etag_304 is h1-only "
+        "error: --scenarios etag_304 is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(partial_body_drop) ->
     %% h2 has its own truncation semantics (RST_STREAM); the h1
     %% Content-Length-mismatch path is what this scenario targets.
     io:format(standard_error,
-        "error: --scenario partial_body_drop is h1-only "
+        "error: --scenarios partial_body_drop is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(cookies_heavy) ->
@@ -3319,32 +3327,32 @@ h2_request_shape(multi_request_body) ->
         binary:copy(~"x", 4096)};
 h2_request_shape(path_with_unicode) ->
     io:format(standard_error,
-        "error: --scenario path_with_unicode is h1-only "
+        "error: --scenarios path_with_unicode is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(cors_preflight) ->
     %% h2 client doesn't support OPTIONS preflight (it bypasses
     %% CORS via origin negotiation); h1-only.
     io:format(standard_error,
-        "error: --scenario cors_preflight is h1-only "
+        "error: --scenarios cors_preflight is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(chunked_request_body) ->
     %% h2 has its own framing (DATA frames); chunked is h1-specific.
     io:format(standard_error,
-        "error: --scenario chunked_request_body is h1-only "
+        "error: --scenarios chunked_request_body is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(redirect_response) ->
     %% Bench h2 client only accepts :status = 200; 302 would
     %% short-circuit to bad_status. h2 follow-up.
     io:format(standard_error,
-        "error: --scenario redirect_response is h1-only "
+        "error: --scenarios redirect_response is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(compressed_request_body) ->
     io:format(standard_error,
-        "error: --scenario compressed_request_body is h1-only "
+        "error: --scenarios compressed_request_body is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(headers_heavy) ->
@@ -3361,14 +3369,14 @@ h2_request_shape(httparena_baseline) ->
     %% h2 variant is meaningful but out of scope for the first round;
     %% this scenario mirrors HttpArena's h1 baseline profile.
     io:format(standard_error,
-        "error: --scenario httparena_baseline is h1-only "
+        "error: --scenarios httparena_baseline is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(httparena_json) ->
     %% h2 variant is meaningful but out of scope for the first round;
     %% this scenario mirrors HttpArena's h1 json profile.
     io:format(standard_error,
-        "error: --scenario httparena_json is h1-only "
+        "error: --scenarios httparena_json is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(httparena_upload_20mb_auto) ->
@@ -3376,12 +3384,12 @@ h2_request_shape(httparena_upload_20mb_auto) ->
     %% flow control); a 20 MB POST over h2 is a separate scenario worth
     %% adding later. h1-only here.
     io:format(standard_error,
-        "error: --scenario httparena_upload_20mb_auto is h1-only "
+        "error: --scenarios httparena_upload_20mb_auto is h1-only "
         "(use --protocol h1)~n", []),
     halt(2);
 h2_request_shape(httparena_upload_20mb_manual) ->
     io:format(standard_error,
-        "error: --scenario httparena_upload_20mb_manual is h1-only "
+        "error: --scenarios httparena_upload_20mb_manual is h1-only "
         "(use --protocol h1)~n", []),
     halt(2).
 

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -198,7 +198,7 @@ maybe_print_protocol_divider(#{protocols := [_]}, _Protocol) ->
 maybe_print_protocol_divider(_Opts, Protocol) ->
     io:format("~n======== protocol: ~s ========~n", [Protocol]).
 
-%% Resolve the `--protocol` sentinel `all` (default when the flag is
+%% Resolve the `--protocols` sentinel `all` (default when the flag is
 %% omitted) to `?KNOWN_PROTOCOLS`. Explicit picks pass through.
 expand_protocols(all) ->
     ?KNOWN_PROTOCOLS;

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -57,61 +57,34 @@
 %% `start_server/2` (plus any `scenario_*` config helpers below).
 -define(KNOWN_SERVERS, [roadrunner, cowboy, elli]).
 
-%% Scenarios known to the bench. `--scenarios` accepts a
-%% comma-separated list (mirroring `--servers`), so each value in the
-%% user's input must validate against this set. Adding a new scenario
-%% requires appending it here, adding a `preflight_scenario/1` clause
-%% if any servers should be filtered, and wiring `scenario_path/1` /
-%% `build_request/N` / `start_server/2` for it.
--define(KNOWN_SCENARIOS, [
+%% Scenarios are partitioned by protocol compatibility. Each scenario
+%% name lives in exactly one of these three macros; adding a new
+%% scenario means picking the right one and wiring the matching
+%% `preflight_scenario/1` clause, `scenario_path/1`, `build_request/N`,
+%% and `start_server/2` bits below. `?KNOWN_SCENARIOS` is the
+%% concatenation, used by `parse_known_atoms/3` for input validation —
+%% the compiler folds the constant-list concatenation, so there's no
+%% runtime cost.
+
+%% Scenarios that run on any wire protocol — their workload doesn't
+%% touch protocol-specific shape, so they survive any future
+%% `?KNOWN_PROTOCOLS` addition without code changes.
+-define(PROTOCOL_AGNOSTIC_SCENARIOS, [
     hello,
     echo,
     large_response,
     json,
     headers_heavy,
-    streaming_response,
-    multi_stream_h2,
-    pipelined_h1,
-    slow_client,
-    connection_storm,
-    mixed_workload,
-    post_4kb_form,
-    large_post_streaming,
-    router_404_storm,
-    varied_paths_router,
-    gzip_response,
-    backpressure_sustained,
-    server_sent_events,
-    expect_100_continue,
-    large_keepalive_session,
-    websocket_msg_throughput,
-    url_with_qs,
-    small_chunked_response,
-    accept_storm_burst,
     head_method,
-    etag_304,
-    partial_body_drop,
     cookies_heavy,
-    tls_handshake_throughput,
-    multi_request_body,
-    path_with_unicode,
-    cors_preflight,
-    chunked_request_body,
-    redirect_response,
-    compressed_request_body,
-    httparena_baseline,
-    httparena_json,
-    httparena_upload_20mb_auto,
-    httparena_upload_20mb_manual
+    multi_request_body
 ]).
 
 %% Scenarios that only make sense over HTTP/1.1 — the listener fixture
 %% or the workload itself depends on h1-specific shape (pipelining,
-%% Connection: close storms, etc.). When `--scenarios all` is paired
-%% with `--protocol h2`, these get filtered out. Mirrors the
+%% Connection: close storms, etc.). Mirrors the
 %% `"error: --scenarios X is h1-only ..."` preflight checks at the
-%% per-scenario h2-workload sites — keep in sync when adding a new
-%% h1-only scenario.
+%% per-scenario h2-workload sites.
 -define(H1_ONLY_SCENARIOS, [
     pipelined_h1,
     slow_client,
@@ -151,6 +124,10 @@
     small_chunked_response,
     tls_handshake_throughput
 ]).
+
+-define(KNOWN_SCENARIOS,
+    ?PROTOCOL_AGNOSTIC_SCENARIOS ++ ?H1_ONLY_SCENARIOS ++ ?H2_ONLY_SCENARIOS
+).
 
 main(Args) ->
     Opts0 = parse_args(Args),

--- a/scripts/bench_matrix.sh
+++ b/scripts/bench_matrix.sh
@@ -124,7 +124,7 @@ if [[ "$SKIP_BENCH" != "1" ]]; then
       echo "[$idx/$total] $s ($p)"
       for run in $(seq 1 "$RUNS"); do
         out=$(mise exec -- "$REPO_ROOT/scripts/bench.escript" \
-          --scenarios "$s" --protocol "$p" \
+          --scenarios "$s" --protocols "$p" \
           --duration "$DURATION" --warmup "$WARMUP" --clients "$CLIENTS" \
           --servers roadrunner,cowboy,elli 2>&1)
         printf '===== %s | %s | run %s =====\n%s\n' "$s" "$p" "$run" "$out" >> "$LOG"

--- a/scripts/bench_matrix.sh
+++ b/scripts/bench_matrix.sh
@@ -124,7 +124,7 @@ if [[ "$SKIP_BENCH" != "1" ]]; then
       echo "[$idx/$total] $s ($p)"
       for run in $(seq 1 "$RUNS"); do
         out=$(mise exec -- "$REPO_ROOT/scripts/bench.escript" \
-          --scenario "$s" --protocol "$p" \
+          --scenarios "$s" --protocol "$p" \
           --duration "$DURATION" --warmup "$WARMUP" --clients "$CLIENTS" \
           --servers roadrunner,cowboy,elli 2>&1)
         printf '===== %s | %s | run %s =====\n%s\n' "$s" "$p" "$run" "$out" >> "$LOG"

--- a/scripts/wrk2_bench.sh
+++ b/scripts/wrk2_bench.sh
@@ -231,8 +231,11 @@ ROWS_FILE="$WORK_DIR/rows.tsv"
 start_standalone() {
     # args: server scenario port_file_path
     local server="$1" scenario="$2" port_file="$3"
+    # `--protocols h1` is required since bench.escript defaults
+    # `--protocols` to all known and `--standalone` rejects
+    # multi-protocol input. wrk2 is h1-only anyway (see top of file).
     "$PROJECT_DIR/scripts/bench.escript" --standalone \
-        --scenarios "$scenario" --servers "$server" \
+        --scenarios "$scenario" --protocols h1 --servers "$server" \
         --port-file "$port_file" >"$WORK_DIR/$server.$scenario.standalone.log" 2>&1 &
     STANDALONE_PID=$!
     local i

--- a/scripts/wrk2_bench.sh
+++ b/scripts/wrk2_bench.sh
@@ -38,8 +38,8 @@
 # Usage:
 #   ./scripts/wrk2_bench.sh                     # full matrix
 #   ./scripts/wrk2_bench.sh --quick             # --runs 1, dev iteration
-#   ./scripts/wrk2_bench.sh --scenario hello    # one scenario only
-#   ./scripts/wrk2_bench.sh --scenario hello,echo
+#   ./scripts/wrk2_bench.sh --scenarios hello    # one scenario only
+#   ./scripts/wrk2_bench.sh --scenarios hello,echo
 #   ./scripts/wrk2_bench.sh --server roadrunner # one server only
 #   ./scripts/wrk2_bench.sh --runs 5 --duration 90
 #   ./scripts/wrk2_bench.sh --threads 16 --conns 100
@@ -63,7 +63,7 @@ WRK2_IMAGE="${WRK2_IMAGE:-cylab/wrk2:latest}"
 # Parse args.
 while [ $# -gt 0 ]; do
     case "$1" in
-        --scenario)   SCENARIO="$2"; shift 2 ;;
+        --scenarios)  SCENARIO="$2"; shift 2 ;;
         --server)     SERVER_FILTER="$2"; shift 2 ;;
         --servers)    SERVER_FILTER="$2"; shift 2 ;;
         --runs)       RUNS="$2"; shift 2 ;;
@@ -192,8 +192,8 @@ command -v docker >/dev/null 2>&1 || {
     exit 2
 }
 
-# Optional filters. `--scenario` accepts a comma-separated list so a
-# small subset can be targeted, e.g. `--scenario hello,echo`.
+# Optional filters. `--scenarios` accepts a comma-separated list so a
+# small subset can be targeted, e.g. `--scenarios hello,echo`.
 if [ -n "$SCENARIO" ]; then
     IFS=',' read -ra SCENARIOS <<< "$SCENARIO"
     for s in "${SCENARIOS[@]}"; do
@@ -232,7 +232,7 @@ start_standalone() {
     # args: server scenario port_file_path
     local server="$1" scenario="$2" port_file="$3"
     "$PROJECT_DIR/scripts/bench.escript" --standalone \
-        --scenario "$scenario" --servers "$server" \
+        --scenarios "$scenario" --servers "$server" \
         --port-file "$port_file" >"$WORK_DIR/$server.$scenario.standalone.log" 2>&1 &
     STANDALONE_PID=$!
     local i

--- a/test/roadrunner_bench_cookies_handler.erl
+++ b/test/roadrunner_bench_cookies_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cookies_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario cookies_heavy`.
+Roadrunner handler for `scripts/bench.escript --scenarios cookies_heavy`.
 
 Calls `roadrunner_req:parse_cookies/1` and returns the cookie
 count. Tests the cookie-header parser hot path (single `Cookie:`

--- a/test/roadrunner_bench_cors_handler.erl
+++ b/test/roadrunner_bench_cors_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cors_handler).
 -moduledoc """
-Roadrunner CORS preflight handler for `scripts/bench.escript --scenario cors_preflight`.
+Roadrunner CORS preflight handler for `scripts/bench.escript --scenarios cors_preflight`.
 
 Responds to OPTIONS /api with `204 No Content` + CORS allow-headers.
 The browser sends this preflight before any actual cross-origin

--- a/test/roadrunner_bench_cowboy_cookies_handler.erl
+++ b/test/roadrunner_bench_cowboy_cookies_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_cookies_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario cookies_heavy`.
+Cowboy handler for `scripts/bench.escript --scenarios cookies_heavy`.
 
 Mirror of `roadrunner_bench_cookies_handler` — parses the request's
 cookies via `cowboy_req:parse_cookies/1` and returns the cookie

--- a/test/roadrunner_bench_cowboy_cors_handler.erl
+++ b/test/roadrunner_bench_cowboy_cors_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_cors_handler).
 -moduledoc """
-Cowboy CORS preflight handler for `scripts/bench.escript --scenario cors_preflight`.
+Cowboy CORS preflight handler for `scripts/bench.escript --scenarios cors_preflight`.
 
 Mirror of `roadrunner_bench_cors_handler`: returns 204 + CORS
 allow-headers.

--- a/test/roadrunner_bench_cowboy_drain_handler.erl
+++ b/test/roadrunner_bench_cowboy_drain_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_drain_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario large_post_streaming`.
+Cowboy handler for `scripts/bench.escript --scenarios large_post_streaming`.
 
 Mirror of `roadrunner_bench_drain_handler`: loops
 `cowboy_req:read_body/1` until the body is fully drained, then

--- a/test/roadrunner_bench_cowboy_echo_handler.erl
+++ b/test/roadrunner_bench_cowboy_echo_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_echo_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario echo`.
+Cowboy handler for `scripts/bench.escript --scenarios echo`.
 
 Mirror of `roadrunner_bench_echo_handler` for cowboy: reads the
 request body and echoes it back. Body is read via

--- a/test/roadrunner_bench_cowboy_etag_handler.erl
+++ b/test/roadrunner_bench_cowboy_etag_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_etag_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario etag_304`.
+Cowboy handler for `scripts/bench.escript --scenarios etag_304`.
 
 Mirror of `roadrunner_bench_etag_handler`: returns 304 when the
 request's If-None-Match matches `\"v1\"`, else 200 with body.

--- a/test/roadrunner_bench_cowboy_form_handler.erl
+++ b/test/roadrunner_bench_cowboy_form_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_form_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario post_4kb_form`.
+Cowboy handler for `scripts/bench.escript --scenarios post_4kb_form`.
 
 Mirror of `roadrunner_bench_form_handler` for cowboy: reads the
 form body via `cowboy_req:read_urlencoded_body/1` (which both reads

--- a/test/roadrunner_bench_cowboy_gzip_handler.erl
+++ b/test/roadrunner_bench_cowboy_gzip_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_gzip_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario gzip_response`.
+Cowboy handler for `scripts/bench.escript --scenarios gzip_response`.
 
 Mirror of `roadrunner_bench_gzip_handler` for cowboy. Compression
 is applied by `cowboy_compress_h` configured in the listener's

--- a/test/roadrunner_bench_cowboy_json_handler.erl
+++ b/test/roadrunner_bench_cowboy_json_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_json_handler).
 -moduledoc """
-Cowboy JSON handler for `scripts/bench.escript --scenario json`.
+Cowboy JSON handler for `scripts/bench.escript --scenarios json`.
 
 Mirrors `roadrunner_bench_json_handler` so cowboy and roadrunner
 return the same wire bytes for the `json` scenario.

--- a/test/roadrunner_bench_cowboy_large_handler.erl
+++ b/test/roadrunner_bench_cowboy_large_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_large_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario large_response`.
+Cowboy handler for `scripts/bench.escript --scenarios large_response`.
 
 Mirror of `roadrunner_bench_large_handler` for cowboy: returns a
 64 KB `application/octet-stream` body. Body is cached in

--- a/test/roadrunner_bench_cowboy_redirect_handler.erl
+++ b/test/roadrunner_bench_cowboy_redirect_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_redirect_handler).
 -moduledoc """
-Cowboy redirect handler for `scripts/bench.escript --scenario redirect_response`.
+Cowboy redirect handler for `scripts/bench.escript --scenarios redirect_response`.
 
 Mirror of `roadrunner_bench_redirect_handler`: 302 + Location.
 """.

--- a/test/roadrunner_bench_cowboy_small_chunks_handler.erl
+++ b/test/roadrunner_bench_cowboy_small_chunks_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_small_chunks_handler).
 -moduledoc """
-Cowboy streaming handler for `scripts/bench.escript --scenario small_chunked_response`.
+Cowboy streaming handler for `scripts/bench.escript --scenarios small_chunked_response`.
 
 Mirrors `roadrunner_bench_small_chunks_handler`: streams 100 × 64-byte
 chunks via `cowboy_req:stream_body/3`.

--- a/test/roadrunner_bench_cowboy_sse_handler.erl
+++ b/test/roadrunner_bench_cowboy_sse_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_sse_handler).
 -moduledoc """
-Cowboy loop handler for `scripts/bench.escript --scenario server_sent_events`.
+Cowboy loop handler for `scripts/bench.escript --scenarios server_sent_events`.
 
 Mirror of `roadrunner_bench_sse_handler` for cowboy. Uses the
 `cowboy_loop` behaviour: `init/2` opens a streaming reply and

--- a/test/roadrunner_bench_cowboy_streaming_handler.erl
+++ b/test/roadrunner_bench_cowboy_streaming_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_streaming_handler).
 -moduledoc """
-Cowboy streaming handler for `scripts/bench.escript --scenario streaming_response`.
+Cowboy streaming handler for `scripts/bench.escript --scenarios streaming_response`.
 
 Mirrors `roadrunner_bench_streaming_handler` so the wire bytes match
 across servers: 4 × 4 KB chunks, the last with `fin`.

--- a/test/roadrunner_bench_cowboy_url_qs_handler.erl
+++ b/test/roadrunner_bench_cowboy_url_qs_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_url_qs_handler).
 -moduledoc """
-Cowboy handler for `scripts/bench.escript --scenario url_with_qs`.
+Cowboy handler for `scripts/bench.escript --scenarios url_with_qs`.
 
 Mirror of `roadrunner_bench_url_qs_handler`: parses the URL's
 query string via `cowboy_req:parse_qs/1` and returns the pair

--- a/test/roadrunner_bench_cowboy_ws_handler.erl
+++ b/test/roadrunner_bench_cowboy_ws_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_cowboy_ws_handler).
 -moduledoc """
-Cowboy WebSocket echo handler for `scripts/bench.escript --scenario
+Cowboy WebSocket echo handler for `scripts/bench.escript --scenarios
 websocket_msg_throughput`.
 
 Mirror of `roadrunner_ws_echo_handler`'s behavior: echoes any text

--- a/test/roadrunner_bench_drain_handler.erl
+++ b/test/roadrunner_bench_drain_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_drain_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario large_post_streaming`.
+Roadrunner handler for `scripts/bench.escript --scenarios large_post_streaming`.
 
 Manual-mode body read: loops `roadrunner_req:read_body/2` with
 `length => 64 KB` until the body is fully drained, then returns a

--- a/test/roadrunner_bench_echo_handler.erl
+++ b/test/roadrunner_bench_echo_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_echo_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario echo`.
+Roadrunner handler for `scripts/bench.escript --scenarios echo`.
 
 Reads the request body (delivered via auto buffering) and echoes it
 back in the response with `Content-Type: application/octet-stream`.

--- a/test/roadrunner_bench_etag_handler.erl
+++ b/test/roadrunner_bench_etag_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_etag_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario etag_304`.
+Roadrunner handler for `scripts/bench.escript --scenarios etag_304`.
 
 Conditional GET: when `If-None-Match: "v1"` matches the server's
 fixed ETag, returns `304 Not Modified` with no body. Otherwise

--- a/test/roadrunner_bench_form_handler.erl
+++ b/test/roadrunner_bench_form_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_form_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario post_4kb_form`.
+Roadrunner handler for `scripts/bench.escript --scenarios post_4kb_form`.
 
 Reads a `application/x-www-form-urlencoded` body, parses it via
 `roadrunner_qs:parse/1`, and returns a small `200 ok` ack with the

--- a/test/roadrunner_bench_gzip_handler.erl
+++ b/test/roadrunner_bench_gzip_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_gzip_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario gzip_response`.
+Roadrunner handler for `scripts/bench.escript --scenarios gzip_response`.
 
 Returns a 16 KB JSON-shaped body. Above the 860-byte threshold of
 `roadrunner_compress`, well-compressible (repeating record shape)

--- a/test/roadrunner_bench_httparena_baseline_handler.erl
+++ b/test/roadrunner_bench_httparena_baseline_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_httparena_baseline_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario httparena_baseline`.
+Roadrunner handler for `scripts/bench.escript --scenarios httparena_baseline`.
 
 Mirrors HttpArena's `baseline` profile: `GET /baseline11?a=I&b=I`
 returns plaintext `integer_to_binary(A + B)`. Exercises query-string

--- a/test/roadrunner_bench_httparena_json_handler.erl
+++ b/test/roadrunner_bench_httparena_json_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_httparena_json_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario httparena_json`.
+Roadrunner handler for `scripts/bench.escript --scenarios httparena_json`.
 
 Mirrors HttpArena's `json` profile: `GET /httparena_json/:count?m=M`
 returns a JSON list of `count` items, each projected with

--- a/test/roadrunner_bench_httparena_upload_handler.erl
+++ b/test/roadrunner_bench_httparena_upload_handler.erl
@@ -1,7 +1,7 @@
 -module(roadrunner_bench_httparena_upload_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario
-httparena_upload_20mb_auto` and `--scenario
+Roadrunner handler for `scripts/bench.escript --scenarios
+httparena_upload_20mb_auto` and `--scenarios
 httparena_upload_20mb_manual`.
 
 Mirrors HttpArena's `upload` profile: `POST /upload` returns the

--- a/test/roadrunner_bench_json_handler.erl
+++ b/test/roadrunner_bench_json_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_json_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario json`.
+Roadrunner handler for `scripts/bench.escript --scenarios json`.
 
 Returns a fixed JSON body (~120 bytes) with `Content-Type:
 application/json`. The body and `Content-Length` are precomputed at

--- a/test/roadrunner_bench_large_handler.erl
+++ b/test/roadrunner_bench_large_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_large_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario large_response`.
+Roadrunner handler for `scripts/bench.escript --scenarios large_response`.
 
 Returns a 64 KB `application/octet-stream` body for `GET /large`.
 The body is computed once via `persistent_term` so the per-request

--- a/test/roadrunner_bench_redirect_handler.erl
+++ b/test/roadrunner_bench_redirect_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_redirect_handler).
 -moduledoc """
-Roadrunner redirect handler for `scripts/bench.escript --scenario redirect_response`.
+Roadrunner redirect handler for `scripts/bench.escript --scenarios redirect_response`.
 
 Returns 302 with `Location: /target`. Common pattern for login
 flows, deprecated-URL forwarding, etc.

--- a/test/roadrunner_bench_small_chunks_handler.erl
+++ b/test/roadrunner_bench_small_chunks_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_small_chunks_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario small_chunked_response`.
+Roadrunner handler for `scripts/bench.escript --scenarios small_chunked_response`.
 
 Streams 100 × 64-byte chunks via `{stream, _, _, Fun}` — distinct
 from `streaming_response`'s 4 × 4 KB. Tests fragmentation overhead

--- a/test/roadrunner_bench_sse_handler.erl
+++ b/test/roadrunner_bench_sse_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_sse_handler).
 -moduledoc """
-Roadrunner SSE handler for `scripts/bench.escript --scenario server_sent_events`.
+Roadrunner SSE handler for `scripts/bench.escript --scenarios server_sent_events`.
 
 Emits 100 small `tick` events as fast as possible, then a comment
 and closes the stream. One bench iteration = one SSE session of

--- a/test/roadrunner_bench_streaming_handler.erl
+++ b/test/roadrunner_bench_streaming_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_streaming_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario streaming_response`.
+Roadrunner handler for `scripts/bench.escript --scenarios streaming_response`.
 
 Returns a `{stream, _, _, Fun}` shape that emits the response body
 in 4 × 4 KB chunks via the `Send/2` callback. Exercises the

--- a/test/roadrunner_bench_url_qs_handler.erl
+++ b/test/roadrunner_bench_url_qs_handler.erl
@@ -1,6 +1,6 @@
 -module(roadrunner_bench_url_qs_handler).
 -moduledoc """
-Roadrunner handler for `scripts/bench.escript --scenario url_with_qs`.
+Roadrunner handler for `scripts/bench.escript --scenarios url_with_qs`.
 
 Calls `roadrunner_req:parse_qs/1` on the URL's query string,
 returns the pair count. Mirrors `roadrunner_bench_form_handler`'s


### PR DESCRIPTION
# Description

Adds an on-demand `Bench` workflow plus the CLI changes that back it.

**Workflow** (`.github/workflows/bench.yml`)

- `workflow_dispatch` only, three inputs: `scenarios`, `protocols`, `duration`
- empty inputs omit the flag so the CLI defaults kick in (omitted = all)
- result table pinned to the run summary
- `bench.log` uploaded as a 90-day artifact (`bench-<run-id>-<attempt>`)

**CLI** (`scripts/bench.escript`)

- `--scenarios`, `--protocols`, `--servers` are all comma-separated lists validated via argparse `{custom, fun}` types
- omitting `--scenarios` or `--protocols` iterates every known value; the iteration drops protocol-incompatible scenarios with a one-line note
- standalone mode rejects multi-scenario / multi-protocol inputs with clean errors

**Caller updates**

- `bench_matrix.sh`, `wrk2_bench.sh`, the wrk2-smoke step in `erlang.yml`, and the test handler moduledocs follow the `--scenario` → `--scenarios` rename

**Behavior shift**: bare `./scripts/bench.escript` used to run the `hello` smoke (~30 s) and now runs every scenario on every protocol (tens of min); single-arg invocations unchanged. A `docs/roadmap.md` entry tracks the artifact-consumer / baseline-diff path as a follow-up.

```
Actions → Bench → Run workflow → leave inputs empty → every cell
./scripts/bench.escript --scenarios hello,echo --protocols h1,h2 → 4 iterations
./scripts/bench.escript --scenarios streaming_response --protocols h1 → halts (h2-only)
gh run download <run-id>  # picks up bench-<run-id>-<attempt>/bench.log
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
