### PR TITLE
Pre-bake the middleware pipeline at compile time

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -62,7 +62,6 @@
     send_internal_error/1,
     send_not_found/1,
     resolve_handler/2,
-    thread_route_cfg/2,
     response_status/1,
     response_kind/1
 ]).
@@ -75,7 +74,7 @@
 -define(KEEP_ALIVE_CP_KEY, {?MODULE, keep_alive_cp}).
 
 -type dispatch() ::
-    {handler, module(), roadrunner_router:route_cfg()}
+    {handler, module(), roadrunner_middleware:next()}
     | {router, ListenerName :: atom()}.
 
 -type proto_opts() :: #{
@@ -327,27 +326,15 @@ scheme({fake, _}) -> http.
 
 -doc false.
 -spec resolve_handler(dispatch(), roadrunner_http1:request()) ->
-    {ok, module(), roadrunner_router:bindings(), roadrunner_router:route_cfg()} | not_found.
-resolve_handler({handler, Mod, Cfg}, _Req) ->
-    {ok, Mod, #{}, Cfg};
+    {ok, module(), roadrunner_router:bindings(), roadrunner_middleware:next()} | not_found.
+resolve_handler({handler, Mod, Pipeline}, _Req) ->
+    {ok, Mod, #{}, Pipeline};
 resolve_handler({router, ListenerName}, Req) ->
     %% Routes are stored in `persistent_term` by `roadrunner_listener` so
     %% the lookup is O(1) and `roadrunner_listener:reload_routes/2` can
     %% atomically swap the table without bouncing the listener.
     Compiled = persistent_term:get({roadrunner_routes, ListenerName}),
     roadrunner_router:match(roadrunner_req:path(Req), Compiled).
-
-%% Thread the matched route's per-handler `state` onto the request so
-%% `roadrunner_req:state/1` can read it. Only sets the field when the
-%% cfg carries it — `state/1` falls back to `undefined` when absent,
-%% which saves one map slot per request on the no-state fast path.
-%% Middlewares are NOT threaded here: they're consumed once by the
-%% conn loops to build the pipeline, then thrown away.
--doc false.
--spec thread_route_cfg(roadrunner_http1:request(), roadrunner_router:route_cfg()) ->
-    roadrunner_http1:request().
-thread_route_cfg(Req, #{state := S}) -> Req#{state => S};
-thread_route_cfg(Req, _) -> Req.
 
 -doc false.
 -spec read_body(

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -74,7 +74,7 @@
 -define(KEEP_ALIVE_CP_KEY, {?MODULE, keep_alive_cp}).
 
 -type dispatch() ::
-    {handler, module(), roadrunner_middleware:next()}
+    {handler, module(), roadrunner_middleware:next(), State :: term()}
     | {router, ListenerName :: atom()}.
 
 -type proto_opts() :: #{
@@ -326,9 +326,10 @@ scheme({fake, _}) -> http.
 
 -doc false.
 -spec resolve_handler(dispatch(), roadrunner_http1:request()) ->
-    {ok, module(), roadrunner_router:bindings(), roadrunner_middleware:next()} | not_found.
-resolve_handler({handler, Mod, Pipeline}, _Req) ->
-    {ok, Mod, #{}, Pipeline};
+    {ok, module(), roadrunner_router:bindings(), roadrunner_middleware:next(), term()}
+    | not_found.
+resolve_handler({handler, Mod, Pipeline, State}, _Req) ->
+    {ok, Mod, #{}, Pipeline, State};
 resolve_handler({router, ListenerName}, Req) ->
     %% Routes are stored in `persistent_term` by `roadrunner_listener` so
     %% the lookup is O(1) and `roadrunner_listener:reload_routes/2` can

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -557,9 +557,8 @@ dispatch_phase(
     Req
 ) ->
     case roadrunner_conn:resolve_handler(Dispatch, Req) of
-        {ok, Handler, Bindings, #{pipeline := Pipeline} = Cfg} ->
-            FullReq = roadrunner_conn:thread_route_cfg(Req#{bindings => Bindings}, Cfg),
-            run_pipeline(S, Handler, FullReq, Pipeline);
+        {ok, Handler, Bindings, Pipeline} ->
+            run_pipeline(S, Handler, Req#{bindings => Bindings}, Pipeline);
         not_found ->
             _ = roadrunner_conn:send_not_found(Socket),
             exit_normal(S)

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -557,10 +557,9 @@ dispatch_phase(
     Req
 ) ->
     case roadrunner_conn:resolve_handler(Dispatch, Req) of
-        {ok, Handler, Bindings, Cfg} ->
+        {ok, Handler, Bindings, #{pipeline := Pipeline} = Cfg} ->
             FullReq = roadrunner_conn:thread_route_cfg(Req#{bindings => Bindings}, Cfg),
-            Mws = maps:get(middlewares, Cfg, []),
-            run_pipeline(S, Handler, FullReq, Mws);
+            run_pipeline(S, Handler, FullReq, Pipeline);
         not_found ->
             _ = roadrunner_conn:send_not_found(Socket),
             exit_normal(S)
@@ -570,10 +569,9 @@ dispatch_phase(
     #loop_state{},
     module(),
     roadrunner_http1:request(),
-    roadrunner_middleware:middleware_list()
+    roadrunner_middleware:next()
 ) -> no_return().
-run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Mws) ->
-    Pipeline = roadrunner_middleware:build_pipeline(Mws, Handler),
+run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     try Pipeline(Req) of

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -557,7 +557,7 @@ dispatch_phase(
     Req
 ) ->
     case roadrunner_conn:resolve_handler(Dispatch, Req) of
-        {ok, Handler, Bindings, Pipeline} ->
+        {ok, Handler, Bindings, Pipeline, _State} ->
             run_pipeline(S, Handler, Req#{bindings => Bindings}, Pipeline);
         not_found ->
             _ = roadrunner_conn:send_not_found(Socket),

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -83,9 +83,16 @@ run_handler(ConnPid, StreamId, Req, ProtoOpts) ->
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     case roadrunner_conn:resolve_handler(Dispatch, Req) of
-        {ok, Handler, Bindings, #{pipeline := Pipeline} = Cfg} ->
-            FullReq = roadrunner_conn:thread_route_cfg(Req#{bindings => Bindings}, Cfg),
-            invoke(ConnPid, StreamId, Handler, Pipeline, FullReq, Metadata, ReqStart);
+        {ok, Handler, Bindings, Pipeline} ->
+            invoke(
+                ConnPid,
+                StreamId,
+                Handler,
+                Pipeline,
+                Req#{bindings => Bindings},
+                Metadata,
+                ReqStart
+            );
         not_found ->
             send_buffered(
                 ConnPid, StreamId, 404, [{~"content-type", ~"text/plain"}], ~"Not Found"

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -75,10 +75,11 @@ init(ConnPid, StreamId, Req, ProtoOpts) ->
 
 run_handler(ConnPid, StreamId, Req, ProtoOpts) ->
     %% `dispatch` is set by listener init and always present. The
-    %% matched route's `Cfg.pipeline` is a pre-composed `next()` fun
-    %% (listener mws ++ per-route mws ending in `fun Handler:handle/1`),
-    %% built once at compile / `reload_routes/2` time — we just call
-    %% it with the request, no per-request closure allocation.
+    %% matched route's `Pipeline` is a pre-composed `next()` fun
+    %% (listener mws ++ per-route mws, with `state` injected up front
+    %% if attached, ending in `fun Handler:handle/1`), built once at
+    %% compile / `reload_routes/2` time — we just call it with the
+    %% request, no per-request closure allocation.
     #{dispatch := Dispatch} = ProtoOpts,
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -75,17 +75,17 @@ init(ConnPid, StreamId, Req, ProtoOpts) ->
 
 run_handler(ConnPid, StreamId, Req, ProtoOpts) ->
     %% `dispatch` is set by listener init and always present. The
-    %% per-route middleware list (listener-wide ++ per-route) is baked
-    %% into the matched route's `Cfg.middlewares` at compile time, so
-    %% we just read it out — no per-request concat.
+    %% matched route's `Cfg.pipeline` is a pre-composed `next()` fun
+    %% (listener mws ++ per-route mws ending in `fun Handler:handle/1`),
+    %% built once at compile / `reload_routes/2` time — we just call
+    %% it with the request, no per-request closure allocation.
     #{dispatch := Dispatch} = ProtoOpts,
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     case roadrunner_conn:resolve_handler(Dispatch, Req) of
-        {ok, Handler, Bindings, Cfg} ->
+        {ok, Handler, Bindings, #{pipeline := Pipeline} = Cfg} ->
             FullReq = roadrunner_conn:thread_route_cfg(Req#{bindings => Bindings}, Cfg),
-            Mws = maps:get(middlewares, Cfg, []),
-            invoke(ConnPid, StreamId, Handler, Mws, FullReq, Metadata, ReqStart);
+            invoke(ConnPid, StreamId, Handler, Pipeline, FullReq, Metadata, ReqStart);
         not_found ->
             send_buffered(
                 ConnPid, StreamId, 404, [{~"content-type", ~"text/plain"}], ~"Not Found"
@@ -95,8 +95,7 @@ run_handler(ConnPid, StreamId, Req, ProtoOpts) ->
             })
     end.
 
-invoke(ConnPid, StreamId, Handler, Mws, Req, Metadata, ReqStart) ->
-    Pipeline = roadrunner_middleware:build_pipeline(Mws, Handler),
+invoke(ConnPid, StreamId, Handler, Pipeline, Req, Metadata, ReqStart) ->
     try Pipeline(Req) of
         {Response, _Req2} ->
             emit_handler_response(ConnPid, StreamId, Handler, Response),

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -84,7 +84,7 @@ run_handler(ConnPid, StreamId, Req, ProtoOpts) ->
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     case roadrunner_conn:resolve_handler(Dispatch, Req) of
-        {ok, Handler, Bindings, Pipeline} ->
+        {ok, Handler, Bindings, Pipeline, _State} ->
             invoke(
                 ConnPid,
                 StreamId,

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -549,12 +549,12 @@ build_proto_opts(Opts, ListenerName) ->
 %% `routes` is the unified dispatch option. Single-handler forms
 %% (bare atom, `{Mod, State}` tuple, or `#{handler := Mod, ...}` map)
 %% all compile to a `{handler, Mod, RouteCfg}` dispatch tag where
-%% `RouteCfg` is a small map carrying `state` and `middlewares` (and
-%% any future per-handler framework knob). A list of route entries
-%% uses the router. When `routes` is omitted, fall back to the default
-%% hello-world handler. List-form routes are published to
-%% `persistent_term` by `publish_routes/2` — the dispatch tag carries
-%% the listener name so the conn can look the table up.
+%% `RouteCfg` carries `pipeline` (the pre-composed middleware chain
+%% ending in `fun Mod:handle/1`) and optionally `state`. A list of
+%% route entries uses the router. When `routes` is omitted, fall back
+%% to the default hello-world handler. List-form routes are published
+%% to `persistent_term` by `publish_routes/2` — the dispatch tag
+%% carries the listener name so the conn can look the table up.
 -spec build_dispatch(opts(), atom()) -> roadrunner_conn:dispatch().
 %% Validate + normalize the `protocols` opt. Returns a 2-tuple:
 %%
@@ -659,30 +659,34 @@ flatten_http2_opts(Entries) ->
     end.
 
 build_dispatch(#{routes := Module} = Opts, _ListenerName) when is_atom(Module) ->
-    {handler, Module, bake_listener_mws(#{}, Opts)};
+    {handler, Module, bake_cfg(Module, Opts, #{}, [])};
 build_dispatch(#{routes := {Module, State}} = Opts, _ListenerName) when is_atom(Module) ->
-    {handler, Module, bake_listener_mws(#{state => State}, Opts)};
+    {handler, Module, bake_cfg(Module, Opts, #{state => State}, [])};
 build_dispatch(#{routes := #{handler := Module} = Route} = Opts, _ListenerName) when
     is_atom(Module)
 ->
-    {handler, Module, bake_listener_mws(maps:without([handler], Route), Opts)};
+    HandlerMws = maps:get(middlewares, Route, []),
+    Cfg = maps:without([handler, middlewares], Route),
+    {handler, Module, bake_cfg(Module, Opts, Cfg, HandlerMws)};
 build_dispatch(#{routes := Routes}, ListenerName) when is_list(Routes) ->
     {router, ListenerName};
 build_dispatch(Opts, _ListenerName) ->
-    {handler, roadrunner_default_handler, bake_listener_mws(#{}, Opts)}.
+    {handler, roadrunner_default_handler, bake_cfg(roadrunner_default_handler, Opts, #{}, [])}.
 
-%% Prepend the listener's `middlewares` opt onto the single-handler
-%% dispatch tag's Cfg `middlewares` key, mirroring
-%% `roadrunner_router:compile/2`'s per-route bake. Cfg keeps no
-%% `middlewares` key when both lists are empty — preserves the no-mws
-%% fast path through `build_pipeline/2`.
--spec bake_listener_mws(roadrunner_router:route_cfg(), opts()) ->
-    roadrunner_router:route_cfg().
-bake_listener_mws(Cfg, Opts) ->
-    case {maps:get(middlewares, Opts, []), maps:get(middlewares, Cfg, [])} of
-        {[], []} -> Cfg;
-        {ListenerMws, HandlerMws} -> Cfg#{middlewares => ListenerMws ++ HandlerMws}
-    end.
+%% Single-handler dispatch counterpart of `roadrunner_router:base_cfg/3`.
+%% Builds the combined listener-mws ++ per-handler-mws pipeline (ending
+%% in `fun Handler:handle/1`) once and stashes it on the dispatch tag's
+%% cfg under `pipeline`. The conn loop reads the fun straight out of
+%% the cfg with no per-request closure allocation.
+-spec bake_cfg(
+    module(),
+    opts(),
+    roadrunner_router:route_cfg(),
+    roadrunner_middleware:middleware_list()
+) -> roadrunner_router:route_cfg().
+bake_cfg(Handler, Opts, Cfg, HandlerMws) ->
+    ListenerMws = maps:get(middlewares, Opts, []),
+    Cfg#{pipeline => roadrunner_middleware:build_pipeline(ListenerMws ++ HandlerMws, Handler)}.
 
 -doc false.
 -spec handle_call(

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -548,14 +548,16 @@ build_proto_opts(Opts, ListenerName) ->
 
 %% `routes` is the unified dispatch option. Single-handler forms
 %% (bare atom, `{Mod, State}` tuple, or `#{handler := Mod, ...}` map)
-%% all compile to a `{handler, Mod, Pipeline}` dispatch tag where
-%% `Pipeline` is the pre-composed `next()` fun: listener mws ++
-%% per-handler mws, optionally wrapped in a state-injecting closure,
-%% ending in `fun Mod:handle/1`. A list of route entries uses the
-%% router. When `routes` is omitted, fall back to the default
-%% hello-world handler. List-form routes are published to
-%% `persistent_term` by `publish_routes/2` — the dispatch tag carries
-%% the listener name so the conn can look the table up.
+%% all compile to a `{handler, Mod, Pipeline, State}` dispatch tag
+%% where `Pipeline` is the pre-composed `next()` fun (listener mws
+%% ++ per-handler mws, optionally wrapped in a state-injecting
+%% closure, ending in `fun Mod:handle/1`) and `State` is the user's
+%% attached state (or `undefined`) exposed alongside for callers
+%% that need to introspect outside the request flow. A list of route
+%% entries uses the router. When `routes` is omitted, fall back to
+%% the default hello-world handler. List-form routes are published
+%% to `persistent_term` by `publish_routes/2` — the dispatch tag
+%% carries the listener name so the conn can look the table up.
 -spec build_dispatch(opts(), atom()) -> roadrunner_conn:dispatch().
 %% Validate + normalize the `protocols` opt. Returns a 2-tuple:
 %%
@@ -660,9 +662,9 @@ flatten_http2_opts(Entries) ->
     end.
 
 build_dispatch(#{routes := Module} = Opts, _ListenerName) when is_atom(Module) ->
-    {handler, Module, bake_pipeline(Module, Opts, [], no_state)};
+    bake_dispatch(Module, Opts, [], no_state);
 build_dispatch(#{routes := {Module, State}} = Opts, _ListenerName) when is_atom(Module) ->
-    {handler, Module, bake_pipeline(Module, Opts, [], {state, State})};
+    bake_dispatch(Module, Opts, [], {state, State});
 build_dispatch(#{routes := #{handler := Module} = Route} = Opts, _ListenerName) when
     is_atom(Module)
 ->
@@ -672,25 +674,35 @@ build_dispatch(#{routes := #{handler := Module} = Route} = Opts, _ListenerName) 
             #{state := S} -> {state, S};
             _ -> no_state
         end,
-    {handler, Module, bake_pipeline(Module, Opts, HandlerMws, StateArg)};
+    bake_dispatch(Module, Opts, HandlerMws, StateArg);
 build_dispatch(#{routes := Routes}, ListenerName) when is_list(Routes) ->
     {router, ListenerName};
 build_dispatch(Opts, _ListenerName) ->
-    {handler, roadrunner_default_handler,
-        bake_pipeline(roadrunner_default_handler, Opts, [], no_state)}.
+    bake_dispatch(roadrunner_default_handler, Opts, [], no_state).
 
 %% Single-handler dispatch counterpart of the router's compile path.
 %% Defers to `roadrunner_middleware:compile_pipeline/3` after combining
-%% the listener-wide and per-handler mws lists.
--spec bake_pipeline(
+%% the listener-wide and per-handler mws lists. State is exposed
+%% alongside the pipeline so `roadrunner_router:match/2`-shaped
+%% callers (and other introspection paths) can read it without
+%% running the pipeline.
+-spec bake_dispatch(
     module(),
     opts(),
     roadrunner_middleware:middleware_list(),
     no_state | {state, term()}
-) -> roadrunner_middleware:next().
-bake_pipeline(Handler, Opts, HandlerMws, StateArg) ->
+) -> roadrunner_conn:dispatch().
+bake_dispatch(Handler, Opts, HandlerMws, StateArg) ->
     ListenerMws = maps:get(middlewares, Opts, []),
-    roadrunner_middleware:compile_pipeline(ListenerMws ++ HandlerMws, Handler, StateArg).
+    Pipeline = roadrunner_middleware:compile_pipeline(
+        ListenerMws ++ HandlerMws, Handler, StateArg
+    ),
+    State =
+        case StateArg of
+            no_state -> undefined;
+            {state, S} -> S
+        end,
+    {handler, Handler, Pipeline, State}.
 
 -doc false.
 -spec handle_call(
@@ -736,7 +748,7 @@ do_reload_routes(
         roadrunner_router:compile(Routes, ListenerMws)
     ),
     ok;
-do_reload_routes(#state{proto_opts = #{dispatch := {handler, _, _}}}, _Routes) ->
+do_reload_routes(#state{proto_opts = #{dispatch := {handler, _, _, _}}}, _Routes) ->
     {error, no_routes}.
 
 -spec do_drain(#state{}, non_neg_integer()) ->

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -548,13 +548,14 @@ build_proto_opts(Opts, ListenerName) ->
 
 %% `routes` is the unified dispatch option. Single-handler forms
 %% (bare atom, `{Mod, State}` tuple, or `#{handler := Mod, ...}` map)
-%% all compile to a `{handler, Mod, RouteCfg}` dispatch tag where
-%% `RouteCfg` carries `pipeline` (the pre-composed middleware chain
-%% ending in `fun Mod:handle/1`) and optionally `state`. A list of
-%% route entries uses the router. When `routes` is omitted, fall back
-%% to the default hello-world handler. List-form routes are published
-%% to `persistent_term` by `publish_routes/2` — the dispatch tag
-%% carries the listener name so the conn can look the table up.
+%% all compile to a `{handler, Mod, Pipeline}` dispatch tag where
+%% `Pipeline` is the pre-composed `next()` fun: listener mws ++
+%% per-handler mws, optionally wrapped in a state-injecting closure,
+%% ending in `fun Mod:handle/1`. A list of route entries uses the
+%% router. When `routes` is omitted, fall back to the default
+%% hello-world handler. List-form routes are published to
+%% `persistent_term` by `publish_routes/2` — the dispatch tag carries
+%% the listener name so the conn can look the table up.
 -spec build_dispatch(opts(), atom()) -> roadrunner_conn:dispatch().
 %% Validate + normalize the `protocols` opt. Returns a 2-tuple:
 %%
@@ -659,34 +660,37 @@ flatten_http2_opts(Entries) ->
     end.
 
 build_dispatch(#{routes := Module} = Opts, _ListenerName) when is_atom(Module) ->
-    {handler, Module, bake_cfg(Module, Opts, #{}, [])};
+    {handler, Module, bake_pipeline(Module, Opts, [], no_state)};
 build_dispatch(#{routes := {Module, State}} = Opts, _ListenerName) when is_atom(Module) ->
-    {handler, Module, bake_cfg(Module, Opts, #{state => State}, [])};
+    {handler, Module, bake_pipeline(Module, Opts, [], {state, State})};
 build_dispatch(#{routes := #{handler := Module} = Route} = Opts, _ListenerName) when
     is_atom(Module)
 ->
     HandlerMws = maps:get(middlewares, Route, []),
-    Cfg = maps:without([handler, middlewares], Route),
-    {handler, Module, bake_cfg(Module, Opts, Cfg, HandlerMws)};
+    StateArg =
+        case Route of
+            #{state := S} -> {state, S};
+            _ -> no_state
+        end,
+    {handler, Module, bake_pipeline(Module, Opts, HandlerMws, StateArg)};
 build_dispatch(#{routes := Routes}, ListenerName) when is_list(Routes) ->
     {router, ListenerName};
 build_dispatch(Opts, _ListenerName) ->
-    {handler, roadrunner_default_handler, bake_cfg(roadrunner_default_handler, Opts, #{}, [])}.
+    {handler, roadrunner_default_handler,
+        bake_pipeline(roadrunner_default_handler, Opts, [], no_state)}.
 
-%% Single-handler dispatch counterpart of `roadrunner_router:base_cfg/3`.
-%% Builds the combined listener-mws ++ per-handler-mws pipeline (ending
-%% in `fun Handler:handle/1`) once and stashes it on the dispatch tag's
-%% cfg under `pipeline`. The conn loop reads the fun straight out of
-%% the cfg with no per-request closure allocation.
--spec bake_cfg(
+%% Single-handler dispatch counterpart of the router's compile path.
+%% Defers to `roadrunner_middleware:compile_pipeline/3` after combining
+%% the listener-wide and per-handler mws lists.
+-spec bake_pipeline(
     module(),
     opts(),
-    roadrunner_router:route_cfg(),
-    roadrunner_middleware:middleware_list()
-) -> roadrunner_router:route_cfg().
-bake_cfg(Handler, Opts, Cfg, HandlerMws) ->
+    roadrunner_middleware:middleware_list(),
+    no_state | {state, term()}
+) -> roadrunner_middleware:next().
+bake_pipeline(Handler, Opts, HandlerMws, StateArg) ->
     ListenerMws = maps:get(middlewares, Opts, []),
-    Cfg#{pipeline => roadrunner_middleware:build_pipeline(ListenerMws ++ HandlerMws, Handler)}.
+    roadrunner_middleware:compile_pipeline(ListenerMws ++ HandlerMws, Handler, StateArg).
 
 -doc false.
 -spec handle_call(

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -172,8 +172,9 @@ compose([Mw | Rest], Handler) ->
 %% Called once per route at listener init / `reload_routes/2` time,
 %% from the router compile path (router-form routes) and the
 %% listener's dispatch builder (single-handler dispatch tag). The
-%% result is stashed under the `pipeline` key on the route cfg; the
-%% conn loops read it straight out and call it with the request.
+%% resulting `next()` fun lands directly in the compiled route entry
+%% (and the `{handler, Mod, Pipeline, State}` dispatch tag) — no
+%% wrapper map. The conn loops just call it with the request.
 %%
 %% Empty list → returns `fun Handler:handle/1` directly, skipping
 %% `compose/2` to save one closure allocation + one indirection on the

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -162,19 +162,22 @@ compose([Mw | Rest], Handler) ->
     Inner = compose(Rest, Handler),
     fun(Req) -> apply_one(Mw, Req, Inner) end.
 
-%% Build the per-request handler pipeline from a combined middleware
-%% list (listener-level ++ per-route) and a target handler module.
-%% Callers concat the two lists at the dispatch site; the order is
-%% listener-first so listener middlewares wrap route middlewares wrap
-%% the handler — first in each list runs outermost.
+%% Build the handler pipeline from a combined middleware list
+%% (listener-level ++ per-route) and a target handler module. The
+%% resulting `next()` fun captures only `Mw` and
+%% `fun Handler:handle/1`, both compile-time constants — no request
+%% state — so it's safe to compose once and reuse across every
+%% request that matches the route.
+%%
+%% Called once per route at listener init / `reload_routes/2` time,
+%% from the router compile path (router-form routes) and the
+%% listener's dispatch builder (single-handler dispatch tag). The
+%% result is stashed under the `pipeline` key on the route cfg; the
+%% conn loops read it straight out and call it with the request.
 %%
 %% Empty list → returns `fun Handler:handle/1` directly, skipping
 %% `compose/2` to save one closure allocation + one indirection on the
 %% no-mws fast path most production handlers hit.
-%%
-%% Used by both the h1 conn loop (`roadrunner_conn_loop:run_pipeline`)
-%% and the h2 stream worker (`roadrunner_http2_stream_worker:invoke`)
-%% so the dispatch shape stays identical across protocols.
 -doc false.
 -spec build_pipeline(middleware_list(), module()) -> next().
 build_pipeline([], Handler) ->

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -106,7 +106,7 @@ server_header(Req, Next) ->
 ```
 """.
 
--export([compose/2, build_pipeline/2]).
+-export([compose/2, build_pipeline/2, compile_pipeline/3]).
 -export_type([middleware/0, middleware_list/0, next/0]).
 
 -doc """
@@ -184,6 +184,21 @@ build_pipeline([], Handler) ->
     fun Handler:handle/1;
 build_pipeline(Mws, Handler) ->
     compose(Mws, fun Handler:handle/1).
+
+%% Compile a per-request pipeline `next()` fun: composes the mws
+%% ending in `fun Handler:handle/1`, optionally wrapped in an
+%% outermost closure that injects `state` onto the request before
+%% middlewares run. Used by `roadrunner_router:compile/2` and
+%% `roadrunner_listener:build_dispatch/2` to pre-bake the full
+%% pipeline at compile / `reload_routes/2` time so the conn loops
+%% don't allocate closures per request.
+-doc false.
+-spec compile_pipeline(middleware_list(), module(), no_state | {state, term()}) -> next().
+compile_pipeline(Mws, Handler, no_state) ->
+    build_pipeline(Mws, Handler);
+compile_pipeline(Mws, Handler, {state, State}) ->
+    Inner = build_pipeline(Mws, Handler),
+    fun(Req) -> Inner(Req#{state => State}) end.
 
 -spec apply_one(middleware(), roadrunner_req:request(), next()) ->
     roadrunner_handler:result().

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -42,7 +42,7 @@ swapping to a trie/DAG later is a non-breaking change for callers.
 
 -export([compile/2, match/2]).
 
--export_type([route/0, routes/0, route_cfg/0, compiled/0, bindings/0]).
+-export_type([route/0, routes/0, compiled/0, bindings/0]).
 
 -doc """
 A single route entry. Three shapes are accepted:
@@ -68,26 +68,6 @@ to the handler via `roadrunner_req:state/1`; unset → `undefined`.
         middlewares => roadrunner_middleware:middleware_list()
     }.
 
--doc """
-Per-route configuration carried alongside the matched handler.
-
-- `pipeline` is the pre-composed middleware chain ending in
-  `fun Handler:handle/1`. Built once at compile / `reload_routes/2`
-  time from the listener-wide mws prepended onto the route's own
-  mws, so the conn loop calls it with the request and gets the
-  handler result back, zero closure allocations per request. Always
-  present in the 4th element of `match/2`'s `{ok, ...}` return; the
-  `=>` arity covers the pre-compile shape the bake helpers accept as
-  input.
-- `state` mirrors what the route entry attached (absent when the
-  route used the 2-tuple shorthand or the bare-atom single-handler
-  form).
-""".
--type route_cfg() :: #{
-    pipeline => roadrunner_middleware:next(),
-    state => term()
-}.
-
 -doc "An ordered list of routes; matched first-to-last.".
 -type routes() :: [route()].
 
@@ -107,7 +87,7 @@ remaining path segments
 The compiled-routes representation `match/2` consumes. Treat as
 opaque: the shape is an implementation detail and may change.
 """.
--opaque compiled() :: [{[segment()], module(), route_cfg()}].
+-opaque compiled() :: [{[segment()], module(), roadrunner_middleware:next()}].
 
 -doc """
 Compile a list of routes into the lookup form `match/2` expects.
@@ -116,35 +96,41 @@ Each path is split on `/` (empty leading/trailing segments dropped),
 and segments starting with `:` are recorded as named captures.
 
 `ListenerMws` is the listener-wide middleware list; it is prepended
-to each route's own `middlewares` so the conn loop reads the full
-pipeline straight from the matched route's cfg — no per-request
-concatenation. Pass `[]` when compiling routes outside a listener
-(typically only in tests).
+to each route's own `middlewares` and composed once into a single
+`next()` fun (with any per-route `state` injected before middlewares
+run). The conn loop calls that fun straight with the request —
+zero closure allocations per request. Pass `[]` for `ListenerMws`
+when compiling routes outside a listener (typically only in tests).
 """.
 -spec compile(routes(), roadrunner_middleware:middleware_list()) -> compiled().
 compile(Routes, ListenerMws) when is_list(Routes), is_list(ListenerMws) ->
     [compile_route(R, ListenerMws) || R <- Routes].
 
 -spec compile_route(route(), roadrunner_middleware:middleware_list()) ->
-    {[segment()], module(), route_cfg()}.
+    {[segment()], module(), roadrunner_middleware:next()}.
 compile_route({Path, Handler}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
-    {compile_path(Path), Handler, base_cfg(Handler, ListenerMws, #{})};
+    {
+        compile_path(Path),
+        Handler,
+        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, no_state)
+    };
 compile_route({Path, Handler, State}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
-    {compile_path(Path), Handler, base_cfg(Handler, ListenerMws, #{state => State})};
+    {
+        compile_path(Path),
+        Handler,
+        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, {state, State})
+    };
 compile_route(#{path := Path, handler := Handler} = Route, ListenerMws) when
     is_binary(Path), is_atom(Handler)
 ->
     RouteMws = maps:get(middlewares, Route, []),
-    Cfg = maps:without([path, handler, middlewares], Route),
-    {compile_path(Path), Handler, base_cfg(Handler, ListenerMws ++ RouteMws, Cfg)}.
-
-%% Compose the combined mws ending in `fun Handler:handle/1` once and
-%% stash the result under `pipeline` on the cfg. The conn loop reads
-%% the fun and calls it with the request — no per-request closure
-%% allocation, regardless of mws count.
--spec base_cfg(module(), roadrunner_middleware:middleware_list(), route_cfg()) -> route_cfg().
-base_cfg(Handler, Mws, Cfg) ->
-    Cfg#{pipeline => roadrunner_middleware:build_pipeline(Mws, Handler)}.
+    Mws = ListenerMws ++ RouteMws,
+    StateArg =
+        case Route of
+            #{state := S} -> {state, S};
+            _ -> no_state
+        end,
+    {compile_path(Path), Handler, roadrunner_middleware:compile_pipeline(Mws, Handler, StateArg)}.
 
 -spec compile_path(binary()) -> [segment()].
 compile_path(Path) ->
@@ -158,25 +144,27 @@ compile_segment(Lit) -> {literal, Lit}.
 -doc """
 Look up the handler for a given request path.
 
-Returns `{ok, Handler, Bindings, RouteCfg}` on a match — `Bindings`
+Returns `{ok, Handler, Bindings, Pipeline}` on a match — `Bindings`
 is a map populated with captures from `:param` segments (empty for
-purely literal routes); `RouteCfg` is the per-route configuration
-map produced at compile time. See `t:route_cfg/0` for its shape.
+purely literal routes); `Pipeline` is the pre-composed `next()` fun
+built at compile time (listener mws ++ per-route mws, optionally
+wrapped in a state-injecting outermost closure, ending in
+`fun Handler:handle/1`). The conn loop calls it with the request.
 Returns `not_found` when no compiled route matches.
 """.
 -spec match(Path :: binary(), compiled()) ->
-    {ok, module(), bindings(), route_cfg()} | not_found.
+    {ok, module(), bindings(), roadrunner_middleware:next()} | not_found.
 match(Path, Compiled) when is_binary(Path), is_list(Compiled) ->
     Segments = path_segments(Path),
     match_first(Segments, Compiled).
 
 -spec match_first([binary()], compiled()) ->
-    {ok, module(), bindings(), route_cfg()} | not_found.
+    {ok, module(), bindings(), roadrunner_middleware:next()} | not_found.
 match_first(_Segments, []) ->
     not_found;
-match_first(Segments, [{Pattern, Handler, Cfg} | Rest]) ->
+match_first(Segments, [{Pattern, Handler, Pipeline} | Rest]) ->
     case match_pattern(Pattern, Segments, #{}) of
-        {ok, Bindings} -> {ok, Handler, Bindings, Cfg};
+        {ok, Bindings} -> {ok, Handler, Bindings, Pipeline};
         no_match -> match_first(Segments, Rest)
     end.
 

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -87,7 +87,7 @@ remaining path segments
 The compiled-routes representation `match/2` consumes. Treat as
 opaque: the shape is an implementation detail and may change.
 """.
--opaque compiled() :: [{[segment()], module(), roadrunner_middleware:next()}].
+-opaque compiled() :: [{[segment()], module(), roadrunner_middleware:next(), term()}].
 
 -doc """
 Compile a list of routes into the lookup form `match/2` expects.
@@ -107,30 +107,37 @@ compile(Routes, ListenerMws) when is_list(Routes), is_list(ListenerMws) ->
     [compile_route(R, ListenerMws) || R <- Routes].
 
 -spec compile_route(route(), roadrunner_middleware:middleware_list()) ->
-    {[segment()], module(), roadrunner_middleware:next()}.
+    {[segment()], module(), roadrunner_middleware:next(), term()}.
 compile_route({Path, Handler}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
     {
         compile_path(Path),
         Handler,
-        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, no_state)
+        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, no_state),
+        undefined
     };
 compile_route({Path, Handler, State}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
     {
         compile_path(Path),
         Handler,
-        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, {state, State})
+        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, {state, State}),
+        State
     };
 compile_route(#{path := Path, handler := Handler} = Route, ListenerMws) when
     is_binary(Path), is_atom(Handler)
 ->
     RouteMws = maps:get(middlewares, Route, []),
     Mws = ListenerMws ++ RouteMws,
-    StateArg =
+    {StateArg, StateValue} =
         case Route of
-            #{state := S} -> {state, S};
-            _ -> no_state
+            #{state := S} -> {{state, S}, S};
+            _ -> {no_state, undefined}
         end,
-    {compile_path(Path), Handler, roadrunner_middleware:compile_pipeline(Mws, Handler, StateArg)}.
+    {
+        compile_path(Path),
+        Handler,
+        roadrunner_middleware:compile_pipeline(Mws, Handler, StateArg),
+        StateValue
+    }.
 
 -spec compile_path(binary()) -> [segment()].
 compile_path(Path) ->
@@ -144,27 +151,30 @@ compile_segment(Lit) -> {literal, Lit}.
 -doc """
 Look up the handler for a given request path.
 
-Returns `{ok, Handler, Bindings, Pipeline}` on a match — `Bindings`
-is a map populated with captures from `:param` segments (empty for
-purely literal routes); `Pipeline` is the pre-composed `next()` fun
-built at compile time (listener mws ++ per-route mws, optionally
-wrapped in a state-injecting outermost closure, ending in
-`fun Handler:handle/1`). The conn loop calls it with the request.
-Returns `not_found` when no compiled route matches.
+Returns `{ok, Handler, Bindings, Pipeline, State}` on a match —
+`Bindings` is a map populated with captures from `:param` segments
+(empty for purely literal routes); `Pipeline` is the pre-composed
+`next()` fun built at compile time (listener mws ++ per-route mws,
+optionally wrapped in a state-injecting outermost closure, ending in
+`fun Handler:handle/1`); `State` is the per-route opaque state
+attached by the user at compile time (or `undefined` when the route
+shape didn't carry any). The conn loop just calls `Pipeline` —
+`State` is for callers who need to introspect a route outside the
+request flow. Returns `not_found` when no compiled route matches.
 """.
 -spec match(Path :: binary(), compiled()) ->
-    {ok, module(), bindings(), roadrunner_middleware:next()} | not_found.
+    {ok, module(), bindings(), roadrunner_middleware:next(), term()} | not_found.
 match(Path, Compiled) when is_binary(Path), is_list(Compiled) ->
     Segments = path_segments(Path),
     match_first(Segments, Compiled).
 
 -spec match_first([binary()], compiled()) ->
-    {ok, module(), bindings(), roadrunner_middleware:next()} | not_found.
+    {ok, module(), bindings(), roadrunner_middleware:next(), term()} | not_found.
 match_first(_Segments, []) ->
     not_found;
-match_first(Segments, [{Pattern, Handler, Pipeline} | Rest]) ->
+match_first(Segments, [{Pattern, Handler, Pipeline, State} | Rest]) ->
     case match_pattern(Pattern, Segments, #{}) of
-        {ok, Bindings} -> {ok, Handler, Bindings, Pipeline};
+        {ok, Bindings} -> {ok, Handler, Bindings, Pipeline, State};
         no_match -> match_first(Segments, Rest)
     end.
 

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -69,18 +69,23 @@ to the handler via `roadrunner_req:state/1`; unset → `undefined`.
     }.
 
 -doc """
-Per-route configuration map carried alongside the matched handler.
-The 4th element of `match/2`'s `{ok, ...}` return.
+Per-route configuration carried alongside the matched handler.
 
-- `state` mirrors what the route entry attached (`undefined` when
-  the route used the 2-tuple shorthand).
-- `middlewares`, when present, is the **pre-baked** combined list:
-  `compile/2`'s `ListenerMws` argument prepended onto the route's
-  own list. Absent when both are empty.
+- `pipeline` is the pre-composed middleware chain ending in
+  `fun Handler:handle/1`. Built once at compile / `reload_routes/2`
+  time from the listener-wide mws prepended onto the route's own
+  mws, so the conn loop calls it with the request and gets the
+  handler result back, zero closure allocations per request. Always
+  present in the 4th element of `match/2`'s `{ok, ...}` return; the
+  `=>` arity covers the pre-compile shape the bake helpers accept as
+  input.
+- `state` mirrors what the route entry attached (absent when the
+  route used the 2-tuple shorthand or the bare-atom single-handler
+  form).
 """.
 -type route_cfg() :: #{
-    state => term(),
-    middlewares => roadrunner_middleware:middleware_list()
+    pipeline => roadrunner_middleware:next(),
+    state => term()
 }.
 
 -doc "An ordered list of routes; matched first-to-last.".
@@ -123,25 +128,23 @@ compile(Routes, ListenerMws) when is_list(Routes), is_list(ListenerMws) ->
 -spec compile_route(route(), roadrunner_middleware:middleware_list()) ->
     {[segment()], module(), route_cfg()}.
 compile_route({Path, Handler}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
-    {compile_path(Path), Handler, with_listener_mws(#{}, ListenerMws)};
+    {compile_path(Path), Handler, base_cfg(Handler, ListenerMws, #{})};
 compile_route({Path, Handler, State}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
-    {compile_path(Path), Handler, with_listener_mws(#{state => State}, ListenerMws)};
+    {compile_path(Path), Handler, base_cfg(Handler, ListenerMws, #{state => State})};
 compile_route(#{path := Path, handler := Handler} = Route, ListenerMws) when
     is_binary(Path), is_atom(Handler)
 ->
-    Cfg = maps:without([path, handler], Route),
-    {compile_path(Path), Handler, with_listener_mws(Cfg, ListenerMws)}.
+    RouteMws = maps:get(middlewares, Route, []),
+    Cfg = maps:without([path, handler, middlewares], Route),
+    {compile_path(Path), Handler, base_cfg(Handler, ListenerMws ++ RouteMws, Cfg)}.
 
-%% Bake listener-level mws onto the per-route cfg's `middlewares` key
-%% so the conn loop reads the full pipeline directly. Omit the key
-%% entirely when the combined list is empty to preserve the no-mws
-%% fast path (`build_pipeline([], Handler)` returns the bare
-%% `fun Handler:handle/1`).
--spec with_listener_mws(route_cfg(), roadrunner_middleware:middleware_list()) -> route_cfg().
-with_listener_mws(Cfg, []) ->
-    Cfg;
-with_listener_mws(Cfg, ListenerMws) ->
-    Cfg#{middlewares => ListenerMws ++ maps:get(middlewares, Cfg, [])}.
+%% Compose the combined mws ending in `fun Handler:handle/1` once and
+%% stash the result under `pipeline` on the cfg. The conn loop reads
+%% the fun and calls it with the request — no per-request closure
+%% allocation, regardless of mws count.
+-spec base_cfg(module(), roadrunner_middleware:middleware_list(), route_cfg()) -> route_cfg().
+base_cfg(Handler, Mws, Cfg) ->
+    Cfg#{pipeline => roadrunner_middleware:build_pipeline(Mws, Handler)}.
 
 -spec compile_path(binary()) -> [segment()].
 compile_path(Path) ->

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -173,7 +173,7 @@ ensure_pg() ->
 
 proto_opts(ListenerName, Counter) ->
     #{
-        dispatch => {handler, roadrunner_hello_handler, #{}},
+        dispatch => {handler, roadrunner_hello_handler, #{pipeline => fun roadrunner_hello_handler:handle/1}},
         middlewares => [],
         max_content_length => 1_000_000,
         request_timeout => 200,

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -173,7 +173,7 @@ ensure_pg() ->
 
 proto_opts(ListenerName, Counter) ->
     #{
-        dispatch => {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+        dispatch => {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         max_content_length => 1_000_000,
         request_timeout => 200,

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -173,7 +173,7 @@ ensure_pg() ->
 
 proto_opts(ListenerName, Counter) ->
     #{
-        dispatch => {handler, roadrunner_hello_handler, #{pipeline => fun roadrunner_hello_handler:handle/1}},
+        dispatch => {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
         middlewares => [],
         max_content_length => 1_000_000,
         request_timeout => 200,

--- a/test/property_test/roadrunner_router_props.erl
+++ b/test/property_test/roadrunner_router_props.erl
@@ -28,7 +28,7 @@ prop_param_bindings_round_trip() ->
             RouteBin = build_route(Pattern),
             Compiled = roadrunner_router:compile([{RouteBin, my_handler}], []),
             case roadrunner_router:match(PathBin, Compiled) of
-                {ok, my_handler, Bindings, Pipeline} when is_function(Pipeline, 1) ->
+                {ok, my_handler, Bindings, Pipeline, _State} when is_function(Pipeline, 1) ->
                     %% Every `:Name` in the pattern must show up in
                     %% Bindings under that exact binary name and value.
                     Expected = expected_bindings(Pattern, Values),

--- a/test/property_test/roadrunner_router_props.erl
+++ b/test/property_test/roadrunner_router_props.erl
@@ -28,7 +28,7 @@ prop_param_bindings_round_trip() ->
             RouteBin = build_route(Pattern),
             Compiled = roadrunner_router:compile([{RouteBin, my_handler}], []),
             case roadrunner_router:match(PathBin, Compiled) of
-                {ok, my_handler, Bindings, #{}} ->
+                {ok, my_handler, Bindings, Pipeline} when is_function(Pipeline, 1) ->
                     %% Every `:Name` in the pattern must show up in
                     %% Bindings under that exact binary name and value.
                     Expected = expected_bindings(Pattern, Values),

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -312,7 +312,10 @@ concurrent_streams_both_dispatch() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_concurrent_test,
-        dispatch => {handler, roadrunner_h2_test_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => fun roadrunner_h2_test_handler:handle/1
+            }},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -374,7 +377,10 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
         client_counter => Counter,
         requests_counter => RequestsCounter,
         listener_name => h2c_dispatch_test,
-        dispatch => {handler, roadrunner_hello_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_hello_handler, #{
+                pipeline => fun roadrunner_hello_handler:handle/1
+            }},
         middlewares => [],
         max_content_length => 1_048_576,
         request_timeout => 30000,
@@ -423,7 +429,10 @@ plaintext_listener_without_h2c_stays_h1() ->
         client_counter => Counter,
         requests_counter => RequestsCounter,
         listener_name => h1_dispatch_test,
-        dispatch => {handler, roadrunner_hello_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_hello_handler, #{
+                pipeline => fun roadrunner_hello_handler:handle/1
+            }},
         middlewares => [],
         max_content_length => 1_048_576,
         request_timeout => 30000,
@@ -884,7 +893,10 @@ middleware_chain_runs() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_mw_test,
-        dispatch => {handler, roadrunner_hello_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_hello_handler, #{
+                pipeline => fun roadrunner_hello_handler:handle/1
+            }},
         middlewares => [Mw]
     },
     Self = self(),
@@ -1535,7 +1547,10 @@ rst_during_stream_response_unwinds_worker() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_rst_during_stream,
-        dispatch => {handler, roadrunner_h2_test_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => fun roadrunner_h2_test_handler:handle/1
+            }},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1611,7 +1626,10 @@ drain_refuses_new_streams() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_drain_test,
-        dispatch => {handler, roadrunner_h2_test_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => fun roadrunner_h2_test_handler:handle/1
+            }},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1662,7 +1680,10 @@ drain_with_in_flight_stream_waits() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_drain_inflight_test,
-        dispatch => {handler, roadrunner_h2_test_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => fun roadrunner_h2_test_handler:handle/1
+            }},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1720,7 +1741,10 @@ drain_message_is_idempotent() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_drain_dup_test,
-        dispatch => {handler, roadrunner_h2_test_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => fun roadrunner_h2_test_handler:handle/1
+            }},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1768,7 +1792,10 @@ drain_then_peer_rst_exits_via_frame_loop() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_drain_rst_test,
-        dispatch => {handler, roadrunner_h2_test_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => fun roadrunner_h2_test_handler:handle/1
+            }},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1941,7 +1968,11 @@ run_h2_with_compress_middleware(Path, ExtraHeaders) ->
         client_counter => Counter,
         listener_name => h2_compress_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{middlewares => [roadrunner_compress]}},
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => roadrunner_middleware:build_pipeline(
+                    [roadrunner_compress], roadrunner_h2_test_handler
+                )
+            }},
         middlewares => [roadrunner_compress]
     },
     Sock = {fake, Self},
@@ -2610,7 +2641,7 @@ post_handshake_handler(Handler) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_strict_test,
-        dispatch => {handler, Handler, #{}},
+        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -2732,7 +2763,10 @@ start_http2_conn() ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => http2_test,
-        dispatch => {handler, roadrunner_hello_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_hello_handler, #{
+                pipeline => fun roadrunner_hello_handler:handle/1
+            }},
         middlewares => [],
         protocols => [http2],
         http2_conn_window => 65535,
@@ -2853,7 +2887,7 @@ run_h2_request_with_handler(Handler, Path) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_handler_test,
-        dispatch => {handler, Handler, #{}},
+        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -2906,7 +2940,10 @@ run_stream_request(Path) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_stream_test,
-        dispatch => {handler, roadrunner_h2_test_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, #{
+                pipeline => fun roadrunner_h2_test_handler:handle/1
+            }},
         middlewares => []
     },
     Sock = {fake, Self},

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -313,7 +313,8 @@ concurrent_streams_both_dispatch() ->
         client_counter => Counter,
         listener_name => h2_concurrent_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -376,7 +377,7 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
         requests_counter => RequestsCounter,
         listener_name => h2c_dispatch_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         max_content_length => 1_048_576,
         request_timeout => 30000,
@@ -426,7 +427,7 @@ plaintext_listener_without_h2c_stays_h1() ->
         requests_counter => RequestsCounter,
         listener_name => h1_dispatch_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         max_content_length => 1_048_576,
         request_timeout => 30000,
@@ -888,7 +889,7 @@ middleware_chain_runs() ->
         client_counter => Counter,
         listener_name => h2_mw_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [Mw]
     },
     Self = self(),
@@ -1540,7 +1541,8 @@ rst_during_stream_response_unwinds_worker() ->
         client_counter => Counter,
         listener_name => h2_rst_during_stream,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1617,7 +1619,8 @@ drain_refuses_new_streams() ->
         client_counter => Counter,
         listener_name => h2_drain_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1669,7 +1672,8 @@ drain_with_in_flight_stream_waits() ->
         client_counter => Counter,
         listener_name => h2_drain_inflight_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1728,7 +1732,8 @@ drain_message_is_idempotent() ->
         client_counter => Counter,
         listener_name => h2_drain_dup_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1777,7 +1782,8 @@ drain_then_peer_rst_exits_via_frame_loop() ->
         client_counter => Counter,
         listener_name => h2_drain_rst_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1953,7 +1959,8 @@ run_h2_with_compress_middleware(Path, ExtraHeaders) ->
             {handler, roadrunner_h2_test_handler,
                 roadrunner_middleware:build_pipeline(
                     [roadrunner_compress], roadrunner_h2_test_handler
-                )},
+                ),
+                undefined},
         middlewares => [roadrunner_compress]
     },
     Sock = {fake, Self},
@@ -2622,7 +2629,7 @@ post_handshake_handler(Handler) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_strict_test,
-        dispatch => {handler, Handler, fun Handler:handle/1},
+        dispatch => {handler, Handler, fun Handler:handle/1, undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -2745,7 +2752,7 @@ start_http2_conn() ->
         client_counter => Counter,
         listener_name => http2_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         protocols => [http2],
         http2_conn_window => 65535,
@@ -2866,7 +2873,7 @@ run_h2_request_with_handler(Handler, Path) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_handler_test,
-        dispatch => {handler, Handler, fun Handler:handle/1},
+        dispatch => {handler, Handler, fun Handler:handle/1, undefined},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -2920,7 +2927,8 @@ run_stream_request(Path) ->
         client_counter => Counter,
         listener_name => h2_stream_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined},
         middlewares => []
     },
     Sock = {fake, Self},

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -313,9 +313,7 @@ concurrent_streams_both_dispatch() ->
         client_counter => Counter,
         listener_name => h2_concurrent_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => fun roadrunner_h2_test_handler:handle/1
-            }},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -378,9 +376,7 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
         requests_counter => RequestsCounter,
         listener_name => h2c_dispatch_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, #{
-                pipeline => fun roadrunner_hello_handler:handle/1
-            }},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
         middlewares => [],
         max_content_length => 1_048_576,
         request_timeout => 30000,
@@ -430,9 +426,7 @@ plaintext_listener_without_h2c_stays_h1() ->
         requests_counter => RequestsCounter,
         listener_name => h1_dispatch_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, #{
-                pipeline => fun roadrunner_hello_handler:handle/1
-            }},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
         middlewares => [],
         max_content_length => 1_048_576,
         request_timeout => 30000,
@@ -894,9 +888,7 @@ middleware_chain_runs() ->
         client_counter => Counter,
         listener_name => h2_mw_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, #{
-                pipeline => fun roadrunner_hello_handler:handle/1
-            }},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
         middlewares => [Mw]
     },
     Self = self(),
@@ -1548,9 +1540,7 @@ rst_during_stream_response_unwinds_worker() ->
         client_counter => Counter,
         listener_name => h2_rst_during_stream,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => fun roadrunner_h2_test_handler:handle/1
-            }},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1627,9 +1617,7 @@ drain_refuses_new_streams() ->
         client_counter => Counter,
         listener_name => h2_drain_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => fun roadrunner_h2_test_handler:handle/1
-            }},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1681,9 +1669,7 @@ drain_with_in_flight_stream_waits() ->
         client_counter => Counter,
         listener_name => h2_drain_inflight_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => fun roadrunner_h2_test_handler:handle/1
-            }},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1742,9 +1728,7 @@ drain_message_is_idempotent() ->
         client_counter => Counter,
         listener_name => h2_drain_dup_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => fun roadrunner_h2_test_handler:handle/1
-            }},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1793,9 +1777,7 @@ drain_then_peer_rst_exits_via_frame_loop() ->
         client_counter => Counter,
         listener_name => h2_drain_rst_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => fun roadrunner_h2_test_handler:handle/1
-            }},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -1968,11 +1950,10 @@ run_h2_with_compress_middleware(Path, ExtraHeaders) ->
         client_counter => Counter,
         listener_name => h2_compress_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => roadrunner_middleware:build_pipeline(
+            {handler, roadrunner_h2_test_handler,
+                roadrunner_middleware:build_pipeline(
                     [roadrunner_compress], roadrunner_h2_test_handler
-                )
-            }},
+                )},
         middlewares => [roadrunner_compress]
     },
     Sock = {fake, Self},
@@ -2641,7 +2622,7 @@ post_handshake_handler(Handler) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_strict_test,
-        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
+        dispatch => {handler, Handler, fun Handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -2764,9 +2745,7 @@ start_http2_conn() ->
         client_counter => Counter,
         listener_name => http2_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, #{
-                pipeline => fun roadrunner_hello_handler:handle/1
-            }},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
         middlewares => [],
         protocols => [http2],
         http2_conn_window => 65535,
@@ -2887,7 +2866,7 @@ run_h2_request_with_handler(Handler, Path) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_handler_test,
-        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
+        dispatch => {handler, Handler, fun Handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},
@@ -2941,9 +2920,7 @@ run_stream_request(Path) ->
         client_counter => Counter,
         listener_name => h2_stream_test,
         dispatch =>
-            {handler, roadrunner_h2_test_handler, #{
-                pipeline => fun roadrunner_h2_test_handler:handle/1
-            }},
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -404,7 +404,8 @@ middleware_pipeline_runs_when_listener_has_middlewares_test() ->
     Opts = (fake_opts(mw))#{
         middlewares := [Identity],
         dispatch :=
-            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -432,7 +433,8 @@ handler_crash_writes_500_and_fires_request_exception_test() ->
     ),
     Opts = (fake_opts(crash))#{
         dispatch :=
-            {handler, roadrunner_crashing_handler, fun roadrunner_crashing_handler:handle/1}
+            {handler, roadrunner_crashing_handler, fun roadrunner_crashing_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -466,7 +468,8 @@ post_body_echoes_via_auto_mode_test() ->
     Sink = spawn_active_sink_with_send_log(Self, Tag, Req),
     Opts = (fake_opts(echo))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -498,7 +501,8 @@ oversized_body_writes_413_and_fires_request_rejected_test() ->
     Opts = (fake_opts(big))#{
         max_content_length := 5,
         dispatch :=
-            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -530,7 +534,8 @@ body_recv_timeout_writes_408_test() ->
     ]),
     Opts = (fake_opts(body_to))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -554,7 +559,8 @@ body_slow_client_exits_silently_test() ->
     ]),
     Opts = (fake_opts(body_slow))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -580,7 +586,8 @@ body_recv_error_writes_400_test() ->
     ]),
     Opts = (fake_opts(body_err))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -611,7 +618,7 @@ manual_mode_dispatches_with_body_state_test() ->
         body_buffering := manual,
         dispatch :=
             {handler, roadrunner_manual_keepalive_handler,
-                fun roadrunner_manual_keepalive_handler:handle/1}
+                fun roadrunner_manual_keepalive_handler:handle/1, undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -636,7 +643,7 @@ manual_mode_bad_framing_writes_400_test() ->
         body_buffering := manual,
         dispatch :=
             {handler, roadrunner_manual_keepalive_handler,
-                fun roadrunner_manual_keepalive_handler:handle/1}
+                fun roadrunner_manual_keepalive_handler:handle/1, undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -692,7 +699,8 @@ two_pipelined_requests_in_one_packet_serve_both_test() ->
     Sink = spawn_active_sink_with_send_log(Self, Tag, Both),
     Opts = (fake_opts(pipelined))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
         max_keep_alive_requests := 2
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -749,7 +757,7 @@ manual_mode_drain_failure_closes_cleanly_test() ->
         body_buffering := manual,
         dispatch :=
             {handler, roadrunner_conn_loop_lazy_manual_handler,
-                fun roadrunner_conn_loop_lazy_manual_handler:handle/1}
+                fun roadrunner_conn_loop_lazy_manual_handler:handle/1, undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -784,7 +792,7 @@ manual_mode_pipelined_leftover_uses_manual_drain_test() ->
         body_buffering := manual,
         dispatch :=
             {handler, roadrunner_manual_keepalive_handler,
-                fun roadrunner_manual_keepalive_handler:handle/1},
+                fun roadrunner_manual_keepalive_handler:handle/1, undefined},
         max_keep_alive_requests := 2
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -816,7 +824,8 @@ keep_alive_idle_timeout_silently_closes_test() ->
     ),
     Opts = (fake_opts(ka_to))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
         keep_alive_timeout := 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -846,7 +855,8 @@ hibernate_after_fires_during_keep_alive_idle_test() ->
     ),
     Opts = (fake_opts(hib))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
         hibernate_after => 50,
         keep_alive_timeout := 5000
     },
@@ -881,7 +891,8 @@ hibernate_path_handles_close_test() ->
     ),
     Opts = (fake_opts(hib_closed))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
         hibernate_after => 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -904,7 +915,8 @@ hibernate_path_handles_tcp_error_test() ->
     ),
     Opts = (fake_opts(hib_err))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
         hibernate_after => 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -930,7 +942,8 @@ hibernate_path_handles_deadline_fired_test() ->
     ),
     Opts = (fake_opts(hib_dl))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
         hibernate_after => 5000,
         keep_alive_timeout := 50
     },
@@ -952,7 +965,8 @@ hibernate_path_drops_stray_messages_test() ->
     ),
     Opts = (fake_opts(hib_stray))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
         hibernate_after => 5000,
         keep_alive_timeout := 200
     },
@@ -1027,7 +1041,7 @@ stream_response_writes_chunked_body_test() ->
     ),
     Opts = (fake_opts(stream))#{
         dispatch :=
-            {handler, roadrunner_stream_handler, fun roadrunner_stream_handler:handle/1}
+            {handler, roadrunner_stream_handler, fun roadrunner_stream_handler:handle/1, undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1052,7 +1066,7 @@ loop_response_runs_until_stop_test() ->
     ),
     Opts = (fake_opts(looprsp))#{
         dispatch :=
-            {handler, roadrunner_loop_handler, fun roadrunner_loop_handler:handle/1}
+            {handler, roadrunner_loop_handler, fun roadrunner_loop_handler:handle/1, undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1087,7 +1101,7 @@ sendfile_response_writes_head_then_body_test() ->
     Opts = (fake_opts(sendf))#{
         dispatch :=
             {handler, roadrunner_conn_loop_sendfile_handler,
-                fun roadrunner_conn_loop_sendfile_handler:handle/1}
+                fun roadrunner_conn_loop_sendfile_handler:handle/1, undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1118,7 +1132,7 @@ sendfile_response_skips_body_for_head_method_test() ->
     Opts = (fake_opts(sendf_head))#{
         dispatch :=
             {handler, roadrunner_conn_loop_sendfile_handler,
-                fun roadrunner_conn_loop_sendfile_handler:handle/1}
+                fun roadrunner_conn_loop_sendfile_handler:handle/1, undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1147,7 +1161,8 @@ websocket_dispatch_invokes_session_run_test() ->
     ),
     Opts = (fake_opts(wsdisp))#{
         dispatch :=
-            {handler, roadrunner_ws_upgrade_handler, fun roadrunner_ws_upgrade_handler:handle/1}
+            {handler, roadrunner_ws_upgrade_handler, fun roadrunner_ws_upgrade_handler:handle/1,
+                undefined}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1194,7 +1209,8 @@ ensure_pg() ->
 
 fake_opts(ListenerName) ->
     #{
-        dispatch => {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+        dispatch =>
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         max_content_length => 10485760,
         request_timeout => 5000,

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -404,9 +404,7 @@ middleware_pipeline_runs_when_listener_has_middlewares_test() ->
     Opts = (fake_opts(mw))#{
         middlewares := [Identity],
         dispatch :=
-            {handler, roadrunner_echo_body_handler, #{
-                pipeline => fun roadrunner_echo_body_handler:handle/1
-            }}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -434,9 +432,7 @@ handler_crash_writes_500_and_fires_request_exception_test() ->
     ),
     Opts = (fake_opts(crash))#{
         dispatch :=
-            {handler, roadrunner_crashing_handler, #{
-                pipeline => fun roadrunner_crashing_handler:handle/1
-            }}
+            {handler, roadrunner_crashing_handler, fun roadrunner_crashing_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -470,9 +466,7 @@ post_body_echoes_via_auto_mode_test() ->
     Sink = spawn_active_sink_with_send_log(Self, Tag, Req),
     Opts = (fake_opts(echo))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, #{
-                pipeline => fun roadrunner_echo_body_handler:handle/1
-            }}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -504,9 +498,7 @@ oversized_body_writes_413_and_fires_request_rejected_test() ->
     Opts = (fake_opts(big))#{
         max_content_length := 5,
         dispatch :=
-            {handler, roadrunner_echo_body_handler, #{
-                pipeline => fun roadrunner_echo_body_handler:handle/1
-            }}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -538,9 +530,7 @@ body_recv_timeout_writes_408_test() ->
     ]),
     Opts = (fake_opts(body_to))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, #{
-                pipeline => fun roadrunner_echo_body_handler:handle/1
-            }}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -564,9 +554,7 @@ body_slow_client_exits_silently_test() ->
     ]),
     Opts = (fake_opts(body_slow))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, #{
-                pipeline => fun roadrunner_echo_body_handler:handle/1
-            }}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -592,9 +580,7 @@ body_recv_error_writes_400_test() ->
     ]),
     Opts = (fake_opts(body_err))#{
         dispatch :=
-            {handler, roadrunner_echo_body_handler, #{
-                pipeline => fun roadrunner_echo_body_handler:handle/1
-            }}
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -624,9 +610,8 @@ manual_mode_dispatches_with_body_state_test() ->
     Opts = (fake_opts(manual))#{
         body_buffering := manual,
         dispatch :=
-            {handler, roadrunner_manual_keepalive_handler, #{
-                pipeline => fun roadrunner_manual_keepalive_handler:handle/1
-            }}
+            {handler, roadrunner_manual_keepalive_handler,
+                fun roadrunner_manual_keepalive_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -650,9 +635,8 @@ manual_mode_bad_framing_writes_400_test() ->
     Opts = (fake_opts(manual_bad))#{
         body_buffering := manual,
         dispatch :=
-            {handler, roadrunner_manual_keepalive_handler, #{
-                pipeline => fun roadrunner_manual_keepalive_handler:handle/1
-            }}
+            {handler, roadrunner_manual_keepalive_handler,
+                fun roadrunner_manual_keepalive_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -708,9 +692,7 @@ two_pipelined_requests_in_one_packet_serve_both_test() ->
     Sink = spawn_active_sink_with_send_log(Self, Tag, Both),
     Opts = (fake_opts(pipelined))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, #{
-                pipeline => fun roadrunner_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
         max_keep_alive_requests := 2
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -766,9 +748,8 @@ manual_mode_drain_failure_closes_cleanly_test() ->
     Opts = (fake_opts(drain_fail))#{
         body_buffering := manual,
         dispatch :=
-            {handler, roadrunner_conn_loop_lazy_manual_handler, #{
-                pipeline => fun roadrunner_conn_loop_lazy_manual_handler:handle/1
-            }}
+            {handler, roadrunner_conn_loop_lazy_manual_handler,
+                fun roadrunner_conn_loop_lazy_manual_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -802,9 +783,8 @@ manual_mode_pipelined_leftover_uses_manual_drain_test() ->
     Opts = (fake_opts(manual_pipe))#{
         body_buffering := manual,
         dispatch :=
-            {handler, roadrunner_manual_keepalive_handler, #{
-                pipeline => fun roadrunner_manual_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_manual_keepalive_handler,
+                fun roadrunner_manual_keepalive_handler:handle/1},
         max_keep_alive_requests := 2
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -836,9 +816,7 @@ keep_alive_idle_timeout_silently_closes_test() ->
     ),
     Opts = (fake_opts(ka_to))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, #{
-                pipeline => fun roadrunner_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
         keep_alive_timeout := 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -868,9 +846,7 @@ hibernate_after_fires_during_keep_alive_idle_test() ->
     ),
     Opts = (fake_opts(hib))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, #{
-                pipeline => fun roadrunner_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
         hibernate_after => 50,
         keep_alive_timeout := 5000
     },
@@ -905,9 +881,7 @@ hibernate_path_handles_close_test() ->
     ),
     Opts = (fake_opts(hib_closed))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, #{
-                pipeline => fun roadrunner_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
         hibernate_after => 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -930,9 +904,7 @@ hibernate_path_handles_tcp_error_test() ->
     ),
     Opts = (fake_opts(hib_err))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, #{
-                pipeline => fun roadrunner_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
         hibernate_after => 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -958,9 +930,7 @@ hibernate_path_handles_deadline_fired_test() ->
     ),
     Opts = (fake_opts(hib_dl))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, #{
-                pipeline => fun roadrunner_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
         hibernate_after => 5000,
         keep_alive_timeout := 50
     },
@@ -982,9 +952,7 @@ hibernate_path_drops_stray_messages_test() ->
     ),
     Opts = (fake_opts(hib_stray))#{
         dispatch :=
-            {handler, roadrunner_keepalive_handler, #{
-                pipeline => fun roadrunner_keepalive_handler:handle/1
-            }},
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1},
         hibernate_after => 5000,
         keep_alive_timeout := 200
     },
@@ -1059,9 +1027,7 @@ stream_response_writes_chunked_body_test() ->
     ),
     Opts = (fake_opts(stream))#{
         dispatch :=
-            {handler, roadrunner_stream_handler, #{
-                pipeline => fun roadrunner_stream_handler:handle/1
-            }}
+            {handler, roadrunner_stream_handler, fun roadrunner_stream_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1086,7 +1052,7 @@ loop_response_runs_until_stop_test() ->
     ),
     Opts = (fake_opts(looprsp))#{
         dispatch :=
-            {handler, roadrunner_loop_handler, #{pipeline => fun roadrunner_loop_handler:handle/1}}
+            {handler, roadrunner_loop_handler, fun roadrunner_loop_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1120,9 +1086,8 @@ sendfile_response_writes_head_then_body_test() ->
     ),
     Opts = (fake_opts(sendf))#{
         dispatch :=
-            {handler, roadrunner_conn_loop_sendfile_handler, #{
-                pipeline => fun roadrunner_conn_loop_sendfile_handler:handle/1
-            }}
+            {handler, roadrunner_conn_loop_sendfile_handler,
+                fun roadrunner_conn_loop_sendfile_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1152,9 +1117,8 @@ sendfile_response_skips_body_for_head_method_test() ->
     ),
     Opts = (fake_opts(sendf_head))#{
         dispatch :=
-            {handler, roadrunner_conn_loop_sendfile_handler, #{
-                pipeline => fun roadrunner_conn_loop_sendfile_handler:handle/1
-            }}
+            {handler, roadrunner_conn_loop_sendfile_handler,
+                fun roadrunner_conn_loop_sendfile_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1183,9 +1147,7 @@ websocket_dispatch_invokes_session_run_test() ->
     ),
     Opts = (fake_opts(wsdisp))#{
         dispatch :=
-            {handler, roadrunner_ws_upgrade_handler, #{
-                pipeline => fun roadrunner_ws_upgrade_handler:handle/1
-            }}
+            {handler, roadrunner_ws_upgrade_handler, fun roadrunner_ws_upgrade_handler:handle/1}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1232,10 +1194,7 @@ ensure_pg() ->
 
 fake_opts(ListenerName) ->
     #{
-        dispatch =>
-            {handler, roadrunner_hello_handler, #{
-                pipeline => fun roadrunner_hello_handler:handle/1
-            }},
+        dispatch => {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
         middlewares => [],
         max_content_length => 10485760,
         request_timeout => 5000,

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -403,7 +403,10 @@ middleware_pipeline_runs_when_listener_has_middlewares_test() ->
     Identity = fun(R, Inner) -> Inner(R) end,
     Opts = (fake_opts(mw))#{
         middlewares := [Identity],
-        dispatch := {handler, roadrunner_echo_body_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, #{
+                pipeline => fun roadrunner_echo_body_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -430,7 +433,10 @@ handler_crash_writes_500_and_fires_request_exception_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(crash))#{
-        dispatch := {handler, roadrunner_crashing_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_crashing_handler, #{
+                pipeline => fun roadrunner_crashing_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -463,7 +469,10 @@ post_body_echoes_via_auto_mode_test() ->
     ]),
     Sink = spawn_active_sink_with_send_log(Self, Tag, Req),
     Opts = (fake_opts(echo))#{
-        dispatch := {handler, roadrunner_echo_body_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, #{
+                pipeline => fun roadrunner_echo_body_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -494,7 +503,10 @@ oversized_body_writes_413_and_fires_request_rejected_test() ->
     Sink = spawn_active_sink_with_send_log(Self, Tag, Req),
     Opts = (fake_opts(big))#{
         max_content_length := 5,
-        dispatch := {handler, roadrunner_echo_body_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, #{
+                pipeline => fun roadrunner_echo_body_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -525,7 +537,10 @@ body_recv_timeout_writes_408_test() ->
         {passive, {error, timeout}}
     ]),
     Opts = (fake_opts(body_to))#{
-        dispatch := {handler, roadrunner_echo_body_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, #{
+                pipeline => fun roadrunner_echo_body_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -548,7 +563,10 @@ body_slow_client_exits_silently_test() ->
         {passive, {error, slow_client}}
     ]),
     Opts = (fake_opts(body_slow))#{
-        dispatch := {handler, roadrunner_echo_body_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, #{
+                pipeline => fun roadrunner_echo_body_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -573,7 +591,10 @@ body_recv_error_writes_400_test() ->
         {passive, {error, closed}}
     ]),
     Opts = (fake_opts(body_err))#{
-        dispatch := {handler, roadrunner_echo_body_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, #{
+                pipeline => fun roadrunner_echo_body_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -602,7 +623,10 @@ manual_mode_dispatches_with_body_state_test() ->
     ]),
     Opts = (fake_opts(manual))#{
         body_buffering := manual,
-        dispatch := {handler, roadrunner_manual_keepalive_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_manual_keepalive_handler, #{
+                pipeline => fun roadrunner_manual_keepalive_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -625,7 +649,10 @@ manual_mode_bad_framing_writes_400_test() ->
     Sink = spawn_scripted_sink(Self, Tag, [{passive, {ok, Headers}}]),
     Opts = (fake_opts(manual_bad))#{
         body_buffering := manual,
-        dispatch := {handler, roadrunner_manual_keepalive_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_manual_keepalive_handler, #{
+                pipeline => fun roadrunner_manual_keepalive_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -680,7 +707,10 @@ two_pipelined_requests_in_one_packet_serve_both_test() ->
         ~"GET / HTTP/1.1\r\nHost: x\r\n\r\nGET / HTTP/1.1\r\nHost: x\r\n\r\n",
     Sink = spawn_active_sink_with_send_log(Self, Tag, Both),
     Opts = (fake_opts(pipelined))#{
-        dispatch := {handler, roadrunner_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, #{
+                pipeline => fun roadrunner_keepalive_handler:handle/1
+            }},
         max_keep_alive_requests := 2
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -735,7 +765,10 @@ manual_mode_drain_failure_closes_cleanly_test() ->
     ]),
     Opts = (fake_opts(drain_fail))#{
         body_buffering := manual,
-        dispatch := {handler, roadrunner_conn_loop_lazy_manual_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_conn_loop_lazy_manual_handler, #{
+                pipeline => fun roadrunner_conn_loop_lazy_manual_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -768,7 +801,10 @@ manual_mode_pipelined_leftover_uses_manual_drain_test() ->
     Sink = spawn_scripted_sink(Self, Tag, [{passive, {ok, Both}}]),
     Opts = (fake_opts(manual_pipe))#{
         body_buffering := manual,
-        dispatch := {handler, roadrunner_manual_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_manual_keepalive_handler, #{
+                pipeline => fun roadrunner_manual_keepalive_handler:handle/1
+            }},
         max_keep_alive_requests := 2
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -799,7 +835,10 @@ keep_alive_idle_timeout_silently_closes_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(ka_to))#{
-        dispatch := {handler, roadrunner_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, #{
+                pipeline => fun roadrunner_keepalive_handler:handle/1
+            }},
         keep_alive_timeout := 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -828,7 +867,10 @@ hibernate_after_fires_during_keep_alive_idle_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(hib))#{
-        dispatch := {handler, roadrunner_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, #{
+                pipeline => fun roadrunner_keepalive_handler:handle/1
+            }},
         hibernate_after => 50,
         keep_alive_timeout := 5000
     },
@@ -862,7 +904,10 @@ hibernate_path_handles_close_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(hib_closed))#{
-        dispatch := {handler, roadrunner_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, #{
+                pipeline => fun roadrunner_keepalive_handler:handle/1
+            }},
         hibernate_after => 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -884,7 +929,10 @@ hibernate_path_handles_tcp_error_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(hib_err))#{
-        dispatch := {handler, roadrunner_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, #{
+                pipeline => fun roadrunner_keepalive_handler:handle/1
+            }},
         hibernate_after => 50
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
@@ -909,7 +957,10 @@ hibernate_path_handles_deadline_fired_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(hib_dl))#{
-        dispatch := {handler, roadrunner_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, #{
+                pipeline => fun roadrunner_keepalive_handler:handle/1
+            }},
         hibernate_after => 5000,
         keep_alive_timeout := 50
     },
@@ -930,7 +981,10 @@ hibernate_path_drops_stray_messages_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(hib_stray))#{
-        dispatch := {handler, roadrunner_keepalive_handler, #{}},
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, #{
+                pipeline => fun roadrunner_keepalive_handler:handle/1
+            }},
         hibernate_after => 5000,
         keep_alive_timeout := 200
     },
@@ -1004,7 +1058,10 @@ stream_response_writes_chunked_body_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(stream))#{
-        dispatch := {handler, roadrunner_stream_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_stream_handler, #{
+                pipeline => fun roadrunner_stream_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1028,7 +1085,8 @@ loop_response_runs_until_stop_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(looprsp))#{
-        dispatch := {handler, roadrunner_loop_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_loop_handler, #{pipeline => fun roadrunner_loop_handler:handle/1}}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1061,7 +1119,10 @@ sendfile_response_writes_head_then_body_test() ->
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(sendf))#{
-        dispatch := {handler, roadrunner_conn_loop_sendfile_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_conn_loop_sendfile_handler, #{
+                pipeline => fun roadrunner_conn_loop_sendfile_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1090,7 +1151,10 @@ sendfile_response_skips_body_for_head_method_test() ->
         Self, Tag, ~"HEAD / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(sendf_head))#{
-        dispatch := {handler, roadrunner_conn_loop_sendfile_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_conn_loop_sendfile_handler, #{
+                pipeline => fun roadrunner_conn_loop_sendfile_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1118,7 +1182,10 @@ websocket_dispatch_invokes_session_run_test() ->
         Self, Tag, ~"GET /ws HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(wsdisp))#{
-        dispatch := {handler, roadrunner_ws_upgrade_handler, #{}}
+        dispatch :=
+            {handler, roadrunner_ws_upgrade_handler, #{
+                pipeline => fun roadrunner_ws_upgrade_handler:handle/1
+            }}
     },
     {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
     Ref = monitor(process, Pid),
@@ -1165,7 +1232,10 @@ ensure_pg() ->
 
 fake_opts(ListenerName) ->
     #{
-        dispatch => {handler, roadrunner_hello_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_hello_handler, #{
+                pipeline => fun roadrunner_hello_handler:handle/1
+            }},
         middlewares => [],
         max_content_length => 10485760,
         request_timeout => 5000,

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -354,17 +354,30 @@ chunked_recv(Chunks) ->
     end.
 
 %% =============================================================================
-%% resolve_handler/2 — dispatch tag → {ok, Mod, Bindings, Pipeline}
+%% resolve_handler/2 — dispatch tag → {ok, Mod, Bindings, Pipeline, State}
 %% =============================================================================
 
-resolve_handler_passes_pipeline_through_test() ->
+resolve_handler_passes_pipeline_and_state_through_test() ->
     %% The handler-form dispatch tag just unpacks: the pre-baked
-    %% pipeline fun comes back as the 4th element. Bindings is empty
-    %% (no router involved).
+    %% pipeline fun comes back as the 4th element and the user's
+    %% attached state as the 5th. Bindings is empty (no router
+    %% involved).
+    Pipeline = fun some_mod:handle/1,
+    State = #{role => admin},
+    ?assertEqual(
+        {ok, some_mod, #{}, Pipeline, State},
+        roadrunner_conn:resolve_handler(
+            {handler, some_mod, Pipeline, State}, dummy_req()
+        )
+    ).
+
+resolve_handler_returns_undefined_state_for_stateless_handler_test() ->
     Pipeline = fun some_mod:handle/1,
     ?assertEqual(
-        {ok, some_mod, #{}, Pipeline},
-        roadrunner_conn:resolve_handler({handler, some_mod, Pipeline}, dummy_req())
+        {ok, some_mod, #{}, Pipeline, undefined},
+        roadrunner_conn:resolve_handler(
+            {handler, some_mod, Pipeline, undefined}, dummy_req()
+        )
     ).
 
 resolve_handler_router_no_match_returns_not_found_test() ->

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -354,23 +354,17 @@ chunked_recv(Chunks) ->
     end.
 
 %% =============================================================================
-%% resolve_handler/2 — dispatch tag → {ok, Mod, Bindings, RouteCfg}
+%% resolve_handler/2 — dispatch tag → {ok, Mod, Bindings, Pipeline}
 %% =============================================================================
 
-resolve_handler_passes_cfg_through_test() ->
-    %% The handler-form dispatch tag just unpacks: same cfg comes back
-    %% as the 4th element. Bindings is empty (no router involved).
-    Cfg = #{pipeline => fun some_mod:handle/1},
+resolve_handler_passes_pipeline_through_test() ->
+    %% The handler-form dispatch tag just unpacks: the pre-baked
+    %% pipeline fun comes back as the 4th element. Bindings is empty
+    %% (no router involved).
+    Pipeline = fun some_mod:handle/1,
     ?assertEqual(
-        {ok, some_mod, #{}, Cfg},
-        roadrunner_conn:resolve_handler({handler, some_mod, Cfg}, dummy_req())
-    ).
-
-resolve_handler_cfg_with_state_test() ->
-    Cfg = #{pipeline => fun some_mod:handle/1, state => #{greeting => ~"hi"}},
-    ?assertEqual(
-        {ok, some_mod, #{}, Cfg},
-        roadrunner_conn:resolve_handler({handler, some_mod, Cfg}, dummy_req())
+        {ok, some_mod, #{}, Pipeline},
+        roadrunner_conn:resolve_handler({handler, some_mod, Pipeline}, dummy_req())
     ).
 
 resolve_handler_router_no_match_returns_not_found_test() ->

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -357,21 +357,17 @@ chunked_recv(Chunks) ->
 %% resolve_handler/2 — dispatch tag → {ok, Mod, Bindings, RouteCfg}
 %% =============================================================================
 
-resolve_handler_empty_cfg_form_returns_empty_cfg_test() ->
-    ?assertEqual(
-        {ok, some_mod, #{}, #{}},
-        roadrunner_conn:resolve_handler({handler, some_mod, #{}}, dummy_req())
-    ).
-
-resolve_handler_cfg_with_state_test() ->
-    Cfg = #{state => #{greeting => ~"hi"}},
+resolve_handler_passes_cfg_through_test() ->
+    %% The handler-form dispatch tag just unpacks: same cfg comes back
+    %% as the 4th element. Bindings is empty (no router involved).
+    Cfg = #{pipeline => fun some_mod:handle/1},
     ?assertEqual(
         {ok, some_mod, #{}, Cfg},
         roadrunner_conn:resolve_handler({handler, some_mod, Cfg}, dummy_req())
     ).
 
-resolve_handler_cfg_with_state_and_middlewares_test() ->
-    Cfg = #{state => #{role => admin}, middlewares => [auth_mw]},
+resolve_handler_cfg_with_state_test() ->
+    Cfg = #{pipeline => fun some_mod:handle/1, state => #{greeting => ~"hi"}},
     ?assertEqual(
         {ok, some_mod, #{}, Cfg},
         roadrunner_conn:resolve_handler({handler, some_mod, Cfg}, dummy_req())

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -224,7 +224,7 @@ start_conn(H2Opts) ->
         client_counter => Counter,
         listener_name => h2_window_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         protocols => [http2],
         http2_conn_window => maps:get(conn_window, H2Opts, 65535),

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -223,7 +223,10 @@ start_conn(H2Opts) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_window_test,
-        dispatch => {handler, roadrunner_hello_handler, #{}},
+        dispatch =>
+            {handler, roadrunner_hello_handler, #{
+                pipeline => fun roadrunner_hello_handler:handle/1
+            }},
         middlewares => [],
         protocols => [http2],
         http2_conn_window => maps:get(conn_window, H2Opts, 65535),

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -224,9 +224,7 @@ start_conn(H2Opts) ->
         client_counter => Counter,
         listener_name => h2_window_test,
         dispatch =>
-            {handler, roadrunner_hello_handler, #{
-                pipeline => fun roadrunner_hello_handler:handle/1
-            }},
+            {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
         middlewares => [],
         protocols => [http2],
         http2_conn_window => maps:get(conn_window, H2Opts, 65535),

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -354,7 +354,7 @@ start_conn(Handler) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_flow_test,
-        dispatch => {handler, Handler, #{}},
+        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
         middlewares => []
     },
     Sock = {fake, Self},

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -354,7 +354,7 @@ start_conn(Handler) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_flow_test,
-        dispatch => {handler, Handler, fun Handler:handle/1},
+        dispatch => {handler, Handler, fun Handler:handle/1, undefined},
         middlewares => []
     },
     Sock = {fake, Self},

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -354,7 +354,7 @@ start_conn(Handler) ->
     ProtoOpts = #{
         client_counter => Counter,
         listener_name => h2_flow_test,
-        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
+        dispatch => {handler, Handler, fun Handler:handle/1},
         middlewares => []
     },
     Sock = {fake, Self},

--- a/test/roadrunner_http2_stream_worker_tests.erl
+++ b/test/roadrunner_http2_stream_worker_tests.erl
@@ -28,9 +28,8 @@ logger_metadata_set_in_h2_worker_test_() ->
         },
         ProtoOpts = #{
             dispatch =>
-                {handler, roadrunner_logger_probe_handler, #{
-                    pipeline => fun roadrunner_logger_probe_handler:handle/1
-                }},
+                {handler, roadrunner_logger_probe_handler,
+                    fun roadrunner_logger_probe_handler:handle/1},
             middlewares => []
         },
         {_WorkerPid, _MonRef} = roadrunner_http2_stream_worker:start(

--- a/test/roadrunner_http2_stream_worker_tests.erl
+++ b/test/roadrunner_http2_stream_worker_tests.erl
@@ -29,7 +29,7 @@ logger_metadata_set_in_h2_worker_test_() ->
         ProtoOpts = #{
             dispatch =>
                 {handler, roadrunner_logger_probe_handler,
-                    fun roadrunner_logger_probe_handler:handle/1},
+                    fun roadrunner_logger_probe_handler:handle/1, undefined},
             middlewares => []
         },
         {_WorkerPid, _MonRef} = roadrunner_http2_stream_worker:start(

--- a/test/roadrunner_http2_stream_worker_tests.erl
+++ b/test/roadrunner_http2_stream_worker_tests.erl
@@ -27,7 +27,10 @@ logger_metadata_set_in_h2_worker_test_() ->
             listener_name => http2_worker_md_test
         },
         ProtoOpts = #{
-            dispatch => {handler, roadrunner_logger_probe_handler, #{}},
+            dispatch =>
+                {handler, roadrunner_logger_probe_handler, #{
+                    pipeline => fun roadrunner_logger_probe_handler:handle/1
+                }},
             middlewares => []
         },
         {_WorkerPid, _MonRef} = roadrunner_http2_stream_worker:start(

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -671,6 +671,25 @@ single_handler_map_form_threads_state_test_() ->
             end}
         end}.
 
+single_handler_map_form_without_state_yields_undefined_state_test_() ->
+    {setup,
+        fun() ->
+            Name = listener_test_single_handler_map_no_state,
+            {ok, _} = roadrunner_listener:start_link(Name, #{
+                port => 0,
+                routes => #{handler => roadrunner_state_echo_handler}
+            }),
+            {Name, roadrunner_listener:port(Name)}
+        end,
+        fun({Name, _Port}) -> ok = roadrunner_listener:stop(Name) end, fun({_Name, Port}) ->
+            {"routes => #{handler} (no state key) leaves state/1 as undefined", fun() ->
+                Reply = http_get_close(Port, ~"/"),
+                ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, Reply),
+                [_Head, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(undefined, binary_to_term(Body))
+            end}
+        end}.
+
 single_handler_bare_atom_form_yields_undefined_state_test_() ->
     {setup,
         fun() ->

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -124,8 +124,11 @@ match_root_wildcard_test() ->
     ).
 
 match_route_with_state_test() ->
-    %% 3-tuple route attaches per-handler state; match/2 surfaces it as
-    %% `#{state => ...}` in the route cfg map.
+    %% 3-tuple route attaches per-handler state. State is baked into
+    %% the pipeline closure (verified behaviorally by
+    %% `compile_bakes_state_into_pipeline_test`); the structural test
+    %% here just confirms the route resolves to the right handler +
+    %% bindings.
     Compiled = roadrunner_router:compile(
         [
             {~"/static/*path", static_handler, #{dir => ~"/var/www"}}
@@ -133,7 +136,7 @@ match_route_with_state_test() ->
         []
     ),
     ?assertEqual(
-        {ok, static_handler, #{~"path" => [~"a.css"]}, #{state => #{dir => ~"/var/www"}}},
+        {ok, static_handler, #{~"path" => [~"a.css"]}, #{}},
         match_no_pipeline(~"/static/a.css", Compiled)
     ).
 
@@ -165,7 +168,7 @@ match_mixed_two_and_three_tuple_routes_test() ->
         match_no_pipeline(~"/", Compiled)
     ),
     ?assertEqual(
-        {ok, static_handler, #{~"path" => [~"a.css"]}, #{state => #{dir => ~"/var/www"}}},
+        {ok, static_handler, #{~"path" => [~"a.css"]}, #{}},
         match_no_pipeline(~"/static/a.css", Compiled)
     ).
 
@@ -194,7 +197,7 @@ match_map_route_with_state_test() ->
         []
     ),
     ?assertEqual(
-        {ok, users_handler, #{~"id" => ~"42"}, #{state => #{role => admin}}},
+        {ok, users_handler, #{~"id" => ~"42"}, #{}},
         match_no_pipeline(~"/users/42", Compiled)
     ).
 
@@ -226,7 +229,7 @@ match_map_route_with_state_and_middlewares_test() ->
         []
     ),
     ?assertEqual(
-        {ok, api_handler, #{~"resource" => ~"users"}, #{state => #{db => primary}}},
+        {ok, api_handler, #{~"resource" => ~"users"}, #{}},
         match_no_pipeline(~"/api/users", Compiled)
     ).
 
@@ -245,7 +248,7 @@ match_mixed_tuple_and_map_routes_test() ->
         match_no_pipeline(~"/", Compiled)
     ),
     ?assertEqual(
-        {ok, about_handler, #{}, #{state => ~"hello"}},
+        {ok, about_handler, #{}, #{}},
         match_no_pipeline(~"/about", Compiled)
     ),
     ?assertEqual(
@@ -394,13 +397,15 @@ match_path_without_leading_slash_resolves_same_as_with_test() ->
     ?assertEqual(Expected, match_no_pipeline(~"users/joe", Compiled)).
 
 %% =============================================================================
-%% Pipeline shape (the post-compile `pipeline` key)
+%% Pipeline shape + state injection (the post-compile 4th element is the
+%% pre-composed `next()` fun; state on 3-tuple / map-with-state routes is
+%% injected onto the req before the chain runs)
 %% =============================================================================
 
-compile_sets_pipeline_on_every_cfg_test() ->
-    %% Every compiled route, regardless of shape, carries a callable
-    %% `pipeline` fun. Shape only — behavior is covered by
-    %% `roadrunner_middleware_tests`.
+compile_returns_callable_pipeline_test() ->
+    %% Every compiled route, regardless of shape, ends with a 1-arity
+    %% fun in the 4th element of `match/2`'s return. Behavior is
+    %% covered by `roadrunner_middleware_tests`.
     Compiled = roadrunner_router:compile(
         [
             {~"/", h},
@@ -412,17 +417,32 @@ compile_sets_pipeline_on_every_cfg_test() ->
     [
         ?assert(is_function(P, 1))
      || Path <- [~"/", ~"/x", ~"/y"],
-        {ok, _, _, #{pipeline := P}} <- [roadrunner_router:match(Path, Compiled)]
+        {ok, _, _, P} <- [roadrunner_router:match(Path, Compiled)]
     ].
+
+compile_bakes_state_into_pipeline_test() ->
+    %% State attached at compile time is injected onto the req by the
+    %% pipeline's outermost closure, so middlewares + handler see it.
+    %% The fixture handler echoes `roadrunner_req:state(Req)` as the
+    %% response body.
+    Compiled = roadrunner_router:compile(
+        [{~"/", roadrunner_state_echo_handler, #{my => state}}], []
+    ),
+    {ok, _, _, Pipeline} = roadrunner_router:match(~"/", Compiled),
+    {{200, _, Body}, _} = Pipeline(empty_req()),
+    ?assertEqual(#{my => state}, binary_to_term(Body)).
 
 %% --- helpers ---
 
-%% Strip the always-present `pipeline` fun from a match result so the
-%% remaining cfg keys can be asserted with `?assertEqual`. The
-%% pipeline itself is funs-are-not-comparable; its behavior is
-%% covered by `roadrunner_middleware_tests`.
+%% Drop the 4th element (the pipeline fun, funs-are-not-comparable) so
+%% the handler module + bindings can be asserted with `?assertEqual`.
+%% State injection is covered separately by
+%% `compile_bakes_state_into_pipeline_test`.
 match_no_pipeline(Path, Compiled) ->
     case roadrunner_router:match(Path, Compiled) of
-        {ok, Mod, Bindings, Cfg} -> {ok, Mod, Bindings, maps:without([pipeline], Cfg)};
+        {ok, Mod, Bindings, _Pipeline} -> {ok, Mod, Bindings, #{}};
         Other -> Other
     end.
+
+empty_req() ->
+    #{method => ~"GET", target => ~"/", version => {1, 1}, headers => []}.

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -417,7 +417,7 @@ compile_returns_callable_pipeline_test() ->
     [
         ?assert(is_function(P, 1))
      || Path <- [~"/", ~"/x", ~"/y"],
-        {ok, _, _, P} <- [roadrunner_router:match(Path, Compiled)]
+        {ok, _, _, P, _} <- [roadrunner_router:match(Path, Compiled)]
     ].
 
 compile_bakes_state_into_pipeline_test() ->
@@ -428,19 +428,44 @@ compile_bakes_state_into_pipeline_test() ->
     Compiled = roadrunner_router:compile(
         [{~"/", roadrunner_state_echo_handler, #{my => state}}], []
     ),
-    {ok, _, _, Pipeline} = roadrunner_router:match(~"/", Compiled),
+    {ok, _, _, Pipeline, _State} = roadrunner_router:match(~"/", Compiled),
     {{200, _, Body}, _} = Pipeline(empty_req()),
     ?assertEqual(#{my => state}, binary_to_term(Body)).
 
+match_exposes_state_as_5th_element_test() ->
+    %% State is also surfaced statically as the 5th element so callers
+    %% that need to introspect a route can read it without running
+    %% the pipeline.
+    Compiled = roadrunner_router:compile(
+        [
+            {~"/none", h},
+            {~"/legacy", h, undefined},
+            {~"/three", h, #{role => admin}},
+            #{path => ~"/map_no_state", handler => h},
+            #{path => ~"/map_with_state", handler => h, state => keep_me}
+        ],
+        []
+    ),
+    [
+        ?assertEqual(Expected, element(5, roadrunner_router:match(P, Compiled)))
+     || {P, Expected} <- [
+            {~"/none", undefined},
+            {~"/legacy", undefined},
+            {~"/three", #{role => admin}},
+            {~"/map_no_state", undefined},
+            {~"/map_with_state", keep_me}
+        ]
+    ].
+
 %% --- helpers ---
 
-%% Drop the 4th element (the pipeline fun, funs-are-not-comparable) so
-%% the handler module + bindings can be asserted with `?assertEqual`.
-%% State injection is covered separately by
-%% `compile_bakes_state_into_pipeline_test`.
+%% Drop the pipeline (4th element) and state (5th) so the handler
+%% module + bindings can be asserted with `?assertEqual`. The
+%% pipeline is funs-are-not-comparable, and state has its own
+%% dedicated test (`match_exposes_state_as_5th_element_test`).
 match_no_pipeline(Path, Compiled) ->
     case roadrunner_router:match(Path, Compiled) of
-        {ok, Mod, Bindings, _Pipeline} -> {ok, Mod, Bindings, #{}};
+        {ok, Mod, Bindings, _Pipeline, _State} -> {ok, Mod, Bindings, #{}};
         Other -> Other
     end.
 

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -8,11 +8,11 @@
 
 compile_empty_test() ->
     Compiled = roadrunner_router:compile([], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/", Compiled)).
 
 match_root_path_test() ->
     Compiled = roadrunner_router:compile([{~"/", home_handler}], []),
-    ?assertEqual({ok, home_handler, #{}, #{}}, roadrunner_router:match(~"/", Compiled)).
+    ?assertEqual({ok, home_handler, #{}, #{}}, match_no_pipeline(~"/", Compiled)).
 
 match_literal_paths_test() ->
     Compiled = roadrunner_router:compile(
@@ -23,18 +23,18 @@ match_literal_paths_test() ->
         ],
         []
     ),
-    ?assertEqual({ok, home_handler, #{}, #{}}, roadrunner_router:match(~"/", Compiled)),
-    ?assertEqual({ok, about_handler, #{}, #{}}, roadrunner_router:match(~"/about", Compiled)),
-    ?assertEqual({ok, users_handler, #{}, #{}}, roadrunner_router:match(~"/users", Compiled)).
+    ?assertEqual({ok, home_handler, #{}, #{}}, match_no_pipeline(~"/", Compiled)),
+    ?assertEqual({ok, about_handler, #{}, #{}}, match_no_pipeline(~"/about", Compiled)),
+    ?assertEqual({ok, users_handler, #{}, #{}}, match_no_pipeline(~"/users", Compiled)).
 
 match_missing_path_returns_not_found_test() ->
     Compiled = roadrunner_router:compile([{~"/", home_handler}], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/nope", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/nope", Compiled)).
 
 match_is_case_sensitive_test() ->
     %% Paths are case-sensitive per RFC 3986 — `/About` is not `/about`.
     Compiled = roadrunner_router:compile([{~"/about", about_handler}], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/About", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/About", Compiled)).
 
 %% =============================================================================
 %% Parameterized segments
@@ -44,27 +44,27 @@ match_single_param_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
     ?assertEqual(
         {ok, users_handler, #{~"id" => ~"42"}, #{}},
-        roadrunner_router:match(~"/users/42", Compiled)
+        match_no_pipeline(~"/users/42", Compiled)
     ).
 
 match_multiple_params_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id/posts/:post_id", post_handler}], []),
     ?assertEqual(
         {ok, post_handler, #{~"id" => ~"42", ~"post_id" => ~"7"}, #{}},
-        roadrunner_router:match(~"/users/42/posts/7", Compiled)
+        match_no_pipeline(~"/users/42/posts/7", Compiled)
     ).
 
 match_too_few_segments_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/users", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/users", Compiled)).
 
 match_too_many_segments_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/users/42/extra", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/users/42/extra", Compiled)).
 
 match_wrong_literal_segment_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/posts/42", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/posts/42", Compiled)).
 
 match_first_route_wins_test() ->
     %% Earlier routes are tried first — a literal entry shadows a wildcard
@@ -78,11 +78,11 @@ match_first_route_wins_test() ->
     ),
     ?assertEqual(
         {ok, me_handler, #{}, #{}},
-        roadrunner_router:match(~"/users/me", Compiled)
+        match_no_pipeline(~"/users/me", Compiled)
     ),
     ?assertEqual(
         {ok, users_handler, #{~"id" => ~"42"}, #{}},
-        roadrunner_router:match(~"/users/42", Compiled)
+        match_no_pipeline(~"/users/42", Compiled)
     ).
 
 %% =============================================================================
@@ -93,14 +93,14 @@ match_wildcard_captures_remainder_test() ->
     Compiled = roadrunner_router:compile([{~"/static/*path", static_handler}], []),
     ?assertEqual(
         {ok, static_handler, #{~"path" => [~"css", ~"main.css"]}, #{}},
-        roadrunner_router:match(~"/static/css/main.css", Compiled)
+        match_no_pipeline(~"/static/css/main.css", Compiled)
     ).
 
 match_wildcard_captures_single_segment_test() ->
     Compiled = roadrunner_router:compile([{~"/static/*path", static_handler}], []),
     ?assertEqual(
         {ok, static_handler, #{~"path" => [~"file.txt"]}, #{}},
-        roadrunner_router:match(~"/static/file.txt", Compiled)
+        match_no_pipeline(~"/static/file.txt", Compiled)
     ).
 
 match_wildcard_captures_empty_remainder_test() ->
@@ -109,18 +109,18 @@ match_wildcard_captures_empty_remainder_test() ->
     Compiled = roadrunner_router:compile([{~"/static/*path", static_handler}], []),
     ?assertEqual(
         {ok, static_handler, #{~"path" => []}, #{}},
-        roadrunner_router:match(~"/static", Compiled)
+        match_no_pipeline(~"/static", Compiled)
     ).
 
 match_root_wildcard_test() ->
     Compiled = roadrunner_router:compile([{~"/*all", catchall_handler}], []),
     ?assertEqual(
         {ok, catchall_handler, #{~"all" => [~"a", ~"b", ~"c"]}, #{}},
-        roadrunner_router:match(~"/a/b/c", Compiled)
+        match_no_pipeline(~"/a/b/c", Compiled)
     ),
     ?assertEqual(
         {ok, catchall_handler, #{~"all" => []}, #{}},
-        roadrunner_router:match(~"/", Compiled)
+        match_no_pipeline(~"/", Compiled)
     ).
 
 match_route_with_state_test() ->
@@ -134,7 +134,7 @@ match_route_with_state_test() ->
     ),
     ?assertEqual(
         {ok, static_handler, #{~"path" => [~"a.css"]}, #{state => #{dir => ~"/var/www"}}},
-        roadrunner_router:match(~"/static/a.css", Compiled)
+        match_no_pipeline(~"/static/a.css", Compiled)
     ).
 
 match_two_tuple_route_returns_empty_cfg_test() ->
@@ -142,14 +142,14 @@ match_two_tuple_route_returns_empty_cfg_test() ->
     Compiled = roadrunner_router:compile([{~"/", home_handler}], []),
     ?assertEqual(
         {ok, home_handler, #{}, #{}},
-        roadrunner_router:match(~"/", Compiled)
+        match_no_pipeline(~"/", Compiled)
     ).
 
 match_two_tuple_with_params_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
     ?assertEqual(
         {ok, users_handler, #{~"id" => ~"42"}, #{}},
-        roadrunner_router:match(~"/users/42", Compiled)
+        match_no_pipeline(~"/users/42", Compiled)
     ).
 
 match_mixed_two_and_three_tuple_routes_test() ->
@@ -162,11 +162,11 @@ match_mixed_two_and_three_tuple_routes_test() ->
     ),
     ?assertEqual(
         {ok, home_handler, #{}, #{}},
-        roadrunner_router:match(~"/", Compiled)
+        match_no_pipeline(~"/", Compiled)
     ),
     ?assertEqual(
         {ok, static_handler, #{~"path" => [~"a.css"]}, #{state => #{dir => ~"/var/www"}}},
-        roadrunner_router:match(~"/static/a.css", Compiled)
+        match_no_pipeline(~"/static/a.css", Compiled)
     ).
 
 %% =============================================================================
@@ -183,7 +183,7 @@ match_map_route_minimum_test() ->
     ),
     ?assertEqual(
         {ok, home_handler, #{}, #{}},
-        roadrunner_router:match(~"/", Compiled)
+        match_no_pipeline(~"/", Compiled)
     ).
 
 match_map_route_with_state_test() ->
@@ -195,10 +195,13 @@ match_map_route_with_state_test() ->
     ),
     ?assertEqual(
         {ok, users_handler, #{~"id" => ~"42"}, #{state => #{role => admin}}},
-        roadrunner_router:match(~"/users/42", Compiled)
+        match_no_pipeline(~"/users/42", Compiled)
     ).
 
 match_map_route_with_middlewares_test() ->
+    %% Map-form route with middlewares: cfg carries `pipeline` post-compile;
+    %% the per-route mws are baked into it. Behavior (mws actually fire) is
+    %% covered end-to-end in `roadrunner_middleware_tests`.
     Compiled = roadrunner_router:compile(
         [
             #{path => ~"/admin/*p", handler => admin_handler, middlewares => [auth_mw, log_mw]}
@@ -206,8 +209,8 @@ match_map_route_with_middlewares_test() ->
         []
     ),
     ?assertEqual(
-        {ok, admin_handler, #{~"p" => [~"x"]}, #{middlewares => [auth_mw, log_mw]}},
-        roadrunner_router:match(~"/admin/x", Compiled)
+        {ok, admin_handler, #{~"p" => [~"x"]}, #{}},
+        match_no_pipeline(~"/admin/x", Compiled)
     ).
 
 match_map_route_with_state_and_middlewares_test() ->
@@ -223,14 +226,12 @@ match_map_route_with_state_and_middlewares_test() ->
         []
     ),
     ?assertEqual(
-        {ok, api_handler, #{~"resource" => ~"users"}, #{
-            state => #{db => primary}, middlewares => [auth_mw]
-        }},
-        roadrunner_router:match(~"/api/users", Compiled)
+        {ok, api_handler, #{~"resource" => ~"users"}, #{state => #{db => primary}}},
+        match_no_pipeline(~"/api/users", Compiled)
     ).
 
 match_mixed_tuple_and_map_routes_test() ->
-    %% Tuple and map entries coexist; each carries its own cfg map.
+    %% Tuple and map entries coexist; each carries its own cfg.
     Compiled = roadrunner_router:compile(
         [
             {~"/", home_handler},
@@ -241,15 +242,15 @@ match_mixed_tuple_and_map_routes_test() ->
     ),
     ?assertEqual(
         {ok, home_handler, #{}, #{}},
-        roadrunner_router:match(~"/", Compiled)
+        match_no_pipeline(~"/", Compiled)
     ),
     ?assertEqual(
         {ok, about_handler, #{}, #{state => ~"hello"}},
-        roadrunner_router:match(~"/about", Compiled)
+        match_no_pipeline(~"/about", Compiled)
     ),
     ?assertEqual(
-        {ok, api_handler, #{~"p" => [~"users"]}, #{middlewares => [auth_mw]}},
-        roadrunner_router:match(~"/api/users", Compiled)
+        {ok, api_handler, #{~"p" => [~"users"]}, #{}},
+        match_no_pipeline(~"/api/users", Compiled)
     ).
 
 match_wildcard_not_last_falls_through_test() ->
@@ -264,7 +265,7 @@ match_wildcard_not_last_falls_through_test() ->
     ),
     ?assertEqual(
         {ok, normal_handler, #{~"rest" => [~"x", ~"y"]}, #{}},
-        roadrunner_router:match(~"/foo/x/y", Compiled)
+        match_no_pipeline(~"/foo/x/y", Compiled)
     ).
 
 %% =============================================================================
@@ -277,20 +278,20 @@ match_double_slash_collapses_to_single_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
     ?assertEqual(
         {ok, users_handler, #{~"id" => ~"42"}, #{}},
-        roadrunner_router:match(~"/users//42", Compiled)
+        match_no_pipeline(~"/users//42", Compiled)
     ).
 
 match_trailing_slash_treated_as_no_slash_test() ->
     Compiled = roadrunner_router:compile([{~"/about", about_handler}], []),
     ?assertEqual(
         {ok, about_handler, #{}, #{}},
-        roadrunner_router:match(~"/about/", Compiled)
+        match_no_pipeline(~"/about/", Compiled)
     ).
 
 match_empty_path_matches_root_route_test() ->
     %% `<<>>` and `<<"/">>` both produce zero segments — equivalent.
     Compiled = roadrunner_router:compile([{~"/", home_handler}], []),
-    ?assertEqual({ok, home_handler, #{}, #{}}, roadrunner_router:match(~"", Compiled)).
+    ?assertEqual({ok, home_handler, #{}, #{}}, match_no_pipeline(~"", Compiled)).
 
 match_param_captures_percent_encoded_segment_test() ->
     %% Router does not percent-decode — handlers see the raw segment.
@@ -298,7 +299,7 @@ match_param_captures_percent_encoded_segment_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
     ?assertEqual(
         {ok, users_handler, #{~"id" => ~"joe%20bob"}, #{}},
-        roadrunner_router:match(~"/users/joe%20bob", Compiled)
+        match_no_pipeline(~"/users/joe%20bob", Compiled)
     ).
 
 match_param_with_special_chars_in_segment_test() ->
@@ -307,7 +308,7 @@ match_param_with_special_chars_in_segment_test() ->
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
     ?assertEqual(
         {ok, users_handler, #{~"id" => ~":star*dot."}, #{}},
-        roadrunner_router:match(~"/users/:star*dot.", Compiled)
+        match_no_pipeline(~"/users/:star*dot.", Compiled)
     ).
 
 match_route_path_with_only_slashes_test() ->
@@ -316,11 +317,11 @@ match_route_path_with_only_slashes_test() ->
     Compiled = roadrunner_router:compile([{~"////", root_handler}], []),
     ?assertEqual(
         {ok, root_handler, #{}, #{}},
-        roadrunner_router:match(~"/", Compiled)
+        match_no_pipeline(~"/", Compiled)
     ),
     ?assertEqual(
         not_found,
-        roadrunner_router:match(~"/anything", Compiled)
+        match_no_pipeline(~"/anything", Compiled)
     ).
 
 %% =============================================================================
@@ -336,7 +337,7 @@ match_empty_param_name_binds_under_empty_binary_test() ->
     Compiled = roadrunner_router:compile([{~"/:", h}], []),
     ?assertEqual(
         {ok, h, #{<<>> => ~"foo"}, #{}},
-        roadrunner_router:match(~"/foo", Compiled)
+        match_no_pipeline(~"/foo", Compiled)
     ).
 
 match_empty_wildcard_name_binds_remainder_under_empty_binary_test() ->
@@ -344,7 +345,7 @@ match_empty_wildcard_name_binds_remainder_under_empty_binary_test() ->
     Compiled = roadrunner_router:compile([{~"/*", h}], []),
     ?assertEqual(
         {ok, h, #{<<>> => [~"a", ~"b", ~"c"]}, #{}},
-        roadrunner_router:match(~"/a/b/c", Compiled)
+        match_no_pipeline(~"/a/b/c", Compiled)
     ).
 
 match_duplicate_param_names_keep_last_binding_test() ->
@@ -354,7 +355,7 @@ match_duplicate_param_names_keep_last_binding_test() ->
     Compiled = roadrunner_router:compile([{~"/:x/:x", h}], []),
     ?assertEqual(
         {ok, h, #{~"x" => ~"second"}, #{}},
-        roadrunner_router:match(~"/first/second", Compiled)
+        match_no_pipeline(~"/first/second", Compiled)
     ).
 
 match_multiple_wildcards_pattern_does_not_match_test() ->
@@ -363,13 +364,13 @@ match_multiple_wildcards_pattern_does_not_match_test() ->
     %% second is treated as a literal. Document so a future change to
     %% allow nested wildcards is intentional.
     Compiled = roadrunner_router:compile([{~"/*a/*b", h}], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/x/y/z", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/x/y/z", Compiled)).
 
 match_wildcard_followed_by_literal_does_not_match_test() ->
     %% Same constraint: anything declared after a wildcard segment is
     %% unreachable.
     Compiled = roadrunner_router:compile([{~"/*tail/post", h}], []),
-    ?assertEqual(not_found, roadrunner_router:match(~"/a/b/post", Compiled)).
+    ?assertEqual(not_found, match_no_pipeline(~"/a/b/post", Compiled)).
 
 match_nul_byte_in_segment_is_captured_raw_test() ->
     %% NUL is just a byte to the router — the request-line parser
@@ -380,7 +381,7 @@ match_nul_byte_in_segment_is_captured_raw_test() ->
     Compiled = roadrunner_router:compile([{~"/admin/:p", h}], []),
     ?assertEqual(
         {ok, h, #{~"p" => <<"sec", 0, "ret">>}, #{}},
-        roadrunner_router:match(<<"/admin/sec", 0, "ret">>, Compiled)
+        match_no_pipeline(<<"/admin/sec", 0, "ret">>, Compiled)
     ).
 
 match_path_without_leading_slash_resolves_same_as_with_test() ->
@@ -389,5 +390,39 @@ match_path_without_leading_slash_resolves_same_as_with_test() ->
     %% `[~"users", ~"joe"]` and match identically.
     Compiled = roadrunner_router:compile([{~"/users/:id", h}], []),
     Expected = {ok, h, #{~"id" => ~"joe"}, #{}},
-    ?assertEqual(Expected, roadrunner_router:match(~"/users/joe", Compiled)),
-    ?assertEqual(Expected, roadrunner_router:match(~"users/joe", Compiled)).
+    ?assertEqual(Expected, match_no_pipeline(~"/users/joe", Compiled)),
+    ?assertEqual(Expected, match_no_pipeline(~"users/joe", Compiled)).
+
+%% =============================================================================
+%% Pipeline shape (the post-compile `pipeline` key)
+%% =============================================================================
+
+compile_sets_pipeline_on_every_cfg_test() ->
+    %% Every compiled route, regardless of shape, carries a callable
+    %% `pipeline` fun. Shape only — behavior is covered by
+    %% `roadrunner_middleware_tests`.
+    Compiled = roadrunner_router:compile(
+        [
+            {~"/", h},
+            {~"/x", h, undefined},
+            #{path => ~"/y", handler => h, middlewares => [auth_mw]}
+        ],
+        []
+    ),
+    [
+        ?assert(is_function(P, 1))
+     || Path <- [~"/", ~"/x", ~"/y"],
+        {ok, _, _, #{pipeline := P}} <- [roadrunner_router:match(Path, Compiled)]
+    ].
+
+%% --- helpers ---
+
+%% Strip the always-present `pipeline` fun from a match result so the
+%% remaining cfg keys can be asserted with `?assertEqual`. The
+%% pipeline itself is funs-are-not-comparable; its behavior is
+%% covered by `roadrunner_middleware_tests`.
+match_no_pipeline(Path, Compiled) ->
+    case roadrunner_router:match(Path, Compiled) of
+        {ok, Mod, Bindings, Cfg} -> {ok, Mod, Bindings, maps:without([pipeline], Cfg)};
+        Other -> Other
+    end.

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -120,9 +120,7 @@ request_rejected_event_fires_on_bad_request_line_test() ->
         Sink = spawn(fun() -> drain_recv_sink(Tag, Self, [{recv, ~"NOT-A-REQUEST\r\n\r\n"}]) end),
         Opts = #{
             dispatch =>
-                {handler, roadrunner_hello_handler, #{
-                    pipeline => fun roadrunner_hello_handler:handle/1
-                }},
+                {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
             middlewares => [],
             max_content_length => 1_000_000,
             request_timeout => 200,

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -120,7 +120,8 @@ request_rejected_event_fires_on_bad_request_line_test() ->
         Sink = spawn(fun() -> drain_recv_sink(Tag, Self, [{recv, ~"NOT-A-REQUEST\r\n\r\n"}]) end),
         Opts = #{
             dispatch =>
-                {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1},
+                {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1,
+                    undefined},
             middlewares => [],
             max_content_length => 1_000_000,
             request_timeout => 200,

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -119,7 +119,10 @@ request_rejected_event_fires_on_bad_request_line_test() ->
         Tag = make_ref(),
         Sink = spawn(fun() -> drain_recv_sink(Tag, Self, [{recv, ~"NOT-A-REQUEST\r\n\r\n"}]) end),
         Opts = #{
-            dispatch => {handler, roadrunner_hello_handler, #{}},
+            dispatch =>
+                {handler, roadrunner_hello_handler, #{
+                    pipeline => fun roadrunner_hello_handler:handle/1
+                }},
             middlewares => [],
             max_content_length => 1_000_000,
             request_timeout => 200,

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -537,7 +537,7 @@ fake_conn_drives_handler_without_sockets_test() ->
 
 fake_proto_opts(Handler) ->
     #{
-        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
+        dispatch => {handler, Handler, fun Handler:handle/1},
         middlewares => [],
         max_content_length => 10485760,
         request_timeout => 5000,

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -537,7 +537,7 @@ fake_conn_drives_handler_without_sockets_test() ->
 
 fake_proto_opts(Handler) ->
     #{
-        dispatch => {handler, Handler, fun Handler:handle/1},
+        dispatch => {handler, Handler, fun Handler:handle/1, undefined},
         middlewares => [],
         max_content_length => 10485760,
         request_timeout => 5000,

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -537,7 +537,7 @@ fake_conn_drives_handler_without_sockets_test() ->
 
 fake_proto_opts(Handler) ->
     #{
-        dispatch => {handler, Handler, #{}},
+        dispatch => {handler, Handler, #{pipeline => fun Handler:handle/1}},
         middlewares => [],
         max_content_length => 10485760,
         request_timeout => 5000,


### PR DESCRIPTION
# Description

- Compose the listener-wide + per-route middleware chain ending in `fun Handler:handle/1` once at listener init / `reload_routes/2` time, store the resulting `next()` fun directly on each compiled route entry
- Bake any per-route `state` into the pipeline's outermost closure so middlewares + handler see it without a per-request `thread_route_cfg/2` step (function removed)
- Collapse the dispatch tag from `{handler, Mod, Cfg}` to `{handler, Mod, Pipeline, State}`; `route_cfg()` type is gone
- `roadrunner_router:match/2` returns `{ok, Mod, Bindings, Pipeline, State}`; the 5th element exposes the user's attached state so callers can introspect routes (e.g. arizona's navigate lookup) without running the pipeline
- Hot path is now `Pipeline(Req#{bindings => Bindings})`: zero closure allocations per request, no map dereference, no state-threading step

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
