### PR TITLE
Drop redundant iolist_to_binary calls on the H2 send path and in the static handler

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -27,7 +27,7 @@
 %%
 %% ```
 %% {h2_send_headers, Worker, Ref, StreamId, Status, Headers, EndStream}
-%% {h2_send_data,    Worker, Ref, StreamId, Bin,    EndStream}
+%% {h2_send_data,    Worker, Ref, StreamId, Data,   EndStream}
 %% {h2_send_trailers, Worker, Ref, StreamId, Trailers}
 %% {h2_worker_done,  StreamId}
 %% ```
@@ -113,7 +113,7 @@
 %% type it as a list to leave room for future enrichment without
 %% reshaping callers.
 -type pending_send() ::
-    {data, reference(), pid(), binary(), boolean()}.
+    {data, reference(), pid(), iodata(), boolean()}.
 
 -type stream_entry() :: #{
     state := stream_state(),
@@ -383,8 +383,8 @@ recv_more(
             exit_clean(State);
         {h2_send_headers, From, Ref, StreamId, Status, Headers, EndStream} ->
             recv_more(handle_send_headers(State, From, Ref, StreamId, Status, Headers, EndStream));
-        {h2_send_data, From, Ref, StreamId, Bin, EndStream} ->
-            recv_more(handle_send_data(State, From, Ref, StreamId, Bin, EndStream));
+        {h2_send_data, From, Ref, StreamId, Data, EndStream} ->
+            recv_more(handle_send_data(State, From, Ref, StreamId, Data, EndStream));
         {h2_send_trailers, From, Ref, StreamId, Trailers} ->
             recv_more(handle_send_trailers(State, From, Ref, StreamId, Trailers));
         {h2_send_response, From, Ref, StreamId, Status, Headers, Body} ->
@@ -962,13 +962,13 @@ handle_send_headers(State, From, Ref, StreamId, Status, Headers, EndStream) ->
             State1
     end.
 
-handle_send_data(State, From, Ref, StreamId, Bin, EndStream) ->
+handle_send_data(State, From, Ref, StreamId, Data, EndStream) ->
     case stream_open(State, StreamId) of
         not_open ->
             _ = (From ! {h2_stream_reset, StreamId}),
             State;
         Stream ->
-            try_send_data(State, Stream, StreamId, From, Ref, Bin, EndStream)
+            try_send_data(State, Stream, StreamId, From, Ref, Data, EndStream)
     end.
 
 handle_send_trailers(State, From, Ref, StreamId, Trailers) ->
@@ -1107,45 +1107,57 @@ close_stream_send_side(#loop{streams = Streams} = State, StreamId) ->
 %% DATA send + flow control
 %% =============================================================================
 
-%% Try to send `Bin` as DATA frame(s). If both windows allow, send
+%% Try to send `Data` as DATA frame(s). If both windows allow, send
 %% everything and ack. If a partial chunk fits, send what we can
 %% and queue the rest. If nothing fits, queue the whole thing.
 %%
-%% Empty `Bin` always means `EndStream = true` because
-%% `roadrunner_http2_stream_response` short-circuits empty `nofin`
-%% sends — the empty-body case here doesn't consume any window
-%% bytes, so it bypasses the window check entirely.
-try_send_data(State, _Stream, StreamId, From, Ref, <<>>, true) ->
-    Frame = roadrunner_http2_frame:encode({data, StreamId, 16#01, <<>>}),
-    _ = send(State, Frame),
-    _ = (From ! {h2_send_ack, Ref}),
-    close_stream_send_side(State, StreamId);
-try_send_data(State, Stream, StreamId, From, Ref, Bin, EndStream) ->
-    case window_budget(State, Stream) of
-        0 ->
-            %% Window closed — queue the whole send.
-            Stream1 = enqueue_pending(Stream, {data, Ref, From, Bin, EndStream}),
-            update_stream(State, StreamId, Stream1);
+%% `Data` is iodata. The single-frame branch in `send_data_chunks`
+%% passes it straight to the frame encoder (which accepts iodata)
+%% and the transport `writev()`s it, so the common streaming case
+%% never materialises to a flat binary.
+%%
+%% Empty `Data` always means `EndStream = true` because workers
+%% short-circuit empty `nofin` sends — the empty-body case here
+%% doesn't consume any window bytes, so it bypasses the window
+%% check entirely.
+try_send_data(State, Stream, StreamId, From, Ref, Data, EndStream) ->
+    case iolist_size(Data) of
+        0 when EndStream ->
+            %% Final empty DATA frame closes the stream.
+            Frame = roadrunner_http2_frame:encode({data, StreamId, 16#01, <<>>}),
+            _ = send(State, Frame),
+            _ = (From ! {h2_send_ack, Ref}),
+            close_stream_send_side(State, StreamId);
         _ ->
-            send_data_chunks(State, Stream, StreamId, From, Ref, Bin, EndStream)
+            case window_budget(State, Stream) of
+                0 ->
+                    %% Window closed — queue the whole send.
+                    Stream1 = enqueue_pending(Stream, {data, Ref, From, Data, EndStream}),
+                    update_stream(State, StreamId, Stream1);
+                _ ->
+                    send_data_chunks(State, Stream, StreamId, From, Ref, Data, EndStream)
+            end
     end.
 
-send_data_chunks(State, Stream, StreamId, From, Ref, Bin, EndStream) ->
+send_data_chunks(State, Stream, StreamId, From, Ref, Data, EndStream) ->
     Available = window_budget(State, Stream),
-    Take = min(min(byte_size(Bin), Available), ?MAX_FRAME_SIZE),
+    Total = iolist_size(Data),
+    Take = min(min(Total, Available), ?MAX_FRAME_SIZE),
     case Take of
         0 ->
             %% Window closed mid-body — queue the remainder.
-            Stream1 = enqueue_pending(Stream, {data, Ref, From, Bin, EndStream}),
+            Stream1 = enqueue_pending(Stream, {data, Ref, From, Data, EndStream}),
             update_stream(State, StreamId, Stream1);
-        N when N =:= byte_size(Bin) ->
-            %% Last chunk — END_STREAM if the caller asked.
+        N when N =:= Total ->
+            %% Fits in one DATA frame and within the window: ship
+            %% iodata straight through. Frame encoder accepts iodata
+            %% and the transport's writev() avoids the flatten.
             Flags =
                 if
                     EndStream -> 16#01;
                     true -> 0
                 end,
-            Frame = roadrunner_http2_frame:encode({data, StreamId, Flags, Bin}),
+            Frame = roadrunner_http2_frame:encode({data, StreamId, Flags, Data}),
             _ = send(State, Frame),
             State1 = consume_send_window(State, StreamId, Stream, N),
             _ = (From ! {h2_send_ack, Ref}),
@@ -1154,6 +1166,12 @@ send_data_chunks(State, Stream, StreamId, From, Ref, Bin, EndStream) ->
                 true -> State1
             end;
         N ->
+            %% Chunking across window/MAX_FRAME_SIZE boundaries:
+            %% materialise once so we can slice with binary patterns
+            %% (sub-binaries, no per-chunk copy). On recursion `Rest`
+            %% is a binary, so `iolist_size/1` becomes O(1) and
+            %% `iolist_to_binary/1` is a no-op BIF.
+            Bin = iolist_to_binary(Data),
             <<Chunk:N/binary, Rest/binary>> = Bin,
             Frame = roadrunner_http2_frame:encode({data, StreamId, 0, Chunk}),
             _ = send(State, Frame),

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -910,44 +910,45 @@ find_content_length([_ | Rest], V) -> find_content_length(Rest, V).
 %% to the two-frame two-message path when the body doesn't fit a
 %% single DATA frame AND the current window — the worker still
 %% sees one ack at the end of the data send.
-handle_send_response(State, From, Ref, StreamId, Status, Headers, <<>>) ->
-    %% Empty body — same wire shape as `handle_send_headers` with
-    %% `EndStream = true` (single HEADERS frame, END_STREAM bit set).
-    case stream_open(State, StreamId) of
-        not_open ->
-            _ = (From ! {h2_stream_reset, StreamId}),
-            State;
-        _Stream ->
-            State1 = encode_and_send_headers(State, StreamId, Status, Headers, true),
-            _ = (From ! {h2_send_ack, Ref}),
-            State1
-    end;
 handle_send_response(State, From, Ref, StreamId, Status, Headers, Body) ->
     case stream_open(State, StreamId) of
         not_open ->
             _ = (From ! {h2_stream_reset, StreamId}),
             State;
         Stream ->
-            BodyLen = byte_size(Body),
-            %% Short-circuit: skip the `window_budget/2` lookup when the
-            %% body already won't fit in one frame.
-            case BodyLen =< ?MAX_FRAME_SIZE andalso window_budget(State, Stream) >= BodyLen of
-                true ->
-                    State1 = encode_and_send_response_atomic(
-                        State, StreamId, Status, Headers, Body
-                    ),
+            case iolist_size(Body) of
+                0 ->
+                    %% Empty body — single HEADERS frame with END_STREAM,
+                    %% same wire shape as `handle_send_headers/_, true)`.
+                    State1 = encode_and_send_headers(State, StreamId, Status, Headers, true),
                     _ = (From ! {h2_send_ack, Ref}),
                     State1;
-                false ->
-                    %% Body too big for one frame OR window too narrow —
-                    %% emit HEADERS now, hand the body to `try_send_data`
-                    %% which fragments / queues + acks the worker on
-                    %% completion.
-                    State1 = encode_and_send_headers(
-                        State, StreamId, Status, Headers, false
-                    ),
-                    #{StreamId := Stream1} = State1#loop.streams,
-                    try_send_data(State1, Stream1, StreamId, From, Ref, Body, true)
+                BodyLen ->
+                    %% Short-circuit: skip the `window_budget/2` lookup
+                    %% when the body already won't fit in one frame.
+                    case
+                        BodyLen =< ?MAX_FRAME_SIZE andalso
+                            window_budget(State, Stream) >= BodyLen
+                    of
+                        true ->
+                            State1 = encode_and_send_response_atomic(
+                                State, StreamId, Status, Headers, Body, BodyLen
+                            ),
+                            _ = (From ! {h2_send_ack, Ref}),
+                            State1;
+                        false ->
+                            %% Body too big for one frame OR window too
+                            %% narrow — emit HEADERS now, hand the body to
+                            %% `try_send_data` which fragments / queues +
+                            %% acks the worker on completion.
+                            State1 = encode_and_send_headers(
+                                State, StreamId, Status, Headers, false
+                            ),
+                            #{StreamId := Stream1} = State1#loop.streams,
+                            try_send_data(
+                                State1, Stream1, StreamId, From, Ref, Body, true
+                            )
+                    end
             end
     end.
 
@@ -1043,16 +1044,19 @@ encode_and_send_headers(
         true -> State1
     end.
 
-%% HEADERS + DATA (END_STREAM) packed into ONE `ssl:send/2`.
-%% Caller has already verified `byte_size(Body)` fits in a single
-%% DATA frame AND in the current send window. Consumes the window
-%% by `byte_size(Body)` and marks the stream's send side closed.
+%% HEADERS + DATA (END_STREAM) packed into ONE `ssl:send/2`. Body
+%% is iodata; the frame encoder accepts it and the transport
+%% `writev()`s the assembled iolist so no flatten happens here.
+%% Caller has already verified `BodyLen` fits in a single DATA
+%% frame AND in the current send window. Consumes the window by
+%% `BodyLen` and marks the stream's send side closed.
 encode_and_send_response_atomic(
     #loop{hpack_enc = Enc, streams = Streams} = State,
     StreamId,
     Status,
     Headers,
-    Body
+    Body,
+    BodyLen
 ) ->
     #{StreamId := Stream} = Streams,
     StatusBin = integer_to_binary(Status),
@@ -1068,7 +1072,7 @@ encode_and_send_response_atomic(
     DFrame = roadrunner_http2_frame:encode({data, StreamId, 16#01, Body}),
     _ = send(State, [HFrame, DFrame]),
     State1 = State#loop{hpack_enc = Enc1},
-    State2 = consume_send_window(State1, StreamId, Stream, byte_size(Body)),
+    State2 = consume_send_window(State1, StreamId, Stream, BodyLen),
     close_stream_send_side(State2, StreamId).
 
 encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1128,20 +1128,19 @@ try_send_data(State, Stream, StreamId, From, Ref, Data, EndStream) ->
             _ = send(State, Frame),
             _ = (From ! {h2_send_ack, Ref}),
             close_stream_send_side(State, StreamId);
-        _ ->
+        Total ->
             case window_budget(State, Stream) of
                 0 ->
                     %% Window closed — queue the whole send.
                     Stream1 = enqueue_pending(Stream, {data, Ref, From, Data, EndStream}),
                     update_stream(State, StreamId, Stream1);
                 _ ->
-                    send_data_chunks(State, Stream, StreamId, From, Ref, Data, EndStream)
+                    send_data_chunks(State, Stream, StreamId, From, Ref, Data, Total, EndStream)
             end
     end.
 
-send_data_chunks(State, Stream, StreamId, From, Ref, Data, EndStream) ->
+send_data_chunks(State, Stream, StreamId, From, Ref, Data, Total, EndStream) ->
     Available = window_budget(State, Stream),
-    Total = iolist_size(Data),
     Take = min(min(Total, Available), ?MAX_FRAME_SIZE),
     case Take of
         0 ->
@@ -1169,15 +1168,15 @@ send_data_chunks(State, Stream, StreamId, From, Ref, Data, EndStream) ->
             %% Chunking across window/MAX_FRAME_SIZE boundaries:
             %% materialise once so we can slice with binary patterns
             %% (sub-binaries, no per-chunk copy). On recursion `Rest`
-            %% is a binary, so `iolist_size/1` becomes O(1) and
-            %% `iolist_to_binary/1` is a no-op BIF.
+            %% is a binary and we thread the running size as `Total -
+            %% N`, so no further `iolist_size/1` walk is needed.
             Bin = iolist_to_binary(Data),
             <<Chunk:N/binary, Rest/binary>> = Bin,
             Frame = roadrunner_http2_frame:encode({data, StreamId, 0, Chunk}),
             _ = send(State, Frame),
             State1 = consume_send_window(State, StreamId, Stream, N),
             #{StreamId := Stream1} = State1#loop.streams,
-            send_data_chunks(State1, Stream1, StreamId, From, Ref, Rest, EndStream)
+            send_data_chunks(State1, Stream1, StreamId, From, Ref, Rest, Total - N, EndStream)
     end.
 
 window_budget(#loop{conn_send_window = ConnW}, #{send_window := StreamW}) ->

--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -60,16 +60,17 @@ info_loop(ConnPid, StreamId, Handler, Push, State) ->
 %% empty DATA frame would be legal on the wire but doesn't advance
 %% the response, and matching h1's behaviour (which skips empty
 %% chunks to avoid emitting the chunked terminator prematurely)
-%% keeps the two paths symmetric.
+%% keeps the two paths symmetric. Non-empty pushes ship as iodata;
+%% the conn fast-paths single-frame sends without materialising and
+%% only flattens when chunking across window/MAX_FRAME_SIZE.
 -spec make_push(pid(), pos_integer()) -> roadrunner_handler:push_fun().
 make_push(ConnPid, StreamId) ->
     fun(Data) ->
-        Bin = iolist_to_binary(Data),
-        case byte_size(Bin) of
+        case iolist_size(Data) of
             0 ->
                 ok;
             _ ->
-                sync_send_data(ConnPid, StreamId, Bin, false),
+                sync_send_data(ConnPid, StreamId, Data, false),
                 ok
         end
     end.
@@ -95,12 +96,12 @@ sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->
         ok
     end).
 
--spec sync_send_data(pid(), pos_integer(), binary(), boolean()) -> ok.
-sync_send_data(ConnPid, StreamId, Bin, EndStream) ->
+-spec sync_send_data(pid(), pos_integer(), iodata(), boolean()) -> ok.
+sync_send_data(ConnPid, StreamId, Data, EndStream) ->
     sync(fun(Ref) ->
         _ =
             (ConnPid !
-                {h2_send_data, self(), Ref, StreamId, Bin, EndStream}),
+                {h2_send_data, self(), Ref, StreamId, Data, EndStream}),
         ok
     end).
 

--- a/src/roadrunner_http2_stream_response.erl
+++ b/src/roadrunner_http2_stream_response.erl
@@ -60,18 +60,17 @@ run(ConnPid, StreamId, Status, Headers, Fun) ->
     ok.
 
 do_send(ConnPid, StreamId, Data, nofin) ->
-    %% Flatten to a binary once — `byte_size/1` after is O(1) and
-    %% the conn-side flow-control arithmetic needs a binary anyway.
-    Bin = iolist_to_binary(Data),
-    byte_size(Bin) > 0 andalso sync_send_data(ConnPid, StreamId, Bin, false),
+    %% Ship as iodata. The conn fast-paths single-frame sends
+    %% without materialising and only flattens when chunking
+    %% across window/MAX_FRAME_SIZE boundaries.
+    iolist_size(Data) > 0 andalso sync_send_data(ConnPid, StreamId, Data, false),
     ok;
 do_send(ConnPid, StreamId, Data, fin) ->
-    sync_send_data(ConnPid, StreamId, iolist_to_binary(Data), true),
+    sync_send_data(ConnPid, StreamId, Data, true),
     put(?FIN_KEY, true),
     ok;
 do_send(ConnPid, StreamId, Data, {fin, Trailers}) ->
-    Bin = iolist_to_binary(Data),
-    byte_size(Bin) > 0 andalso sync_send_data(ConnPid, StreamId, Bin, false),
+    iolist_size(Data) > 0 andalso sync_send_data(ConnPid, StreamId, Data, false),
     sync_send_trailers(ConnPid, StreamId, Trailers),
     put(?FIN_KEY, true),
     ok.
@@ -82,9 +81,9 @@ sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->
         ok
     end).
 
-sync_send_data(ConnPid, StreamId, Bin, EndStream) ->
+sync_send_data(ConnPid, StreamId, Data, EndStream) ->
     sync(fun(Ref) ->
-        _ = (ConnPid ! {h2_send_data, self(), Ref, StreamId, Bin, EndStream}),
+        _ = (ConnPid ! {h2_send_data, self(), Ref, StreamId, Data, EndStream}),
         ok
     end).
 

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -219,9 +219,8 @@ emit_501(ConnPid, StreamId) ->
 %% or constrained windows; the worker still sees a single sync
 %% round-trip in either case.
 send_buffered(ConnPid, StreamId, Status, Headers, Body) ->
-    Bin = iolist_to_binary(Body),
     sync(fun(Ref) ->
-        _ = (ConnPid ! {h2_send_response, self(), Ref, StreamId, Status, Headers, Bin}),
+        _ = (ConnPid ! {h2_send_response, self(), Ref, StreamId, Status, Headers, Body}),
         ok
     end).
 

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -410,22 +410,23 @@ target_inside_docroot(FilePath, Req) ->
     %% crash and bubble up as a 500 instead of silently 404'ing.
     {ok, Target} = file:read_link(FilePath),
     #{dir := Dir} = roadrunner_req:route_opts(Req),
-    TargetBin = iolist_to_binary([Target]),
-    case filename:pathtype(TargetBin) of
+    case filename:pathtype(Target) of
         relative ->
-            %% A relative target without any `..` segments must
-            %% land inside the directory containing the symlink,
-            %% which by construction is inside `dir`.
-            Segments = filename:split(TargetBin),
-            not lists:member(~"..", Segments);
+            %% A relative target without any `..` segments must land
+            %% inside the directory containing the symlink, which by
+            %% construction is inside `dir`. The framework runs with
+            %% binary file names (default UTF-8 native encoding), so
+            %% `filename:split/1` yields binaries and the `~".."`
+            %% literal matches directly.
+            not lists:member(~"..", filename:split(Target));
         _ ->
             %% `filename:absname/1` strips trailing slashes (except for
             %% the root `/` itself, which we don't reasonably support
             %% as a docroot anyway), so a single appended `/` is enough
             %% to make `string:prefix/2` an exact directory check
-            %% rather than a sibling-prefix false positive.
-            DirAbs = iolist_to_binary([filename:absname(Dir), $/]),
-            string:prefix(TargetBin, DirAbs) =/= nomatch
+            %% rather than a sibling-prefix false positive. `string:prefix/2`
+            %% accepts chardata, so neither argument needs flattening.
+            string:prefix(Target, [filename:absname(Dir), $/]) =/= nomatch
     end.
 
 %% Parse an IMF-fixdate header back into a posix timestamp. Returns

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -314,6 +314,23 @@ static_test_() ->
                 Reply = http_get(Port, ~"/static/escape_link.txt"),
                 ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
             end},
+            {"absolute symlink whose target lives inside the docroot is followed", fun() ->
+                %% Covers the acceptance side of the absolute-pathtype
+                %% branch; the prefix check on `[absname(Dir), $/]`
+                %% must say `=/= nomatch`.
+                Reply = http_get(Port, ~"/static/inside_abs_link.txt"),
+                ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, Reply),
+                {match, _} = re:run(Reply, ~"hello via link")
+            end},
+            {"absolute symlink to a sibling-prefixed dir is refused", fun() ->
+                %% `<Dir>_evil/leak.txt` shares a prefix with `<Dir>`
+                %% but is NOT inside it. The trailing `/` on the
+                %% prefix check is what saves us here — without it,
+                %% `string:prefix` would match and the leak would
+                %% pass.
+                Reply = http_get(Port, ~"/static/sibling_attack.txt"),
+                ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
+            end},
             {"relative symlink with .. segments in target is refused", fun() ->
                 Reply = http_get(Port, ~"/static/dotdot_link.txt"),
                 ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
@@ -489,6 +506,24 @@ setup() ->
         filename:join(Dir, "escape_link.txt")
     ),
     _ = file:make_symlink(~"../etc/passwd", filename:join(Dir, "dotdot_link.txt")),
+    %% Absolute symlink that DOES land inside the docroot — the
+    %% pathtype/2 absolute branch must accept this. (The other
+    %% absolute test only covers rejection.)
+    _ = file:make_symlink(
+        filename:join(Dir, "notes.txt"),
+        filename:join(Dir, "inside_abs_link.txt")
+    ),
+    %% Sibling-prefix attack: a directory whose name shares a prefix
+    %% with `Dir`. Without the trailing `/` in the prefix check,
+    %% `string:prefix("<Dir>_evil/leak.txt", "<Dir>")` would match
+    %% and let the symlink through. With the `/`, it must be refused.
+    SiblingDir = Dir ++ "_evil",
+    ok = filelib:ensure_dir(filename:join(SiblingDir, "x")),
+    ok = file:write_file(filename:join(SiblingDir, "leak.txt"), ~"sibling leak"),
+    _ = file:make_symlink(
+        filename:join(SiblingDir, "leak.txt"),
+        filename:join(Dir, "sibling_attack.txt")
+    ),
     %% Empty subdirectory — `filename:join` can resolve a path to it,
     %% but `file:read_file_info` reports `type = directory` so the
     %% handler returns 404 instead of trying to send it.


### PR DESCRIPTION
# Description

The HTTP/2 send path hands handler-supplied iodata through to the transport instead of materialising in the worker; the conn flattens only on the chunking branch, where binary slicing across window boundaries needs it. The static handler's symlink-escape check sheds two `iolist_to_binary([X])` wraps and picks up tests for the absolute-symlink branches.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
