### PR TITLE
Polish public API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Standards conformance:
 - **HTTP/2**: RFC 9113 (frames + multiplexing) + RFC 7541 (HPACK).
   Opt-in per listener via `protocols => [http1, http2]` (or
   `[http2]` for h2c prior-knowledge on plain TCP). Conformance
-  harness: [`scripts/h2spec.sh`](scripts/h2spec.sh) (drives
+  harness: [`scripts/h2spec.sh`](https://github.com/arizona-framework/roadrunner/blob/main/scripts/h2spec.sh) (drives
   [h2spec](https://github.com/summerwind/h2spec)).
 - **Content-Encoding** (RFC 9110 §8.4.1): gzip + deflate with
   qvalue-aware `Accept-Encoding` negotiation (RFC 9110 §12.5.3),
   works unchanged over HTTP/2.
 - **WebSocket**: RFC 6455. Conformance harness:
-  [`scripts/autobahn.escript`](scripts/autobahn.escript) (drives the
+  [`scripts/autobahn.escript`](https://github.com/arizona-framework/roadrunner/blob/main/scripts/autobahn.escript) (drives the
   [Autobahn|Testsuite](https://github.com/crossbario/autobahn-testsuite)
   fuzzingclient).
 - **WebSocket compression**: RFC 7692 `permessage-deflate`,
@@ -55,7 +55,7 @@ Standards conformance:
 
 Median req/s on a 12th-gen i9-12900HX, 50 clients, 5 s warmup + 5 s
 measure, loopback. Full per-protocol grid + p50/p99 + memory shape
-in [`docs/comparison.md`](docs/comparison.md).
+in [`docs/comparison.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/comparison.md).
 
 | scenario                  | roadrunner    | cowboy        | elli          |
 |---------------------------|--------------:|--------------:|--------------:|
@@ -75,8 +75,8 @@ band — the comparison doc has the full honest framing.
 The numbers above are throughput from `scripts/bench.escript`
 (closed-loop). For Coordinated-Omission-corrected tail latency at
 sustained rates (open-loop, via wrk2), see
-[`docs/wrk2_results.md`](docs/wrk2_results.md) and the
-methodology section in [`docs/comparison.md`](docs/comparison.md).
+[`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md);
+the comparison doc has the methodology breakdown.
 
 ## Quickstart
 
@@ -244,17 +244,17 @@ roadrunner:start_listener(my_listener, #{port => 8080, routes => hello_handler})
 
 ## Documentation
 
-- [`docs/comparison.md`](docs/comparison.md) — full side-by-side
+- [`docs/comparison.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/comparison.md) — full side-by-side
   benchmarks vs cowboy and elli (throughput, latency, architectural
   trade-offs, reproduction commands).
-- [`docs/bench_results.md`](docs/bench_results.md) — full per-protocol
+- [`docs/bench_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/bench_results.md) — full per-protocol
   matrix with p50 / p99 across every scenario.
-- [`docs/resource_results.md`](docs/resource_results.md) — memory + CPU
+- [`docs/resource_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/resource_results.md) — memory + CPU
   shape per scenario.
 - [`docs/conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md)
   — the connection-process model trade-offs and the one h2 case
   cowboy still wins.
-- [`docs/roadmap.md`](docs/roadmap.md) — deferred items, with rough
+- [`docs/roadmap.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/roadmap.md) — deferred items, with rough
   effort estimates for each.
 
 ## Design philosophy
@@ -288,7 +288,7 @@ I also accept coffees ☕
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup,
+Contributions are welcome! Please see [CONTRIBUTING.md](https://github.com/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md) for development setup,
 testing guidelines, and contribution workflow.
 
 ### Contributors
@@ -328,4 +328,4 @@ Copyright (c) 2026 [William Fank Thomé](https://github.com/williamthome)
 Roadrunner is open-source under the Apache 2.0 License on
 [GitHub](https://github.com/arizona-framework/roadrunner).
 
-See [LICENSE.md](LICENSE.md) for more information.
+See [LICENSE.md](https://github.com/arizona-framework/roadrunner/blob/main/LICENSE.md) for more information.

--- a/docs/bench_internals.md
+++ b/docs/bench_internals.md
@@ -279,4 +279,6 @@ alongside throughput:
 ```
 
 For hot-path analysis, add `--profile --profile-tool eprof` (or
-`fprof`).
+`fprof`); the workflow established in
+[`conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md)
+applies directly.

--- a/docs/bench_internals.md
+++ b/docs/bench_internals.md
@@ -279,6 +279,4 @@ alongside throughput:
 ```
 
 For hot-path analysis, add `--profile --profile-tool eprof` (or
-`fprof`); the workflow established in
-[`conn_lifecycle_investigation.md`](conn_lifecycle_investigation.md)
-applies directly.
+`fprof`).

--- a/rebar.config
+++ b/rebar.config
@@ -127,7 +127,7 @@
     %% etc.) are implementation detail; their docstrings are
     %% dev-reader narrative, not API contract.
     {filter_modules,
-        "^roadrunner(_(handler|req|resp|router|listener|static|ws|ws_handler|middleware|cookie|qs|uri|sse|multipart))?$"}
+        "^roadrunner(_(handler|req|resp|router|listener|static|ws|ws_handler|middleware|http|cookie|qs|uri|sse|multipart))?$"}
 ]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -123,11 +123,11 @@
     {source_url, "https://github.com/arizona-framework/roadrunner"},
     {prefix_ref_vsn_with_v, false},
     %% Whitelist only public-API modules — internal helpers
-    %% (`roadrunner_conn*`, `roadrunner_http*`, `roadrunner_ws`, etc.)
-    %% are implementation detail; their docstrings are dev-reader
-    %% narrative, not API contract.
+    %% (`roadrunner_conn*`, `roadrunner_http1`, `roadrunner_http2*`,
+    %% etc.) are implementation detail; their docstrings are
+    %% dev-reader narrative, not API contract.
     {filter_modules,
-        "^roadrunner(_(handler|req|resp|router|listener|static|ws_handler|cookie|qs|uri|sse|multipart))?$"}
+        "^roadrunner(_(handler|req|resp|router|listener|static|ws_handler|middleware|cookie|qs|uri|sse|multipart))?$"}
 ]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -127,7 +127,7 @@
     %% etc.) are implementation detail; their docstrings are
     %% dev-reader narrative, not API contract.
     {filter_modules,
-        "^roadrunner(_(handler|req|resp|router|listener|static|ws_handler|middleware|cookie|qs|uri|sse|multipart))?$"}
+        "^roadrunner(_(handler|req|resp|router|listener|static|ws|ws_handler|middleware|cookie|qs|uri|sse|multipart))?$"}
 ]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -108,15 +108,30 @@
 {ex_doc, [
     {extras, [
         "README.md",
-        "CONTRIBUTING.md",
-        "CHANGELOG.md",
-        "LICENSE.md",
         "docs/comparison.md",
         "docs/bench_results.md",
         "docs/bench_internals.md",
         "docs/resource_results.md",
         "docs/wrk2_results.md",
-        "docs/roadmap.md"
+        "CONTRIBUTING.md",
+        "docs/roadmap.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ]},
+    {groups_for_extras, [
+        {<<"Benchmarks">>, [
+            <<"docs/comparison.md">>,
+            <<"docs/bench_results.md">>,
+            <<"docs/bench_internals.md">>,
+            <<"docs/resource_results.md">>,
+            <<"docs/wrk2_results.md">>
+        ]},
+        {<<"Project">>, [
+            <<"CONTRIBUTING.md">>,
+            <<"docs/roadmap.md">>,
+            <<"CHANGELOG.md">>,
+            <<"LICENSE.md">>
+        ]}
     ]},
     {main, "README.md"},
     {api_reference, true},

--- a/src/roadrunner_acceptor.erl
+++ b/src/roadrunner_acceptor.erl
@@ -1,15 +1,15 @@
 -module(roadrunner_acceptor).
--moduledoc """
-Acceptor process — spins on `gen_tcp:accept/1` for a listen socket
-and hands each accepted connection off to a `roadrunner_conn` worker.
+-moduledoc false.
 
-Spawn-linked to the owning `roadrunner_listener`: a listener stop closes
-the listen socket, the acceptor's `accept/1` returns `{error, _}`,
-and the acceptor exits cleanly. Unrelated acceptor crashes propagate
-back via the link, taking the listener down for supervisor restart.
-Connection workers are spawned **without** a link so that a crash
-in one connection does not bring down the acceptor.
-""".
+%% Acceptor process — spins on `gen_tcp:accept/1` for a listen socket
+%% and hands each accepted connection off to a `roadrunner_conn` worker.
+%%
+%% Spawn-linked to the owning `roadrunner_listener`: a listener stop closes
+%% the listen socket, the acceptor's `accept/1` returns `{error, _}`,
+%% and the acceptor exits cleanly. Unrelated acceptor crashes propagate
+%% back via the link, taking the listener down for supervisor restart.
+%% Connection workers are spawned **without** a link so that a crash
+%% in one connection does not bring down the acceptor.
 
 -export([start_link/3]).
 

--- a/src/roadrunner_app.erl
+++ b/src/roadrunner_app.erl
@@ -1,9 +1,5 @@
-%%%-------------------------------------------------------------------
-%% @doc roadrunner public API
-%% @end
-%%%-------------------------------------------------------------------
-
 -module(roadrunner_app).
+-moduledoc false.
 
 -behaviour(application).
 
@@ -16,5 +12,3 @@ start(_StartType, _StartArgs) ->
 -spec stop(term()) -> ok.
 stop(_State) ->
     ok.
-
-%% internal functions

--- a/src/roadrunner_bin.erl
+++ b/src/roadrunner_bin.erl
@@ -1,13 +1,13 @@
 -module(roadrunner_bin).
--moduledoc """
-Binary-level helpers — operations on `binary()` that several
-modules need but don't belong to any specific protocol module
-(`roadrunner_http1`, `roadrunner_ws`, `roadrunner_uri`, etc.).
+-moduledoc false.
 
-Mirrors OTP's stdlib `binary` module in spirit: things that work
-on bytes, with no protocol semantics. Don't put non-binary helpers
-here — give them their own module.
-""".
+%% Binary-level helpers — operations on `binary()` that several
+%% modules need but don't belong to any specific protocol module
+%% (`roadrunner_http1`, `roadrunner_ws`, `roadrunner_uri`, etc.).
+%%
+%% Mirrors OTP's stdlib `binary` module in spirit: things that work
+%% on bytes, with no protocol semantics. Don't put non-binary helpers
+%% here — give them their own module.
 
 -export([ascii_lowercase/1, trim_ows/1, trim_trailing_ows/1]).
 

--- a/src/roadrunner_compress.erl
+++ b/src/roadrunner_compress.erl
@@ -1,63 +1,63 @@
 -module(roadrunner_compress).
--moduledoc """
-Response-compression middleware. Supports `gzip` and `deflate`
-Content-Encoding per RFC 9110 §8.4.1.
+-moduledoc false.
 
-Add to a listener's `middlewares` opt (or a route's `route_opts.middlewares`)
-to compress eligible response bodies based on the request's `Accept-Encoding`
-header. Replaces cowboy's deprecated `cowboy_compress_h` stream handler
-for arizona's migration.
-
-```erlang
-roadrunner_listener:start_link(my_app, #{
-    port => 8080,
-    routes => Routes,
-    middlewares => [roadrunner_compress]
-}).
-```
-
-A response is compressed when **all** of these are true:
-
-- The client's `Accept-Encoding` header includes `gzip` or `deflate`
-  (substring match per token; qvalue ranking is a follow-up).
-- The handler's response does not already carry a `Content-Encoding`
-  header (i.e. it isn't already compressed).
-- The body is at least `?THRESHOLD` bytes (default 860 — same as
-  cowboy's default; below this the compression overhead outweighs
-  the bandwidth saving).
-
-When compressed:
-
-- `Content-Encoding: gzip` (or `deflate`) is added.
-- `Content-Length` is rewritten to the compressed size.
-- `Vary: Accept-Encoding` is added.
-
-When not compressed (body too small, client doesn't accept any
-supported encoding, or response already encoded), the response
-passes through unchanged **except** that `Vary: Accept-Encoding` is
-added if the client indicated a supported encoding — caches that
-key on this header will then handle the next variant correctly.
-
-## Encoding selection
-
-When the client accepts both gzip and deflate, **gzip wins**. gzip has
-a more deterministic on-the-wire format (RFC 1952) and broader
-client tolerance than `Content-Encoding: deflate` — historically
-some servers shipped raw deflate (RFC 1951) instead of the
-zlib-wrapped form RFC 9110 §8.4.1.3 mandates (RFC 1950), and a
-handful of older clients still ship workarounds for both shapes.
-gzip avoids the question.
-
-## What this does NOT cover
-
-- **`{loop, ...}` and `{websocket, ...}` returns** — passed through;
-  these aren't HTTP body responses.
-- **Brotli (`br`) Content-Encoding** — would require a NIF dep
-  (`brotli`); deferred until there's user pull.
-- **Qvalue-aware Accept-Encoding parsing** — current implementation
-  is substring-match per token; treats `gzip;q=0` as "accepts gzip"
-  (a real conformance bug). Tracked separately.
-""".
+%% Response-compression middleware. Supports `gzip` and `deflate`
+%% Content-Encoding per RFC 9110 §8.4.1.
+%%
+%% Add to a listener's `middlewares` opt (or a route's `route_opts.middlewares`)
+%% to compress eligible response bodies based on the request's `Accept-Encoding`
+%% header. Replaces cowboy's deprecated `cowboy_compress_h` stream handler
+%% for arizona's migration.
+%%
+%% ```erlang
+%% roadrunner_listener:start_link(my_app, #{
+%%     port => 8080,
+%%     routes => Routes,
+%%     middlewares => [roadrunner_compress]
+%% }).
+%% ```
+%%
+%% A response is compressed when **all** of these are true:
+%%
+%% - The client's `Accept-Encoding` header includes `gzip` or `deflate`
+%%   (substring match per token; qvalue ranking is a follow-up).
+%% - The handler's response does not already carry a `Content-Encoding`
+%%   header (i.e. it isn't already compressed).
+%% - The body is at least `?THRESHOLD` bytes (default 860 — same as
+%%   cowboy's default; below this the compression overhead outweighs
+%%   the bandwidth saving).
+%%
+%% When compressed:
+%%
+%% - `Content-Encoding: gzip` (or `deflate`) is added.
+%% - `Content-Length` is rewritten to the compressed size.
+%% - `Vary: Accept-Encoding` is added.
+%%
+%% When not compressed (body too small, client doesn't accept any
+%% supported encoding, or response already encoded), the response
+%% passes through unchanged **except** that `Vary: Accept-Encoding` is
+%% added if the client indicated a supported encoding — caches that
+%% key on this header will then handle the next variant correctly.
+%%
+%% ## Encoding selection
+%%
+%% When the client accepts both gzip and deflate, **gzip wins**. gzip has
+%% a more deterministic on-the-wire format (RFC 1952) and broader
+%% client tolerance than `Content-Encoding: deflate` — historically
+%% some servers shipped raw deflate (RFC 1951) instead of the
+%% zlib-wrapped form RFC 9110 §8.4.1.3 mandates (RFC 1950), and a
+%% handful of older clients still ship workarounds for both shapes.
+%% gzip avoids the question.
+%%
+%% ## What this does NOT cover
+%%
+%% - **`{loop, ...}` and `{websocket, ...}` returns** — passed through;
+%%   these aren't HTTP body responses.
+%% - **Brotli (`br`) Content-Encoding** — would require a NIF dep
+%%   (`brotli`); deferred until there's user pull.
+%% - **Qvalue-aware Accept-Encoding parsing** — current implementation
+%%   is substring-match per token; treats `gzip;q=0` as "accepts gzip"
+%%   (a real conformance bug). Tracked separately.
 
 -behaviour(roadrunner_middleware).
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -1,31 +1,31 @@
 -module(roadrunner_conn).
--moduledoc """
-Public connection-process API and pure helpers.
+-moduledoc false.
 
-`start/2` spawns the per-connection process — `roadrunner_conn_loop`,
-a tail-recursive loop with phase tracking via `proc_lib:set_label/1`
-for observer / recon visibility.
-
-The other public functions are pure-ish helpers; many are also called
-directly from `roadrunner_req` (manual body buffering) and from
-`roadrunner_conn_tests.erl`'s closure-driven unit tests.
-
-Per-connection behavior — keep-alive (capped by
-`max_keep_alive_requests`, idle-bound by `keep_alive_timeout`),
-`Expect: 100-continue`, HEAD body suppression, anti-Slowloris rate
-check (`min_bytes_per_second`), the five handler return shapes
-(`{Status, Headers, Body}`, `{stream, ...}`, `{loop, ...}`,
-`{sendfile, ...}`, `{websocket, ...}`) — lives in `roadrunner_conn_loop`
-and the response-shape-specific modules (`roadrunner_stream_response`,
-`roadrunner_loop_response`, `roadrunner_ws_session`).
-
-The 4xx/5xx error responses (400 on parse failure, 408 on
-first-request silence, 413 on oversized bodies, 500 on handler
-crashes) are emitted via the `send_*/1` helpers exported here. Idle
-keep-alive timeouts and slow-client rate violations close the
-connection silently — no response to a peer that wasn't going to
-read it anyway.
-""".
+%% Public connection-process API and pure helpers.
+%%
+%% `start/2` spawns the per-connection process — `roadrunner_conn_loop`,
+%% a tail-recursive loop with phase tracking via `proc_lib:set_label/1`
+%% for observer / recon visibility.
+%%
+%% The other public functions are pure-ish helpers; many are also called
+%% directly from `roadrunner_req` (manual body buffering) and from
+%% `roadrunner_conn_tests.erl`'s closure-driven unit tests.
+%%
+%% Per-connection behavior — keep-alive (capped by
+%% `max_keep_alive_requests`, idle-bound by `keep_alive_timeout`),
+%% `Expect: 100-continue`, HEAD body suppression, anti-Slowloris rate
+%% check (`min_bytes_per_second`), the five handler return shapes
+%% (`{Status, Headers, Body}`, `{stream, ...}`, `{loop, ...}`,
+%% `{sendfile, ...}`, `{websocket, ...}`) — lives in `roadrunner_conn_loop`
+%% and the response-shape-specific modules (`roadrunner_stream_response`,
+%% `roadrunner_loop_response`, `roadrunner_ws_session`).
+%%
+%% The 4xx/5xx error responses (400 on parse failure, 408 on
+%% first-request silence, 413 on oversized bodies, 500 on handler
+%% crashes) are emitted via the `send_*/1` helpers exported here. Idle
+%% keep-alive timeouts and slow-client rate violations close the
+%% connection silently — no response to a peer that wasn't going to
+%% read it anyway.
 
 -export([
     start/2,

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -252,6 +252,7 @@ generate_request_id(_Empty) ->
 
 %% Replaces (not merges) the conn process's logger metadata so a
 %% keep-alive request never inherits the previous request's correlation.
+
 -doc false.
 -spec set_request_logger_metadata(roadrunner_http1:request()) -> ok.
 set_request_logger_metadata(#{
@@ -278,6 +279,7 @@ set_request_logger_metadata(#{
 %% running average to meet `MinRate` bytes/sec, otherwise return
 %% `{error, slow_client}`. The state is a per-conn atomics ref — no
 %% cross-process contention.
+
 -doc false.
 -spec make_recv(roadrunner_transport:socket(), integer(), non_neg_integer()) ->
     fun(() -> {ok, binary()} | {error, request_timeout | slow_client | term()}).
@@ -374,6 +376,7 @@ read_body(Req, Buffered, RecvFun, MaxCL) ->
 %% this if no body bytes have already arrived in the buffer — once we
 %% see body data the client clearly didn't wait, and the 100 line is
 %% redundant.
+
 -doc false.
 -spec maybe_send_continue(roadrunner_transport:socket(), roadrunner_http1:request(), binary()) ->
     ok.
@@ -551,6 +554,7 @@ read_chunked(Buf, RecvFun, MaxCL, Decoded) ->
 %% path; `roadrunner_conn_loop`'s finishing phase threads `Leftover`
 %% forward into the next `reading_request` parse so pipelined
 %% clients get their N+1 request seen.
+
 -doc false.
 -spec drain_body(roadrunner_http1:request()) -> {ok, binary()} | {error, term()}.
 drain_body(#{body_state := BS}) ->
@@ -802,6 +806,7 @@ parse_loop(Buf, RecvFun) ->
 
 %% Order matters — `{websocket, _, _}` is a 3-tuple too, so the
 %% atom-tagged variants must precede the buffered catch-all.
+
 -doc false.
 -spec response_status(roadrunner_handler:response()) -> roadrunner_http1:status().
 response_status({stream, Status, _, _}) -> Status;
@@ -821,6 +826,7 @@ response_kind({_, _, _}) -> buffered.
 
 %% HTTP/1.0 default close. HTTP/1.1 keep-alive unless either side
 %% set Connection: close.
+
 -doc false.
 -spec keep_alive_decision(roadrunner_http1:request(), roadrunner_http1:headers()) ->
     keep_alive | close.
@@ -924,6 +930,7 @@ send_bad_request(Socket) ->
 %% 413 we're about to send before we close. Bounded by `2 * MaxCL`
 %% (memory) and a 1-second per-recv timeout (wall-clock) so a slow
 %% peer can't pin us indefinitely.
+
 -doc false.
 -spec drain_oversized_body(binary(), roadrunner_transport:socket(), non_neg_integer()) -> ok.
 drain_oversized_body(Buffered, Socket, MaxCL) ->

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -252,7 +252,6 @@ generate_request_id(_Empty) ->
 
 %% Replaces (not merges) the conn process's logger metadata so a
 %% keep-alive request never inherits the previous request's correlation.
-
 -doc false.
 -spec set_request_logger_metadata(roadrunner_http1:request()) -> ok.
 set_request_logger_metadata(#{
@@ -279,7 +278,6 @@ set_request_logger_metadata(#{
 %% running average to meet `MinRate` bytes/sec, otherwise return
 %% `{error, slow_client}`. The state is a per-conn atomics ref — no
 %% cross-process contention.
-
 -doc false.
 -spec make_recv(roadrunner_transport:socket(), integer(), non_neg_integer()) ->
     fun(() -> {ok, binary()} | {error, request_timeout | slow_client | term()}).
@@ -376,7 +374,6 @@ read_body(Req, Buffered, RecvFun, MaxCL) ->
 %% this if no body bytes have already arrived in the buffer — once we
 %% see body data the client clearly didn't wait, and the 100 line is
 %% redundant.
-
 -doc false.
 -spec maybe_send_continue(roadrunner_transport:socket(), roadrunner_http1:request(), binary()) ->
     ok.
@@ -554,7 +551,6 @@ read_chunked(Buf, RecvFun, MaxCL, Decoded) ->
 %% path; `roadrunner_conn_loop`'s finishing phase threads `Leftover`
 %% forward into the next `reading_request` parse so pipelined
 %% clients get their N+1 request seen.
-
 -doc false.
 -spec drain_body(roadrunner_http1:request()) -> {ok, binary()} | {error, term()}.
 drain_body(#{body_state := BS}) ->
@@ -806,7 +802,6 @@ parse_loop(Buf, RecvFun) ->
 
 %% Order matters — `{websocket, _, _}` is a 3-tuple too, so the
 %% atom-tagged variants must precede the buffered catch-all.
-
 -doc false.
 -spec response_status(roadrunner_handler:response()) -> roadrunner_http1:status().
 response_status({stream, Status, _, _}) -> Status;
@@ -826,7 +821,6 @@ response_kind({_, _, _}) -> buffered.
 
 %% HTTP/1.0 default close. HTTP/1.1 keep-alive unless either side
 %% set Connection: close.
-
 -doc false.
 -spec keep_alive_decision(roadrunner_http1:request(), roadrunner_http1:headers()) ->
     keep_alive | close.
@@ -930,7 +924,6 @@ send_bad_request(Socket) ->
 %% 413 we're about to send before we close. Bounded by `2 * MaxCL`
 %% (memory) and a 1-second per-recv timeout (wall-clock) so a slow
 %% peer can't pin us indefinitely.
-
 -doc false.
 -spec drain_oversized_body(binary(), roadrunner_transport:socket(), non_neg_integer()) -> ok.
 drain_oversized_body(Buffered, Socket, MaxCL) ->

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -414,7 +414,6 @@ recv_with_hibernate(
 %% Hibernate continuation. Re-enters `recv_request_bytes/2` so
 %% the next iteration picks up wherever the recv shape demands
 %% (with or without hibernation, depending on `hibernate_after`).
-
 -doc false.
 -spec recv_request_bytes_hib(#loop_state{}, integer()) -> no_return().
 recv_request_bytes_hib(S, Deadline) ->

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -414,6 +414,7 @@ recv_with_hibernate(
 %% Hibernate continuation. Re-enters `recv_request_bytes/2` so
 %% the next iteration picks up wherever the recv shape demands
 %% (with or without hibernation, depending on `hibernate_after`).
+
 -doc false.
 -spec recv_request_bytes_hib(#loop_state{}, integer()) -> no_return().
 recv_request_bytes_hib(S, Deadline) ->

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -1,51 +1,51 @@
 -module(roadrunner_conn_loop).
--moduledoc """
-Tail-recursive per-connection process for HTTP/1.1.
+-moduledoc false.
 
-The lifecycle (`awaiting_shoot → reading_request → reading_body →
-dispatching → finishing → loop or close`) is expressed as direct
-function calls between phase functions. No `gen_statem` dispatch,
-no per-request timer arms in the steady state.
-
-## Two recv paths
-
-Default is **passive recv** — `gen_tcp:recv(Socket, 0, ChunkTimeout)`
-in a loop with mailbox drain checks at `?DRAIN_CHECK_INTERVAL_MS`
-(100 ms) granularity. Bypasses `gen_tcp_socket`'s gen_statem dispatch
-on every recv (saves ~7 % CPU on the hot path: `gen:do_call/4`,
-`recv_data_deliver/4`, `gen_statem:loop/3`, `nif_getopt/3`).
-
-When the listener sets `hibernate_after => Ms > 0`, the recv path
-flips to **active-mode** (`{active, once}` + receive). The receive's
-`after Ms` clause has a window to call `erlang:hibernate/3` between
-keep-alive iterations so the conn's heap GCs and shrinks — only
-`receive` supports hibernation; passive recv blocks the process
-inside a NIF.
-
-## Phase introspection vs hot-path cost
-
-The label set on the conn process via `proc_lib:set_label/1` is
-written **at most twice per conn**: once at `init_loop` time
-(`{roadrunner_conn, awaiting_shoot, ListenerName}`) and once at the
-`shoot` handoff (`refine_conn_label/2` rewrites it to include the
-peer). The phases AFTER `awaiting_shoot` (read_request, read_body,
-dispatching, finishing) run in microseconds on the happy path — too
-fast for an operator's `observer` snapshot to catch a specific phase
-anyway. Per-phase label updates measured ~1.2 % CPU on hello (4
-writes/req, each touching the process dictionary) and contributed
-to run-to-run variance. Stuck conns still surface via the conn-entry
-label and the `reading_request` idle window (where hibernation
-parks the process).
-
-## Stability features preserved
-
-Drain via `pg`-broadcast, slot tracking via atomics, full telemetry
-pairing (`[roadrunner, request, start | stop | exception]` with
-shared `StartMono`), HEAD body suppression, `Expect: 100-continue`,
-anti-Slowloris rate-check on the request-read phase, all five
-response shapes (buffered, `{stream, ...}`, `{loop, ...}`,
-`{sendfile, ...}`, `{websocket, ...}`).
-""".
+%% Tail-recursive per-connection process for HTTP/1.1.
+%%
+%% The lifecycle (`awaiting_shoot → reading_request → reading_body →
+%% dispatching → finishing → loop or close`) is expressed as direct
+%% function calls between phase functions. No `gen_statem` dispatch,
+%% no per-request timer arms in the steady state.
+%%
+%% ## Two recv paths
+%%
+%% Default is **passive recv** — `gen_tcp:recv(Socket, 0, ChunkTimeout)`
+%% in a loop with mailbox drain checks at `?DRAIN_CHECK_INTERVAL_MS`
+%% (100 ms) granularity. Bypasses `gen_tcp_socket`'s gen_statem dispatch
+%% on every recv (saves ~7 % CPU on the hot path: `gen:do_call/4`,
+%% `recv_data_deliver/4`, `gen_statem:loop/3`, `nif_getopt/3`).
+%%
+%% When the listener sets `hibernate_after => Ms > 0`, the recv path
+%% flips to **active-mode** (`{active, once}` + receive). The receive's
+%% `after Ms` clause has a window to call `erlang:hibernate/3` between
+%% keep-alive iterations so the conn's heap GCs and shrinks — only
+%% `receive` supports hibernation; passive recv blocks the process
+%% inside a NIF.
+%%
+%% ## Phase introspection vs hot-path cost
+%%
+%% The label set on the conn process via `proc_lib:set_label/1` is
+%% written **at most twice per conn**: once at `init_loop` time
+%% (`{roadrunner_conn, awaiting_shoot, ListenerName}`) and once at the
+%% `shoot` handoff (`refine_conn_label/2` rewrites it to include the
+%% peer). The phases AFTER `awaiting_shoot` (read_request, read_body,
+%% dispatching, finishing) run in microseconds on the happy path — too
+%% fast for an operator's `observer` snapshot to catch a specific phase
+%% anyway. Per-phase label updates measured ~1.2 % CPU on hello (4
+%% writes/req, each touching the process dictionary) and contributed
+%% to run-to-run variance. Stuck conns still surface via the conn-entry
+%% label and the `reading_request` idle window (where hibernation
+%% parks the process).
+%%
+%% ## Stability features preserved
+%%
+%% Drain via `pg`-broadcast, slot tracking via atomics, full telemetry
+%% pairing (`[roadrunner, request, start | stop | exception]` with
+%% shared `StartMono`), HEAD body suppression, `Expect: 100-continue`,
+%% anti-Slowloris rate-check on the request-read phase, all five
+%% response shapes (buffered, `{stream, ...}`, `{loop, ...}`,
+%% `{sendfile, ...}`, `{websocket, ...}`).
 
 -export([start/2]).
 

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1,56 +1,56 @@
 -module(roadrunner_conn_loop_http2).
--moduledoc """
-HTTP/2 (RFC 9113) connection process.
+-moduledoc false.
 
-Driven by either TLS ALPN-negotiated `h2` or a plaintext listener
-configured with `protocols => [http2]` (RFC 7540 §3.4 prior-knowledge).
-The dispatch decision lives in `roadrunner_conn_loop:awaiting_shoot/3`;
-this module is transport-agnostic and reads frames via
-`roadrunner_transport:recv/3` either way.
-
-Phase H8b — true multiplexing with per-stream workers. The conn
-process owns:
-
-- the active-mode socket (sole reader / writer of bytes),
-- the HPACK encoder / decoder (single context per direction
-  shared across all streams),
-- the connection-level flow-control windows and per-stream
-  windows / pending-send queues,
-- a `streams` map keyed by stream id, and `worker_refs` mapping
-  monitor refs back to stream ids for `'DOWN'` correlation.
-
-Once a request stream finishes receiving (HEADERS + body +
-END_STREAM), the conn spawns a `roadrunner_http2_stream_worker`
-process. The worker resolves the route, runs middleware + handler,
-and translates the response into messages back to the conn:
-
-```
-{h2_send_headers, Worker, Ref, StreamId, Status, Headers, EndStream}
-{h2_send_data,    Worker, Ref, StreamId, Bin,    EndStream}
-{h2_send_trailers, Worker, Ref, StreamId, Trailers}
-{h2_worker_done,  StreamId}
-```
-
-The conn replies `{h2_send_ack, Ref}` once the corresponding
-frame(s) are on the wire — so workers are synchronously
-back-pressured against flow control without buffering.
-
-Workers are spawn_monitored (NOT linked) so a handler crash
-resets only the affected stream — `'DOWN'` triggers
-`RST_STREAM(INTERNAL_ERROR)` and the other in-flight streams
-keep running. `MAX_CONCURRENT_STREAMS=100` is advertised; HEADERS
-beyond that limit get `RST_STREAM(REFUSED_STREAM)`.
-
-Response shapes supported:
-
-| shape | h2 |
-|---|---|
-| `{Status, Headers, Body}` (buffered) | yes |
-| `{stream, _, _, Fun}` | yes |
-| `{loop, _}` | yes (worker enters handle_info loop) |
-| `{sendfile, _}` | yes (chunked DATA via the stream-response engine) |
-| `{websocket, _, _}` | 501 (Phase H13) |
-""".
+%% HTTP/2 (RFC 9113) connection process.
+%%
+%% Driven by either TLS ALPN-negotiated `h2` or a plaintext listener
+%% configured with `protocols => [http2]` (RFC 7540 §3.4 prior-knowledge).
+%% The dispatch decision lives in `roadrunner_conn_loop:awaiting_shoot/3`;
+%% this module is transport-agnostic and reads frames via
+%% `roadrunner_transport:recv/3` either way.
+%%
+%% Phase H8b — true multiplexing with per-stream workers. The conn
+%% process owns:
+%%
+%% - the active-mode socket (sole reader / writer of bytes),
+%% - the HPACK encoder / decoder (single context per direction
+%%   shared across all streams),
+%% - the connection-level flow-control windows and per-stream
+%%   windows / pending-send queues,
+%% - a `streams` map keyed by stream id, and `worker_refs` mapping
+%%   monitor refs back to stream ids for `'DOWN'` correlation.
+%%
+%% Once a request stream finishes receiving (HEADERS + body +
+%% END_STREAM), the conn spawns a `roadrunner_http2_stream_worker`
+%% process. The worker resolves the route, runs middleware + handler,
+%% and translates the response into messages back to the conn:
+%%
+%% ```
+%% {h2_send_headers, Worker, Ref, StreamId, Status, Headers, EndStream}
+%% {h2_send_data,    Worker, Ref, StreamId, Bin,    EndStream}
+%% {h2_send_trailers, Worker, Ref, StreamId, Trailers}
+%% {h2_worker_done,  StreamId}
+%% ```
+%%
+%% The conn replies `{h2_send_ack, Ref}` once the corresponding
+%% frame(s) are on the wire — so workers are synchronously
+%% back-pressured against flow control without buffering.
+%%
+%% Workers are spawn_monitored (NOT linked) so a handler crash
+%% resets only the affected stream — `'DOWN'` triggers
+%% `RST_STREAM(INTERNAL_ERROR)` and the other in-flight streams
+%% keep running. `MAX_CONCURRENT_STREAMS=100` is advertised; HEADERS
+%% beyond that limit get `RST_STREAM(REFUSED_STREAM)`.
+%%
+%% Response shapes supported:
+%%
+%% | shape | h2 |
+%% |---|---|
+%% | `{Status, Headers, Body}` (buffered) | yes |
+%% | `{stream, _, _, Fun}` | yes |
+%% | `{loop, _}` | yes (worker enters handle_info loop) |
+%% | `{sendfile, _}` | yes (chunked DATA via the stream-response engine) |
+%% | `{websocket, _, _}` | 501 (Phase H13) |
 
 -export([enter/5]).
 

--- a/src/roadrunner_cookie.erl
+++ b/src/roadrunner_cookie.erl
@@ -82,7 +82,7 @@ with one of:
   `Expires` contains a CTL or `;` (the bytes that would let a
   malicious caller smuggle attributes or split the header line)
 
-Crashing matches the discipline of `roadrunner_http1:check_header_safe/2`:
+Crashing matches the discipline applied elsewhere in the framework:
 a programmer bug echoing user input into a cookie turns into a 500, not
 a wire-level vulnerability.
 """.

--- a/src/roadrunner_cookie.erl
+++ b/src/roadrunner_cookie.erl
@@ -15,6 +15,23 @@ Provides `parse/1` for the request-side `Cookie` header and
 
 -export_type([serialize_opts/0]).
 
+-doc """
+Optional attributes for the `Set-Cookie` header per RFC 6265 §4.1.
+
+- `domain` — explicit `Domain` attribute. Default is the response
+  host (no `Domain` attribute emitted), which limits the cookie
+  to that exact host.
+- `path` — explicit `Path` attribute. Default is `/`.
+- `max_age` — seconds until the cookie expires. `0` deletes the
+  cookie. Browsers prefer `Max-Age` over `Expires` when both are
+  present (RFC 6265 §5.3 step 3).
+- `expires` — IMF-fixdate string for clients that ignore
+  `Max-Age` (use `roadrunner_http:format_http_date/1`).
+- `secure` — restrict transmission to HTTPS.
+- `http_only` — hide from JavaScript (`document.cookie`).
+- `same_site` — cross-site request policy: `strict`, `lax`, or
+  `none`. `none` requires `secure => true`.
+""".
 -type serialize_opts() :: #{
     domain => binary(),
     path => binary(),

--- a/src/roadrunner_default_handler.erl
+++ b/src/roadrunner_default_handler.erl
@@ -1,15 +1,15 @@
 -module(roadrunner_default_handler).
--moduledoc """
-Default `roadrunner_handler` — used when a listener starts with no
-`routes` opt configured. Returns 404 with a body pointing the
-operator at the quickstart, so a smoke `curl` against an otherwise-
-blank listener tells you what to do next instead of silently 200-ing.
+-moduledoc false.
 
-Operators wire their own handler via the listener's `routes` opt:
-either a bare module atom (every request goes to that handler) or
-a list of `{Path, Module, Opts}` tuples (routed dispatch). See
-`t:roadrunner_listener:opts/0` and the project README.
-""".
+%% Default `roadrunner_handler` — used when a listener starts with no
+%% `routes` opt configured. Returns 404 with a body pointing the
+%% operator at the quickstart, so a smoke `curl` against an otherwise-
+%% blank listener tells you what to do next instead of silently 200-ing.
+%%
+%% Operators wire their own handler via the listener's `routes` opt:
+%% either a bare module atom (every request goes to that handler) or
+%% a list of `{Path, Module, Opts}` tuples (routed dispatch). See
+%% `t:roadrunner_listener:opts/0` and the project README.
 
 -behaviour(roadrunner_handler).
 

--- a/src/roadrunner_handler.erl
+++ b/src/roadrunner_handler.erl
@@ -82,7 +82,26 @@ lowercase names; handler-supplied tuples must follow suit.
     | {websocket, Module :: module(), State :: term()}.
 -type result() :: {response(), roadrunner_req:request()}.
 
+-doc """
+Invoked once per parsed request. Receives the request map and
+returns a `{Response, Req2}` pair where `Response` is one of the
+shapes listed in the moduledoc (buffered, stream, sendfile, loop,
+websocket) and `Req2` is the (possibly mutated) request map threaded
+back to the framework. Always return `Req2` so the conn can drain
+unread bodies in manual-buffering mode and response middlewares can
+observe / rewrite.
+""".
 -callback handle(Request :: roadrunner_req:request()) -> result().
+
+-doc """
+Optional, only fired for `{loop, _, _, State}` responses. The
+framework dispatches every non-OTP Erlang message delivered to the
+conn (or h2 worker) process through this callback. `Push(Data)`
+writes one chunk to the wire. Return `{ok, NewState}` to keep
+looping or `{stop, NewState}` to emit the size-0 terminator and
+close. Handlers that don't export this callback can't use
+`{loop, ...}` responses.
+""".
 -callback handle_info(Info :: term(), Push :: push_fun(), State :: term()) ->
     {ok, NewState :: term()} | {stop, NewState :: term()}.
 

--- a/src/roadrunner_handler.erl
+++ b/src/roadrunner_handler.erl
@@ -52,7 +52,17 @@ handle(Req) ->
 ```
 """.
 
--export_type([send_fun/0, stream_fun/0, push_fun/0, sendfile_spec/0, response/0, result/0]).
+-export_type([
+    send_fun/0,
+    stream_fun/0,
+    push_fun/0,
+    sendfile_spec/0,
+    response/0,
+    result/0,
+    next/0,
+    middleware/0,
+    middleware_list/0
+]).
 
 -type send_fun() ::
     fun((iodata(), nofin | fin | {fin, roadrunner_req:headers()}) -> ok | {error, term()}).
@@ -81,6 +91,26 @@ lowercase names; handler-supplied tuples must follow suit.
     | {sendfile, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), sendfile_spec()}
     | {websocket, Module :: module(), State :: term()}.
 -type result() :: {response(), roadrunner_req:request()}.
+
+-doc """
+The continuation passed to a middleware's `call/2`: a fun that runs
+the rest of the pipeline (other middlewares + the inner handler) on
+the request and returns the same `result/0` shape every middleware
+returns.
+""".
+-type next() :: fun((roadrunner_req:request()) -> result()).
+
+-doc """
+A single entry in a listener's or route's `middlewares` list. Either:
+- A module that implements `-behaviour(roadrunner_middleware)` (its
+  `call/2` is invoked).
+- A `fun((Request, Next) -> Result)` invoked directly.
+""".
+-type middleware() ::
+    module()
+    | fun((roadrunner_req:request(), next()) -> result()).
+
+-type middleware_list() :: [middleware()].
 
 -callback handle(Request :: roadrunner_req:request()) -> result().
 -callback handle_info(Info :: term(), Push :: push_fun(), State :: term()) ->

--- a/src/roadrunner_handler.erl
+++ b/src/roadrunner_handler.erl
@@ -52,17 +52,7 @@ handle(Req) ->
 ```
 """.
 
--export_type([
-    send_fun/0,
-    stream_fun/0,
-    push_fun/0,
-    sendfile_spec/0,
-    response/0,
-    result/0,
-    next/0,
-    middleware/0,
-    middleware_list/0
-]).
+-export_type([send_fun/0, stream_fun/0, push_fun/0, sendfile_spec/0, response/0, result/0]).
 
 -type send_fun() ::
     fun((iodata(), nofin | fin | {fin, roadrunner_req:headers()}) -> ok | {error, term()}).
@@ -91,26 +81,6 @@ lowercase names; handler-supplied tuples must follow suit.
     | {sendfile, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), sendfile_spec()}
     | {websocket, Module :: module(), State :: term()}.
 -type result() :: {response(), roadrunner_req:request()}.
-
--doc """
-The continuation passed to a middleware's `call/2`: a fun that runs
-the rest of the pipeline (other middlewares + the inner handler) on
-the request and returns the same `result/0` shape every middleware
-returns.
-""".
--type next() :: fun((roadrunner_req:request()) -> result()).
-
--doc """
-A single entry in a listener's or route's `middlewares` list. Either:
-- A module that implements `-behaviour(roadrunner_middleware)` (its
-  `call/2` is invoked).
-- A `fun((Request, Next) -> Result)` invoked directly.
-""".
--type middleware() ::
-    module()
-    | fun((roadrunner_req:request(), next()) -> result()).
-
--type middleware_list() :: [middleware()].
 
 -callback handle(Request :: roadrunner_req:request()) -> result().
 -callback handle_info(Info :: term(), Push :: push_fun(), State :: term()) ->

--- a/src/roadrunner_handler.erl
+++ b/src/roadrunner_handler.erl
@@ -54,10 +54,40 @@ handle(Req) ->
 
 -export_type([send_fun/0, stream_fun/0, push_fun/0, sendfile_spec/0, response/0, result/0]).
 
+-doc """
+The chunk-writing callback handed to a `t:stream_fun/0`. Each call
+emits one chunk on the wire:
+
+- `Send(Data, nofin)` — write `Data` and expect more.
+- `Send(Data, fin)` — write `Data` then the size-0 terminator.
+- `Send(Data, {fin, Trailers})` — write `Data`, the terminator, and
+  serialized trailer headers (RFC 9112 §7.1.2).
+
+Returns `ok` on success or `{error, Reason}` if the wire write
+failed (peer close, kernel error, etc.).
+""".
 -type send_fun() ::
     fun((iodata(), nofin | fin | {fin, roadrunner_req:headers()}) -> ok | {error, term()}).
+
+-doc """
+The stream callback for `{stream, _, _, Fun}` responses. The
+framework calls `Fun(Send)` with a `t:send_fun/0`; the fun emits
+chunks via `Send` and returns when the stream is complete.
+""".
 -type stream_fun() :: fun((send_fun()) -> any()).
+
+-doc """
+The push callback handed to a `{loop, _, _, State}` handler via
+`handle_info/3`. Each call writes one chunk to the wire.
+""".
 -type push_fun() :: fun((iodata()) -> ok | {error, term()}).
+
+-doc """
+The `{Filename, Offset, Length}` triple for a `{sendfile, _, _, _}`
+response. Bytes `[Offset, Offset+Length)` of the file are emitted
+verbatim — the handler is responsible for setting `Content-Length`
+and `Content-Type` headers on the response.
+""".
 -type sendfile_spec() :: {
     Filename :: file:filename_all(),
     Offset :: non_neg_integer(),
@@ -80,6 +110,13 @@ lowercase names; handler-supplied tuples must follow suit.
     | {loop, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), State :: term()}
     | {sendfile, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), sendfile_spec()}
     | {websocket, Module :: module(), State :: term()}.
+
+-doc """
+What `handle/1` returns: a pair of the handler's `t:response/0` and
+the (possibly mutated) request map. Threading `Req2` back lets the
+conn drain unread bodies in manual-buffering mode and response
+middlewares observe / rewrite.
+""".
 -type result() :: {response(), roadrunner_req:request()}.
 
 -doc """

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -53,16 +53,14 @@ auto-inject the `Date` response header per RFC 9110 §6.6.1.
 Built via direct bit-syntax binary construction rather than
 `io_lib:format/2` because the shape is fixed (RFC 9110 mandates
 exact widths and the day/month abbreviations) and this function
-runs once per response on the hot path — a 250 k req/s listener
-calls it 250 k times per second.
+runs on the response hot path.
 
 Cached via `persistent_term` keyed by the current Posix second:
 the formatted binary is identical for every request that lands in
 the same second, so we recompute it only when the second ticks
-over. Microbench: full build ~292 ns/call, cache hit ~38 ns/call
-(−87 %). Updates are racy on the second-boundary (multiple
-processes may put the same value), but each put writes the same
-binary so the race is benign.
+over. Updates are racy on the second boundary (multiple processes
+may put the same value), but each put writes the same binary so
+the race is benign.
 """.
 -spec http_date_now() -> binary().
 http_date_now() ->

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -1,30 +1,30 @@
 -module(roadrunner_http).
--moduledoc """
-Protocol-version-agnostic HTTP semantics shared by HTTP/1.1
-(`roadrunner_http1`) and any future HTTP/2 (`roadrunner_http2_*`)
-modules.
+-moduledoc false.
 
-What lives here is RFC 9110 semantics — types and helpers whose
-meaning doesn't depend on wire framing — not RFC 9112 syntax.
-The HTTP/1.1 wire codec (request-line / header / chunked
-parsers, status-line + CRLF response encoder) stays in
-`roadrunner_http1`. HTTP/2 frame codec + HPACK live in their
-own modules.
-
-Items here:
-
-- Header list shape: `[{binary(), binary()}]`.
-- HTTP status codes: `100..599` and the redirect subset.
-- Protocol version tuple: `{Major, Minor}`.
-- IMF-fixdate formatter (`http_date_now/0` for the current
-  time, `format_http_date/1` for an arbitrary posix timestamp)
-  for the `Date` response header per RFC 9110 §5.6.7 and the
-  `Last-Modified` response header used by the static handler.
-
-`roadrunner_http1` re-exports these as type aliases so existing
-callers using `roadrunner_http1:request()` / `:headers()` etc.
-keep compiling unchanged.
-""".
+%% Protocol-version-agnostic HTTP semantics shared by HTTP/1.1
+%% (`roadrunner_http1`) and any future HTTP/2 (`roadrunner_http2_*`)
+%% modules.
+%%
+%% What lives here is RFC 9110 semantics — types and helpers whose
+%% meaning doesn't depend on wire framing — not RFC 9112 syntax.
+%% The HTTP/1.1 wire codec (request-line / header / chunked
+%% parsers, status-line + CRLF response encoder) stays in
+%% `roadrunner_http1`. HTTP/2 frame codec + HPACK live in their
+%% own modules.
+%%
+%% Items here:
+%%
+%% - Header list shape: `[{binary(), binary()}]`.
+%% - HTTP status codes: `100..599` and the redirect subset.
+%% - Protocol version tuple: `{Major, Minor}`.
+%% - IMF-fixdate formatter (`http_date_now/0` for the current
+%%   time, `format_http_date/1` for an arbitrary posix timestamp)
+%%   for the `Date` response header per RFC 9110 §5.6.7 and the
+%%   `Last-Modified` response header used by the static handler.
+%%
+%% `roadrunner_http1` re-exports these as type aliases so existing
+%% callers using `roadrunner_http1:request()` / `:headers()` etc.
+%% keep compiling unchanged.
 
 -on_load(init_cache/0).
 

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -1,30 +1,30 @@
 -module(roadrunner_http).
--moduledoc false.
+-moduledoc """
+Protocol-version-agnostic HTTP semantics shared by HTTP/1.1
+(`roadrunner_http1`) and HTTP/2 (`roadrunner_http2_*`) modules.
 
-%% Protocol-version-agnostic HTTP semantics shared by HTTP/1.1
-%% (`roadrunner_http1`) and any future HTTP/2 (`roadrunner_http2_*`)
-%% modules.
-%%
-%% What lives here is RFC 9110 semantics — types and helpers whose
-%% meaning doesn't depend on wire framing — not RFC 9112 syntax.
-%% The HTTP/1.1 wire codec (request-line / header / chunked
-%% parsers, status-line + CRLF response encoder) stays in
-%% `roadrunner_http1`. HTTP/2 frame codec + HPACK live in their
-%% own modules.
-%%
-%% Items here:
-%%
-%% - Header list shape: `[{binary(), binary()}]`.
-%% - HTTP status codes: `100..599` and the redirect subset.
-%% - Protocol version tuple: `{Major, Minor}`.
-%% - IMF-fixdate formatter (`http_date_now/0` for the current
-%%   time, `format_http_date/1` for an arbitrary posix timestamp)
-%%   for the `Date` response header per RFC 9110 §5.6.7 and the
-%%   `Last-Modified` response header used by the static handler.
-%%
-%% `roadrunner_http1` re-exports these as type aliases so existing
-%% callers using `roadrunner_http1:request()` / `:headers()` etc.
-%% keep compiling unchanged.
+What lives here is RFC 9110 semantics — types and helpers whose
+meaning doesn't depend on wire framing — not RFC 9112 syntax.
+The HTTP/1.1 wire codec (request-line / header / chunked
+parsers, status-line + CRLF response encoder) stays in
+`roadrunner_http1`. HTTP/2 frame codec + HPACK live in their
+own modules.
+
+Items here:
+
+- Header list shape: `[{binary(), binary()}]`.
+- HTTP status codes: `100..599` and the redirect subset.
+- Protocol version tuple: `{Major, Minor}`.
+- IMF-fixdate formatter (`http_date_now/0` for the current
+  time, `format_http_date/1` for an arbitrary posix timestamp)
+  for the `Date` response header per RFC 9110 §5.6.7 and the
+  `Last-Modified` response header used by the static handler.
+
+`roadrunner_http1` and `roadrunner_req` re-export the primitive
+types as aliases so existing callers keep compiling unchanged.
+The request map shape lives in `roadrunner_req` alongside the
+accessors that operate on it.
+""".
 
 -on_load(init_cache/0).
 

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -1,13 +1,13 @@
 -module(roadrunner_http1).
--moduledoc """
-HTTP/1.1 wire codec — pure binary parsers and encoders.
+-moduledoc false.
 
-All functions are pure and incremental: parsers accept partial inputs
-and return `{more, _}` until a complete unit can be decoded. They never
-raise on hostile input — malformed bytes from the wire become
-tagged `{error, _}` results, leaving the caller in control of the
-response (`400`, `414`, `431`, etc.).
-""".
+%% HTTP/1.1 wire codec — pure binary parsers and encoders.
+%%
+%% All functions are pure and incremental: parsers accept partial inputs
+%% and return `{more, _}` until a complete unit can be decoded. They never
+%% raise on hostile input — malformed bytes from the wire become
+%% tagged `{error, _}` results, leaving the caller in control of the
+%% response (`400`, `414`, `431`, etc.).
 
 -export([
     parse_request_line/1,

--- a/src/roadrunner_http2_frame.erl
+++ b/src/roadrunner_http2_frame.erl
@@ -1,67 +1,67 @@
 -module(roadrunner_http2_frame).
--moduledoc """
-HTTP/2 (RFC 9113 §4 + §6) frame codec — pure binary parsers and
-encoders for all 10 frame types.
+-moduledoc false.
 
-This module is purely about wire-format syntax: it parses bytes into
-typed terms and encodes typed terms back to bytes. It does **not**
-enforce stream-state validity (RFC 9113 §5.1), connection-level
-validity (e.g. SETTINGS arriving before the preface), or flow-control
-arithmetic (§5.2). Those constraints are enforced by callers in
-later phases.
-
-## Frame types
-
-| Type | Hex | Module spec |
-|------|-----|-------------|
-| DATA          | 0x0 | RFC 9113 §6.1 |
-| HEADERS       | 0x1 | RFC 9113 §6.2 |
-| PRIORITY      | 0x2 | RFC 9113 §6.3 (deprecated, MUST accept) |
-| RST_STREAM    | 0x3 | RFC 9113 §6.4 |
-| SETTINGS      | 0x4 | RFC 9113 §6.5 |
-| PUSH_PROMISE  | 0x5 | RFC 9113 §6.6 |
-| PING          | 0x6 | RFC 9113 §6.7 |
-| GOAWAY        | 0x7 | RFC 9113 §6.8 |
-| WINDOW_UPDATE | 0x8 | RFC 9113 §6.9 |
-| CONTINUATION  | 0x9 | RFC 9113 §6.10 |
-
-## API
-
-`parse(Bin, MaxFrameSize)` is incremental: it returns
-`{ok, frame(), Rest}` when a complete frame has been decoded,
-`{more, Need}` when more bytes are required, or `{error, Reason}`
-on syntactic failure. `encode(frame())` returns iodata.
-
-Frame flags are kept as the raw 8-bit byte in the parsed shape —
-higher layers interpret them per-type. Reserved bits in flag bytes
-MUST be ignored on receive (§4.1) and MUST be sent as 0; the
-encoder zeros any unknown bits.
-
-## Padding
-
-DATA, HEADERS, and PUSH_PROMISE frames support optional padding
-(PADDED flag, 0x8 — RFC 9113 §6.1 / §6.2 / §6.6). When present the
-first byte of the payload is the pad length, followed by the
-fragment, followed by `pad-length` bytes of padding. Pad length
-larger than the available frame payload is `PROTOCOL_ERROR`.
-
-## Stream id 0 / non-zero rules
-
-Per RFC 9113 §6, certain frame types MUST be on stream 0
-(SETTINGS, PING, GOAWAY) and others MUST be on a non-zero stream
-(DATA, HEADERS, PRIORITY, RST_STREAM, PUSH_PROMISE,
-WINDOW_UPDATE-on-stream, CONTINUATION). The parser enforces this
-at parse time with a `stream_id_violation` error so callers don't
-have to re-validate.
-
-## MAX_FRAME_SIZE
-
-Per RFC 9113 §6.5.2 SETTINGS_MAX_FRAME_SIZE governs the largest
-frame payload the receiver will accept. The codec takes the limit
-as an explicit argument so it can grow as the client advertises a
-higher value. Frames whose `length` exceeds the limit fail with
-`frame_size_error`.
-""".
+%% HTTP/2 (RFC 9113 §4 + §6) frame codec — pure binary parsers and
+%% encoders for all 10 frame types.
+%%
+%% This module is purely about wire-format syntax: it parses bytes into
+%% typed terms and encodes typed terms back to bytes. It does **not**
+%% enforce stream-state validity (RFC 9113 §5.1), connection-level
+%% validity (e.g. SETTINGS arriving before the preface), or flow-control
+%% arithmetic (§5.2). Those constraints are enforced by callers in
+%% later phases.
+%%
+%% ## Frame types
+%%
+%% | Type | Hex | Module spec |
+%% |------|-----|-------------|
+%% | DATA          | 0x0 | RFC 9113 §6.1 |
+%% | HEADERS       | 0x1 | RFC 9113 §6.2 |
+%% | PRIORITY      | 0x2 | RFC 9113 §6.3 (deprecated, MUST accept) |
+%% | RST_STREAM    | 0x3 | RFC 9113 §6.4 |
+%% | SETTINGS      | 0x4 | RFC 9113 §6.5 |
+%% | PUSH_PROMISE  | 0x5 | RFC 9113 §6.6 |
+%% | PING          | 0x6 | RFC 9113 §6.7 |
+%% | GOAWAY        | 0x7 | RFC 9113 §6.8 |
+%% | WINDOW_UPDATE | 0x8 | RFC 9113 §6.9 |
+%% | CONTINUATION  | 0x9 | RFC 9113 §6.10 |
+%%
+%% ## API
+%%
+%% `parse(Bin, MaxFrameSize)` is incremental: it returns
+%% `{ok, frame(), Rest}` when a complete frame has been decoded,
+%% `{more, Need}` when more bytes are required, or `{error, Reason}`
+%% on syntactic failure. `encode(frame())` returns iodata.
+%%
+%% Frame flags are kept as the raw 8-bit byte in the parsed shape —
+%% higher layers interpret them per-type. Reserved bits in flag bytes
+%% MUST be ignored on receive (§4.1) and MUST be sent as 0; the
+%% encoder zeros any unknown bits.
+%%
+%% ## Padding
+%%
+%% DATA, HEADERS, and PUSH_PROMISE frames support optional padding
+%% (PADDED flag, 0x8 — RFC 9113 §6.1 / §6.2 / §6.6). When present the
+%% first byte of the payload is the pad length, followed by the
+%% fragment, followed by `pad-length` bytes of padding. Pad length
+%% larger than the available frame payload is `PROTOCOL_ERROR`.
+%%
+%% ## Stream id 0 / non-zero rules
+%%
+%% Per RFC 9113 §6, certain frame types MUST be on stream 0
+%% (SETTINGS, PING, GOAWAY) and others MUST be on a non-zero stream
+%% (DATA, HEADERS, PRIORITY, RST_STREAM, PUSH_PROMISE,
+%% WINDOW_UPDATE-on-stream, CONTINUATION). The parser enforces this
+%% at parse time with a `stream_id_violation` error so callers don't
+%% have to re-validate.
+%%
+%% ## MAX_FRAME_SIZE
+%%
+%% Per RFC 9113 §6.5.2 SETTINGS_MAX_FRAME_SIZE governs the largest
+%% frame payload the receiver will accept. The codec takes the limit
+%% as an explicit argument so it can grow as the client advertises a
+%% higher value. Frames whose `length` exceeds the limit fail with
+%% `frame_size_error`.
 
 -export([parse/2, encode/1]).
 

--- a/src/roadrunner_http2_hpack.erl
+++ b/src/roadrunner_http2_hpack.erl
@@ -1,44 +1,44 @@
 -module(roadrunner_http2_hpack).
--moduledoc """
-HPACK header compression for HTTP/2 (RFC 7541).
+-moduledoc false.
 
-HPACK encodes header lists as a sequence of representations,
-each referring to a static (61-entry, RFC-defined) or dynamic
-(per-connection, FIFO) header table. Names and values are
-length-prefixed strings, optionally Huffman-encoded
-(`roadrunner_http2_hpack_huffman`).
-
-This module exposes:
-
-- `new_decoder/1` / `new_encoder/1` — fresh per-connection
-  contexts pinned at a max table size.
-- `decode/2` — parse a header block fragment, mutating the
-  decoder's dynamic table per the spec.
-- `encode/2` — emit a header block, mutating the encoder's
-  dynamic table.
-- `set_max_table_size/2` — drop the configured maximum;
-  decoders apply the change to inbound updates, encoders MUST
-  emit a Dynamic Table Size Update on the next `encode/2`
-  call.
-
-Header names are returned as **lowercase binaries** per RFC 9113
-§8.2 case-folding requirement; the decoder rejects any uppercase
-character in a literal name field with `bad_header_name`.
-
-## Representations (RFC 7541 §6)
-
-| Prefix bits | Meaning |
-|----|---|
-| `1xxxxxxx` | Indexed Header Field |
-| `01xxxxxx` | Literal w/ Incremental Indexing — indexed/new name |
-| `001xxxxx` | Dynamic Table Size Update |
-| `0001xxxx` | Literal Never Indexed |
-| `0000xxxx` | Literal w/o Indexing |
-
-The encoder here always uses Literal w/ Incremental Indexing
-when emitting non-indexed pairs. Indexed-name + literal-value
-takes priority when the name appears in the static table.
-""".
+%% HPACK header compression for HTTP/2 (RFC 7541).
+%%
+%% HPACK encodes header lists as a sequence of representations,
+%% each referring to a static (61-entry, RFC-defined) or dynamic
+%% (per-connection, FIFO) header table. Names and values are
+%% length-prefixed strings, optionally Huffman-encoded
+%% (`roadrunner_http2_hpack_huffman`).
+%%
+%% This module exposes:
+%%
+%% - `new_decoder/1` / `new_encoder/1` — fresh per-connection
+%%   contexts pinned at a max table size.
+%% - `decode/2` — parse a header block fragment, mutating the
+%%   decoder's dynamic table per the spec.
+%% - `encode/2` — emit a header block, mutating the encoder's
+%%   dynamic table.
+%% - `set_max_table_size/2` — drop the configured maximum;
+%%   decoders apply the change to inbound updates, encoders MUST
+%%   emit a Dynamic Table Size Update on the next `encode/2`
+%%   call.
+%%
+%% Header names are returned as **lowercase binaries** per RFC 9113
+%% §8.2 case-folding requirement; the decoder rejects any uppercase
+%% character in a literal name field with `bad_header_name`.
+%%
+%% ## Representations (RFC 7541 §6)
+%%
+%% | Prefix bits | Meaning |
+%% |----|---|
+%% | `1xxxxxxx` | Indexed Header Field |
+%% | `01xxxxxx` | Literal w/ Incremental Indexing — indexed/new name |
+%% | `001xxxxx` | Dynamic Table Size Update |
+%% | `0001xxxx` | Literal Never Indexed |
+%% | `0000xxxx` | Literal w/o Indexing |
+%%
+%% The encoder here always uses Literal w/ Incremental Indexing
+%% when emitting non-indexed pairs. Indexed-name + literal-value
+%% takes priority when the name appears in the static table.
 
 -export([
     new_decoder/1,

--- a/src/roadrunner_http2_hpack_huffman.erl
+++ b/src/roadrunner_http2_hpack_huffman.erl
@@ -1,37 +1,37 @@
 -module(roadrunner_http2_hpack_huffman).
--moduledoc """
-HPACK Huffman codec (RFC 7541 §5.2 + Appendix B).
+-moduledoc false.
 
-The static Huffman code table maps each of the 256 byte values plus
-an end-of-string symbol (id 256) to a variable-length bit string of
-5 to 30 bits. Encoded strings are zero-padded with `1`-bits at the
-end of the final byte to reach a byte boundary; the EOS symbol
-(`11111111 11111111 11111111 111111`) is **never** emitted as part
-of a string and MUST trigger a decode error if it appears.
-
-## Encoding
-
-`encode(Bin)` walks the input byte-by-byte, looking up each byte's
-code in the encode table (a 256-element tuple of `{NumBits, Code}`)
-and packing the bits into the output via a small accumulator.
-EOS-padding is applied at the end.
-
-## Decoding
-
-`decode(Bin)` uses a 4-bit-nibble state machine. Each state has
-16 transitions; a transition either emits 0/1/2 bytes and lands
-in a new state, or rejects with `eos_in_string` (EOS symbol seen
-mid-string) or `invalid_huffman` (no path through the tree).
-
-The state table is a tuple keyed by state id (state 0 is the root
-of the prefix tree); each entry is `{TransitionsTuple, AcceptFlag}`.
-A state is accepting if pad bits (all `1`s) from this point lie on
-the EOS path of the tree — i.e. terminating the input here is
-valid.
-
-Both tables are constructed at module-load time and stashed in
-`persistent_term` so the hot path does no allocation.
-""".
+%% HPACK Huffman codec (RFC 7541 §5.2 + Appendix B).
+%%
+%% The static Huffman code table maps each of the 256 byte values plus
+%% an end-of-string symbol (id 256) to a variable-length bit string of
+%% 5 to 30 bits. Encoded strings are zero-padded with `1`-bits at the
+%% end of the final byte to reach a byte boundary; the EOS symbol
+%% (`11111111 11111111 11111111 111111`) is **never** emitted as part
+%% of a string and MUST trigger a decode error if it appears.
+%%
+%% ## Encoding
+%%
+%% `encode(Bin)` walks the input byte-by-byte, looking up each byte's
+%% code in the encode table (a 256-element tuple of `{NumBits, Code}`)
+%% and packing the bits into the output via a small accumulator.
+%% EOS-padding is applied at the end.
+%%
+%% ## Decoding
+%%
+%% `decode(Bin)` uses a 4-bit-nibble state machine. Each state has
+%% 16 transitions; a transition either emits 0/1/2 bytes and lands
+%% in a new state, or rejects with `eos_in_string` (EOS symbol seen
+%% mid-string) or `invalid_huffman` (no path through the tree).
+%%
+%% The state table is a tuple keyed by state id (state 0 is the root
+%% of the prefix tree); each entry is `{TransitionsTuple, AcceptFlag}`.
+%% A state is accepting if pad bits (all `1`s) from this point lie on
+%% the EOS path of the tree — i.e. terminating the input here is
+%% valid.
+%%
+%% Both tables are constructed at module-load time and stashed in
+%% `persistent_term` so the hot path does no allocation.
 
 -on_load(init_tables/0).
 

--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -1,21 +1,21 @@
 -module(roadrunner_http2_loop_response).
--moduledoc """
-HTTP/2 `{loop, _}` response: message-driven streaming over h2 DATA frames.
+-moduledoc false.
 
-Mirrors `roadrunner_loop_response` (the h1 path) but runs in the
-per-stream worker process and emits DATA frames via the conn's
-`{h2_send_data, ...}` message protocol. Same mailbox contract as
-h1: a handler's `self() ! Msg` and `register/2` calls from
-`handle/1` work because the worker IS the dispatch process. OTP
-shapes (`{system, _, _}`, `{'$gen_call', _, _}`, `{'$gen_cast', _}`)
-are silently dropped via dedicated receive clauses; we're a plain
-spawn, not a `gen_*`, so `gen_server:call/2,3` against the worker
-will time out instead of surfacing in `handle_info/3`.
-
-On `{stop, _NewState}` the worker emits an empty DATA frame with
-END_STREAM and returns; the conn cleans up the stream slot via the
-worker's `'DOWN'` signal.
-""".
+%% HTTP/2 `{loop, _}` response: message-driven streaming over h2 DATA frames.
+%%
+%% Mirrors `roadrunner_loop_response` (the h1 path) but runs in the
+%% per-stream worker process and emits DATA frames via the conn's
+%% `{h2_send_data, ...}` message protocol. Same mailbox contract as
+%% h1: a handler's `self() ! Msg` and `register/2` calls from
+%% `handle/1` work because the worker IS the dispatch process. OTP
+%% shapes (`{system, _, _}`, `{'$gen_call', _, _}`, `{'$gen_cast', _}`)
+%% are silently dropped via dedicated receive clauses; we're a plain
+%% spawn, not a `gen_*`, so `gen_server:call/2,3` against the worker
+%% will time out instead of surfacing in `handle_info/3`.
+%%
+%% On `{stop, _NewState}` the worker emits an empty DATA frame with
+%% END_STREAM and returns; the conn cleans up the stream slot via the
+%% worker's `'DOWN'` signal.
 
 -export([run/5]).
 

--- a/src/roadrunner_http2_request.erl
+++ b/src/roadrunner_http2_request.erl
@@ -1,32 +1,32 @@
 -module(roadrunner_http2_request).
--moduledoc """
-Build a roadrunner request map from an HTTP/2 HEADERS block
-(decoded HPACK header list) per RFC 9113 §8.3.
+-moduledoc false.
 
-The request shape is the same `roadrunner_http1:request()` map
-that HTTP/1.1 produces — pseudo-headers (`:method`, `:scheme`,
-`:authority`, `:path`) get normalized into the existing `method`
-/ `scheme` / `target` / regular-header fields so handler code
-(and `roadrunner_req` accessors) doesn't care which protocol
-served the request.
-
-## Validation (RFC 9113 §8.1.2)
-
-- Exactly one each of `:method`, `:scheme`, `:path` is required;
-  CONNECT requests omit `:scheme`/`:path` and require
-  `:authority` (we accept the simpler "GET-style" request shape
-  here; CONNECT and Extended CONNECT for WebSocket-over-h2
-  support arrive later).
-- Pseudo-headers MUST appear before regular headers; mixing is
-  a `protocol_error`.
-- Pseudo-headers other than the four defined are rejected.
-- `:path` MUST NOT be empty (an h2 client should send `/` for
-  the origin form).
-- Header field names MUST be lowercase — already enforced by
-  `roadrunner_http2_hpack:decode/2`.
-- `Connection`-specific headers MUST NOT appear (RFC 9113
-  §8.2.2). Rejected.
-""".
+%% Build a roadrunner request map from an HTTP/2 HEADERS block
+%% (decoded HPACK header list) per RFC 9113 §8.3.
+%%
+%% The request shape is the same `roadrunner_http1:request()` map
+%% that HTTP/1.1 produces — pseudo-headers (`:method`, `:scheme`,
+%% `:authority`, `:path`) get normalized into the existing `method`
+%% / `scheme` / `target` / regular-header fields so handler code
+%% (and `roadrunner_req` accessors) doesn't care which protocol
+%% served the request.
+%%
+%% ## Validation (RFC 9113 §8.1.2)
+%%
+%% - Exactly one each of `:method`, `:scheme`, `:path` is required;
+%%   CONNECT requests omit `:scheme`/`:path` and require
+%%   `:authority` (we accept the simpler "GET-style" request shape
+%%   here; CONNECT and Extended CONNECT for WebSocket-over-h2
+%%   support arrive later).
+%% - Pseudo-headers MUST appear before regular headers; mixing is
+%%   a `protocol_error`.
+%% - Pseudo-headers other than the four defined are rejected.
+%% - `:path` MUST NOT be empty (an h2 client should send `/` for
+%%   the origin form).
+%% - Header field names MUST be lowercase — already enforced by
+%%   `roadrunner_http2_hpack:decode/2`.
+%% - `Connection`-specific headers MUST NOT appear (RFC 9113
+%%   §8.2.2). Rejected.
 
 -export([from_headers/3]).
 

--- a/src/roadrunner_http2_settings.erl
+++ b/src/roadrunner_http2_settings.erl
@@ -1,33 +1,33 @@
 -module(roadrunner_http2_settings).
--moduledoc """
-HTTP/2 SETTINGS state and frame helpers (RFC 9113 §6.5).
+-moduledoc false.
 
-A SETTINGS frame carries zero or more 6-byte parameter records:
-2-byte identifier + 4-byte value. The frame applies to the connection
-as a whole (stream id MUST be 0). The receiver records the new
-values and replies with a SETTINGS frame whose ACK flag is set
-(payload empty).
-
-This module is Phase H2 of the HTTP/2 plan — enough to negotiate the
-preamble and answer ACK requirements. Validation of obvious value
-ranges (negative `INITIAL_WINDOW_SIZE`, zero `MAX_FRAME_SIZE`, etc.)
-arrives with the full frame codec in Phase H3 and the stream state
-machine in Phase H5.
-
-The known parameter identifiers per RFC 9113 §6.5.2:
-
-| id | name                             | default     |
-|----|----------------------------------|-------------|
-| 1  | `SETTINGS_HEADER_TABLE_SIZE`     | 4096        |
-| 2  | `SETTINGS_ENABLE_PUSH`           | 1           |
-| 3  | `SETTINGS_MAX_CONCURRENT_STREAMS`| (no limit)  |
-| 4  | `SETTINGS_INITIAL_WINDOW_SIZE`   | 65535       |
-| 5  | `SETTINGS_MAX_FRAME_SIZE`        | 16384       |
-| 6  | `SETTINGS_MAX_HEADER_LIST_SIZE`  | (no limit)  |
-
-Unknown identifiers MUST be ignored (RFC 9113 §6.5.2 last paragraph)
-— preserves forward compatibility with future SETTINGS extensions.
-""".
+%% HTTP/2 SETTINGS state and frame helpers (RFC 9113 §6.5).
+%%
+%% A SETTINGS frame carries zero or more 6-byte parameter records:
+%% 2-byte identifier + 4-byte value. The frame applies to the connection
+%% as a whole (stream id MUST be 0). The receiver records the new
+%% values and replies with a SETTINGS frame whose ACK flag is set
+%% (payload empty).
+%%
+%% This module is Phase H2 of the HTTP/2 plan — enough to negotiate the
+%% preamble and answer ACK requirements. Validation of obvious value
+%% ranges (negative `INITIAL_WINDOW_SIZE`, zero `MAX_FRAME_SIZE`, etc.)
+%% arrives with the full frame codec in Phase H3 and the stream state
+%% machine in Phase H5.
+%%
+%% The known parameter identifiers per RFC 9113 §6.5.2:
+%%
+%% | id | name                             | default     |
+%% |----|----------------------------------|-------------|
+%% | 1  | `SETTINGS_HEADER_TABLE_SIZE`     | 4096        |
+%% | 2  | `SETTINGS_ENABLE_PUSH`           | 1           |
+%% | 3  | `SETTINGS_MAX_CONCURRENT_STREAMS`| (no limit)  |
+%% | 4  | `SETTINGS_INITIAL_WINDOW_SIZE`   | 65535       |
+%% | 5  | `SETTINGS_MAX_FRAME_SIZE`        | 16384       |
+%% | 6  | `SETTINGS_MAX_HEADER_LIST_SIZE`  | (no limit)  |
+%%
+%% Unknown identifiers MUST be ignored (RFC 9113 §6.5.2 last paragraph)
+%% — preserves forward compatibility with future SETTINGS extensions.
 
 -export([
     new/0,

--- a/src/roadrunner_http2_stream_response.erl
+++ b/src/roadrunner_http2_stream_response.erl
@@ -1,34 +1,34 @@
 -module(roadrunner_http2_stream_response).
--moduledoc """
-HTTP/2 `{stream, ...}` response — body delivered as one or more
-DATA frames, with optional trailers as a closing HEADERS frame.
+-moduledoc false.
 
-Mirrors `roadrunner_stream_response` so the handler-facing
-`Send/2` API stays protocol-agnostic. Translation table:
-
-| `Send(Data, FinFlag)` | h1 wire | h2 wire |
-|---|---|---|
-| `Send(Data, nofin)` | one chunk | DATA, no END_STREAM |
-| `Send(Data, fin)` | chunk + `0\\r\\n\\r\\n` | DATA + END_STREAM |
-| `Send(Data, {fin, Trailers})` | chunk + `0` + trailers | DATA + HEADERS + END_STREAM |
-
-Empty data is special-cased to match the h1 behavior:
-- `Send(<<>>, nofin)` is a no-op (no zero-length DATA frame).
-- `Send(<<>>, fin)` emits an empty DATA frame with END_STREAM.
-- `Send(<<>>, {fin, Trailers})` emits the trailer HEADERS frame
-  (with END_STREAM) and no DATA.
-
-The `Send` callback runs in the worker process and synchronously
-round-trips with the conn process for each emission — `Send`
-returns only after the conn has written the corresponding frame
-on the wire (or queued it pending a `WINDOW_UPDATE`). This
-threads natural backpressure: a slow consumer stalls the worker
-without us having to explicitly buffer.
-
-If the handler returns without calling `Send(_, fin)` /
-`{fin, _}` we auto-close the stream with an empty `END_STREAM`
-DATA frame so the peer doesn't see a half-open stream.
-""".
+%% HTTP/2 `{stream, ...}` response — body delivered as one or more
+%% DATA frames, with optional trailers as a closing HEADERS frame.
+%%
+%% Mirrors `roadrunner_stream_response` so the handler-facing
+%% `Send/2` API stays protocol-agnostic. Translation table:
+%%
+%% | `Send(Data, FinFlag)` | h1 wire | h2 wire |
+%% |---|---|---|
+%% | `Send(Data, nofin)` | one chunk | DATA, no END_STREAM |
+%% | `Send(Data, fin)` | chunk + `0\\r\\n\\r\\n` | DATA + END_STREAM |
+%% | `Send(Data, {fin, Trailers})` | chunk + `0` + trailers | DATA + HEADERS + END_STREAM |
+%%
+%% Empty data is special-cased to match the h1 behavior:
+%% - `Send(<<>>, nofin)` is a no-op (no zero-length DATA frame).
+%% - `Send(<<>>, fin)` emits an empty DATA frame with END_STREAM.
+%% - `Send(<<>>, {fin, Trailers})` emits the trailer HEADERS frame
+%%   (with END_STREAM) and no DATA.
+%%
+%% The `Send` callback runs in the worker process and synchronously
+%% round-trips with the conn process for each emission — `Send`
+%% returns only after the conn has written the corresponding frame
+%% on the wire (or queued it pending a `WINDOW_UPDATE`). This
+%% threads natural backpressure: a slow consumer stalls the worker
+%% without us having to explicitly buffer.
+%%
+%% If the handler returns without calling `Send(_, fin)` /
+%% `{fin, _}` we auto-close the stream with an empty `END_STREAM`
+%% DATA frame so the peer doesn't see a half-open stream.
 
 -export([run/5]).
 

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -1,44 +1,44 @@
 -module(roadrunner_http2_stream_worker).
--moduledoc """
-Per-stream worker process for HTTP/2 dispatch (Phase H8b).
+-moduledoc false.
 
-Spawned by `roadrunner_conn_loop_http2` once a request stream
-finishes receiving (HEADERS + body + END_STREAM). The worker:
-
-1. Resolves the route + middleware stack.
-2. Calls the handler.
-3. Translates the response shape (`{Status, Headers, Body}` or
-   `{stream, _, _, Fun}`) into messages back to the conn process,
-   which is the single owner of HPACK encoder state and frame I/O.
-
-Worker → conn protocol (synchronous round-trip per write so the
-worker doesn't outpace flow control or the wire):
-
-```
-Worker → Conn: {h2_send_headers, Worker, Ref, StreamId, Status, Headers, EndStream}
-Conn   → Worker: {h2_send_ack, Ref}                       %% frame written
-
-Worker → Conn: {h2_send_data, Worker, Ref, StreamId, Data, EndStream}
-Conn   → Worker: {h2_send_ack, Ref}                       %% frame written
-                  %% (delayed if the conn or stream send window was
-                  %% closed — drained on the next WINDOW_UPDATE)
-
-Worker → Conn: {h2_send_trailers, Worker, Ref, StreamId, Trailers}
-Conn   → Worker: {h2_send_ack, Ref}
-
-Worker → Conn: {h2_worker_done, StreamId}                 %% normal exit
-```
-
-If the peer cancels the stream (`RST_STREAM` or worker-level error
-on the conn side), the conn sends `{h2_stream_reset, StreamId}` —
-the worker observes this on its next sync round and exits without
-emitting further frames.
-
-Crash isolation: workers are spawn_monitored (NOT linked) so a
-handler crash resets only the affected stream — the conn
-observes the `'DOWN'` and emits
-`RST_STREAM(INTERNAL_ERROR)`, leaving in-flight peers untouched.
-""".
+%% Per-stream worker process for HTTP/2 dispatch (Phase H8b).
+%%
+%% Spawned by `roadrunner_conn_loop_http2` once a request stream
+%% finishes receiving (HEADERS + body + END_STREAM). The worker:
+%%
+%% 1. Resolves the route + middleware stack.
+%% 2. Calls the handler.
+%% 3. Translates the response shape (`{Status, Headers, Body}` or
+%%    `{stream, _, _, Fun}`) into messages back to the conn process,
+%%    which is the single owner of HPACK encoder state and frame I/O.
+%%
+%% Worker → conn protocol (synchronous round-trip per write so the
+%% worker doesn't outpace flow control or the wire):
+%%
+%% ```
+%% Worker → Conn: {h2_send_headers, Worker, Ref, StreamId, Status, Headers, EndStream}
+%% Conn   → Worker: {h2_send_ack, Ref}                       %% frame written
+%%
+%% Worker → Conn: {h2_send_data, Worker, Ref, StreamId, Data, EndStream}
+%% Conn   → Worker: {h2_send_ack, Ref}                       %% frame written
+%%                   %% (delayed if the conn or stream send window was
+%%                   %% closed — drained on the next WINDOW_UPDATE)
+%%
+%% Worker → Conn: {h2_send_trailers, Worker, Ref, StreamId, Trailers}
+%% Conn   → Worker: {h2_send_ack, Ref}
+%%
+%% Worker → Conn: {h2_worker_done, StreamId}                 %% normal exit
+%% ```
+%%
+%% If the peer cancels the stream (`RST_STREAM` or worker-level error
+%% on the conn side), the conn sends `{h2_stream_reset, StreamId}` —
+%% the worker observes this on its next sync round and exits without
+%% emitting further frames.
+%%
+%% Crash isolation: workers are spawn_monitored (NOT linked) so a
+%% handler crash resets only the affected stream — the conn
+%% observes the `'DOWN'` and emits
+%% `RST_STREAM(INTERNAL_ERROR)`, leaving in-flight peers untouched.
 
 -export([start/4]).
 -export([init/4]).

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -246,6 +246,7 @@ reload_routes(Name, Routes) ->
 
 %% --- gen_server callbacks ---
 
+-doc false.
 -spec init(opts()) -> {ok, #state{}} | {stop, term()}.
 init(#{port := Port} = Opts) ->
     ListenerName = listener_name(),
@@ -561,6 +562,7 @@ build_dispatch(#{routes := Routes}, ListenerName) when is_list(Routes) ->
 build_dispatch(_Opts, _ListenerName) ->
     {handler, roadrunner_default_handler}.
 
+-doc false.
 -spec handle_call(
     port
     | info
@@ -647,10 +649,12 @@ wait_for_drain(Counter, Deadline, Group) ->
 drain_group(#{listener_name := Name}) ->
     {roadrunner_drain, Name}.
 
+-doc false.
 -spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
+-doc false.
 -spec handle_info(term(), #state{}) -> {noreply, #state{}}.
 handle_info(reconcile_slots, #state{reconciliation = disabled} = State) ->
     %% Race: a `slot_reconciliation` opt change between scheduling and
@@ -719,6 +723,7 @@ count_up_to(_, Cap, N) when N >= Cap -> Cap;
 count_up_to([], _Cap, N) -> N;
 count_up_to([_ | T], Cap, N) -> count_up_to(T, Cap, N + 1).
 
+-doc false.
 -spec terminate(term(), #state{}) -> ok.
 terminate(_Reason, #state{listen_socket = LSocket, proto_opts = ProtoOpts}) ->
     erase_routes(ProtoOpts),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -37,6 +37,54 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_MAX_CLIENTS, 150).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
 
+-doc """
+Listener configuration map.
+
+Required:
+- `port` — TCP port to bind. `0` lets the kernel pick an ephemeral
+  port; query it back with `port/1`.
+
+Routing (pick one):
+- `routes => module()` — single-handler dispatch. Every request
+  goes to `Module:handle/1`.
+- `routes => roadrunner_router:routes()` — list of
+  `{Path, Handler, Opts}` tuples; first match wins.
+
+Optional middleware and timing knobs (durations in milliseconds):
+- `middlewares` — listener-wide pipeline applied to every request.
+- `max_content_length` — request-body cap; over-cap reads return
+  `payload_too_large`. Default 10 MB.
+- `request_timeout` — header-read timeout on a fresh conn.
+  Default 30 s.
+- `keep_alive_timeout` — idle timeout between requests on a
+  keep-alive conn. Default 60 s.
+- `num_acceptors` — size of the acceptor pool. Default 10.
+- `max_keep_alive_requests` — requests served per conn before
+  forced close. Default 1000.
+- `max_clients` — concurrent connection cap. Default 150.
+- `min_bytes_per_second` — slow-loris guard on the request-read
+  phase (0 disables). Default 100.
+- `rate_check_interval` — how often the rate guard re-checks
+  (ms). Default 1000.
+- `body_buffering` — `auto` (default; framework reads the full
+  body before invoking the handler) or `manual` (handler calls
+  `roadrunner_req:read_body/1,2`).
+- `slot_reconciliation` — `disabled` (default) or
+  `#{interval := Ms}` to periodically reap slots orphaned by
+  brutal-kill exits.
+- `graceful_drain` — opt out of the per-conn pg drain group
+  (`true` default; `false` trades drain notification for ~10 %
+  lower per-conn overhead on short-lived workloads).
+- `hibernate_after` — when set, idle conns hibernate after this
+  many milliseconds of main-loop idle time.
+- `protocols` — list of `t:protocol_entry/0`. Default `[http1]`.
+  On TLS this drives `alpn_preferred_protocols` automatically.
+- `tls` — `[ssl:tls_server_option()]` for HTTPS. Empty / absent
+  for plain HTTP.
+
+The inline source comments next to each field carry the deeper
+ops-tuning rationale.
+""".
 -type opts() :: #{
     port := inet:port_number(),
     routes => module() | roadrunner_router:routes(),
@@ -123,8 +171,38 @@ All duration and interval values in `opts()` are in milliseconds —
     tls => [ssl:tls_server_option()]
 }.
 
+-doc """
+One protocol entry in the listener's `protocols` list. Either a
+bare atom (`http1` / `http2`) for default opts, or a tuple
+`{Proto, ProtoOpts}` carrying protocol-specific tuning. HTTP/1
+currently has no tunables (its opts map must be empty); HTTP/2
+tunables live under `t:http2_opts/0`.
+
+On TLS the list drives `alpn_preferred_protocols`. On plain TCP,
+`[http2]` means prior-knowledge h2c (client sends the h2 preface
+directly); `[http1, http2]` on plain TCP is rejected at `init/1`
+since there's no `Upgrade: h2c` implementation.
+""".
 -type protocol_entry() :: http1 | http2 | {http1, #{}} | {http2, http2_opts()}.
 
+-doc """
+HTTP/2 listener tunables (under `{http2, ThisMap}` in `protocols`).
+
+- `conn_window` — connection-level receive window peak in bytes
+  (`1..2^31-1`). RFC 9113 default `65535`; values above the
+  default emit an early `WINDOW_UPDATE(0, peak - 65535)` after
+  the server SETTINGS. Worst-case memory is
+  `max_clients × peak`.
+- `stream_window` — stream-level receive window peak in bytes
+  (`1..2^31-1`). Advertised via `SETTINGS_INITIAL_WINDOW_SIZE`.
+  Default `65535`. Setting above `conn_window` is allowed but
+  not useful — the conn-level peak is the binding constraint.
+- `window_refill_threshold` — refill trigger in bytes. When the
+  remaining window drops below this, the conn refills back to
+  the peak. Lower threshold = fewer `WINDOW_UPDATE` frames per
+  byte consumed but a smaller live window between refills.
+  Default `32768`.
+""".
 -type http2_opts() :: #{
     conn_window => 1..16#7FFFFFFF,
     stream_window => 1..16#7FFFFFFF,

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -4,10 +4,10 @@ Listener gen_server — owns the listening socket and the acceptor pool
 for one named roadrunner instance.
 
 Plain TCP is backed by `gen_tcp` with the legacy `inet_drv` backend.
-The OTP-27 `{inet_backend, socket}` NIF path was tried but adds ~46%
-own-time overhead on short-lived connections via per-socket-option
-lookups (see `docs/conn_lifecycle_investigation.md`). TLS is backed
-by `ssl`, gated by the `tls` opt.
+The OTP-27 `{inet_backend, socket}` NIF path was tried but adds
+significant own-time overhead on short-lived connections via
+per-socket-option lookups. TLS is backed by `ssl`, gated by the
+`tls` opt.
 Both paths share the same `roadrunner_transport` tagged-socket abstraction.
 
 On `init/1` the listener opens the listen socket, builds the shared

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -40,7 +40,7 @@ All duration and interval values in `opts()` are in milliseconds —
 -type opts() :: #{
     port := inet:port_number(),
     routes => module() | roadrunner_router:routes(),
-    middlewares => roadrunner_handler:middleware_list(),
+    middlewares => roadrunner_middleware:middleware_list(),
     max_content_length => non_neg_integer(),
     request_timeout => non_neg_integer(),
     keep_alive_timeout => non_neg_integer(),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -323,7 +323,6 @@ reload_routes(Name, Routes) ->
     gen_server:call(Name, {reload_routes, Routes}).
 
 %% --- gen_server callbacks ---
-
 -doc false.
 -spec init(opts()) -> {ok, #state{}} | {stop, term()}.
 init(#{port := Port} = Opts) ->

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -40,7 +40,7 @@ All duration and interval values in `opts()` are in milliseconds —
 -type opts() :: #{
     port := inet:port_number(),
     routes => module() | roadrunner_router:routes(),
-    middlewares => roadrunner_middleware:middleware_list(),
+    middlewares => roadrunner_handler:middleware_list(),
     max_content_length => non_neg_integer(),
     request_timeout => non_neg_integer(),
     keep_alive_timeout => non_neg_integer(),

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -1,36 +1,36 @@
 -module(roadrunner_loop_response).
--moduledoc """
-Per-connection `{loop, ...}` response — message-driven streaming.
+-moduledoc false.
 
-Called by `roadrunner_conn_loop:dispatch_response/4` after a handler
-returns `{loop, Status, Headers, State}`. Writes the status line +
-chunked headers, then runs a recursive selective-receive loop that
-dispatches every Erlang message through `Module:handle_info/3`. The
-handler's `Push(Data)` callback frames the data as one chunk and
-writes it. On `{stop, _NewState}` the loop emits the size-0 chunked
-terminator and returns.
-
-**Runs in the conn process**, not a child — handlers commonly do
-`self() ! Msg` or `register(Name, self())` from `handle/1`,
-expecting the loop to share their mailbox. Splitting into a child
-process would break that contract; the loop stays inline.
-
-## Mailbox contract
-
-The conn is a plain `proc_lib`-spawned loop, not a `gen_*` behaviour,
-so it doesn't speak the OTP `sys` / `gen_call` / `gen_cast` protocols.
-The receive selectively skips those shapes (`{system, _, _}`,
-`{'$gen_call', _, _}`, `{'$gen_cast', _}`) so a misuse like
-`gen_server:call(ConnPid, _)` doesn't accidentally surface as an
-`handle_info/3` event to the user handler. Concretely:
-
-- `sys:get_state/1`, `sys:trace/2`, `gen_server:call/2,3` and
-  friends against the conn process will appear to hang — the
-  caller should expect to time out.
-- Any other Erlang message reaches the handler's `handle_info/3`
-  verbatim. Handlers should pattern-match defensively (with a
-  catch-all clause) rather than crash on unexpected messages.
-""".
+%% Per-connection `{loop, ...}` response — message-driven streaming.
+%%
+%% Called by `roadrunner_conn_loop:dispatch_response/4` after a handler
+%% returns `{loop, Status, Headers, State}`. Writes the status line +
+%% chunked headers, then runs a recursive selective-receive loop that
+%% dispatches every Erlang message through `Module:handle_info/3`. The
+%% handler's `Push(Data)` callback frames the data as one chunk and
+%% writes it. On `{stop, _NewState}` the loop emits the size-0 chunked
+%% terminator and returns.
+%%
+%% **Runs in the conn process**, not a child — handlers commonly do
+%% `self() ! Msg` or `register(Name, self())` from `handle/1`,
+%% expecting the loop to share their mailbox. Splitting into a child
+%% process would break that contract; the loop stays inline.
+%%
+%% ## Mailbox contract
+%%
+%% The conn is a plain `proc_lib`-spawned loop, not a `gen_*` behaviour,
+%% so it doesn't speak the OTP `sys` / `gen_call` / `gen_cast` protocols.
+%% The receive selectively skips those shapes (`{system, _, _}`,
+%% `{'$gen_call', _, _}`, `{'$gen_cast', _}`) so a misuse like
+%% `gen_server:call(ConnPid, _)` doesn't accidentally surface as an
+%% `handle_info/3` event to the user handler. Concretely:
+%%
+%% - `sys:get_state/1`, `sys:trace/2`, `gen_server:call/2,3` and
+%%   friends against the conn process will appear to hang — the
+%%   caller should expect to time out.
+%% - Any other Erlang message reaches the handler's `handle_info/3`
+%%   verbatim. Handlers should pattern-match defensively (with a
+%%   catch-all clause) rather than crash on unexpected messages.
 
 -export([run/5]).
 

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -112,6 +112,20 @@ server_header(Req, Next) ->
     | fun((roadrunner_req:request(), next()) -> roadrunner_handler:result()).
 -type middleware_list() :: [middleware()].
 
+-doc """
+The middleware contract. `Request` is the current request map;
+`Next` is a continuation that runs the rest of the pipeline (other
+middlewares + the inner handler) and returns the same
+`t:roadrunner_handler:result/0` shape every middleware returns.
+
+The middleware decides whether to:
+- pass through unchanged (`Next(Req)`),
+- transform the request (`Next(Req#{...})`),
+- short-circuit (return `{Response, Req}` without calling `Next`),
+- wrap the response (let `Next(Req)` run, then transform what it
+  returned),
+- run side effects around the call (log, time, instrument).
+""".
 -callback call(Request :: roadrunner_req:request(), Next :: next()) ->
     roadrunner_handler:result().
 

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -1,108 +1,108 @@
 -module(roadrunner_middleware).
--moduledoc """
-Continuation-style middleware for roadrunner handlers.
+-moduledoc false.
 
-A middleware wraps the rest of the request pipeline:
-
-```erlang
--callback call(Request, Next) -> Result when
-    Request :: roadrunner_req:request(),
-    Next :: fun((Request) -> Result),
-    Result :: roadrunner_handler:result().
-```
-
-The pipeline (handler at its core) returns `{Response, Req2}`. Each
-middleware sees the same shape and is expected to return it — either
-straight from `Next` or after transforming it.
-
-Each middleware decides:
-
-- **pass through unchanged** — `Next(Req)`
-- **transform the request** — `Next(Req#{...})`
-- **short-circuit / halt** — return `{Response, Req}` without calling
-  `Next`
-- **wrap the response** — let `Next(Req)` run, then transform what it
-  returned (status, headers, body)
-- **side effects around the call** — log, time, instrument
-
-This shape is deliberately lighter than cowboy's deprecated
-`(Req, Env)` middlewares (which couldn't see the response) and
-much lighter than cowboy stream handlers (which split the request
-lifecycle into five callbacks). It matches the modern
-continuation/decorator pattern used by Plug.Builder, Express.js,
-Tower, and Servant.
-
-## No direct wire writes from middleware
-
-Middleware code never has access to the underlying socket — the
-`Request` map intentionally excludes any socket reference. To
-respond, a middleware **must** return a `Result` (either the one
-from `Next(Req)` or its own response triple); there is no
-`roadrunner_req:reply/4` equivalent to cowboy's mid-flight
-`cowboy_req:reply/4`.
-
-This is a feature, not a limitation. Bytes only hit the wire from
-one place — the conn process — which means:
-
-- `[roadrunner, request, stop]` telemetry fires for every request,
-  with consistent duration and status metadata.
-- gzip wrapping, response transforms, and `Content-Length` framing
-  are applied uniformly regardless of which middleware produced
-  the response.
-- Send errors are handled in one place (`[roadrunner, response,
-  send_failed]` telemetry, drain bookkeeping, slot release).
-- The "halt" pattern is structurally simple: don't call `Next`, just
-  return a response. There's no second halt protocol to maintain
-  (compare: an arizona cowboy adapter has to support BOTH stashed
-  redirects AND raw-write-from-middleware to stay backward-compatible
-  with cowboy's permissiveness; the roadrunner adapter only handles
-  the stashed-redirect path).
-
-If you're porting middleware from cowboy that called
-`cowboy_req:reply/4` directly, replace the call with returning a
-response triple — `{Status, Headers, Body}` — from the middleware,
-and the framework writes the bytes.
-
-## Where middlewares live
-
-- **Listener-level**: `roadrunner_listener:start_link(_, #{middlewares => [...]})`.
-  These run for every request — single-handler and routed.
-- **Per-route**: in the 3-tuple route opts under the `middlewares` key:
-  `{~"/path", handler_mod, #{middlewares => [...]}}`.
-
-When both are configured, listener middlewares wrap route middlewares
-which wrap the handler — first in each list runs outermost.
-
-## Middleware shape
-
-Each entry in a middlewares list is one of:
-
-- `module()` — the module's `call/2` (this behaviour callback) is invoked.
-- `fun((Request, Next) -> Result)` — invoked directly.
-
-## Examples
-
-```erlang
-%% Auth check — halt with 401 when missing.
-auth(Req, Next) ->
-    case roadrunner_req:header(~"authorization", Req) of
-        undefined -> {roadrunner_resp:unauthorized(), Req};
-        _ -> Next(Req)
-    end.
-
-%% Around: time the whole request including the response write.
-timing(Req, Next) ->
-    Start = erlang:monotonic_time(millisecond),
-    Result = Next(Req),
-    logger:info(#{took_ms => erlang:monotonic_time(millisecond) - Start}),
-    Result.
-
-%% Inject a server header on every response.
-server_header(Req, Next) ->
-    {{S, H, B}, Req2} = Next(Req),
-    {{S, [{~"server", ~"roadrunner"} | H], B}, Req2}.
-```
-""".
+%% Continuation-style middleware for roadrunner handlers.
+%%
+%% A middleware wraps the rest of the request pipeline:
+%%
+%% ```erlang
+%% -callback call(Request, Next) -> Result when
+%%     Request :: roadrunner_req:request(),
+%%     Next :: fun((Request) -> Result),
+%%     Result :: roadrunner_handler:result().
+%% ```
+%%
+%% The pipeline (handler at its core) returns `{Response, Req2}`. Each
+%% middleware sees the same shape and is expected to return it — either
+%% straight from `Next` or after transforming it.
+%%
+%% Each middleware decides:
+%%
+%% - **pass through unchanged** — `Next(Req)`
+%% - **transform the request** — `Next(Req#{...})`
+%% - **short-circuit / halt** — return `{Response, Req}` without calling
+%%   `Next`
+%% - **wrap the response** — let `Next(Req)` run, then transform what it
+%%   returned (status, headers, body)
+%% - **side effects around the call** — log, time, instrument
+%%
+%% This shape is deliberately lighter than cowboy's deprecated
+%% `(Req, Env)` middlewares (which couldn't see the response) and
+%% much lighter than cowboy stream handlers (which split the request
+%% lifecycle into five callbacks). It matches the modern
+%% continuation/decorator pattern used by Plug.Builder, Express.js,
+%% Tower, and Servant.
+%%
+%% ## No direct wire writes from middleware
+%%
+%% Middleware code never has access to the underlying socket — the
+%% `Request` map intentionally excludes any socket reference. To
+%% respond, a middleware **must** return a `Result` (either the one
+%% from `Next(Req)` or its own response triple); there is no
+%% `roadrunner_req:reply/4` equivalent to cowboy's mid-flight
+%% `cowboy_req:reply/4`.
+%%
+%% This is a feature, not a limitation. Bytes only hit the wire from
+%% one place — the conn process — which means:
+%%
+%% - `[roadrunner, request, stop]` telemetry fires for every request,
+%%   with consistent duration and status metadata.
+%% - gzip wrapping, response transforms, and `Content-Length` framing
+%%   are applied uniformly regardless of which middleware produced
+%%   the response.
+%% - Send errors are handled in one place (`[roadrunner, response,
+%%   send_failed]` telemetry, drain bookkeeping, slot release).
+%% - The "halt" pattern is structurally simple: don't call `Next`, just
+%%   return a response. There's no second halt protocol to maintain
+%%   (compare: an arizona cowboy adapter has to support BOTH stashed
+%%   redirects AND raw-write-from-middleware to stay backward-compatible
+%%   with cowboy's permissiveness; the roadrunner adapter only handles
+%%   the stashed-redirect path).
+%%
+%% If you're porting middleware from cowboy that called
+%% `cowboy_req:reply/4` directly, replace the call with returning a
+%% response triple — `{Status, Headers, Body}` — from the middleware,
+%% and the framework writes the bytes.
+%%
+%% ## Where middlewares live
+%%
+%% - **Listener-level**: `roadrunner_listener:start_link(_, #{middlewares => [...]})`.
+%%   These run for every request — single-handler and routed.
+%% - **Per-route**: in the 3-tuple route opts under the `middlewares` key:
+%%   `{~"/path", handler_mod, #{middlewares => [...]}}`.
+%%
+%% When both are configured, listener middlewares wrap route middlewares
+%% which wrap the handler — first in each list runs outermost.
+%%
+%% ## Middleware shape
+%%
+%% Each entry in a middlewares list is one of:
+%%
+%% - `module()` — the module's `call/2` (this behaviour callback) is invoked.
+%% - `fun((Request, Next) -> Result)` — invoked directly.
+%%
+%% ## Examples
+%%
+%% ```erlang
+%% %% Auth check — halt with 401 when missing.
+%% auth(Req, Next) ->
+%%     case roadrunner_req:header(~"authorization", Req) of
+%%         undefined -> {roadrunner_resp:unauthorized(), Req};
+%%         _ -> Next(Req)
+%%     end.
+%%
+%% %% Around: time the whole request including the response write.
+%% timing(Req, Next) ->
+%%     Start = erlang:monotonic_time(millisecond),
+%%     Result = Next(Req),
+%%     logger:info(#{took_ms => erlang:monotonic_time(millisecond) - Start}),
+%%     Result.
+%%
+%% %% Inject a server header on every response.
+%% server_header(Req, Next) ->
+%%     {{S, H, B}, Req2} = Next(Req),
+%%     {{S, [{~"server", ~"roadrunner"} | H], B}, Req2}.
+%% ```
 
 -export([compose/2, build_pipeline/3]).
 -export_type([middleware/0, middleware_list/0, next/0]).

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -173,7 +173,6 @@ compose([Mw | Rest], Handler) ->
 %% Used by both the h1 conn loop (`roadrunner_conn_loop:run_pipeline`)
 %% and the h2 stream worker (`roadrunner_http2_stream_worker:invoke`)
 %% so the dispatch shape stays identical across protocols.
-
 -doc false.
 -spec build_pipeline(middleware_list(), roadrunner_req:request(), module()) -> next().
 build_pipeline([], Req, Handler) ->

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -1,115 +1,116 @@
 -module(roadrunner_middleware).
--moduledoc false.
+-moduledoc """
+Continuation-style middleware for roadrunner handlers.
 
-%% Continuation-style middleware for roadrunner handlers.
-%%
-%% A middleware wraps the rest of the request pipeline:
-%%
-%% ```erlang
-%% -callback call(Request, Next) -> Result when
-%%     Request :: roadrunner_req:request(),
-%%     Next :: fun((Request) -> Result),
-%%     Result :: roadrunner_handler:result().
-%% ```
-%%
-%% The pipeline (handler at its core) returns `{Response, Req2}`. Each
-%% middleware sees the same shape and is expected to return it — either
-%% straight from `Next` or after transforming it.
-%%
-%% Each middleware decides:
-%%
-%% - **pass through unchanged** — `Next(Req)`
-%% - **transform the request** — `Next(Req#{...})`
-%% - **short-circuit / halt** — return `{Response, Req}` without calling
-%%   `Next`
-%% - **wrap the response** — let `Next(Req)` run, then transform what it
-%%   returned (status, headers, body)
-%% - **side effects around the call** — log, time, instrument
-%%
-%% This shape is deliberately lighter than cowboy's deprecated
-%% `(Req, Env)` middlewares (which couldn't see the response) and
-%% much lighter than cowboy stream handlers (which split the request
-%% lifecycle into five callbacks). It matches the modern
-%% continuation/decorator pattern used by Plug.Builder, Express.js,
-%% Tower, and Servant.
-%%
-%% ## No direct wire writes from middleware
-%%
-%% Middleware code never has access to the underlying socket — the
-%% `Request` map intentionally excludes any socket reference. To
-%% respond, a middleware **must** return a `Result` (either the one
-%% from `Next(Req)` or its own response triple); there is no
-%% `roadrunner_req:reply/4` equivalent to cowboy's mid-flight
-%% `cowboy_req:reply/4`.
-%%
-%% This is a feature, not a limitation. Bytes only hit the wire from
-%% one place — the conn process — which means:
-%%
-%% - `[roadrunner, request, stop]` telemetry fires for every request,
-%%   with consistent duration and status metadata.
-%% - gzip wrapping, response transforms, and `Content-Length` framing
-%%   are applied uniformly regardless of which middleware produced
-%%   the response.
-%% - Send errors are handled in one place (`[roadrunner, response,
-%%   send_failed]` telemetry, drain bookkeeping, slot release).
-%% - The "halt" pattern is structurally simple: don't call `Next`, just
-%%   return a response. There's no second halt protocol to maintain
-%%   (compare: an arizona cowboy adapter has to support BOTH stashed
-%%   redirects AND raw-write-from-middleware to stay backward-compatible
-%%   with cowboy's permissiveness; the roadrunner adapter only handles
-%%   the stashed-redirect path).
-%%
-%% If you're porting middleware from cowboy that called
-%% `cowboy_req:reply/4` directly, replace the call with returning a
-%% response triple — `{Status, Headers, Body}` — from the middleware,
-%% and the framework writes the bytes.
-%%
-%% ## Where middlewares live
-%%
-%% - **Listener-level**: `roadrunner_listener:start_link(_, #{middlewares => [...]})`.
-%%   These run for every request — single-handler and routed.
-%% - **Per-route**: in the 3-tuple route opts under the `middlewares` key:
-%%   `{~"/path", handler_mod, #{middlewares => [...]}}`.
-%%
-%% When both are configured, listener middlewares wrap route middlewares
-%% which wrap the handler — first in each list runs outermost.
-%%
-%% ## Middleware shape
-%%
-%% Each entry in a middlewares list is one of:
-%%
-%% - `module()` — the module's `call/2` (this behaviour callback) is invoked.
-%% - `fun((Request, Next) -> Result)` — invoked directly.
-%%
-%% ## Examples
-%%
-%% ```erlang
-%% %% Auth check — halt with 401 when missing.
-%% auth(Req, Next) ->
-%%     case roadrunner_req:header(~"authorization", Req) of
-%%         undefined -> {roadrunner_resp:unauthorized(), Req};
-%%         _ -> Next(Req)
-%%     end.
-%%
-%% %% Around: time the whole request including the response write.
-%% timing(Req, Next) ->
-%%     Start = erlang:monotonic_time(millisecond),
-%%     Result = Next(Req),
-%%     logger:info(#{took_ms => erlang:monotonic_time(millisecond) - Start}),
-%%     Result.
-%%
-%% %% Inject a server header on every response.
-%% server_header(Req, Next) ->
-%%     {{S, H, B}, Req2} = Next(Req),
-%%     {{S, [{~"server", ~"roadrunner"} | H], B}, Req2}.
-%% ```
+A middleware wraps the rest of the request pipeline:
+
+```erlang
+-callback call(Request, Next) -> Result when
+    Request :: roadrunner_req:request(),
+    Next :: fun((Request) -> Result),
+    Result :: roadrunner_handler:result().
+```
+
+The pipeline (handler at its core) returns `{Response, Req2}`. Each
+middleware sees the same shape and is expected to return it — either
+straight from `Next` or after transforming it.
+
+Each middleware decides:
+
+- **pass through unchanged** — `Next(Req)`
+- **transform the request** — `Next(Req#{...})`
+- **short-circuit / halt** — return `{Response, Req}` without calling
+  `Next`
+- **wrap the response** — let `Next(Req)` run, then transform what it
+  returned (status, headers, body)
+- **side effects around the call** — log, time, instrument
+
+This shape is deliberately lighter than cowboy's deprecated
+`(Req, Env)` middlewares (which couldn't see the response) and
+much lighter than cowboy stream handlers (which split the request
+lifecycle into five callbacks). It matches the modern
+continuation/decorator pattern used by Plug.Builder, Express.js,
+Tower, and Servant.
+
+## No direct wire writes from middleware
+
+Middleware code never has access to the underlying socket — the
+`Request` map intentionally excludes any socket reference. To
+respond, a middleware **must** return a `Result` (either the one
+from `Next(Req)` or its own response triple); there is no `reply`
+escape hatch equivalent to cowboy's mid-flight `cowboy_req:reply/4`.
+
+This is a feature, not a limitation. Bytes only hit the wire from
+one place — the conn process — which means:
+
+- `[roadrunner, request, stop]` telemetry fires for every request,
+  with consistent duration and status metadata.
+- gzip wrapping, response transforms, and `Content-Length` framing
+  are applied uniformly regardless of which middleware produced
+  the response.
+- Send errors are handled in one place (`[roadrunner, response,
+  send_failed]` telemetry, drain bookkeeping, slot release).
+- The "halt" pattern is structurally simple: don't call `Next`, just
+  return a response. There's no second halt protocol to maintain
+  (compare: an arizona cowboy adapter has to support BOTH stashed
+  redirects AND raw-write-from-middleware to stay backward-compatible
+  with cowboy's permissiveness; the roadrunner adapter only handles
+  the stashed-redirect path).
+
+If you're porting middleware from cowboy that called
+`cowboy_req:reply/4` directly, replace the call with returning a
+response triple — `{Status, Headers, Body}` — from the middleware,
+and the framework writes the bytes.
+
+## Where middlewares live
+
+- **Listener-level**: `roadrunner_listener:start_link(_, #{middlewares => [...]})`.
+  These run for every request — single-handler and routed.
+- **Per-route**: in the 3-tuple route opts under the `middlewares` key:
+  `{~"/path", handler_mod, #{middlewares => [...]}}`.
+
+When both are configured, listener middlewares wrap route middlewares
+which wrap the handler — first in each list runs outermost.
+
+## Middleware shape
+
+Each entry in a middlewares list is one of:
+
+- `module()` — the module's `call/2` (this behaviour callback) is invoked.
+- `fun((Request, Next) -> Result)` — invoked directly.
+
+## Examples
+
+```erlang
+%% Auth check — halt with 401 when missing.
+auth(Req, Next) ->
+    case roadrunner_req:header(~"authorization", Req) of
+        undefined -> {roadrunner_resp:unauthorized(), Req};
+        _ -> Next(Req)
+    end.
+
+%% Around: time the whole request including the response write.
+timing(Req, Next) ->
+    Start = erlang:monotonic_time(millisecond),
+    Result = Next(Req),
+    logger:info(#{took_ms => erlang:monotonic_time(millisecond) - Start}),
+    Result.
+
+%% Inject a server header on every response.
+server_header(Req, Next) ->
+    {{S, H, B}, Req2} = Next(Req),
+    {{S, [{~"server", ~"roadrunner"} | H], B}, Req2}.
+```
+""".
 
 -export([compose/2, build_pipeline/3]).
 -export_type([middleware/0, middleware_list/0, next/0]).
 
--type next() :: roadrunner_handler:next().
--type middleware() :: roadrunner_handler:middleware().
--type middleware_list() :: roadrunner_handler:middleware_list().
+-type next() :: fun((roadrunner_req:request()) -> roadrunner_handler:result()).
+-type middleware() ::
+    module()
+    | fun((roadrunner_req:request(), next()) -> roadrunner_handler:result()).
+-type middleware_list() :: [middleware()].
 
 -callback call(Request :: roadrunner_req:request(), Next :: next()) ->
     roadrunner_handler:result().
@@ -130,26 +131,21 @@ compose([Mw | Rest], Handler) ->
     Inner = compose(Rest, Handler),
     fun(Req) -> apply_one(Mw, Req, Inner) end.
 
--doc """
-Build the per-request handler pipeline from listener-level
-middlewares + the request's route-level middlewares (read from
-`Req#{route_opts}`) + a target handler module.
-
-Listener middlewares wrap the route middlewares wrap the handler.
-When BOTH lists are empty, returns `fun Handler:handle/1` directly
-— skipping `compose/2` saves one closure allocation + one
-indirection on the no-mws fast path most production handlers hit.
-Otherwise composes the concatenated list with the handler at the
-center.
-
-Takes the request directly (rather than a pre-computed RouteMws)
-so the route-mws pattern-match is folded into this function — one
-fewer function-call frame than the older `route_middlewares/1`
-chain. Used by both the h1 conn loop
-(`roadrunner_conn_loop:run_pipeline`) and the h2 stream worker
-(`roadrunner_http2_stream_worker:invoke`) so the dispatch shape
-stays identical across protocols.
-""".
+%% Build the per-request handler pipeline from listener-level
+%% middlewares + the request's route-level middlewares (read from
+%% `Req#{route_opts}`) + a target handler module.
+%%
+%% Listener middlewares wrap the route middlewares wrap the handler.
+%% When BOTH lists are empty, returns `fun Handler:handle/1` directly
+%% — skipping `compose/2` saves one closure allocation + one
+%% indirection on the no-mws fast path most production handlers hit.
+%% Otherwise composes the concatenated list with the handler at the
+%% center.
+%%
+%% Used by both the h1 conn loop (`roadrunner_conn_loop:run_pipeline`)
+%% and the h2 stream worker (`roadrunner_http2_stream_worker:invoke`)
+%% so the dispatch shape stays identical across protocols.
+-doc false.
 -spec build_pipeline(middleware_list(), roadrunner_req:request(), module()) -> next().
 build_pipeline([], Req, Handler) ->
     case route_mws(Req) of

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -106,10 +106,24 @@ server_header(Req, Next) ->
 -export([compose/2, build_pipeline/3]).
 -export_type([middleware/0, middleware_list/0, next/0]).
 
+-doc """
+The continuation passed to a middleware's `call/2`: a fun that runs
+the rest of the pipeline (other middlewares + the inner handler)
+and returns the same `t:roadrunner_handler:result/0` shape every
+middleware returns.
+""".
 -type next() :: fun((roadrunner_req:request()) -> roadrunner_handler:result()).
+
+-doc """
+A single entry in a `middlewares` list. Either a module that
+implements `-behaviour(roadrunner_middleware)` (its `call/2` is
+invoked) or a `fun((Request, Next) -> Result)` invoked directly.
+""".
 -type middleware() ::
     module()
     | fun((roadrunner_req:request(), next()) -> roadrunner_handler:result()).
+
+-doc "An ordered list of `t:middleware/0` entries.".
 -type middleware_list() :: [middleware()].
 
 -doc """
@@ -159,6 +173,7 @@ compose([Mw | Rest], Handler) ->
 %% Used by both the h1 conn loop (`roadrunner_conn_loop:run_pipeline`)
 %% and the h2 stream worker (`roadrunner_http2_stream_worker:invoke`)
 %% so the dispatch shape stays identical across protocols.
+
 -doc false.
 -spec build_pipeline(middleware_list(), roadrunner_req:request(), module()) -> next().
 build_pipeline([], Req, Handler) ->

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -107,11 +107,9 @@
 -export([compose/2, build_pipeline/3]).
 -export_type([middleware/0, middleware_list/0, next/0]).
 
--type next() :: fun((roadrunner_req:request()) -> roadrunner_handler:result()).
--type middleware() ::
-    module()
-    | fun((roadrunner_req:request(), next()) -> roadrunner_handler:result()).
--type middleware_list() :: [middleware()].
+-type next() :: roadrunner_handler:next().
+-type middleware() :: roadrunner_handler:middleware().
+-type middleware_list() :: roadrunner_handler:middleware_list().
 
 -callback call(Request :: roadrunner_req:request(), Next :: next()) ->
     roadrunner_handler:result().

--- a/src/roadrunner_multipart.erl
+++ b/src/roadrunner_multipart.erl
@@ -66,6 +66,12 @@ listener's `max_content_length` (default 10 MB).
 -export([parse/2, boundary/1, params/1]).
 -export_type([part/0]).
 
+-doc """
+One section of a parsed `multipart/form-data` body. `headers` is
+the part's headers (names lowercased, values OWS-trimmed) as a list
+of `{Name, Value}` binaries; `body` is the raw bytes between
+end-of-headers and the next boundary.
+""".
 -type part() :: #{
     headers := [{binary(), binary()}],
     body := binary()

--- a/src/roadrunner_multipart.erl
+++ b/src/roadrunner_multipart.erl
@@ -2,13 +2,16 @@
 -moduledoc """
 Parser for `multipart/form-data` request bodies (RFC 7578).
 
-Two entry points:
+Three entry points:
 
 - `boundary/1` — pull the `boundary=…` parameter out of a
   `Content-Type` header value, handling unquoted, quoted, and
   parameter-mixed forms.
 - `parse/2` — split a buffered body into a list of `part()` maps,
   each with its own `headers` and decoded `body`.
+- `params/1` — parse the `key=value` parameters of any structured
+  header value (e.g. `Content-Type`, `Content-Disposition`) into
+  a lowercase-keyed map.
 
 Typical handler shape:
 

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -1,19 +1,15 @@
 -module(roadrunner_req).
 -moduledoc """
-Pure accessors over a `request()` map, plus the public type
-aliases for the request-side surface.
+Pure accessors over the `request()` map.
 
 Decouples handler code from the underlying map shape — handlers should
 prefer these functions over direct `maps:get/2` so the request
 representation can evolve without breaking them.
 
-The exported types (`request/0`, `headers/0`, `version/0`,
-`status/0`, `redirect_status/0`) are the **public** request-side
-surface. Internal modules may use the underlying
-`roadrunner_http1:*` types directly; user code (handlers,
-middleware, custom response builders) should reach in through
-this module so the internal h1 module can be renamed or
-restructured without breaking the public contract.
+The `request/0` type is canonical here. The shared HTTP primitives
+re-exported alongside it (`headers/0`, `version/0`, `status/0`,
+`redirect_status/0`) are aliases of the definitions in
+`roadrunner_http`.
 """.
 
 -on_load(init_patterns/0).
@@ -26,11 +22,38 @@ restructured without breaking the public contract.
 
 -export_type([request/0, headers/0, version/0, status/0, redirect_status/0]).
 
--type request() :: roadrunner_http1:request().
--type headers() :: roadrunner_http1:headers().
--type version() :: roadrunner_http1:version().
--type status() :: roadrunner_http1:status().
--type redirect_status() :: roadrunner_http1:redirect_status().
+-doc """
+The parsed request map handlers receive.
+
+Required fields are present on every request the framework
+delivers; optional fields are populated by the framework when
+applicable (e.g. `body` in `body_buffering => auto` mode,
+`bindings` for routed dispatch, `request_id` for telemetry).
+
+The `cached_decisions` and `body_state` fields are framework
+internals — typed as `term()` here because their precise shapes
+are not part of the public contract and can change between releases.
+""".
+-type request() :: #{
+    method := binary(),
+    target := binary(),
+    version := version(),
+    headers := headers(),
+    cached_decisions => term(),
+    body => iodata(),
+    bindings => roadrunner_router:bindings(),
+    peer => {inet:ip_address(), inet:port_number()} | undefined,
+    scheme => http | https,
+    route_opts => term(),
+    body_state => term(),
+    request_id => binary(),
+    listener_name => atom()
+}.
+
+-type headers() :: roadrunner_http:headers().
+-type version() :: roadrunner_http:version().
+-type status() :: roadrunner_http:status().
+-type redirect_status() :: roadrunner_http:redirect_status().
 
 -export([
     method/1,

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -33,11 +33,34 @@ swapping to a trie/DAG later is a non-breaking change for callers.
 
 -export_type([route/0, routes/0, compiled/0, bindings/0]).
 
+-doc """
+A single route entry: `{Path, Handler, Opts}` where `Path` is a
+binary pattern (literal segments, `:param` captures, or `*wildcard`
+catch-all), `Handler` is the module implementing
+`roadrunner_handler`, and `Opts` is opaque per-route data threaded
+back to the handler via `roadrunner_req:route_opts/1`.
+""".
 -type route() :: {Path :: binary(), Handler :: module(), Opts :: term()}.
+
+-doc "An ordered list of routes; matched first-to-last.".
 -type routes() :: [route()].
+
+-doc """
+Captured route parameters, populated by `match/2`.
+
+`:param` segments produce a single binary value
+(`#{~"id" => ~"42"}`). `*wildcard` segments produce the list of
+remaining path segments
+(`#{~"rest" => [~"a", ~"b"]}`). Empty for routes with no captures.
+""".
 -type bindings() :: #{binary() => binary() | [binary()]}.
 
 -type segment() :: {literal, binary()} | {param, binary()} | {wildcard, binary()}.
+
+-doc """
+The compiled-routes representation `match/2` consumes. Treat as
+opaque: the shape is an implementation detail and may change.
+""".
 -opaque compiled() :: [{[segment()], module(), term()}].
 
 -doc """

--- a/src/roadrunner_stream_response.erl
+++ b/src/roadrunner_stream_response.erl
@@ -1,24 +1,24 @@
 -module(roadrunner_stream_response).
--moduledoc """
-Per-connection `{stream, ...}` response — chunked Transfer-Encoding.
+-moduledoc false.
 
-Called by `roadrunner_conn:dispatch_response/4` after a handler returns
-`{stream, Status, Headers, Fun}`. Writes the status line + chunked
-headers, then calls the user's `Fun(Send)` with a `Send/2` callback
-that frames each emission as one chunk on the wire.
-
-`Send(Data, FinFlag)` — `FinFlag` is one of:
-- `nofin` — write `Data` as one chunk; expect more.
-- `fin` — write `Data` as one chunk, then the size-0 terminator.
-- `{fin, Trailers}` — same as `fin` but the terminator is followed
-  by serialized trailer headers (RFC 9112 §7.1.2).
-
-Empty data is special-cased: `Send(<<>>, nofin)` is a no-op (a
-zero-length chunk encodes as `0\r\n\r\n`, the chunked terminator,
-which would prematurely end the response).
-
-Pure functions, no process spawn — runs in the conn process.
-""".
+%% Per-connection `{stream, ...}` response — chunked Transfer-Encoding.
+%%
+%% Called by `roadrunner_conn:dispatch_response/4` after a handler returns
+%% `{stream, Status, Headers, Fun}`. Writes the status line + chunked
+%% headers, then calls the user's `Fun(Send)` with a `Send/2` callback
+%% that frames each emission as one chunk on the wire.
+%%
+%% `Send(Data, FinFlag)` — `FinFlag` is one of:
+%% - `nofin` — write `Data` as one chunk; expect more.
+%% - `fin` — write `Data` as one chunk, then the size-0 terminator.
+%% - `{fin, Trailers}` — same as `fin` but the terminator is followed
+%%   by serialized trailer headers (RFC 9112 §7.1.2).
+%%
+%% Empty data is special-cased: `Send(<<>>, nofin)` is a no-op (a
+%% zero-length chunk encodes as `0\r\n\r\n`, the chunked terminator,
+%% which would prematurely end the response).
+%%
+%% Pure functions, no process spawn — runs in the conn process.
 
 -export([run/4]).
 

--- a/src/roadrunner_sup.erl
+++ b/src/roadrunner_sup.erl
@@ -1,9 +1,7 @@
-%%%-------------------------------------------------------------------
-%% @doc roadrunner top level supervisor.
-%% @end
-%%%-------------------------------------------------------------------
-
 -module(roadrunner_sup).
+-moduledoc false.
+
+%% roadrunner top level supervisor.
 
 -behaviour(supervisor).
 

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -1,126 +1,126 @@
 -module(roadrunner_telemetry).
--moduledoc """
-Telemetry event emitters for roadrunner.
+-moduledoc false.
 
-Centralizes the event names and the metadata shape so subscribers
-have one module to grep for and tests have one place to attach.
-
-## Events
-
-- `[roadrunner, request, start]` — fired by `roadrunner_conn` once a request's
-  headers parse and `request_id` is assigned, before the
-  middleware/handler pipeline is invoked.
-
-  - **Measurements:** `system_time` (`erlang:system_time/0`).
-  - **Metadata:** `request_id`, `peer`, `method`, `path`, `scheme`,
-    `listener_name`.
-
-- `[roadrunner, request, stop]` — fired after the handler's response is
-  written to the wire (or, for `stream`/`loop`/`websocket`, after the
-  initial dispatch returns).
-
-  - **Measurements:** `duration` in `native` time units. Convert
-    with `erlang:convert_time_unit(Duration, native, microsecond)`.
-  - **Metadata:** start metadata + `status` (response code, `101`
-    for websocket upgrades) and `response_kind`
-    (`buffered | stream | loop | websocket`).
-
-- `[roadrunner, request, exception]` — fired when the
-  middleware/handler pipeline raises. The exception is rethrown
-  after the event is emitted so the conn's existing 500-on-crash
-  path is preserved.
-
-  - **Measurements:** `duration`.
-  - **Metadata:** start metadata + `kind` (`error | exit | throw`)
-    and `reason`.
-
-- `[roadrunner, response, send_failed]` — fired when a primary response
-  write (`buffered_response`, `stream_response_head`,
-  `loop_response_head`, or `websocket_upgrade_response`) returns
-  `{error, _}`. Status line was already going on the wire, so the
-  conn closes shortly after; this event lets operators correlate
-  the failure with the `request_id` from the conn's `logger`
-  process metadata.
-
-  - **Measurements:** `system_time`.
-  - **Metadata:** `phase`, `reason`, plus the conn's logger
-    process metadata (`request_id`, `peer`, `method`, `path`).
-
-- `[roadrunner, listener, accept]` — fired in the conn process once
-  the acceptor's `shoot` signal has been received and the peername
-  is known. Subscribers can use this to drive a "live connections"
-  gauge or correlate with `[roadrunner, listener, conn_close]`.
-
-  - **Measurements:** `system_time`.
-  - **Metadata:** `listener_name`, `peer`.
-
-- `[roadrunner, listener, conn_close]` — fired when the conn process is
-  about to exit (after the keep-alive loop ends, before the after-
-  clause releases the slot). `requests_served` is the count of
-  successfully-parsed requests on this conn; parse failures and
-  silent timeout/slow-client kicks are NOT counted.
-
-  - **Measurements:** `duration` in `native` time units.
-  - **Metadata:** `listener_name`, `peer`, `requests_served`.
-
-- `[roadrunner, ws, upgrade]` — fired in the conn process once the
-  WebSocket handshake response has been written. Marks the
-  transition from HTTP/1.1 keep-alive into the WS frame loop.
-
-  - **Measurements:** `system_time`.
-  - **Metadata:** `listener_name`, `peer`, `request_id`, `module`
-    (the `roadrunner_ws_handler` module driving the loop).
-
-- `[roadrunner, ws, frame_in]` — fired for every frame parsed from the
-  client, including control frames (`ping`, `pong`, `close`) that
-  the conn handles internally before delegating to the user
-  handler.
-
-  - **Measurements:** `system_time`, `payload_size` (bytes).
-  - **Metadata:** `listener_name`, `peer`, `request_id`, `module`,
-    `opcode` (`text | binary | continuation | close | ping | pong`).
-
-- `[roadrunner, ws, frame_out]` — fired for every frame written back to
-  the client: handler `{reply, ...}` outputs, automatic pong
-  responses, and the close frame on shutdown. Each frame in a
-  batched `{reply, [F1, F2, ...]}` produces one event.
-
-  - **Measurements:** `system_time`, `payload_size` (bytes).
-  - **Metadata:** `listener_name`, `peer`, `request_id`, `module`,
-    `opcode`.
-
-The `start_time` value returned by `request_start/1` must be passed
-back into `request_stop/3` / `request_exception/4` to compute
-`duration`. Subscribers can wire up via `telemetry:attach/4` in
-production or `telemetry_test:attach_event_handlers/2` in tests.
-
-## Stability
-
-The following events have a **stable** contract — event name,
-measurement keys, and the listed metadata keys will not change
-without a major-version bump:
-
-- `[roadrunner, request, stop]` — measurements: `duration`
-  (native units). Metadata: `request_id`, `peer`, `method`,
-  `path`, `scheme`, `listener_name`, `status`, `response_kind`.
-- `[roadrunner, ws, upgrade]` — measurements: `system_time`.
-  Metadata: `listener_name`, `peer`, `request_id`, `module`.
-- `[roadrunner, ws, frame_out]` — measurements: `system_time`,
-  `payload_size`. Metadata: `listener_name`, `peer`,
-  `request_id`, `module`, `opcode`.
-
-All other events listed above (`request, start`,
-`request, exception`, `response, send_failed`,
-`listener, accept`, `listener, conn_close`,
-`request, rejected`, `listener, slots_reconciled`,
-`drain, acknowledged`, `ws, frame_in`) are **unstable**: their
-event name, measurement keys, or metadata schema may change in
-any minor release. Production subscribers depending on those
-events should pin a roadrunner version.
-
-Stable events may gain *additional* metadata keys in any release;
-they will not lose or rename listed keys without a major bump.
-""".
+%% Telemetry event emitters for roadrunner.
+%%
+%% Centralizes the event names and the metadata shape so subscribers
+%% have one module to grep for and tests have one place to attach.
+%%
+%% ## Events
+%%
+%% - `[roadrunner, request, start]` — fired by `roadrunner_conn` once a request's
+%%   headers parse and `request_id` is assigned, before the
+%%   middleware/handler pipeline is invoked.
+%%
+%%   - **Measurements:** `system_time` (`erlang:system_time/0`).
+%%   - **Metadata:** `request_id`, `peer`, `method`, `path`, `scheme`,
+%%     `listener_name`.
+%%
+%% - `[roadrunner, request, stop]` — fired after the handler's response is
+%%   written to the wire (or, for `stream`/`loop`/`websocket`, after the
+%%   initial dispatch returns).
+%%
+%%   - **Measurements:** `duration` in `native` time units. Convert
+%%     with `erlang:convert_time_unit(Duration, native, microsecond)`.
+%%   - **Metadata:** start metadata + `status` (response code, `101`
+%%     for websocket upgrades) and `response_kind`
+%%     (`buffered | stream | loop | websocket`).
+%%
+%% - `[roadrunner, request, exception]` — fired when the
+%%   middleware/handler pipeline raises. The exception is rethrown
+%%   after the event is emitted so the conn's existing 500-on-crash
+%%   path is preserved.
+%%
+%%   - **Measurements:** `duration`.
+%%   - **Metadata:** start metadata + `kind` (`error | exit | throw`)
+%%     and `reason`.
+%%
+%% - `[roadrunner, response, send_failed]` — fired when a primary response
+%%   write (`buffered_response`, `stream_response_head`,
+%%   `loop_response_head`, or `websocket_upgrade_response`) returns
+%%   `{error, _}`. Status line was already going on the wire, so the
+%%   conn closes shortly after; this event lets operators correlate
+%%   the failure with the `request_id` from the conn's `logger`
+%%   process metadata.
+%%
+%%   - **Measurements:** `system_time`.
+%%   - **Metadata:** `phase`, `reason`, plus the conn's logger
+%%     process metadata (`request_id`, `peer`, `method`, `path`).
+%%
+%% - `[roadrunner, listener, accept]` — fired in the conn process once
+%%   the acceptor's `shoot` signal has been received and the peername
+%%   is known. Subscribers can use this to drive a "live connections"
+%%   gauge or correlate with `[roadrunner, listener, conn_close]`.
+%%
+%%   - **Measurements:** `system_time`.
+%%   - **Metadata:** `listener_name`, `peer`.
+%%
+%% - `[roadrunner, listener, conn_close]` — fired when the conn process is
+%%   about to exit (after the keep-alive loop ends, before the after-
+%%   clause releases the slot). `requests_served` is the count of
+%%   successfully-parsed requests on this conn; parse failures and
+%%   silent timeout/slow-client kicks are NOT counted.
+%%
+%%   - **Measurements:** `duration` in `native` time units.
+%%   - **Metadata:** `listener_name`, `peer`, `requests_served`.
+%%
+%% - `[roadrunner, ws, upgrade]` — fired in the conn process once the
+%%   WebSocket handshake response has been written. Marks the
+%%   transition from HTTP/1.1 keep-alive into the WS frame loop.
+%%
+%%   - **Measurements:** `system_time`.
+%%   - **Metadata:** `listener_name`, `peer`, `request_id`, `module`
+%%     (the `roadrunner_ws_handler` module driving the loop).
+%%
+%% - `[roadrunner, ws, frame_in]` — fired for every frame parsed from the
+%%   client, including control frames (`ping`, `pong`, `close`) that
+%%   the conn handles internally before delegating to the user
+%%   handler.
+%%
+%%   - **Measurements:** `system_time`, `payload_size` (bytes).
+%%   - **Metadata:** `listener_name`, `peer`, `request_id`, `module`,
+%%     `opcode` (`text | binary | continuation | close | ping | pong`).
+%%
+%% - `[roadrunner, ws, frame_out]` — fired for every frame written back to
+%%   the client: handler `{reply, ...}` outputs, automatic pong
+%%   responses, and the close frame on shutdown. Each frame in a
+%%   batched `{reply, [F1, F2, ...]}` produces one event.
+%%
+%%   - **Measurements:** `system_time`, `payload_size` (bytes).
+%%   - **Metadata:** `listener_name`, `peer`, `request_id`, `module`,
+%%     `opcode`.
+%%
+%% The `start_time` value returned by `request_start/1` must be passed
+%% back into `request_stop/3` / `request_exception/4` to compute
+%% `duration`. Subscribers can wire up via `telemetry:attach/4` in
+%% production or `telemetry_test:attach_event_handlers/2` in tests.
+%%
+%% ## Stability
+%%
+%% The following events have a **stable** contract — event name,
+%% measurement keys, and the listed metadata keys will not change
+%% without a major-version bump:
+%%
+%% - `[roadrunner, request, stop]` — measurements: `duration`
+%%   (native units). Metadata: `request_id`, `peer`, `method`,
+%%   `path`, `scheme`, `listener_name`, `status`, `response_kind`.
+%% - `[roadrunner, ws, upgrade]` — measurements: `system_time`.
+%%   Metadata: `listener_name`, `peer`, `request_id`, `module`.
+%% - `[roadrunner, ws, frame_out]` — measurements: `system_time`,
+%%   `payload_size`. Metadata: `listener_name`, `peer`,
+%%   `request_id`, `module`, `opcode`.
+%%
+%% All other events listed above (`request, start`,
+%% `request, exception`, `response, send_failed`,
+%% `listener, accept`, `listener, conn_close`,
+%% `request, rejected`, `listener, slots_reconciled`,
+%% `drain, acknowledged`, `ws, frame_in`) are **unstable**: their
+%% event name, measurement keys, or metadata schema may change in
+%% any minor release. Production subscribers depending on those
+%% events should pin a roadrunner version.
+%%
+%% Stable events may gain *additional* metadata keys in any release;
+%% they will not lose or rename listed keys without a major bump.
 
 -export([
     request_start/1,

--- a/src/roadrunner_transport.erl
+++ b/src/roadrunner_transport.erl
@@ -1,43 +1,43 @@
 -module(roadrunner_transport).
--moduledoc """
-Tagged-socket transport abstraction over `gen_tcp`, `ssl`, and a
-`fake` test backend.
+-moduledoc false.
 
-A socket is `{Module, RawSocket}` so callers don't have to know whether
-they're talking to plain TCP, TLS, or a test fixture.
-
-The `{fake, Pid}` variant is a per-connection test helper: every
-`send/2`, `recv/3`, `setopts/2`, and `close/1` call dispatches to
-`Pid` as an Erlang message, letting tests drive a `roadrunner_conn`
-byte-by-byte without spinning up a listener. See
-`roadrunner_transport_tests` for the message protocol.
-
-## Active-mode reads
-
-`setopts/2` + `messages/1` switch the underlying socket to active
-mode (`[{active, once}]` / `[{active, N}]`) so the controlling
-process receives data as `info` events instead of blocking in
-`recv/3`. This is what lets `erlang:hibernate/3` fire from a
-`receive ... after` clause — passive recv holds the process inside
-a NIF indefinitely, so hibernation has no window to run.
-`roadrunner_conn_loop`'s `recv_with_hibernate/3` and
-`roadrunner_ws_session` (gen_statem with `{hibernate_after, _}`)
-both rely on active mode for this reason. See `messages/1` for the
-per-transport tag triples.
-
-## TLS defaults
-
-`default_tls_opts/0` returns a hardened option list that
-`roadrunner_listener` merges underneath user-supplied `tls` opts (user
-values win for any key they specify). The defaults are aligned with
-the upstream OTP `ssl_hardening.md` guide: TLS 1.2/1.3 only,
-`honor_cipher_order`, `client_renegotiation` off, AEAD-only
-ECDHE-or-1.3 cipher list filtered through `ssl:filter_cipher_suites/2`,
-and the OTP-default signature algorithms / supported groups
-re-asserted so we don't drift if upstream lowers standards. OCSP
-stapling is intentionally absent — `ssl` does not support
-server-side stapling at the time of writing.
-""".
+%% Tagged-socket transport abstraction over `gen_tcp`, `ssl`, and a
+%% `fake` test backend.
+%%
+%% A socket is `{Module, RawSocket}` so callers don't have to know whether
+%% they're talking to plain TCP, TLS, or a test fixture.
+%%
+%% The `{fake, Pid}` variant is a per-connection test helper: every
+%% `send/2`, `recv/3`, `setopts/2`, and `close/1` call dispatches to
+%% `Pid` as an Erlang message, letting tests drive a `roadrunner_conn`
+%% byte-by-byte without spinning up a listener. See
+%% `roadrunner_transport_tests` for the message protocol.
+%%
+%% ## Active-mode reads
+%%
+%% `setopts/2` + `messages/1` switch the underlying socket to active
+%% mode (`[{active, once}]` / `[{active, N}]`) so the controlling
+%% process receives data as `info` events instead of blocking in
+%% `recv/3`. This is what lets `erlang:hibernate/3` fire from a
+%% `receive ... after` clause — passive recv holds the process inside
+%% a NIF indefinitely, so hibernation has no window to run.
+%% `roadrunner_conn_loop`'s `recv_with_hibernate/3` and
+%% `roadrunner_ws_session` (gen_statem with `{hibernate_after, _}`)
+%% both rely on active mode for this reason. See `messages/1` for the
+%% per-transport tag triples.
+%%
+%% ## TLS defaults
+%%
+%% `default_tls_opts/0` returns a hardened option list that
+%% `roadrunner_listener` merges underneath user-supplied `tls` opts (user
+%% values win for any key they specify). The defaults are aligned with
+%% the upstream OTP `ssl_hardening.md` guide: TLS 1.2/1.3 only,
+%% `honor_cipher_order`, `client_renegotiation` off, AEAD-only
+%% ECDHE-or-1.3 cipher list filtered through `ssl:filter_cipher_suites/2`,
+%% and the OTP-default signature algorithms / supported groups
+%% re-asserted so we don't drift if upstream lowers standards. OCSP
+%% stapling is intentionally absent — `ssl` does not support
+%% server-side stapling at the time of writing.
 
 -export([
     listen/2,

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -7,11 +7,11 @@ referenced by `roadrunner_ws_handler` callback signatures, plus the
 permessage-deflate extension shape negotiated during the handshake.
 
 The exported wire-level functions (frame parse/encode, handshake
-response builder, extension negotiation) are framework plumbing used
-by `roadrunner_ws_session`. Most applications implement the
-`roadrunner_ws_handler` behaviour and receive already-parsed frames;
-the protocol functions are exposed for advanced use cases (custom
-session transports, low-level testing).
+response builder, extension negotiation) are framework plumbing
+called from `roadrunner_ws_session`. They're not part of the
+documented public API — implement `roadrunner_ws_handler` to write
+WebSocket endpoints and let the framework deliver already-parsed
+frames.
 """.
 
 -on_load(init_patterns/0).

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -32,13 +32,8 @@
 -define(EXT_QUOTE_CP_KEY, {?MODULE, ext_quote_cp}).
 -define(UPGRADE_CP_KEY, {?MODULE, upgrade_cp}).
 
--type opcode() :: continuation | text | binary | close | ping | pong.
--type frame() :: #{
-    fin := boolean(),
-    rsv1 := boolean(),
-    opcode := opcode(),
-    payload := binary()
-}.
+-type opcode() :: roadrunner_ws_handler:opcode().
+-type frame() :: roadrunner_ws_handler:frame().
 
 %% A single offer in the `Sec-WebSocket-Extensions` header. Parameter
 %% values are `binary()` for `key=value` pairs or `true` for bare flag
@@ -79,12 +74,7 @@
     none
     | {permessage_deflate, permessage_deflate_params(), ResponseHeaderValue :: binary()}.
 
-%% Close status codes a server is permitted to send per RFC 6455 §7.4.
-%% 1004/1005/1006 are reserved (MUST NOT appear on the wire);
-%% 1012/1013 are unassigned. 3000-3999 is the IANA-registered range,
-%% 4000-4999 is for application-private use.
--type close_code() ::
-    1000..1003 | 1007..1011 | 1014 | 3000..4999.
+-type close_code() :: roadrunner_ws_handler:close_code().
 
 %% RFC 6455 §1.3 magic GUID concatenated with the client key before
 %% hashing — fixed by spec.

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -1,11 +1,18 @@
 -module(roadrunner_ws).
--moduledoc false.
+-moduledoc """
+WebSocket protocol primitives (RFC 6455 + RFC 7692).
 
-%% WebSocket support — RFC 6455.
-%%
-%% This first slice provides the **handshake** helpers only. Frame
-%% parsing, masking, and the conn-level protocol switch arrive in later
-%% features.
+Owns the protocol-level types (`opcode/0`, `frame/0`, `close_code/0`)
+referenced by `roadrunner_ws_handler` callback signatures, plus the
+permessage-deflate extension shape negotiated during the handshake.
+
+The exported wire-level functions (frame parse/encode, handshake
+response builder, extension negotiation) are framework plumbing used
+by `roadrunner_ws_session`. Most applications implement the
+`roadrunner_ws_handler` behaviour and receive already-parsed frames;
+the protocol functions are exposed for advanced use cases (custom
+session transports, low-level testing).
+""".
 
 -on_load(init_patterns/0).
 
@@ -18,7 +25,6 @@
 -export_type([
     opcode/0,
     frame/0,
-    extension/0,
     parse_opts/0,
     encode_opts/0,
     permessage_deflate_params/0,
@@ -32,8 +38,13 @@
 -define(EXT_QUOTE_CP_KEY, {?MODULE, ext_quote_cp}).
 -define(UPGRADE_CP_KEY, {?MODULE, upgrade_cp}).
 
--type opcode() :: roadrunner_ws_handler:opcode().
--type frame() :: roadrunner_ws_handler:frame().
+-type opcode() :: continuation | text | binary | close | ping | pong.
+-type frame() :: #{
+    fin := boolean(),
+    rsv1 := boolean(),
+    opcode := opcode(),
+    payload := binary()
+}.
 
 %% A single offer in the `Sec-WebSocket-Extensions` header. Parameter
 %% values are `binary()` for `key=value` pairs or `true` for bare flag
@@ -74,7 +85,12 @@
     none
     | {permessage_deflate, permessage_deflate_params(), ResponseHeaderValue :: binary()}.
 
--type close_code() :: roadrunner_ws_handler:close_code().
+%% Close status codes a server is permitted to send per RFC 6455 §7.4.
+%% 1004/1005/1006 are reserved (MUST NOT appear on the wire);
+%% 1012/1013 are unassigned. 3000-3999 is the IANA-registered range,
+%% 4000-4999 is for application-private use.
+-type close_code() ::
+    1000..1003 | 1007..1011 | 1014 | 3000..4999.
 
 %% RFC 6455 §1.3 magic GUID concatenated with the client key before
 %% hashing — fixed by spec.
@@ -87,30 +103,28 @@
 -define(OP_PING, 9).
 -define(OP_PONG, 10).
 
--doc """
-Compute the `Sec-WebSocket-Accept` value from a client-provided
-`Sec-WebSocket-Key` per RFC 6455 §4.2.2 step 5: SHA-1 of the key
-concatenated with the WebSocket GUID, base64-encoded.
-""".
+%% Compute the `Sec-WebSocket-Accept` value from a client-provided
+%% `Sec-WebSocket-Key` per RFC 6455 §4.2.2 step 5: SHA-1 of the key
+%% concatenated with the WebSocket GUID, base64-encoded.
+-doc false.
 -spec accept_key(Key :: binary()) -> binary().
 accept_key(Key) when is_binary(Key) ->
     base64:encode(crypto:hash(sha, <<Key/binary, ?WS_GUID/binary>>)).
 
--doc """
-Validate the request headers for a WebSocket upgrade and build the
-`101 Switching Protocols` response.
-
-Returns `{ok, 101, Headers, <<>>, Negotiated}` on success, or
-`{error, Reason}` when the request is missing or has wrong values
-for any of the required handshake headers (`Upgrade: websocket`, a
-`Connection` header containing the `upgrade` token, and a non-empty
-`Sec-WebSocket-Key`).
-
-`Negotiated` is `none` if no extension was offered or accepted, or
-`{permessage_deflate, Params, _}` when RFC 7692 was negotiated.
-The session uses this to set up zlib state. The agreed extension's
-response header is already in `Headers`.
-""".
+%% Validate the request headers for a WebSocket upgrade and build the
+%% `101 Switching Protocols` response.
+%%
+%% Returns `{ok, 101, Headers, <<>>, Negotiated}` on success, or
+%% `{error, Reason}` when the request is missing or has wrong values
+%% for any of the required handshake headers (`Upgrade: websocket`, a
+%% `Connection` header containing the `upgrade` token, and a non-empty
+%% `Sec-WebSocket-Key`).
+%%
+%% `Negotiated` is `none` if no extension was offered or accepted, or
+%% `{permessage_deflate, Params, _}` when RFC 7692 was negotiated.
+%% The session uses this to set up zlib state. The agreed extension's
+%% response header is already in `Headers`.
+-doc false.
 -spec handshake_response(roadrunner_req:headers()) ->
     {ok, roadrunner_req:status(), roadrunner_req:headers(), iodata(), negotiated()}
     | {error,
@@ -230,30 +244,23 @@ header_lookup(Name, Headers) ->
         false -> undefined
     end.
 
--doc """
-Parse a `Sec-WebSocket-Extensions` header value into a list of
-`{ExtensionName, Params}` tuples per RFC 6455 §9.1 grammar.
-
-Each offer in the header is comma-separated. Within an offer, the
-extension name comes first followed by optional `;`-separated
-parameters. Parameters may be bare (`client_no_context_takeover`,
-returned as `{<<"client_no_context_takeover">>, true}`) or
-key=value (`server_max_window_bits=10`, returned as
-`{<<"server_max_window_bits">>, <<"10">>}`).
-
-Names and parameter keys are lowercased; parameter values are
-returned verbatim (with surrounding quotes stripped). The order of
-offers AND of parameters within an offer is preserved — RFC 7692
-relies on offer order for negotiation precedence.
-
-Returns `[]` for an absent / empty header value.
-
-```erlang
-parse_extensions(<<"permessage-deflate; client_max_window_bits=15, x-foo">>).
-%% => [{<<"permessage-deflate">>, [{<<"client_max_window_bits">>, <<"15">>}]},
-%%     {<<"x-foo">>, []}]
-```
-""".
+%% Parse a `Sec-WebSocket-Extensions` header value into a list of
+%% `{ExtensionName, Params}` tuples per RFC 6455 §9.1 grammar.
+%%
+%% Each offer in the header is comma-separated. Within an offer, the
+%% extension name comes first followed by optional `;`-separated
+%% parameters. Parameters may be bare (`client_no_context_takeover`,
+%% returned as `{<<"client_no_context_takeover">>, true}`) or
+%% key=value (`server_max_window_bits=10`, returned as
+%% `{<<"server_max_window_bits">>, <<"10">>}`).
+%%
+%% Names and parameter keys are lowercased; parameter values are
+%% returned verbatim (with surrounding quotes stripped). The order of
+%% offers AND of parameters within an offer is preserved — RFC 7692
+%% relies on offer order for negotiation precedence.
+%%
+%% Returns `[]` for an absent / empty header value.
+-doc false.
 -spec parse_extensions(binary() | undefined) -> [extension()].
 parse_extensions(undefined) ->
     [];
@@ -303,25 +310,24 @@ unquote(<<$", Rest/binary>>) ->
 unquote(V) ->
     V.
 
--doc """
-Pick the first acceptable offer from a parsed `Sec-WebSocket-Extensions`
-list. Today only `permessage-deflate` (RFC 7692) is supported; all
-other extension names are skipped.
-
-Returns `none` if no acceptable offer is found, or
-`{permessage_deflate, NegotiatedParams, ResponseHeaderValue}` where:
-
-- `NegotiatedParams` is a map suitable for setting up the inflate /
-  deflate zlib contexts and for honoring the `*_no_context_takeover`
-  reset semantics.
-- `ResponseHeaderValue` is the value to put in the response's
-  `Sec-WebSocket-Extensions` header per RFC 7692 §5.1 (echoes the
-  negotiated parameters with their agreed values).
-
-Per RFC 6455 §9.1, when multiple extensions are offered the server
-processes them in order and picks the first one it can accept;
-unrecognised offers are silently skipped.
-""".
+%% Pick the first acceptable offer from a parsed
+%% `Sec-WebSocket-Extensions` list. Today only `permessage-deflate`
+%% (RFC 7692) is supported; all other extension names are skipped.
+%%
+%% Returns `none` if no acceptable offer is found, or
+%% `{permessage_deflate, NegotiatedParams, ResponseHeaderValue}` where:
+%%
+%% - `NegotiatedParams` is a map suitable for setting up the inflate /
+%%   deflate zlib contexts and for honoring the `*_no_context_takeover`
+%%   reset semantics.
+%% - `ResponseHeaderValue` is the value to put in the response's
+%%   `Sec-WebSocket-Extensions` header per RFC 7692 §5.1 (echoes the
+%%   negotiated parameters with their agreed values).
+%%
+%% Per RFC 6455 §9.1, when multiple extensions are offered the server
+%% processes them in order and picks the first one it can accept;
+%% unrecognised offers are silently skipped.
+-doc false.
 -spec negotiate_extensions([extension()]) -> negotiated().
 negotiate_extensions([]) ->
     none;
@@ -426,25 +432,24 @@ format_pmd_flag(Name, true) -> [~"; ", Name].
 format_pmd_kv(_Name, Default, Default) -> [];
 format_pmd_kv(Name, Value, _Default) -> [~"; ", Name, ~"=", integer_to_binary(Value)].
 
--doc """
-Decode a single WebSocket frame from the buffer.
-
-Returns `{ok, Frame, Rest}` on success — `Frame` is a map with
-`fin`, `rsv1`, `opcode`, and (already-unmasked) `payload`. Returns
-`{more, undefined}` when more bytes are needed to complete the
-frame, or `{error, _}` for protocol violations:
-- `bad_rsv` — RSV2 or RSV3 set, or RSV1 set without an extension
-  permitting it (default: not permitted).
-- `bad_opcode` — opcode is reserved (3-7, 0xB-0xF).
-- `not_masked` — server-side requires the MASK bit on every client frame.
-- `fragmented_control` — control frame (close/ping/pong) with FIN=0,
-  forbidden by RFC 6455 §5.5.
-- `control_frame_too_large` — control frame with payload >125 bytes,
-  forbidden by RFC 6455 §5.5.
-
-Use `parse_frame/2` with `#{allow_rsv1 => true}` once a permessage
-extension (RFC 7692) has been negotiated.
-""".
+%% Decode a single WebSocket frame from the buffer.
+%%
+%% Returns `{ok, Frame, Rest}` on success — `Frame` is a map with
+%% `fin`, `rsv1`, `opcode`, and (already-unmasked) `payload`. Returns
+%% `{more, undefined}` when more bytes are needed to complete the
+%% frame, or `{error, _}` for protocol violations:
+%% - `bad_rsv` — RSV2 or RSV3 set, or RSV1 set without an extension
+%%   permitting it (default: not permitted).
+%% - `bad_opcode` — opcode is reserved (3-7, 0xB-0xF).
+%% - `not_masked` — server-side requires the MASK bit on every client frame.
+%% - `fragmented_control` — control frame (close/ping/pong) with FIN=0,
+%%   forbidden by RFC 6455 §5.5.
+%% - `control_frame_too_large` — control frame with payload >125 bytes,
+%%   forbidden by RFC 6455 §5.5.
+%%
+%% Use `parse_frame/2` with `#{allow_rsv1 => true}` once a permessage
+%% extension (RFC 7692) has been negotiated.
+-doc false.
 -spec parse_frame(binary()) ->
     {ok, frame(), Rest :: binary()}
     | {more, undefined}
@@ -452,13 +457,12 @@ extension (RFC 7692) has been negotiated.
 parse_frame(Bin) ->
     parse_frame(Bin, #{}).
 
--doc """
-Decode a single WebSocket frame, with extension awareness.
-
-`Opts` may include `allow_rsv1 => true` to permit the RSV1 bit
-(needed once `permessage-deflate` is negotiated per RFC 7692).
-RSV2 and RSV3 remain unconditionally rejected.
-""".
+%% Decode a single WebSocket frame, with extension awareness.
+%%
+%% `Opts` may include `allow_rsv1 => true` to permit the RSV1 bit
+%% (needed once `permessage-deflate` is negotiated per RFC 7692).
+%% RSV2 and RSV3 remain unconditionally rejected.
+-doc false.
 -spec parse_frame(binary(), parse_opts()) ->
     {ok, frame(), Rest :: binary()}
     | {more, undefined}
@@ -495,23 +499,22 @@ do_parse_frame(<<Fin:1, Rsv1:1, 0:2, Op:4, Mask:1, Len7:7, Rest/binary>>, _Allow
 do_parse_frame(_, _AllowRsv1, _Pre) ->
     {more, undefined}.
 
--doc """
-Sneak-peek a partially-buffered frame: parse just enough of the
-header to expose the payload region. Returns:
-
-- `{ok, #{opcode => _, fin => _, rsv1 => _, total_payload_len => _,
-         mask_key => _, payload_offset => _}, BytesAvailable}` when
-  the header is fully buffered; `BytesAvailable` is the number of
-  payload bytes already in `Buf` (may be 0..total_payload_len).
-- `{more, undefined}` if even the header isn't complete.
-- `{error, _}` for the same protocol violations `parse_frame/2`
-  rejects.
-
-Used by `roadrunner_ws_session` to validate text-frame UTF-8
-payload bytes incrementally as TCP chunks arrive — well before
-the frame as a whole completes. Honors `allow_rsv1` the same way
-`parse_frame/2` does.
-""".
+%% Sneak-peek a partially-buffered frame: parse just enough of the
+%% header to expose the payload region. Returns:
+%%
+%% - `{ok, #{opcode => _, fin => _, rsv1 => _, total_payload_len => _,
+%%          mask_key => _, payload_offset => _}, BytesAvailable}` when
+%%   the header is fully buffered; `BytesAvailable` is the number of
+%%   payload bytes already in `Buf` (may be 0..total_payload_len).
+%% - `{more, undefined}` if even the header isn't complete.
+%% - `{error, _}` for the same protocol violations `parse_frame/2`
+%%   rejects.
+%%
+%% Used by `roadrunner_ws_session` to validate text-frame UTF-8
+%% payload bytes incrementally as TCP chunks arrive — well before
+%% the frame as a whole completes. Honors `allow_rsv1` the same way
+%% `parse_frame/2` does.
+-doc false.
 -spec peek_frame_header(binary(), parse_opts()) ->
     {ok, map(), non_neg_integer()}
     | {more, undefined}
@@ -683,24 +686,24 @@ unmask_chunks(<<O:8>>, MK, Acc) ->
 unmask_chunks(<<>>, _MK, Acc) ->
     Acc.
 
--doc """
-Encode a single WebSocket frame for the server→client direction.
-
-Server frames are sent **unmasked** per RFC 6455 §5.1. Picks the
-shortest valid length encoding: 7-bit literal for ≤125 bytes, 16-bit
-extended (126) for ≤65535, 64-bit extended (127) for larger.
-
-`Fin` controls the FIN bit — pass `true` for the only or last frame
-of a message and `false` for non-final fragments of a continuation
-sequence.
-
-Use `encode_frame/4` with `#{rsv1 => true}` once `permessage-deflate`
-is negotiated and you're emitting a compressed first-fragment.
-""".
+%% Encode a single WebSocket frame for the server→client direction.
+%%
+%% Server frames are sent unmasked per RFC 6455 §5.1. Picks the
+%% shortest valid length encoding: 7-bit literal for ≤125 bytes,
+%% 16-bit extended (126) for ≤65535, 64-bit extended (127) for larger.
+%%
+%% `Fin` controls the FIN bit — pass `true` for the only or last frame
+%% of a message and `false` for non-final fragments of a continuation
+%% sequence.
+%%
+%% Use `encode_frame/4` with `#{rsv1 => true}` once `permessage-deflate`
+%% is negotiated and you're emitting a compressed first-fragment.
+-doc false.
 -spec encode_frame(opcode(), iodata(), boolean()) -> iodata().
 encode_frame(Opcode, Payload, Fin) ->
     encode_frame(Opcode, Payload, Fin, #{}).
 
+-doc false.
 -spec encode_frame(opcode(), iodata(), boolean(), encode_opts()) -> iodata().
 encode_frame(Opcode, Payload, Fin, Opts) ->
     Op = encode_opcode(Opcode),

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -1,11 +1,11 @@
 -module(roadrunner_ws).
--moduledoc """
-WebSocket support — RFC 6455.
+-moduledoc false.
 
-This first slice provides the **handshake** helpers only. Frame
-parsing, masking, and the conn-level protocol switch arrive in later
-features.
-""".
+%% WebSocket support — RFC 6455.
+%%
+%% This first slice provides the **handshake** helpers only. Frame
+%% parsing, masking, and the conn-level protocol switch arrive in later
+%% features.
 
 -on_load(init_patterns/0).
 

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -38,7 +38,23 @@ frames.
 -define(EXT_QUOTE_CP_KEY, {?MODULE, ext_quote_cp}).
 -define(UPGRADE_CP_KEY, {?MODULE, upgrade_cp}).
 
+-doc """
+WebSocket frame opcodes (RFC 6455 §11.8). `continuation` only
+appears on the wire — the session reassembles fragmented messages
+before dispatching to `c:roadrunner_ws_handler:handle_frame/2`, so
+handlers see `text` or `binary` for data and `ping`/`pong`/`close`
+for control. Outbound replies use `text`, `binary`, `ping`, `pong`,
+or `close`.
+""".
 -type opcode() :: continuation | text | binary | close | ping | pong.
+
+-doc """
+A parsed WebSocket frame. `payload` is the post-unmask (and
+post-reassembly + post-inflate, when delivered to a handler) bytes
+the application should treat as the message body. `rsv1` carries
+the RFC 7692 compression flag when permessage-deflate was
+negotiated; otherwise always `false`.
+""".
 -type frame() :: #{
     fin := boolean(),
     rsv1 := boolean(),
@@ -51,29 +67,36 @@ frames.
 %% parameters (e.g. `client_no_context_takeover`).
 -type extension() :: {binary(), [{binary(), binary() | true}]}.
 
-%% Parse-side options. `allow_rsv1 => true` surfaces the RSV1 bit in
-%% the returned frame map (per RFC 7692 the bit signals a compressed
-%% message). RSV2 and RSV3 are always rejected — no IETF extension
-%% uses them.
+-doc """
+Parse-side options for `parse_frame/2`.
+
+- `allow_rsv1` — surface the RSV1 bit in the returned frame map.
+  Set once permessage-deflate (RFC 7692) is negotiated. RSV2 and
+  RSV3 are always rejected; no IETF extension uses them.
+- `pre_unmasked` — caller-supplied already-unmasked payload. When
+  this matches the frame's length, `parse_frame/2` skips its own
+  unmask pass and uses the supplied bytes directly.
+""".
 -type parse_opts() :: #{
     allow_rsv1 => boolean(),
-    %% Caller-supplied unmasked payload. When this matches the frame's
-    %% length, `parse_frame/2` skips its own `unmask/2` call and uses
-    %% the supplied bytes directly. `roadrunner_ws_session` populates
-    %% this from its incremental UTF-8 validation pass — same bytes
-    %% would otherwise be unmasked twice.
     pre_unmasked => binary()
 }.
 
-%% Encode-side options. `rsv1 => true` sets the RSV1 bit on the
-%% emitted frame; the caller is responsible for ensuring an
-%% extension that uses the bit is in effect.
+-doc """
+Encode-side options for `encode_frame/4`.
+
+- `rsv1` — set the RSV1 bit on the emitted frame. The caller is
+  responsible for ensuring an extension that uses the bit is in
+  effect (RFC 7692 permessage-deflate).
+""".
 -type encode_opts() :: #{rsv1 => boolean()}.
 
-%% Negotiated permessage-deflate parameters per RFC 7692 §7.1.
-%% Window-bits values are zlib's (8..15). The `*_no_context_takeover`
-%% flags mirror the request; when `true`, the corresponding zlib
-%% context is reset after every message.
+-doc """
+Negotiated permessage-deflate parameters per RFC 7692 §7.1.
+Window-bits values are zlib's (8..15). The `*_no_context_takeover`
+flags mirror the request; when `true`, the corresponding zlib
+context is reset after every message.
+""".
 -type permessage_deflate_params() :: #{
     server_max_window_bits := 8..15,
     client_max_window_bits := 8..15,
@@ -81,14 +104,24 @@ frames.
     client_no_context_takeover := boolean()
 }.
 
+-doc """
+The outcome of extension negotiation during the upgrade handshake.
+`none` means no extension was offered or accepted;
+`{permessage_deflate, Params, ResponseHeaderValue}` means RFC 7692
+was negotiated with the given parameters, and `ResponseHeaderValue`
+is the value placed in the response's `Sec-WebSocket-Extensions`
+header.
+""".
 -type negotiated() ::
     none
     | {permessage_deflate, permessage_deflate_params(), ResponseHeaderValue :: binary()}.
 
-%% Close status codes a server is permitted to send per RFC 6455 §7.4.
-%% 1004/1005/1006 are reserved (MUST NOT appear on the wire);
-%% 1012/1013 are unassigned. 3000-3999 is the IANA-registered range,
-%% 4000-4999 is for application-private use.
+-doc """
+Close status codes a server is permitted to send per RFC 6455 §7.4.
+1004/1005/1006 are reserved (MUST NOT appear on the wire);
+1012/1013 are unassigned. 3000-3999 is the IANA-registered range,
+4000-4999 is for application-private use.
+""".
 -type close_code() ::
     1000..1003 | 1007..1011 | 1014 | 3000..4999.
 
@@ -106,6 +139,7 @@ frames.
 %% Compute the `Sec-WebSocket-Accept` value from a client-provided
 %% `Sec-WebSocket-Key` per RFC 6455 §4.2.2 step 5: SHA-1 of the key
 %% concatenated with the WebSocket GUID, base64-encoded.
+
 -doc false.
 -spec accept_key(Key :: binary()) -> binary().
 accept_key(Key) when is_binary(Key) ->
@@ -124,6 +158,7 @@ accept_key(Key) when is_binary(Key) ->
 %% `{permessage_deflate, Params, _}` when RFC 7692 was negotiated.
 %% The session uses this to set up zlib state. The agreed extension's
 %% response header is already in `Headers`.
+
 -doc false.
 -spec handshake_response(roadrunner_req:headers()) ->
     {ok, roadrunner_req:status(), roadrunner_req:headers(), iodata(), negotiated()}
@@ -260,6 +295,7 @@ header_lookup(Name, Headers) ->
 %% relies on offer order for negotiation precedence.
 %%
 %% Returns `[]` for an absent / empty header value.
+
 -doc false.
 -spec parse_extensions(binary() | undefined) -> [extension()].
 parse_extensions(undefined) ->
@@ -327,6 +363,7 @@ unquote(V) ->
 %% Per RFC 6455 §9.1, when multiple extensions are offered the server
 %% processes them in order and picks the first one it can accept;
 %% unrecognised offers are silently skipped.
+
 -doc false.
 -spec negotiate_extensions([extension()]) -> negotiated().
 negotiate_extensions([]) ->
@@ -449,6 +486,7 @@ format_pmd_kv(Name, Value, _Default) -> [~"; ", Name, ~"=", integer_to_binary(Va
 %%
 %% Use `parse_frame/2` with `#{allow_rsv1 => true}` once a permessage
 %% extension (RFC 7692) has been negotiated.
+
 -doc false.
 -spec parse_frame(binary()) ->
     {ok, frame(), Rest :: binary()}
@@ -462,6 +500,7 @@ parse_frame(Bin) ->
 %% `Opts` may include `allow_rsv1 => true` to permit the RSV1 bit
 %% (needed once `permessage-deflate` is negotiated per RFC 7692).
 %% RSV2 and RSV3 remain unconditionally rejected.
+
 -doc false.
 -spec parse_frame(binary(), parse_opts()) ->
     {ok, frame(), Rest :: binary()}
@@ -514,6 +553,7 @@ do_parse_frame(_, _AllowRsv1, _Pre) ->
 %% payload bytes incrementally as TCP chunks arrive — well before
 %% the frame as a whole completes. Honors `allow_rsv1` the same way
 %% `parse_frame/2` does.
+
 -doc false.
 -spec peek_frame_header(binary(), parse_opts()) ->
     {ok, map(), non_neg_integer()}
@@ -698,6 +738,7 @@ unmask_chunks(<<>>, _MK, Acc) ->
 %%
 %% Use `encode_frame/4` with `#{rsv1 => true}` once `permessage-deflate`
 %% is negotiated and you're emitting a compressed first-fragment.
+
 -doc false.
 -spec encode_frame(opcode(), iodata(), boolean()) -> iodata().
 encode_frame(Opcode, Payload, Fin) ->

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -139,7 +139,6 @@ Close status codes a server is permitted to send per RFC 6455 §7.4.
 %% Compute the `Sec-WebSocket-Accept` value from a client-provided
 %% `Sec-WebSocket-Key` per RFC 6455 §4.2.2 step 5: SHA-1 of the key
 %% concatenated with the WebSocket GUID, base64-encoded.
-
 -doc false.
 -spec accept_key(Key :: binary()) -> binary().
 accept_key(Key) when is_binary(Key) ->
@@ -158,7 +157,6 @@ accept_key(Key) when is_binary(Key) ->
 %% `{permessage_deflate, Params, _}` when RFC 7692 was negotiated.
 %% The session uses this to set up zlib state. The agreed extension's
 %% response header is already in `Headers`.
-
 -doc false.
 -spec handshake_response(roadrunner_req:headers()) ->
     {ok, roadrunner_req:status(), roadrunner_req:headers(), iodata(), negotiated()}
@@ -295,7 +293,6 @@ header_lookup(Name, Headers) ->
 %% relies on offer order for negotiation precedence.
 %%
 %% Returns `[]` for an absent / empty header value.
-
 -doc false.
 -spec parse_extensions(binary() | undefined) -> [extension()].
 parse_extensions(undefined) ->
@@ -363,7 +360,6 @@ unquote(V) ->
 %% Per RFC 6455 §9.1, when multiple extensions are offered the server
 %% processes them in order and picks the first one it can accept;
 %% unrecognised offers are silently skipped.
-
 -doc false.
 -spec negotiate_extensions([extension()]) -> negotiated().
 negotiate_extensions([]) ->
@@ -486,7 +482,6 @@ format_pmd_kv(Name, Value, _Default) -> [~"; ", Name, ~"=", integer_to_binary(Va
 %%
 %% Use `parse_frame/2` with `#{allow_rsv1 => true}` once a permessage
 %% extension (RFC 7692) has been negotiated.
-
 -doc false.
 -spec parse_frame(binary()) ->
     {ok, frame(), Rest :: binary()}
@@ -500,7 +495,6 @@ parse_frame(Bin) ->
 %% `Opts` may include `allow_rsv1 => true` to permit the RSV1 bit
 %% (needed once `permessage-deflate` is negotiated per RFC 7692).
 %% RSV2 and RSV3 remain unconditionally rejected.
-
 -doc false.
 -spec parse_frame(binary(), parse_opts()) ->
     {ok, frame(), Rest :: binary()}
@@ -553,7 +547,6 @@ do_parse_frame(_, _AllowRsv1, _Pre) ->
 %% payload bytes incrementally as TCP chunks arrive — well before
 %% the frame as a whole completes. Honors `allow_rsv1` the same way
 %% `parse_frame/2` does.
-
 -doc false.
 -spec peek_frame_header(binary(), parse_opts()) ->
     {ok, map(), non_neg_integer()}
@@ -738,7 +731,6 @@ unmask_chunks(<<>>, _MK, Acc) ->
 %%
 %% Use `encode_frame/4` with `#{rsv1 => true}` once `permessage-deflate`
 %% is negotiated and you're emitting a compressed first-fragment.
-
 -doc false.
 -spec encode_frame(opcode(), iodata(), boolean()) -> iodata().
 encode_frame(Opcode, Payload, Fin) ->

--- a/src/roadrunner_ws_handler.erl
+++ b/src/roadrunner_ws_handler.erl
@@ -63,18 +63,49 @@ NewState}`, `{ok, NewState}`, `{close, NewState}`, or
 
 -type opt() :: hibernate.
 
+-doc """
+The four data/control opcodes a handler sees. `continuation` only
+appears at the wire level — the session reassembles fragmented
+messages before dispatching to `handle_frame/2`, so handlers
+receive `text` or `binary` for data and `ping` / `pong` / `close`
+for control. Outbound replies may use `text`, `binary`, `ping`,
+`pong`, or `close`.
+""".
+-type opcode() :: continuation | text | binary | close | ping | pong.
+
+-doc """
+The frame map handed to `handle_frame/2`. `payload` is the
+post-unmask, post-reassembly (and post-inflate, for compressed
+messages) bytes — exactly what the handler should treat as the
+message body.
+""".
+-type frame() :: #{
+    fin := boolean(),
+    rsv1 := boolean(),
+    opcode := opcode(),
+    payload := binary()
+}.
+
+-doc """
+Close status codes a server is permitted to send per RFC 6455 §7.4.
+1004/1005/1006 are reserved (MUST NOT appear on the wire);
+1012/1013 are unassigned. 3000-3999 is the IANA-registered range,
+4000-4999 is for application-private use.
+""".
+-type close_code() :: 1000..1003 | 1007..1011 | 1014 | 3000..4999.
+
 -type result() ::
-    {reply, Frames :: [{roadrunner_ws:opcode(), iodata()}], NewState :: term()}
-    | {reply, Frames :: [{roadrunner_ws:opcode(), iodata()}], NewState :: term(), [opt()]}
+    {reply, Frames :: [{opcode(), iodata()}], NewState :: term()}
+    | {reply, Frames :: [{opcode(), iodata()}], NewState :: term(), [opt()]}
     | {ok, NewState :: term()}
     | {ok, NewState :: term(), [opt()]}
     | {close, NewState :: term()}
-    | {close, Code :: roadrunner_ws:close_code(), Reason :: iodata(), NewState :: term()}.
+    | {close, Code :: close_code(), Reason :: iodata(), NewState :: term()}.
 
 -callback init(State :: term()) -> result().
--callback handle_frame(Frame :: roadrunner_ws:frame(), State :: term()) -> result().
+-callback handle_frame(Frame :: frame(), State :: term()) -> result().
 -callback handle_info(Info :: term(), State :: term()) -> result().
 
 -optional_callbacks([init/1, handle_info/2]).
 
--export_type([opt/0, result/0]).
+-export_type([opt/0, result/0, opcode/0, frame/0, close_code/0]).

--- a/src/roadrunner_ws_handler.erl
+++ b/src/roadrunner_ws_handler.erl
@@ -63,49 +63,18 @@ NewState}`, `{ok, NewState}`, `{close, NewState}`, or
 
 -type opt() :: hibernate.
 
--doc """
-The four data/control opcodes a handler sees. `continuation` only
-appears at the wire level — the session reassembles fragmented
-messages before dispatching to `handle_frame/2`, so handlers
-receive `text` or `binary` for data and `ping` / `pong` / `close`
-for control. Outbound replies may use `text`, `binary`, `ping`,
-`pong`, or `close`.
-""".
--type opcode() :: continuation | text | binary | close | ping | pong.
-
--doc """
-The frame map handed to `handle_frame/2`. `payload` is the
-post-unmask, post-reassembly (and post-inflate, for compressed
-messages) bytes — exactly what the handler should treat as the
-message body.
-""".
--type frame() :: #{
-    fin := boolean(),
-    rsv1 := boolean(),
-    opcode := opcode(),
-    payload := binary()
-}.
-
--doc """
-Close status codes a server is permitted to send per RFC 6455 §7.4.
-1004/1005/1006 are reserved (MUST NOT appear on the wire);
-1012/1013 are unassigned. 3000-3999 is the IANA-registered range,
-4000-4999 is for application-private use.
-""".
--type close_code() :: 1000..1003 | 1007..1011 | 1014 | 3000..4999.
-
 -type result() ::
-    {reply, Frames :: [{opcode(), iodata()}], NewState :: term()}
-    | {reply, Frames :: [{opcode(), iodata()}], NewState :: term(), [opt()]}
+    {reply, Frames :: [{roadrunner_ws:opcode(), iodata()}], NewState :: term()}
+    | {reply, Frames :: [{roadrunner_ws:opcode(), iodata()}], NewState :: term(), [opt()]}
     | {ok, NewState :: term()}
     | {ok, NewState :: term(), [opt()]}
     | {close, NewState :: term()}
-    | {close, Code :: close_code(), Reason :: iodata(), NewState :: term()}.
+    | {close, Code :: roadrunner_ws:close_code(), Reason :: iodata(), NewState :: term()}.
 
 -callback init(State :: term()) -> result().
--callback handle_frame(Frame :: frame(), State :: term()) -> result().
+-callback handle_frame(Frame :: roadrunner_ws:frame(), State :: term()) -> result().
 -callback handle_info(Info :: term(), State :: term()) -> result().
 
 -optional_callbacks([init/1, handle_info/2]).
 
--export_type([opt/0, result/0, opcode/0, frame/0, close_code/0]).
+-export_type([opt/0, result/0]).

--- a/src/roadrunner_ws_handler.erl
+++ b/src/roadrunner_ws_handler.erl
@@ -61,8 +61,28 @@ NewState}`, `{ok, NewState}`, `{close, NewState}`, or
 `Opts` list for `hibernate` on the reply / ok shapes.
 """.
 
+-doc """
+Per-event option flags. Currently only `hibernate` is recognized;
+when included in a 4-tuple callback return, the framework hibernates
+the session process after the event finishes processing.
+""".
 -type opt() :: hibernate.
 
+-doc """
+Unified return shape for all `roadrunner_ws_handler` callbacks.
+
+- `{reply, Frames, NewState}` — emit each `{Opcode, Payload}` frame
+  (always with FIN=true) and keep the session open.
+- `{reply, Frames, NewState, Opts}` — same, with an opt list (e.g.
+  `[hibernate]`).
+- `{ok, NewState}` — no outbound frames, keep the session open.
+- `{ok, NewState, Opts}` — same, with an opt list.
+- `{close, NewState}` — send an empty close frame and terminate.
+- `{close, Code, Reason, NewState}` — send a close frame carrying
+  `Code` (RFC 6455 §7.4 server-permitted code) and UTF-8 `Reason`.
+  The framework crashes the session if `Code` / `Reason` is invalid
+  rather than emit a malformed close.
+""".
 -type result() ::
     {reply, Frames :: [{roadrunner_ws:opcode(), iodata()}], NewState :: term()}
     | {reply, Frames :: [{roadrunner_ws:opcode(), iodata()}], NewState :: term(), [opt()]}

--- a/src/roadrunner_ws_handler.erl
+++ b/src/roadrunner_ws_handler.erl
@@ -71,8 +71,35 @@ NewState}`, `{ok, NewState}`, `{close, NewState}`, or
     | {close, NewState :: term()}
     | {close, Code :: roadrunner_ws:close_code(), Reason :: iodata(), NewState :: term()}.
 
+-doc """
+Optional. Runs once in the session process after the 101 has been
+written to the wire and before the first frame is read, with the
+state from the upgrade tuple `{websocket, Module, State}`. Use it
+to register pubsub subscriptions, start linked workers, or push
+priming frames at connect-time. Returns the same shape as
+`handle_frame/2`. Handlers that don't export this callback skip
+the init step.
+""".
 -callback init(State :: term()) -> result().
+
+-doc """
+Invoked for each non-control frame received from the client, after
+the framework has reassembled fragmented messages (so the handler
+always sees a complete `text` or `binary` payload). Returns one of
+the `result/0` shapes: reply with frames, stay open, close
+gracefully, or close with a code + reason. Control frames
+(`ping`/`pong`/`close`) are auto-handled by the framework and
+never reach this callback.
+""".
 -callback handle_frame(Frame :: roadrunner_ws:frame(), State :: term()) -> result().
+
+-doc """
+Optional. Receives any Erlang message delivered to the session
+process that isn't a transport `active`-mode event. Use for
+pubsub / asynchronous push patterns. Returns the same shape as
+`handle_frame/2`. Handlers that don't export this callback have
+unknown messages dropped silently.
+""".
 -callback handle_info(Info :: term(), State :: term()) -> result().
 
 -optional_callbacks([init/1, handle_info/2]).

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -443,7 +443,6 @@ early_validate_text(Data, Buf, Opts) ->
 %% Unmask `Slice` where its first byte sits at `Offset` into the
 %% logical payload (so the mask-key cycle is right). RFC 6455 §5.3
 %% mask: payload[i] = masked[i] XOR maskKey[i mod 4].
-
 -doc false.
 -spec unmask_slice(binary(), binary(), non_neg_integer()) -> binary().
 unmask_slice(Slice, <<MaskKey:32>>, Offset) ->

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -443,6 +443,7 @@ early_validate_text(Data, Buf, Opts) ->
 %% Unmask `Slice` where its first byte sits at `Offset` into the
 %% logical payload (so the mask-key cycle is right). RFC 6455 §5.3
 %% mask: payload[i] = masked[i] XOR maskKey[i mod 4].
+
 -doc false.
 -spec unmask_slice(binary(), binary(), non_neg_integer()) -> binary().
 unmask_slice(Slice, <<MaskKey:32>>, Offset) ->

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -1,64 +1,64 @@
 -module(roadrunner_ws_session).
--moduledoc """
-Per-connection WebSocket session — runs the frame loop in its own
-`gen_statem` process after `roadrunner_conn:upgrade_to_websocket/4`
-hands the socket off.
+-moduledoc false.
 
-The session owns the socket for its lifetime: the parent `roadrunner_conn`
-launcher (`run/4`) starts the session, transfers controlling-process,
-sends the `socket_ready` startup signal (mirroring the conn's `shoot`
-pattern), and waits via a monitor for the session to terminate.
-When the session exits — peer close frame, recv error, frame parse
-error, or handler-driven `{close, _}` — the launcher returns and the
-parent's `[roadrunner, listener, conn_close]` telemetry fires after.
-
-States:
-- `awaiting_socket` — gates the frame loop until controlling-process
-  has transferred and the launcher has sent `socket_ready`.
-- `frame_loop` — parse/dispatch frames as they arrive; the socket
-  is in active-once mode so bytes arrive as `info` events and the
-  gen_statem returns to its main loop between frames.
-
-## Active-mode reads
-
-`frame_loop` uses active-once reads (`roadrunner_transport:setopts(_,
-[{active, once}])`): after each event the state callback returns,
-gen_statem is idle in its main loop, and `hibernate` actions
-actually take effect. Without active mode we'd be blocked inside
-`roadrunner_transport:recv/3` and hibernation would be a no-op.
-
-## Handler hibernation opt-in
-
-The `roadrunner_ws_handler` callback supports an optional 4-tuple
-return shape: `{reply, OutFrames, NewState, Opts}` and
-`{ok, NewState, Opts}`, where `Opts` is a list that may contain
-`hibernate`. When present, the gen_statem hibernates after this
-event is fully processed — process heap drops to ~1KB until the
-next inbound frame wakes it up. For an idle WebSocket session
-this is the difference between holding ~5–8KB of process memory
-indefinitely vs. ~1KB.
-
-3-tuple returns (`{reply, OutFrames, NewState}`, `{ok, NewState}`,
-`{close, NewState}`) stay valid — the 4-tuple is purely additive.
-
-## Optional handler callbacks
-
-`init/1` runs once on the awaiting_socket → frame_loop transition,
-**before** the first inbound frame; the handler can push priming
-frames or refuse the session by returning `{close, _}`. `handle_info/2`
-receives any non-transport info message (a pubsub broadcast a handler
-subscribed to in `init/1`, an exit signal from a linked worker, etc.)
-and returns the same shape as `handle_frame/2`. Both are
-`-optional_callbacks` — handlers that don't export them get the
-old behavior (no init action, stray info dropped silently). Whether
-each is exported is cached in `#data` at session start so the BIF
-check doesn't run on every event.
-
-Telemetry: `[roadrunner, ws, upgrade]` fires from `run/4` once the
-launcher has decided to enter the session; `[roadrunner, ws, frame_in]`
-and `[roadrunner, ws, frame_out]` fire from the gen_statem itself for
-every frame.
-""".
+%% Per-connection WebSocket session — runs the frame loop in its own
+%% `gen_statem` process after `roadrunner_conn:upgrade_to_websocket/4`
+%% hands the socket off.
+%%
+%% The session owns the socket for its lifetime: the parent `roadrunner_conn`
+%% launcher (`run/4`) starts the session, transfers controlling-process,
+%% sends the `socket_ready` startup signal (mirroring the conn's `shoot`
+%% pattern), and waits via a monitor for the session to terminate.
+%% When the session exits — peer close frame, recv error, frame parse
+%% error, or handler-driven `{close, _}` — the launcher returns and the
+%% parent's `[roadrunner, listener, conn_close]` telemetry fires after.
+%%
+%% States:
+%% - `awaiting_socket` — gates the frame loop until controlling-process
+%%   has transferred and the launcher has sent `socket_ready`.
+%% - `frame_loop` — parse/dispatch frames as they arrive; the socket
+%%   is in active-once mode so bytes arrive as `info` events and the
+%%   gen_statem returns to its main loop between frames.
+%%
+%% ## Active-mode reads
+%%
+%% `frame_loop` uses active-once reads (`roadrunner_transport:setopts(_,
+%% [{active, once}])`): after each event the state callback returns,
+%% gen_statem is idle in its main loop, and `hibernate` actions
+%% actually take effect. Without active mode we'd be blocked inside
+%% `roadrunner_transport:recv/3` and hibernation would be a no-op.
+%%
+%% ## Handler hibernation opt-in
+%%
+%% The `roadrunner_ws_handler` callback supports an optional 4-tuple
+%% return shape: `{reply, OutFrames, NewState, Opts}` and
+%% `{ok, NewState, Opts}`, where `Opts` is a list that may contain
+%% `hibernate`. When present, the gen_statem hibernates after this
+%% event is fully processed — process heap drops to ~1KB until the
+%% next inbound frame wakes it up. For an idle WebSocket session
+%% this is the difference between holding ~5–8KB of process memory
+%% indefinitely vs. ~1KB.
+%%
+%% 3-tuple returns (`{reply, OutFrames, NewState}`, `{ok, NewState}`,
+%% `{close, NewState}`) stay valid — the 4-tuple is purely additive.
+%%
+%% ## Optional handler callbacks
+%%
+%% `init/1` runs once on the awaiting_socket → frame_loop transition,
+%% **before** the first inbound frame; the handler can push priming
+%% frames or refuse the session by returning `{close, _}`. `handle_info/2`
+%% receives any non-transport info message (a pubsub broadcast a handler
+%% subscribed to in `init/1`, an exit signal from a linked worker, etc.)
+%% and returns the same shape as `handle_frame/2`. Both are
+%% `-optional_callbacks` — handlers that don't export them get the
+%% old behavior (no init action, stray info dropped silently). Whether
+%% each is exported is cached in `#data` at session start so the BIF
+%% check doesn't run on every event.
+%%
+%% Telemetry: `[roadrunner, ws, upgrade]` fires from `run/4` once the
+%% launcher has decided to enter the session; `[roadrunner, ws, frame_in]`
+%% and `[roadrunner, ws, frame_out]` fire from the gen_statem itself for
+%% every frame.
 
 -behaviour(gen_statem).
 


### PR DESCRIPTION
# Description

Tighten the public documentation surface so hexdocs only renders what users need to read.

- Hide 26 internal modules with `-moduledoc false.`
- Promote `roadrunner_middleware`, `roadrunner_ws`, `roadrunner_http` to public so user-facing types live in their semantic home
- Document every public callback and non-trivial type
- Group hexdocs extras into Benchmarks and Project sections
- README links use absolute GitHub URLs

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
