### PR TITLE
Tighten type exports to one canonical home per type

### DIFF
--- a/src/roadrunner_compress.erl
+++ b/src/roadrunner_compress.erl
@@ -99,8 +99,8 @@ transform(_Req, Other) ->
 %% goes on every response that isn't already content-encoded.
 -spec transform_buffered(
     roadrunner_req:request(),
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     iodata()
 ) -> roadrunner_handler:response().
 transform_buffered(Req, Status, Headers, Body) ->
@@ -126,8 +126,8 @@ transform_buffered(Req, Status, Headers, Body) ->
 
 -spec transform_stream(
     roadrunner_req:request(),
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     roadrunner_handler:stream_fun()
 ) -> roadrunner_handler:response().
 transform_stream(Req, Status, Headers, Fun) ->
@@ -151,8 +151,8 @@ transform_stream(Req, Status, Headers, Fun) ->
 %% bytes to the conn's real `Send`. The zlib context is released in
 %% a `try/after` so a crashing user fun doesn't leak the resource.
 -spec wrap_stream(
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     roadrunner_handler:stream_fun(),
     gzip | deflate
 ) ->
@@ -187,8 +187,8 @@ wrap_stream(Status, Headers, Fun, Encoding) ->
     {stream, Status, NewHeaders, WrappedFun}.
 
 -spec compress(
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     iodata(),
     gzip | deflate
 ) -> roadrunner_handler:response().
@@ -323,11 +323,11 @@ parse_q(QBin, Default) ->
             end
     end.
 
--spec has_header(binary(), roadrunner_req:headers()) -> boolean().
+-spec has_header(binary(), roadrunner_http:headers()) -> boolean().
 has_header(Name, Headers) ->
     lists:keymember(Name, 1, Headers).
 
--spec add_vary(roadrunner_req:headers()) -> roadrunner_req:headers().
+-spec add_vary(roadrunner_http:headers()) -> roadrunner_http:headers().
 add_vary(Headers) ->
     case has_header(~"vary", Headers) of
         true -> Headers;

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -253,7 +253,7 @@ generate_request_id(_Empty) ->
 %% Replaces (not merges) the conn process's logger metadata so a
 %% keep-alive request never inherits the previous request's correlation.
 -doc false.
--spec set_request_logger_metadata(roadrunner_http1:request()) -> ok.
+-spec set_request_logger_metadata(roadrunner_req:request()) -> ok.
 set_request_logger_metadata(#{
     request_id := RequestId,
     method := Method,
@@ -325,7 +325,7 @@ scheme({ssl, _}) -> https;
 scheme({fake, _}) -> http.
 
 -doc false.
--spec resolve_handler(dispatch(), roadrunner_http1:request()) ->
+-spec resolve_handler(dispatch(), roadrunner_req:request()) ->
     {ok, module(), roadrunner_router:bindings(), roadrunner_middleware:next(), term()}
     | not_found.
 resolve_handler({handler, Mod, Pipeline, State}, _Req) ->
@@ -339,7 +339,7 @@ resolve_handler({router, ListenerName}, Req) ->
 
 -doc false.
 -spec read_body(
-    roadrunner_http1:request(),
+    roadrunner_req:request(),
     binary(),
     fun(() -> {ok, binary()} | {error, term()}),
     non_neg_integer()
@@ -376,7 +376,7 @@ read_body(Req, Buffered, RecvFun, MaxCL) ->
 %% see body data the client clearly didn't wait, and the 100 line is
 %% redundant.
 -doc false.
--spec maybe_send_continue(roadrunner_transport:socket(), roadrunner_http1:request(), binary()) ->
+-spec maybe_send_continue(roadrunner_transport:socket(), roadrunner_req:request(), binary()) ->
     ok.
 maybe_send_continue(Socket, Req, Buffered) ->
     case Buffered =:= ~"" andalso has_continue_expectation(Req) of
@@ -387,7 +387,7 @@ maybe_send_continue(Socket, Req, Buffered) ->
             ok
     end.
 
--spec has_continue_expectation(roadrunner_http1:request()) -> boolean().
+-spec has_continue_expectation(roadrunner_req:request()) -> boolean().
 has_continue_expectation(#{cached_decisions := #{expects_continue := EC}}) ->
     EC;
 has_continue_expectation(Req) ->
@@ -417,7 +417,7 @@ make_body_state(Framing, Buffered, Recv, Max) ->
     }.
 
 -doc false.
--spec body_framing(roadrunner_http1:request()) ->
+-spec body_framing(roadrunner_req:request()) ->
     none
     | chunked
     | {content_length, non_neg_integer()}
@@ -553,7 +553,7 @@ read_chunked(Buf, RecvFun, MaxCL, Decoded) ->
 %% forward into the next `reading_request` parse so pipelined
 %% clients get their N+1 request seen.
 -doc false.
--spec drain_body(roadrunner_http1:request()) -> {ok, binary()} | {error, term()}.
+-spec drain_body(roadrunner_req:request()) -> {ok, binary()} | {error, term()}.
 drain_body(#{body_state := BS}) ->
     case consume_body_state(BS, all) of
         {ok, _Bytes, #{buffered := Leftover}} -> {ok, Leftover};
@@ -770,7 +770,7 @@ fill_iolist(Need, Recv) ->
             E
     end.
 
--spec content_length(roadrunner_http1:request()) ->
+-spec content_length(roadrunner_req:request()) ->
     none | {ok, non_neg_integer()} | {error, bad_content_length}.
 content_length(Req) ->
     case roadrunner_req:header(~"content-length", Req) of
@@ -787,7 +787,7 @@ content_length(Req) ->
 
 -doc false.
 -spec parse_loop(binary(), fun(() -> {ok, binary()} | {error, term()})) ->
-    {ok, roadrunner_http1:request(), binary()} | {error, term()}.
+    {ok, roadrunner_req:request(), binary()} | {error, term()}.
 parse_loop(Buf, RecvFun) ->
     case roadrunner_http1:parse_request(Buf) of
         {ok, Req, Rest} ->
@@ -823,7 +823,7 @@ response_kind({_, _, _}) -> buffered.
 %% HTTP/1.0 default close. HTTP/1.1 keep-alive unless either side
 %% set Connection: close.
 -doc false.
--spec keep_alive_decision(roadrunner_http1:request(), roadrunner_http1:headers()) ->
+-spec keep_alive_decision(roadrunner_req:request(), roadrunner_http1:headers()) ->
     keep_alive | close.
 %% Common-case fast path: HTTP/1.1, parser-cached request `Connection`
 %% empty, response has no `connection` header → `keep_alive` directly.
@@ -843,7 +843,7 @@ keep_alive_decision(
 keep_alive_decision(Req, RespHeaders) ->
     keep_alive_decision_full(Req, RespHeaders).
 
--spec keep_alive_decision_full(roadrunner_http1:request(), roadrunner_http1:headers()) ->
+-spec keep_alive_decision_full(roadrunner_req:request(), roadrunner_http1:headers()) ->
     keep_alive | close.
 keep_alive_decision_full(Req, RespHeaders) ->
     ReqConn = req_connection_lower(Req),
@@ -876,7 +876,7 @@ keep_alive_decision_full(Req, RespHeaders) ->
 %% Returns the request's `Connection` header value, lowercased. Reads from
 %% `cached_decisions` when present (parser populates it once per request)
 %% and falls back to a per-call lowercase for manually-built request maps.
--spec req_connection_lower(roadrunner_http1:request()) -> binary().
+-spec req_connection_lower(roadrunner_req:request()) -> binary().
 req_connection_lower(#{cached_decisions := #{connection_lower := V}}) ->
     V;
 req_connection_lower(Req) ->

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -804,7 +804,7 @@ parse_loop(Buf, RecvFun) ->
 %% Order matters — `{websocket, _, _}` is a 3-tuple too, so the
 %% atom-tagged variants must precede the buffered catch-all.
 -doc false.
--spec response_status(roadrunner_handler:response()) -> roadrunner_http1:status().
+-spec response_status(roadrunner_handler:response()) -> roadrunner_http:status().
 response_status({stream, Status, _, _}) -> Status;
 response_status({loop, Status, _, _}) -> Status;
 response_status({sendfile, Status, _, _}) -> Status;
@@ -823,7 +823,7 @@ response_kind({_, _, _}) -> buffered.
 %% HTTP/1.0 default close. HTTP/1.1 keep-alive unless either side
 %% set Connection: close.
 -doc false.
--spec keep_alive_decision(roadrunner_req:request(), roadrunner_http1:headers()) ->
+-spec keep_alive_decision(roadrunner_req:request(), roadrunner_http:headers()) ->
     keep_alive | close.
 %% Common-case fast path: HTTP/1.1, parser-cached request `Connection`
 %% empty, response has no `connection` header → `keep_alive` directly.
@@ -843,7 +843,7 @@ keep_alive_decision(
 keep_alive_decision(Req, RespHeaders) ->
     keep_alive_decision_full(Req, RespHeaders).
 
--spec keep_alive_decision_full(roadrunner_req:request(), roadrunner_http1:headers()) ->
+-spec keep_alive_decision_full(roadrunner_req:request(), roadrunner_http:headers()) ->
     keep_alive | close.
 keep_alive_decision_full(Req, RespHeaders) ->
     ReqConn = req_connection_lower(Req),
@@ -885,7 +885,7 @@ req_connection_lower(Req) ->
         V -> roadrunner_bin:ascii_lowercase(V)
     end.
 
--spec resp_connection_token(roadrunner_http1:headers()) -> binary().
+-spec resp_connection_token(roadrunner_http:headers()) -> binary().
 resp_connection_token(Headers) ->
     case header_value(~"connection", Headers) of
         undefined -> ~"";
@@ -902,7 +902,7 @@ init_patterns() ->
     persistent_term:put(?KEEP_ALIVE_CP_KEY, binary:compile_pattern(~"keep-alive")),
     ok.
 
--spec header_value(binary(), roadrunner_http1:headers()) -> binary() | undefined.
+-spec header_value(binary(), roadrunner_http:headers()) -> binary() | undefined.
 header_value(Name, Headers) ->
     case lists:keyfind(Name, 1, Headers) of
         {_, V} -> V;

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -34,7 +34,7 @@
     peer/1,
     try_acquire_slot/1,
     release_slot/1,
-    consume_body_state/2,
+    consume_body_reader/2,
     join_drain_group/2
 ]).
 %% Internal helpers shared with `roadrunner_conn_loop`. Marked `-doc false`
@@ -52,7 +52,7 @@
     maybe_send_continue/3,
     refine_conn_label/2,
     scheme/1,
-    make_body_state/4,
+    make_body_reader/4,
     drain_body/1,
     keep_alive_decision/2,
     send_request_timeout/1,
@@ -66,7 +66,7 @@
     response_kind/1
 ]).
 
--export_type([proto_opts/0, dispatch/0, body_state/0]).
+-export_type([proto_opts/0, dispatch/0, body_reader/0]).
 
 -on_load(init_patterns/0).
 
@@ -134,7 +134,7 @@
 %% wire but not yet handed to the caller — used for chunked framing
 %% to absorb a chunk's payload across multiple length-bounded calls.
 %% `done` flips true once the size-0 last chunk is parsed.
--type body_state() :: #{
+-type body_reader() :: #{
     framing := none | chunked | {content_length, non_neg_integer()},
     buffered := binary(),
     bytes_read := non_neg_integer(),
@@ -399,13 +399,13 @@ has_continue_expectation(Req) ->
     end.
 
 -doc false.
--spec make_body_state(
+-spec make_body_reader(
     none | chunked | {content_length, non_neg_integer()},
     binary(),
     fun(() -> {ok, binary()} | {error, term()}),
     non_neg_integer()
-) -> body_state().
-make_body_state(Framing, Buffered, Recv, Max) ->
+) -> body_reader().
+make_body_reader(Framing, Buffered, Recv, Max) ->
     #{
         framing => Framing,
         buffered => Buffered,
@@ -547,21 +547,21 @@ read_chunked(Buf, RecvFun, MaxCL, Decoded) ->
     end.
 
 %% Read and discard whatever the handler left in the manual-mode
-%% `body_state`, returning any post-body leftover bytes that belong
+%% `body_reader`, returning any post-body leftover bytes that belong
 %% to a pipelined next request. Called only on the 4-tuple response
 %% path; `roadrunner_conn_loop`'s finishing phase threads `Leftover`
 %% forward into the next `reading_request` parse so pipelined
 %% clients get their N+1 request seen.
 -doc false.
 -spec drain_body(roadrunner_req:request()) -> {ok, binary()} | {error, term()}.
-drain_body(#{body_state := BS}) ->
-    case consume_body_state(BS, all) of
+drain_body(#{body_reader := BS}) ->
+    case consume_body_reader(BS, all) of
         {ok, _Bytes, #{buffered := Leftover}} -> {ok, Leftover};
         {error, _} = E -> E
     end.
 
 -doc """
-Consume bytes from a manual-mode `body_state()`. Returns either the
+Consume bytes from a manual-mode `body_reader()`. Returns either the
 final tail (`{ok, Bytes, NewState}` — the body has been fully drained)
 or a partial chunk (`{more, Bytes, NewState}` — more is still pending).
 Used by `roadrunner_req:read_body/1,2`; not part of the public API.
@@ -570,22 +570,22 @@ Used by `roadrunner_req:read_body/1,2`; not part of the public API.
 bytes — content-length framing only; chunked falls through to a
 full read).
 """.
--spec consume_body_state(body_state(), all | next_chunk | {length, non_neg_integer()}) ->
-    {ok, iodata(), body_state()}
-    | {more, iodata(), body_state()}
+-spec consume_body_reader(body_reader(), all | next_chunk | {length, non_neg_integer()}) ->
+    {ok, iodata(), body_reader()}
+    | {more, iodata(), body_reader()}
     | {error, term()}.
-consume_body_state(#{framing := none} = BS, _Mode) ->
+consume_body_reader(#{framing := none} = BS, _Mode) ->
     %% Per RFC 9112 §6.3: no framing means the body is empty.
     %% Any `buffered` bytes are pipelined-next-request leftovers —
-    %% preserve them in the body_state's `buffered` field so
+    %% preserve them in the body_reader's `buffered` field so
     %% `roadrunner_conn_loop`'s finishing phase can thread them into
     %% the next `reading_request` parse for full pipelining support.
     {ok, <<>>, BS};
-consume_body_state(
+consume_body_reader(
     #{framing := {content_length, N}, bytes_read := Read} = BS, _Mode
 ) when Read >= N ->
     {ok, <<>>, BS};
-consume_body_state(
+consume_body_reader(
     #{
         framing := {content_length, N},
         bytes_read := Read,
@@ -618,15 +618,15 @@ consume_body_state(
                     E
             end
     end;
-consume_body_state(#{framing := chunked} = BS, all) ->
+consume_body_reader(#{framing := chunked} = BS, all) ->
     %% Drain everything left: any pending decoded bytes plus all
     %% remaining chunks, accumulated in one return. Iodata stays unflattened
     %% so callers that only need `iolist_size/1` or want to forward via
     %% `gen_tcp:send/2` skip a flatten.
     chunked_collect(BS, infinity);
-consume_body_state(#{framing := chunked} = BS, {length, N}) ->
+consume_body_reader(#{framing := chunked} = BS, {length, N}) ->
     chunked_collect(BS, N);
-consume_body_state(#{framing := chunked} = BS, next_chunk) ->
+consume_body_reader(#{framing := chunked} = BS, next_chunk) ->
     next_chunk(BS).
 %% Non-chunked framing (none, content_length) is handled by the
 %% earlier clauses above — `next_chunk` is treated as a full drain
@@ -637,10 +637,10 @@ consume_body_state(#{framing := chunked} = BS, next_chunk) ->
 %% `infinity` (drain to end — caller asked for `all`) or a positive
 %% integer (caller asked for `{length, N}`). Returns
 %% `{ok | more, Bytes, BS2}` with Bytes as iodata (propagated through
-%% `consume_body_state` to the public API unflattened).
--spec chunked_collect(body_state(), infinity | non_neg_integer()) ->
-    {ok, iodata(), body_state()}
-    | {more, iodata(), body_state()}
+%% `consume_body_reader` to the public API unflattened).
+-spec chunked_collect(body_reader(), infinity | non_neg_integer()) ->
+    {ok, iodata(), body_reader()}
+    | {more, iodata(), body_reader()}
     | {error, term()}.
 chunked_collect(#{pending := Pending} = BS, Want) when
     Want =/= infinity, byte_size(Pending) >= Want
@@ -691,13 +691,13 @@ chunked_collect(#{buffered := Buf, recv := Recv, max := Max, bytes_read := Read}
             E
     end.
 
-%% Pull exactly one decoded chunk out of a chunked body_state. Pending
+%% Pull exactly one decoded chunk out of a chunked body_reader. Pending
 %% bytes (left over from a length-bounded read) are returned first; if
 %% pending is empty, parse the next wire chunk. End-of-body returns
 %% `{ok, <<>>, BS}`.
--spec next_chunk(body_state()) ->
-    {ok, binary(), body_state()}
-    | {more, binary(), body_state()}
+-spec next_chunk(body_reader()) ->
+    {ok, binary(), body_reader()}
+    | {more, binary(), body_reader()}
     | {error, term()}.
 next_chunk(#{pending := Pending} = BS) when byte_size(Pending) > 0 ->
     {more, Pending, BS#{pending := <<>>}};
@@ -733,7 +733,7 @@ fill_n(N, Buf, _Recv) when byte_size(Buf) >= N ->
     {ok, Bytes, Rest};
 fill_n(N, Buf, Recv) ->
     %% Body recursion that conses each recv chunk onto the iolist on
-    %% the way OUT. The iolist propagates through `consume_body_state`
+    %% the way OUT. The iolist propagates through `consume_body_reader`
     %% to the caller unflattened so callers that only need
     %% `iolist_size/1` (or want to forward via `gen_tcp:send/2`) avoid
     %% an O(total-body) copy.

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -66,7 +66,7 @@
     response_kind/1
 ]).
 
--export_type([proto_opts/0, dispatch/0, body_reader/0]).
+-export_type([proto_opts/0, dispatch/0]).
 
 -on_load(init_patterns/0).
 
@@ -124,26 +124,6 @@
     %% `#{hibernate_after := Ms}` against `proto_opts()`.
     hibernate_after => pos_integer(),
     rate_check_interval => pos_integer()
-}.
-
--doc """
-Body-read envelope attached to the request in `body_buffering =>
-manual` mode. `roadrunner_req:read_body/1,2` consumes from it; the
-conn owns the recv closure and tracks how much remains.
-
-`pending` holds decoded body bytes that have been parsed off the
-wire but not yet handed to the caller — used for chunked framing
-to absorb a chunk's payload across multiple length-bounded calls.
-`done` flips true once the size-0 last chunk is parsed.
-""".
--type body_reader() :: #{
-    framing := none | chunked | {content_length, non_neg_integer()},
-    buffered := binary(),
-    bytes_read := non_neg_integer(),
-    pending := binary(),
-    done := boolean(),
-    recv := fun(() -> {ok, binary()} | {error, term()}),
-    max := non_neg_integer()
 }.
 
 -doc """
@@ -406,7 +386,7 @@ has_continue_expectation(Req) ->
     binary(),
     fun(() -> {ok, binary()} | {error, term()}),
     non_neg_integer()
-) -> body_reader().
+) -> roadrunner_req:body_reader().
 make_body_reader(Framing, Buffered, Recv, Max) ->
     #{
         framing => Framing,
@@ -563,7 +543,7 @@ drain_body(#{body_reader := BS}) ->
     end.
 
 -doc """
-Consume bytes from a manual-mode `body_reader()`. Returns either the
+Consume bytes from a manual-mode `roadrunner_req:body_reader()`. Returns either the
 final tail (`{ok, Bytes, NewState}` — the body has been fully drained)
 or a partial chunk (`{more, Bytes, NewState}` — more is still pending).
 Used by `roadrunner_req:read_body/1,2`; not part of the public API.
@@ -572,9 +552,11 @@ Used by `roadrunner_req:read_body/1,2`; not part of the public API.
 bytes — content-length framing only; chunked falls through to a
 full read).
 """.
--spec consume_body_reader(body_reader(), all | next_chunk | {length, non_neg_integer()}) ->
-    {ok, iodata(), body_reader()}
-    | {more, iodata(), body_reader()}
+-spec consume_body_reader(
+    roadrunner_req:body_reader(), all | next_chunk | {length, non_neg_integer()}
+) ->
+    {ok, iodata(), roadrunner_req:body_reader()}
+    | {more, iodata(), roadrunner_req:body_reader()}
     | {error, term()}.
 consume_body_reader(#{framing := none} = BS, _Mode) ->
     %% Per RFC 9112 §6.3: no framing means the body is empty.
@@ -640,9 +622,9 @@ consume_body_reader(#{framing := chunked} = BS, next_chunk) ->
 %% integer (caller asked for `{length, N}`). Returns
 %% `{ok | more, Bytes, BS2}` with Bytes as iodata (propagated through
 %% `consume_body_reader` to the public API unflattened).
--spec chunked_collect(body_reader(), infinity | non_neg_integer()) ->
-    {ok, iodata(), body_reader()}
-    | {more, iodata(), body_reader()}
+-spec chunked_collect(roadrunner_req:body_reader(), infinity | non_neg_integer()) ->
+    {ok, iodata(), roadrunner_req:body_reader()}
+    | {more, iodata(), roadrunner_req:body_reader()}
     | {error, term()}.
 chunked_collect(#{pending := Pending} = BS, Want) when
     Want =/= infinity, byte_size(Pending) >= Want
@@ -697,9 +679,9 @@ chunked_collect(#{buffered := Buf, recv := Recv, max := Max, bytes_read := Read}
 %% bytes (left over from a length-bounded read) are returned first; if
 %% pending is empty, parse the next wire chunk. End-of-body returns
 %% `{ok, <<>>, BS}`.
--spec next_chunk(body_reader()) ->
-    {ok, binary(), body_reader()}
-    | {more, binary(), body_reader()}
+-spec next_chunk(roadrunner_req:body_reader()) ->
+    {ok, binary(), roadrunner_req:body_reader()}
+    | {more, binary(), roadrunner_req:body_reader()}
     | {error, term()}.
 next_chunk(#{pending := Pending} = BS) when byte_size(Pending) > 0 ->
     {more, Pending, BS#{pending := <<>>}};

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -126,14 +126,16 @@
     rate_check_interval => pos_integer()
 }.
 
-%% Opaque body-read state attached to the request in manual buffering
-%% mode. `roadrunner_req:read_body/1,2` consumes from this state; the conn
-%% owns the recv closure and tracks how much remains.
-%%
-%% `pending` holds decoded body bytes that have been parsed off the
-%% wire but not yet handed to the caller — used for chunked framing
-%% to absorb a chunk's payload across multiple length-bounded calls.
-%% `done` flips true once the size-0 last chunk is parsed.
+-doc """
+Body-read envelope attached to the request in `body_buffering =>
+manual` mode. `roadrunner_req:read_body/1,2` consumes from it; the
+conn owns the recv closure and tracks how much remains.
+
+`pending` holds decoded body bytes that have been parsed off the
+wire but not yet handed to the caller — used for chunked framing
+to absorb a chunk's payload across multiple length-bounded calls.
+`done` flips true once the size-0 last chunk is parsed.
+""".
 -type body_reader() :: #{
     framing := none | chunked | {content_length, non_neg_integer()},
     buffered := binary(),

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -489,7 +489,7 @@ handle_request_bytes(
 %%
 %% Auto-buffering reads the full body synchronously via the recv
 %% closure (passive `gen_tcp:recv` with the request_timeout deadline).
-%% Manual buffering builds a body_state the handler will pull from
+%% Manual buffering builds a body_reader the handler will pull from
 %% via `roadrunner_req:read_body/1,2`.
 -spec read_body_phase(#loop_state{}, roadrunner_req:request(), integer()) -> no_return().
 read_body_phase(
@@ -534,10 +534,10 @@ read_body_phase(
                     _ = roadrunner_conn:send_bad_request(Socket),
                     exit_normal(S);
                 Framing ->
-                    BodyState = roadrunner_conn:make_body_state(
+                    BodyState = roadrunner_conn:make_body_reader(
                         Framing, Buffered, Recv, MaxCL
                     ),
-                    dispatch_phase(S, Req#{body_state => BodyState})
+                    dispatch_phase(S, Req#{body_reader => BodyState})
             end
     end.
 
@@ -735,28 +735,28 @@ buffered_finish(S, Req, Headers) ->
             end;
         {error, _} ->
             %% Drain failure — close. Manual-mode handlers can leave the
-            %% body_state in a broken state if they read past EOF.
+            %% body_reader in a broken state if they read past EOF.
             exit_normal(S)
     end.
 
-%% Manual-mode body_state owns its post-body leftover (returned by
+%% Manual-mode body_reader owns its post-body leftover (returned by
 %% `drain_body/1`). Auto-mode stashes the leftover in the loop state's
 %% `buffered` field — set by `read_body_phase` on `read_body/4` return.
 -spec pipelined_leftover(roadrunner_req:request(), #loop_state{}, binary()) -> binary().
-pipelined_leftover(Req, _S, ManualLeftover) when is_map_key(body_state, Req) ->
+pipelined_leftover(Req, _S, ManualLeftover) when is_map_key(body_reader, Req) ->
     ManualLeftover;
 pipelined_leftover(_Req, #loop_state{buffered = Buf}, _ManualLeftover) ->
     Buf.
 
 %% In auto-mode the body has already been fully read by
-%% `read_body_phase` — the request map has no `body_state` key, and
+%% `read_body_phase` — the request map has no `body_reader` key, and
 %% `roadrunner_conn:drain_body/1`'s second clause would just return
 %% `{ok, <<>>}`. Skip the call entirely on auto. Manual-mode (where
 %% the handler may have left bytes unread) goes through the real
-%% `drain_body/1` which consumes the body_state.
+%% `drain_body/1` which consumes the body_reader.
 -spec drain_body_if_manual(roadrunner_req:request()) ->
     {ok, binary()} | {error, term()}.
-drain_body_if_manual(#{body_state := _} = Req) ->
+drain_body_if_manual(#{body_reader := _} = Req) ->
     roadrunner_conn:drain_body(Req);
 drain_body_if_manual(_Req) ->
     {ok, <<>>}.

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -674,7 +674,7 @@ dispatch_response(Socket, _Handler, _Req, {Status, Headers0, Body}) when is_inte
 %% only fires for handler-emitted responses (status ≥ 200); 1xx
 %% interim responses are emitted by the framework directly without
 %% routing through this path, so we don't need a 1xx skip here.
--spec with_date(roadrunner_http1:headers()) -> roadrunner_http1:headers().
+-spec with_date(roadrunner_http:headers()) -> roadrunner_http:headers().
 with_date(Headers) ->
     case lists:keymember(~"date", 1, Headers) of
         true -> Headers;
@@ -712,7 +712,7 @@ finishing_phase(S, Req, _Response) ->
 -spec buffered_finish(
     #loop_state{},
     roadrunner_req:request(),
-    roadrunner_http1:headers()
+    roadrunner_http:headers()
 ) -> no_return().
 buffered_finish(S, Req, Headers) ->
     case drain_body_if_manual(Req) of

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -491,7 +491,7 @@ handle_request_bytes(
 %% closure (passive `gen_tcp:recv` with the request_timeout deadline).
 %% Manual buffering builds a body_state the handler will pull from
 %% via `roadrunner_req:read_body/1,2`.
--spec read_body_phase(#loop_state{}, roadrunner_http1:request(), integer()) -> no_return().
+-spec read_body_phase(#loop_state{}, roadrunner_req:request(), integer()) -> no_return().
 read_body_phase(
     #loop_state{
         socket = Socket,
@@ -548,7 +548,7 @@ read_body_phase(
 %% request_exception telemetry. The 5 response shapes (buffered,
 %% stream, loop, sendfile, websocket) dispatch to their respective
 %% writers via `dispatch_response/4`.
--spec dispatch_phase(#loop_state{}, roadrunner_http1:request()) -> no_return().
+-spec dispatch_phase(#loop_state{}, roadrunner_req:request()) -> no_return().
 dispatch_phase(
     #loop_state{
         socket = Socket,
@@ -567,7 +567,7 @@ dispatch_phase(
 -spec run_pipeline(
     #loop_state{},
     module(),
-    roadrunner_http1:request(),
+    roadrunner_req:request(),
     roadrunner_middleware:next()
 ) -> no_return().
 run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
@@ -608,7 +608,7 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
 -spec dispatch_response(
     roadrunner_transport:socket(),
     module(),
-    roadrunner_http1:request(),
+    roadrunner_req:request(),
     roadrunner_handler:response()
 ) -> ok.
 dispatch_response(Socket, _Handler, Req, {websocket, Mod, State}) when is_atom(Mod) ->
@@ -698,7 +698,7 @@ with_date(Headers) ->
 %% subsequent `case` dispatch. Buffered (3-tuple) is the only shape
 %% eligible for keep-alive; stream/loop/sendfile/websocket writers
 %% own the wire from here and force close.
--spec finishing_phase(#loop_state{}, roadrunner_http1:request(), roadrunner_handler:response()) ->
+-spec finishing_phase(#loop_state{}, roadrunner_req:request(), roadrunner_handler:response()) ->
     no_return().
 finishing_phase(S, Req, {Status, Headers, _Body}) when is_integer(Status) ->
     buffered_finish(S, Req, Headers);
@@ -711,7 +711,7 @@ finishing_phase(S, Req, _Response) ->
 
 -spec buffered_finish(
     #loop_state{},
-    roadrunner_http1:request(),
+    roadrunner_req:request(),
     roadrunner_http1:headers()
 ) -> no_return().
 buffered_finish(S, Req, Headers) ->
@@ -742,7 +742,7 @@ buffered_finish(S, Req, Headers) ->
 %% Manual-mode body_state owns its post-body leftover (returned by
 %% `drain_body/1`). Auto-mode stashes the leftover in the loop state's
 %% `buffered` field — set by `read_body_phase` on `read_body/4` return.
--spec pipelined_leftover(roadrunner_http1:request(), #loop_state{}, binary()) -> binary().
+-spec pipelined_leftover(roadrunner_req:request(), #loop_state{}, binary()) -> binary().
 pipelined_leftover(Req, _S, ManualLeftover) when is_map_key(body_state, Req) ->
     ManualLeftover;
 pipelined_leftover(_Req, #loop_state{buffered = Buf}, _ManualLeftover) ->
@@ -754,14 +754,14 @@ pipelined_leftover(_Req, #loop_state{buffered = Buf}, _ManualLeftover) ->
 %% `{ok, <<>>}`. Skip the call entirely on auto. Manual-mode (where
 %% the handler may have left bytes unread) goes through the real
 %% `drain_body/1` which consumes the body_state.
--spec drain_body_if_manual(roadrunner_http1:request()) ->
+-spec drain_body_if_manual(roadrunner_req:request()) ->
     {ok, binary()} | {error, term()}.
 drain_body_if_manual(#{body_state := _} = Req) ->
     roadrunner_conn:drain_body(Req);
 drain_body_if_manual(_Req) ->
     {ok, <<>>}.
 
--spec telemetry_metadata(roadrunner_http1:request()) -> roadrunner_telemetry:metadata().
+-spec telemetry_metadata(roadrunner_req:request()) -> roadrunner_telemetry:metadata().
 telemetry_metadata(Req) ->
     #{
         request_id => maps:get(request_id, Req),

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -836,13 +836,13 @@ dispatch_stream(
             {RequestId, NewBuf} = roadrunner_conn:generate_request_id(
                 State#loop.req_id_buffer
             ),
-            ConnInfo = #{
+            RequestContext = #{
                 peer => Peer,
                 scheme => Scheme,
                 listener_name => ListenerName,
                 request_id => RequestId
             },
-            case roadrunner_http2_request:from_headers(Headers, BodyIolist, ConnInfo) of
+            case roadrunner_http2_request:from_headers(Headers, BodyIolist, RequestContext) of
                 {ok, Req} ->
                     {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
                         self(), StreamId, Req, ProtoOpts

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -120,7 +120,7 @@
     header_fragment := binary(),
     end_headers := boolean(),
     end_stream_seen := boolean(),
-    headers := undefined | [roadrunner_http2_hpack:header()],
+    headers := undefined | roadrunner_http:headers(),
     body := iolist(),
     %% Cumulative byte count of received DATA payload, used to
     %% validate against the request's `content-length` header at

--- a/src/roadrunner_handler.erl
+++ b/src/roadrunner_handler.erl
@@ -67,7 +67,7 @@ Returns `ok` on success or `{error, Reason}` if the wire write
 failed (peer close, kernel error, etc.).
 """.
 -type send_fun() ::
-    fun((iodata(), nofin | fin | {fin, roadrunner_req:headers()}) -> ok | {error, term()}).
+    fun((iodata(), nofin | fin | {fin, roadrunner_http:headers()}) -> ok | {error, term()}).
 
 -doc """
 The stream callback for `{stream, _, _, Fun}` responses. The
@@ -105,10 +105,10 @@ across protocols. Framework helpers (`roadrunner_resp:*`,
 lowercase names; handler-supplied tuples must follow suit.
 """.
 -type response() ::
-    {StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), Body :: iodata()}
-    | {stream, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), stream_fun()}
-    | {loop, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), State :: term()}
-    | {sendfile, StatusCode :: roadrunner_req:status(), roadrunner_req:headers(), sendfile_spec()}
+    {StatusCode :: roadrunner_http:status(), roadrunner_http:headers(), Body :: iodata()}
+    | {stream, StatusCode :: roadrunner_http:status(), roadrunner_http:headers(), stream_fun()}
+    | {loop, StatusCode :: roadrunner_http:status(), roadrunner_http:headers(), State :: term()}
+    | {sendfile, StatusCode :: roadrunner_http:status(), roadrunner_http:headers(), sendfile_spec()}
     | {websocket, Module :: module(), State :: term()}.
 
 -doc """

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -20,8 +20,6 @@
     compute_cached_decisions/1
 ]).
 
--export_type([cached_decisions/0]).
-
 -on_load(init_patterns/0).
 
 -define(MAX_REQUEST_LINE, 8192).
@@ -54,42 +52,6 @@
 -type headers() :: roadrunner_http:headers().
 -type status() :: roadrunner_http:status().
 
--doc """
-Framework internal — handlers should ignore both this type and the
-`cached_decisions` field on `t:roadrunner_req:request/0` that
-carries it. H1-parser hot-path optimization: pre-computed answers
-for case-insensitive headers the connection layer reads on every
-request (chunked / transfer-encoding / expect-continue /
-connection / content-length / host). Exported so cross-module
-specs can reference it; not part of the user-facing handler API.
-""".
--type cached_decisions() :: #{
-    %% True iff `Transfer-Encoding: chunked` (case-insensitive). Hot path
-    %% at body-framing time — saves a per-request lowercase scan.
-    is_chunked := boolean(),
-    %% True iff *any* `Transfer-Encoding` header is present (chunked or
-    %% otherwise). Distinguishes "no TE → use Content-Length" from
-    %% "non-chunked TE → bad_transfer_encoding" without a per-request
-    %% header re-lookup. Always implied by `is_chunked := true`.
-    has_transfer_encoding := boolean(),
-    %% True iff `Expect: 100-continue` (case-insensitive). Used by the
-    %% body-read path to decide whether to send a 100 before recv.
-    expects_continue := boolean(),
-    %% Lowercased value of the `Connection` header (`~""` if absent).
-    %% `roadrunner_conn:keep_alive_decision/2` and `has_token/2` operate on
-    %% this directly without re-lowercasing.
-    connection_lower := binary(),
-    %% Parsed `Content-Length`. `none` if absent; `{ok, N}` if a valid
-    %% non-negative integer; `{error, bad_content_length}` if present but
-    %% malformed. `roadrunner_conn:body_framing/1` consumes this directly
-    %% on the cached path, avoiding a `roadrunner_req:header/2` lookup
-    %% (which lowercases the lookup name) plus a `binary_to_integer/1`.
-    content_length := none | {ok, non_neg_integer()} | {error, bad_content_length},
-    %% True iff a `Host` header is present. Drives the RFC 7230 §5.4
-    %% missing-host rejection for HTTP/1.1 without a per-request
-    %% keymember walk.
-    has_host := boolean()
-}.
 -doc """
 Parse the HTTP/1.1 request line.
 
@@ -521,7 +483,7 @@ check_cls_consistent(_, _) -> error.
 %% Reusing the cached values avoids ~3 lowercase scans per request on
 %% the hot path measured via `scripts/stress.escript --profile`.
 -doc false.
--spec compute_cached_decisions(headers()) -> cached_decisions().
+-spec compute_cached_decisions(headers()) -> roadrunner_req:cached_decisions().
 compute_cached_decisions(Headers) ->
     compute_cached_decisions_loop(Headers, #{
         is_chunked => false,
@@ -532,7 +494,8 @@ compute_cached_decisions(Headers) ->
         has_host => false
     }).
 
--spec compute_cached_decisions_loop(headers(), cached_decisions()) -> cached_decisions().
+-spec compute_cached_decisions_loop(headers(), roadrunner_req:cached_decisions()) ->
+    roadrunner_req:cached_decisions().
 compute_cached_decisions_loop([], Acc) ->
     Acc;
 compute_cached_decisions_loop([{~"transfer-encoding", V} | Rest], Acc) ->
@@ -618,7 +581,7 @@ parse_request(Bin) when is_binary(Bin) ->
 %% header. Absence is a 400 Bad Request, also a request-smuggling
 %% mitigation when proxies forward to backends that disagree on the
 %% target host. HTTP/1.0 didn't require it.
--spec validate_host(version(), cached_decisions()) -> ok | {error, missing_host}.
+-spec validate_host(version(), roadrunner_req:cached_decisions()) -> ok | {error, missing_host}.
 validate_host({1, 1}, #{has_host := true}) -> ok;
 validate_host({1, 1}, #{has_host := false}) -> {error, missing_host};
 validate_host({1, 0}, _Decisions) -> ok.

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -16,8 +16,7 @@
     parse_request/1,
     parse_chunk/1,
     check_header_safe/2,
-    response/3,
-    compute_cached_decisions/1
+    response/3
 ]).
 
 -export_type([cached_decisions/0]).
@@ -53,6 +52,8 @@
 -type version() :: roadrunner_http:version().
 -type headers() :: roadrunner_http:headers().
 -type status() :: roadrunner_http:status().
+
+-doc false.
 -type cached_decisions() :: #{
     %% True iff `Transfer-Encoding: chunked` (case-insensitive). Hot path
     %% at body-framing time — saves a per-request lowercase scan.
@@ -495,18 +496,22 @@ check_cls_consistent(_, []) -> ok;
 check_cls_consistent(V, [V | Rest]) -> check_cls_consistent(V, Rest);
 check_cls_consistent(_, _) -> error.
 
--doc """
-Walk a parsed header list once and return pre-computed decisions for the
-case-insensitive headers that the connection layer reads on every request.
-
-Header names are already lowercased by `parse_header/1`; this pass also
-lowercases the value of `Connection` (whose tokens are case-insensitive
-per RFC 9110) and computes booleans for `Transfer-Encoding: chunked` and
-`Expect: 100-continue`.
-
-Reusing the cached values avoids ~3 lowercase scans per request on the
-hot path measured via `scripts/stress.escript --profile`.
-""".
+%% Walk a parsed header list once and return pre-computed decisions for
+%% the case-insensitive headers that the connection layer reads on every
+%% request.
+%%
+%% Header names are already lowercased by `parse_header/1`; this pass
+%% also lowercases the value of `Connection` (whose tokens are
+%% case-insensitive per RFC 9110) and computes booleans for
+%% `Transfer-Encoding: chunked` and `Expect: 100-continue`.
+%%
+%% Reusing the cached values avoids ~3 lowercase scans per request on
+%% the hot path measured via `scripts/stress.escript --profile`.
+%%
+%% Internal hot-path helper — not part of the public API. The result
+%% is stashed on the request map's `cached_decisions` field for
+%% `roadrunner_conn` to read; handlers should ignore it.
+-doc false.
 -spec compute_cached_decisions(headers()) -> cached_decisions().
 compute_cached_decisions(Headers) ->
     compute_cached_decisions_loop(Headers, #{

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -20,7 +20,7 @@
     compute_cached_decisions/1
 ]).
 
--export_type([version/0, headers/0, request/0, status/0, redirect_status/0, cached_decisions/0]).
+-export_type([version/0, headers/0, status/0, redirect_status/0, cached_decisions/0]).
 
 -on_load(init_patterns/0).
 
@@ -47,7 +47,7 @@
 -define(SEMICOLON_KEY, {?MODULE, semicolon_cp}).
 
 %% Re-exported as type aliases from `roadrunner_http` so existing
-%% callers using `roadrunner_http1:request()` / `:headers()` /
+%% callers using `roadrunner_req:request()` / `:headers()` /
 %% `:status()` / `:redirect_status()` / `:version()` keep compiling.
 %% New code calls the shared module directly.
 -type version() :: roadrunner_http:version().
@@ -81,57 +81,6 @@
     %% keymember walk.
     has_host := boolean()
 }.
--type request() :: #{
-    method := binary(),
-    target := binary(),
-    version := version(),
-    headers := headers(),
-    %% Pre-computed decisions for known case-insensitive headers, populated
-    %% by `parse_request/1`. Hot-path consumers (`roadrunner_conn:body_framing/1`,
-    %% `keep_alive_decision/2`, `has_continue_expectation/1`) read these
-    %% instead of re-lowercasing header values per request. Absent for
-    %% manually-built request maps — consumers fall back to the raw
-    %% `headers` list when missing.
-    cached_decisions => cached_decisions(),
-    %% Body is set by `roadrunner_conn` before the handler is invoked. Auto
-    %% mode delivers the full body here as `iodata()` (an iolist of recv
-    %% chunks for multi-chunk bodies, a single binary otherwise) so the conn
-    %% can skip a flatten that many handlers do not need. Handlers that
-    %% require a flat binary call `iolist_to_binary/1` themselves. The parser
-    %% never populates this field; it leaves the buffered body in the
-    %% `Rest` element of `parse_request/1` instead.
-    body => iodata(),
-    %% Bindings captured from `:param` segments by `roadrunner_router`, also set
-    %% by `roadrunner_conn` before dispatch. Empty map when the dispatch is a
-    %% single-handler one (no routing) or the route has no params.
-    bindings => roadrunner_router:bindings(),
-    %% Client TCP peer captured once per connection from `inet:peername/1`.
-    %% `undefined` when the OS call fails (rare; usually socket teardown).
-    peer => {inet:ip_address(), inet:port_number()} | undefined,
-    %% Connection scheme — `http` for plain TCP, `https` for TLS. Set
-    %% once per connection by `roadrunner_conn` from the transport tag.
-    scheme => http | https,
-    %% Per-route handler state attached at compile time via the 3-tuple
-    %% route shape `{Path, Handler, State}` or the map shape's `state` key
-    %% (and the listener's `{Module, State}` single-handler form).
-    %% `undefined` when no state was attached.
-    state => term(),
-    %% Body-read state attached by `roadrunner_conn` in `body_buffering => manual`
-    %% mode. Threaded through `roadrunner_req:read_body/1,2`. Never present in
-    %% `auto` mode or in manually-constructed request maps.
-    body_state => roadrunner_conn:body_state(),
-    %% Per-request correlation token attached by `roadrunner_conn` once the
-    %% headers parse. 16 lowercase hex chars (8 bytes of CSPRNG output).
-    %% Mirrored into `logger:set_process_metadata/1` so any `?LOG_*` call
-    %% from middleware or the handler picks it up automatically.
-    request_id => binary(),
-    %% Registered name of the owning `roadrunner_listener`. Set once per
-    %% conn from `proto_opts.listener_name`. Surfaced in
-    %% `roadrunner_telemetry` event metadata so subscribers can filter by
-    %% listener in multi-listener deployments.
-    listener_name => atom()
-}.
-
 -doc """
 Parse the HTTP/1.1 request line.
 
@@ -624,7 +573,7 @@ Spec deviates from the original plan: the result is a map rather than
 a record, so callers don't need to include a header file.
 """.
 -spec parse_request(binary()) ->
-    {ok, request(), Rest :: binary()}
+    {ok, roadrunner_req:request(), Rest :: binary()}
     | {more, undefined}
     | {error,
         bad_request_line

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -54,11 +54,15 @@
 -type headers() :: roadrunner_http:headers().
 -type status() :: roadrunner_http:status().
 
-%% H1-parser internal hot-path optimization (no public contract).
-%% Surfaces on the request map as the `cached_decisions` field; both
-%% the field and this type are framework internals — handlers should
-%% ignore them. Exported only so cross-module specs (e.g. the field's
-%% type annotation in `roadrunner_req:request/0`) can reference it.
+-doc """
+Framework internal — handlers should ignore both this type and the
+`cached_decisions` field on `t:roadrunner_req:request/0` that
+carries it. H1-parser hot-path optimization: pre-computed answers
+for case-insensitive headers the connection layer reads on every
+request (chunked / transfer-encoding / expect-continue /
+connection / content-length / host). Exported so cross-module
+specs can reference it; not part of the user-facing handler API.
+""".
 -type cached_decisions() :: #{
     %% True iff `Transfer-Encoding: chunked` (case-insensitive). Hot path
     %% at body-framing time — saves a per-request lowercase scan.

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -16,7 +16,8 @@
     parse_request/1,
     parse_chunk/1,
     check_header_safe/2,
-    response/3
+    response/3,
+    compute_cached_decisions/1
 ]).
 
 -export_type([cached_decisions/0]).
@@ -53,7 +54,11 @@
 -type headers() :: roadrunner_http:headers().
 -type status() :: roadrunner_http:status().
 
--doc false.
+%% H1-parser internal hot-path optimization (no public contract).
+%% Surfaces on the request map as the `cached_decisions` field; both
+%% the field and this type are framework internals — handlers should
+%% ignore them. Exported only so cross-module specs (e.g. the field's
+%% type annotation in `roadrunner_req:request/0`) can reference it.
 -type cached_decisions() :: #{
     %% True iff `Transfer-Encoding: chunked` (case-insensitive). Hot path
     %% at body-framing time — saves a per-request lowercase scan.
@@ -496,9 +501,13 @@ check_cls_consistent(_, []) -> ok;
 check_cls_consistent(V, [V | Rest]) -> check_cls_consistent(V, Rest);
 check_cls_consistent(_, _) -> error.
 
-%% Walk a parsed header list once and return pre-computed decisions for
-%% the case-insensitive headers that the connection layer reads on every
-%% request.
+%% Walk a parsed header list once and return pre-computed decisions
+%% for the case-insensitive headers that the connection layer reads
+%% on every request.
+%%
+%% Internal hot-path helper — not part of the public handler API. The
+%% result is stashed on the request map's `cached_decisions` field
+%% for `roadrunner_conn` to read; handlers should ignore it.
 %%
 %% Header names are already lowercased by `parse_header/1`; this pass
 %% also lowercases the value of `Connection` (whose tokens are
@@ -507,10 +516,6 @@ check_cls_consistent(_, _) -> error.
 %%
 %% Reusing the cached values avoids ~3 lowercase scans per request on
 %% the hot path measured via `scripts/stress.escript --profile`.
-%%
-%% Internal hot-path helper — not part of the public API. The result
-%% is stashed on the request map's `cached_decisions` field for
-%% `roadrunner_conn` to read; handlers should ignore it.
 -doc false.
 -spec compute_cached_decisions(headers()) -> cached_decisions().
 compute_cached_decisions(Headers) ->

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -20,7 +20,7 @@
     compute_cached_decisions/1
 ]).
 
--export_type([version/0, headers/0, status/0, redirect_status/0, cached_decisions/0]).
+-export_type([cached_decisions/0]).
 
 -on_load(init_patterns/0).
 
@@ -46,14 +46,13 @@
 -define(SPACE_KEY, {?MODULE, space_cp}).
 -define(SEMICOLON_KEY, {?MODULE, semicolon_cp}).
 
-%% Re-exported as type aliases from `roadrunner_http` so existing
-%% callers using `roadrunner_req:request()` / `:headers()` /
-%% `:status()` / `:redirect_status()` / `:version()` keep compiling.
-%% New code calls the shared module directly.
+%% Module-local aliases for the shared HTTP primitives so this
+%% module's specs stay readable. The canonical, exported type lives
+%% at `roadrunner_http:<name>/0` — that's where cross-module callers
+%% should reference it from.
 -type version() :: roadrunner_http:version().
 -type headers() :: roadrunner_http:headers().
 -type status() :: roadrunner_http:status().
--type redirect_status() :: roadrunner_http:redirect_status().
 -type cached_decisions() :: #{
     %% True iff `Transfer-Encoding: chunked` (case-insensitive). Hot path
     %% at body-framing time — saves a per-request lowercase scan.

--- a/src/roadrunner_http2_hpack.erl
+++ b/src/roadrunner_http2_hpack.erl
@@ -48,7 +48,7 @@
     set_max_table_size/2
 ]).
 
--export_type([context/0, header/0, decode_error/0]).
+-export_type([context/0, decode_error/0]).
 
 %% RFC 7541 Appendix A — 61 static-table entries. Defined up here
 %% so it expands in every later guard / arithmetic site below.

--- a/src/roadrunner_http2_hpack_huffman.erl
+++ b/src/roadrunner_http2_hpack_huffman.erl
@@ -37,8 +37,10 @@
 
 -export([encode/1, decode/1]).
 
--export_type([decode_error/0]).
-
+%% Internal-only: HPACK's `decode_error/0` union (the public surface)
+%% folds these two Huffman-specific variants into the single
+%% `huffman_decode_error` token in `roadrunner_http2_hpack:decode/2`'s
+%% spec. Callers that need to discriminate them stay inside this module.
 -type decode_error() ::
     invalid_padding
     | eos_in_string.

--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -26,8 +26,8 @@ Returns when the handler's `handle_info/3` returns `{stop, _}`.
 -spec run(
     pid(),
     pos_integer(),
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     {module(), term()}
 ) -> ok.
 run(ConnPid, StreamId, Status, Headers, {Handler, State}) ->
@@ -84,8 +84,8 @@ make_push(ConnPid, StreamId) ->
 -spec sync_send_headers(
     pid(),
     pos_integer(),
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     boolean()
 ) -> ok.
 sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->

--- a/src/roadrunner_http2_request.erl
+++ b/src/roadrunner_http2_request.erl
@@ -4,7 +4,7 @@
 %% Build a roadrunner request map from an HTTP/2 HEADERS block
 %% (decoded HPACK header list) per RFC 9113 §8.3.
 %%
-%% The request shape is the same `roadrunner_http1:request()` map
+%% The request shape is the same `roadrunner_req:request()` map
 %% that HTTP/1.1 produces — pseudo-headers (`:method`, `:scheme`,
 %% `:authority`, `:path`) get normalized into the existing `method`
 %% / `scheme` / `target` / regular-header fields so handler code
@@ -52,7 +52,7 @@ Build a request map from a decoded HPACK header list. `ConnInfo`
 carries the per-connection bits the HTTP/1 conn already has —
 peer, scheme (from the TLS tag), listener_name, request_id.
 
-The returned map is `roadrunner_http1:request()` shape with
+The returned map is `roadrunner_req:request()` shape with
 `version => {2, 0}`, `target` set to the `:path` pseudo-header
 value, and `method` set to `:method`. The `:authority`
 pseudo-header is forwarded as a `host` header so handlers that
@@ -63,7 +63,7 @@ for header-only requests). Stored on the request map as `iodata()`;
 handlers requiring a flat binary call `iolist_to_binary/1` themselves.
 """.
 -spec from_headers([roadrunner_http2_hpack:header()], iodata(), conn_info()) ->
-    {ok, roadrunner_http1:request()} | {error, build_error()}.
+    {ok, roadrunner_req:request()} | {error, build_error()}.
 from_headers(Headers, Body, ConnInfo) ->
     maybe
         {ok, Pseudo, Regular} ?= partition(Headers),
@@ -169,7 +169,7 @@ check_banned([_ | Rest]) -> check_banned(Rest).
     [roadrunner_http2_hpack:header()],
     binary(),
     map()
-) -> roadrunner_http1:request().
+) -> roadrunner_req:request().
 build(Method, Path, Authority, Regular, Body, ConnInfo) ->
     %% Forward `:authority` as a `host` header so existing h1
     %% handler code that reads `Host` still works. (RFC 9113

--- a/src/roadrunner_http2_request.erl
+++ b/src/roadrunner_http2_request.erl
@@ -62,7 +62,7 @@ read it via `roadrunner_req:header/2` still work.
 for header-only requests). Stored on the request map as `iodata()`;
 handlers requiring a flat binary call `iolist_to_binary/1` themselves.
 """.
--spec from_headers([roadrunner_http2_hpack:header()], iodata(), conn_info()) ->
+-spec from_headers(roadrunner_http:headers(), iodata(), conn_info()) ->
     {ok, roadrunner_req:request()} | {error, build_error()}.
 from_headers(Headers, Body, ConnInfo) ->
     maybe
@@ -85,13 +85,13 @@ from_headers(Headers, Body, ConnInfo) ->
 %% which body-recurses the rest. Splitting the two phases avoids
 %% the prior shape's double recursion (cons-forward AND cons-back
 %% on every regular header).
--spec partition([roadrunner_http2_hpack:header()]) ->
-    {ok, map(), [roadrunner_http2_hpack:header()]} | {error, build_error()}.
+-spec partition(roadrunner_http:headers()) ->
+    {ok, map(), roadrunner_http:headers()} | {error, build_error()}.
 partition(Headers) ->
     partition(Headers, #{}).
 
--spec partition([roadrunner_http2_hpack:header()], map()) ->
-    {ok, map(), [roadrunner_http2_hpack:header()]} | {error, build_error()}.
+-spec partition(roadrunner_http:headers(), map()) ->
+    {ok, map(), roadrunner_http:headers()} | {error, build_error()}.
 partition([], Pseudo) ->
     {ok, Pseudo, []};
 partition([{<<":", _/binary>> = Name, Value} | Rest], Pseudo) ->
@@ -116,8 +116,8 @@ partition([H | Rest], Pseudo) ->
 
 %% Body-recurse the regular-header tail. A pseudo-header arriving
 %% here is RFC 9113 §8.1.2.1 PROTOCOL_ERROR.
--spec partition_regular([roadrunner_http2_hpack:header()]) ->
-    {ok, [roadrunner_http2_hpack:header()]} | {error, build_error()}.
+-spec partition_regular(roadrunner_http:headers()) ->
+    {ok, roadrunner_http:headers()} | {error, build_error()}.
 partition_regular([]) ->
     {ok, []};
 partition_regular([{<<":", _/binary>>, _} | _]) ->
@@ -150,7 +150,7 @@ validate_pseudo(Pseudo) ->
 %% keeps the hot path branch-friendly: the BEAM compiles the
 %% literal-binary clauses to a hash/select, no `lists:member`
 %% function call per header.
--spec check_banned([roadrunner_http2_hpack:header()]) ->
+-spec check_banned(roadrunner_http:headers()) ->
     ok | {error, connection_specific_header}.
 check_banned([]) -> ok;
 check_banned([{~"connection", _} | _]) -> {error, connection_specific_header};
@@ -166,7 +166,7 @@ check_banned([_ | Rest]) -> check_banned(Rest).
     binary(),
     binary(),
     binary() | undefined,
-    [roadrunner_http2_hpack:header()],
+    roadrunner_http:headers(),
     binary(),
     map()
 ) -> roadrunner_req:request().

--- a/src/roadrunner_http2_request.erl
+++ b/src/roadrunner_http2_request.erl
@@ -30,7 +30,7 @@
 
 -export([from_headers/3]).
 
--export_type([build_error/0, conn_info/0]).
+-export_type([build_error/0, request_context/0]).
 
 -type build_error() ::
     missing_pseudo_header
@@ -40,7 +40,7 @@
     | empty_path
     | connection_specific_header.
 
--type conn_info() :: #{
+-type request_context() :: #{
     peer := {inet:ip_address(), inet:port_number()} | undefined,
     scheme := http | https,
     request_id := binary(),
@@ -48,7 +48,7 @@
 }.
 
 -doc """
-Build a request map from a decoded HPACK header list. `ConnInfo`
+Build a request map from a decoded HPACK header list. `RequestContext`
 carries the per-connection bits the HTTP/1 conn already has —
 peer, scheme (from the TLS tag), listener_name, request_id.
 
@@ -62,18 +62,18 @@ read it via `roadrunner_req:header/2` still work.
 for header-only requests). Stored on the request map as `iodata()`;
 handlers requiring a flat binary call `iolist_to_binary/1` themselves.
 """.
--spec from_headers(roadrunner_http:headers(), iodata(), conn_info()) ->
+-spec from_headers(roadrunner_http:headers(), iodata(), request_context()) ->
     {ok, roadrunner_req:request()} | {error, build_error()}.
-from_headers(Headers, Body, ConnInfo) ->
+from_headers(Headers, Body, RequestContext) ->
     maybe
         {ok, Pseudo, Regular} ?= partition(Headers),
         %% `validate_pseudo` returns the parsed `:scheme` value but we
         %% deliberately discard it — the authoritative scheme comes
-        %% from the conn (`ConnInfo.scheme`) since clients can lie
+        %% from the conn (`RequestContext.scheme`) since clients can lie
         %% about the pseudo-header value.
         {ok, Method, _Scheme, Path, Authority} ?= validate_pseudo(Pseudo),
         ok ?= check_banned(Regular),
-        {ok, build(Method, Path, Authority, Regular, Body, ConnInfo)}
+        {ok, build(Method, Path, Authority, Regular, Body, RequestContext)}
     end.
 
 %% Walk the decoded header list, collecting pseudo-headers (names
@@ -170,7 +170,7 @@ check_banned([_ | Rest]) -> check_banned(Rest).
     binary(),
     map()
 ) -> roadrunner_req:request().
-build(Method, Path, Authority, Regular, Body, ConnInfo) ->
+build(Method, Path, Authority, Regular, Body, RequestContext) ->
     %% Forward `:authority` as a `host` header so existing h1
     %% handler code that reads `Host` still works. (RFC 9113
     %% §8.3.1 says an h2 server MUST treat `:authority` like
@@ -181,14 +181,14 @@ build(Method, Path, Authority, Regular, Body, ConnInfo) ->
             _ -> [{~"host", Authority} | Regular]
         end,
     %% Caller (`roadrunner_conn_loop_http2:dispatch_stream`)
-    %% always builds `ConnInfo` with all four fields populated, so
+    %% always builds `RequestContext` with all four fields populated, so
     %% pattern-matching wins vs. four `maps:get/3` calls.
     #{
         peer := Peer,
         scheme := Scheme,
         request_id := RequestId,
         listener_name := ListenerName
-    } = ConnInfo,
+    } = RequestContext,
     #{
         method => Method,
         target => Path,

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -55,13 +55,13 @@ affected stream, not tear down the whole connection. The conn
 sees the `'DOWN'` and emits `RST_STREAM(INTERNAL_ERROR)` for the
 stream's id, leaving the other 99 streams intact.
 """.
--spec start(pid(), pos_integer(), roadrunner_http1:request(), map()) ->
+-spec start(pid(), pos_integer(), roadrunner_req:request(), map()) ->
     {pid(), reference()}.
 start(ConnPid, StreamId, Req, ProtoOpts) ->
     spawn_monitor(?MODULE, init, [ConnPid, StreamId, Req, ProtoOpts]).
 
 -doc false.
--spec init(pid(), pos_integer(), roadrunner_http1:request(), map()) -> ok.
+-spec init(pid(), pos_integer(), roadrunner_req:request(), map()) -> ok.
 init(ConnPid, StreamId, Req, ProtoOpts) ->
     proc_lib:set_label({roadrunner_http2_stream_worker, StreamId}),
     %% Mirror the h1 path: attach request-scoped metadata so any
@@ -132,7 +132,7 @@ invoke(ConnPid, StreamId, Handler, Pipeline, Req, Metadata, ReqStart) ->
             )
     end.
 
--spec telemetry_metadata(roadrunner_http1:request()) -> roadrunner_telemetry:metadata().
+-spec telemetry_metadata(roadrunner_req:request()) -> roadrunner_telemetry:metadata().
 telemetry_metadata(#{
     request_id := RequestId,
     peer := Peer,

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -40,8 +40,8 @@ loop. Returns when the handler's `handle_info/3` returns `{stop, _}`.
 """.
 -spec run(
     roadrunner_transport:socket(),
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     module(),
     term()
 ) -> ok.

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -20,7 +20,7 @@ re-exported alongside it (`headers/0`, `version/0`, `status/0`,
 -define(EQ_CP_KEY, {?MODULE, eq_cp}).
 -define(QUOTE_CP_KEY, {?MODULE, quote_cp}).
 
--export_type([request/0]).
+-export_type([request/0, body_reader/0, cached_decisions/0]).
 
 -doc """
 The parsed request map handlers receive.
@@ -41,13 +41,11 @@ care which protocol delivered the bytes.
     version := version(),
     headers := headers(),
     %% H1-parser internal optimization — handlers should ignore.
-    %% See `t:roadrunner_http1:cached_decisions/0` for the shape.
-    %% Hot-path framework code (`roadrunner_conn:body_framing/1`,
-    %% `keep_alive_decision/2`, `has_continue_expectation/1`) reads
-    %% it directly to avoid re-lowercasing header values per
-    %% request. Absent on h2 requests and on manually-built request
-    %% maps.
-    cached_decisions => roadrunner_http1:cached_decisions(),
+    %% Hot-path conn helpers (`body_framing/1`,
+    %% `keep_alive_decision/2`, `has_continue_expectation/1`) read
+    %% this directly to skip per-request header re-lowercasing.
+    %% Absent on h2 requests and on manually-built request maps.
+    cached_decisions => cached_decisions(),
     %% Body is set by `roadrunner_conn` before the handler is
     %% invoked. Auto mode delivers the full body as `iodata()` (an
     %% iolist of recv chunks for multi-chunk bodies, a single binary
@@ -78,7 +76,7 @@ care which protocol delivered the bytes.
     %% `body_buffering => manual` mode. Threaded through
     %% `roadrunner_req:read_body/1,2`. Never present in `auto` mode
     %% or in manually-constructed request maps.
-    body_reader => roadrunner_conn:body_reader(),
+    body_reader => body_reader(),
     %% Per-request correlation token attached by `roadrunner_conn`
     %% once the headers parse. 16 lowercase hex chars (8 bytes of
     %% CSPRNG output). Mirrored into `logger:set_process_metadata/1`
@@ -94,6 +92,43 @@ care which protocol delivered the bytes.
 
 -type headers() :: roadrunner_http:headers().
 -type version() :: roadrunner_http:version().
+
+-doc """
+Framework-internal h1-parser hot-path optimization carried on the
+request map's `cached_decisions` field. Handlers should ignore both
+the field and this type — they're absent on h2 requests and on
+manually-built request maps. Populated by the h1 parser at
+request-read time and consumed by framework code to skip
+per-request header re-lowercasing on the dispatch hot path.
+""".
+-type cached_decisions() :: #{
+    is_chunked := boolean(),
+    has_transfer_encoding := boolean(),
+    expects_continue := boolean(),
+    connection_lower := binary(),
+    content_length := none | {ok, non_neg_integer()} | {error, bad_content_length},
+    has_host := boolean()
+}.
+
+-doc """
+Body-read envelope attached to the request in `body_buffering =>
+manual` mode. `read_body/1,2` consumes from it; the conn owns the
+recv closure and tracks how much remains.
+
+`pending` holds decoded body bytes that have been parsed off the
+wire but not yet handed to the caller — used for chunked framing
+to absorb a chunk's payload across multiple length-bounded calls.
+`done` flips true once the size-0 last chunk is parsed.
+""".
+-type body_reader() :: #{
+    framing := none | chunked | {content_length, non_neg_integer()},
+    buffered := binary(),
+    bytes_read := non_neg_integer(),
+    pending := binary(),
+    done := boolean(),
+    recv := fun(() -> {ok, binary()} | {error, term()}),
+    max := non_neg_integer()
+}.
 
 -export([
     method/1,

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -79,7 +79,7 @@ care which protocol delivered the bytes.
     %% `body_buffering => manual` mode. Threaded through
     %% `roadrunner_req:read_body/1,2`. Never present in `auto` mode
     %% or in manually-constructed request maps.
-    body_state => roadrunner_conn:body_state(),
+    body_reader => roadrunner_conn:body_reader(),
     %% Per-request correlation token attached by `roadrunner_conn`
     %% once the headers parse. 16 lowercase hex chars (8 bytes of
     %% CSPRNG output). Mirrored into `logger:set_process_metadata/1`
@@ -288,17 +288,17 @@ effect — the buffered bytes are returned in one shot.
     {ok, iodata(), request()}
     | {more, iodata(), request()}
     | {error, term()}.
-read_body(#{body_state := BS} = Req, Opts) ->
+read_body(#{body_reader := BS} = Req, Opts) ->
     Mode =
         case Opts of
             #{length := L} -> {length, L};
             _ -> all
         end,
-    case roadrunner_conn:consume_body_state(BS, Mode) of
+    case roadrunner_conn:consume_body_reader(BS, Mode) of
         {ok, Bytes, BS2} ->
-            {ok, Bytes, Req#{body_state := BS2, body => Bytes}};
+            {ok, Bytes, Req#{body_reader := BS2, body => Bytes}};
         {more, Bytes, BS2} ->
-            {more, Bytes, Req#{body_state := BS2}};
+            {more, Bytes, Req#{body_reader := BS2}};
         {error, _} = E ->
             E
     end;
@@ -328,12 +328,12 @@ chunks get drained for keep-alive.
     {ok, iodata(), request()}
     | {more, iodata(), request()}
     | {error, term()}.
-read_body_chunked(#{body_state := BS} = Req) ->
-    case roadrunner_conn:consume_body_state(BS, next_chunk) of
+read_body_chunked(#{body_reader := BS} = Req) ->
+    case roadrunner_conn:consume_body_reader(BS, next_chunk) of
         {ok, Bytes, BS2} ->
-            {ok, Bytes, Req#{body_state := BS2, body => Bytes}};
+            {ok, Bytes, Req#{body_reader := BS2, body => Bytes}};
         {more, Bytes, BS2} ->
-            {more, Bytes, Req#{body_state := BS2}};
+            {more, Bytes, Req#{body_reader := BS2}};
         {error, _} = E ->
             E
     end;

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -40,13 +40,14 @@ care which protocol delivered the bytes.
     target := binary(),
     version := version(),
     headers := headers(),
+    %% H1-parser internal optimization (no public contract).
     %% Pre-computed decisions for known case-insensitive headers,
     %% populated by `roadrunner_http1:parse_request/1`. Hot-path
-    %% consumers (`roadrunner_conn:body_framing/1`,
-    %% `keep_alive_decision/2`, `has_continue_expectation/1`) read
-    %% these instead of re-lowercasing header values per request.
-    %% Absent for manually-built request maps — consumers fall back
-    %% to the raw `headers` list when missing.
+    %% framework code (`roadrunner_conn:body_framing/1`,
+    %% `keep_alive_decision/2`, `has_continue_expectation/1`) reads
+    %% it directly to avoid re-lowercasing header values per request.
+    %% Handlers should ignore this field — it's absent on h2 requests
+    %% and on manually-built request maps.
     cached_decisions => roadrunner_http1:cached_decisions(),
     %% Body is set by `roadrunner_conn` before the handler is
     %% invoked. Auto mode delivers the full body as `iodata()` (an

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -48,7 +48,7 @@ care which protocol delivered the bytes.
     %% it directly to avoid re-lowercasing header values per request.
     %% Handlers should ignore this field — it's absent on h2 requests
     %% and on manually-built request maps.
-    cached_decisions => roadrunner_http1:cached_decisions(),
+    cached_decisions => term(),
     %% Body is set by `roadrunner_conn` before the handler is
     %% invoked. Auto mode delivers the full body as `iodata()` (an
     %% iolist of recv chunks for multi-chunk bodies, a single binary
@@ -79,7 +79,7 @@ care which protocol delivered the bytes.
     %% `body_buffering => manual` mode. Threaded through
     %% `roadrunner_req:read_body/1,2`. Never present in `auto` mode
     %% or in manually-constructed request maps.
-    body_reader => roadrunner_conn:body_reader(),
+    body_reader => term(),
     %% Per-request correlation token attached by `roadrunner_conn`
     %% once the headers parse. 16 lowercase hex chars (8 bytes of
     %% CSPRNG output). Mirrored into `logger:set_process_metadata/1`

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -20,7 +20,7 @@ re-exported alongside it (`headers/0`, `version/0`, `status/0`,
 -define(EQ_CP_KEY, {?MODULE, eq_cp}).
 -define(QUOTE_CP_KEY, {?MODULE, quote_cp}).
 
--export_type([request/0, headers/0, version/0, status/0, redirect_status/0]).
+-export_type([request/0]).
 
 -doc """
 The parsed request map handlers receive.
@@ -94,8 +94,6 @@ care which protocol delivered the bytes.
 
 -type headers() :: roadrunner_http:headers().
 -type version() :: roadrunner_http:version().
--type status() :: roadrunner_http:status().
--type redirect_status() :: roadrunner_http:redirect_status().
 
 -export([
     method/1,

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -40,15 +40,14 @@ care which protocol delivered the bytes.
     target := binary(),
     version := version(),
     headers := headers(),
-    %% H1-parser internal optimization (no public contract).
-    %% Pre-computed decisions for known case-insensitive headers,
-    %% populated by `roadrunner_http1:parse_request/1`. Hot-path
-    %% framework code (`roadrunner_conn:body_framing/1`,
+    %% H1-parser internal optimization — handlers should ignore.
+    %% See `t:roadrunner_http1:cached_decisions/0` for the shape.
+    %% Hot-path framework code (`roadrunner_conn:body_framing/1`,
     %% `keep_alive_decision/2`, `has_continue_expectation/1`) reads
-    %% it directly to avoid re-lowercasing header values per request.
-    %% Handlers should ignore this field — it's absent on h2 requests
-    %% and on manually-built request maps.
-    cached_decisions => term(),
+    %% it directly to avoid re-lowercasing header values per
+    %% request. Absent on h2 requests and on manually-built request
+    %% maps.
+    cached_decisions => roadrunner_http1:cached_decisions(),
     %% Body is set by `roadrunner_conn` before the handler is
     %% invoked. Auto mode delivers the full body as `iodata()` (an
     %% iolist of recv chunks for multi-chunk bodies, a single binary
@@ -79,7 +78,7 @@ care which protocol delivered the bytes.
     %% `body_buffering => manual` mode. Threaded through
     %% `roadrunner_req:read_body/1,2`. Never present in `auto` mode
     %% or in manually-constructed request maps.
-    body_reader => term(),
+    body_reader => roadrunner_conn:body_reader(),
     %% Per-request correlation token attached by `roadrunner_conn`
     %% once the headers parse. 16 lowercase hex chars (8 bytes of
     %% CSPRNG output). Mirrored into `logger:set_process_metadata/1`

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -30,23 +30,65 @@ delivers; optional fields are populated by the framework when
 applicable (e.g. `body` in `body_buffering => auto` mode,
 `bindings` for routed dispatch, `request_id` for telemetry).
 
-The `cached_decisions` and `body_state` fields are framework
-internals — typed as `term()` here because their precise shapes
-are not part of the public contract and can change between releases.
+The same shape flows through both the h1 and h2 paths — h2's
+`roadrunner_http2_request` synthesizes a request matching this
+type from frames + pseudo-headers, so handlers don't have to
+care which protocol delivered the bytes.
 """.
 -type request() :: #{
     method := binary(),
     target := binary(),
     version := version(),
     headers := headers(),
-    cached_decisions => term(),
+    %% Pre-computed decisions for known case-insensitive headers,
+    %% populated by `roadrunner_http1:parse_request/1`. Hot-path
+    %% consumers (`roadrunner_conn:body_framing/1`,
+    %% `keep_alive_decision/2`, `has_continue_expectation/1`) read
+    %% these instead of re-lowercasing header values per request.
+    %% Absent for manually-built request maps — consumers fall back
+    %% to the raw `headers` list when missing.
+    cached_decisions => roadrunner_http1:cached_decisions(),
+    %% Body is set by `roadrunner_conn` before the handler is
+    %% invoked. Auto mode delivers the full body as `iodata()` (an
+    %% iolist of recv chunks for multi-chunk bodies, a single binary
+    %% otherwise) so the conn can skip a flatten that many handlers
+    %% do not need. Handlers that require a flat binary call
+    %% `iolist_to_binary/1` themselves. The parser never populates
+    %% this field; it leaves the buffered body in the `Rest` element
+    %% of `roadrunner_http1:parse_request/1` instead.
     body => iodata(),
+    %% Bindings captured from `:param` segments by
+    %% `roadrunner_router`, set by `roadrunner_conn` before dispatch.
+    %% Empty map for single-handler dispatch or routes with no params.
     bindings => roadrunner_router:bindings(),
+    %% Client TCP peer captured once per connection from
+    %% `inet:peername/1`. `undefined` when the OS call fails (rare;
+    %% usually socket teardown).
     peer => {inet:ip_address(), inet:port_number()} | undefined,
+    %% Connection scheme — `http` for plain TCP, `https` for TLS.
+    %% Set once per connection by `roadrunner_conn` from the
+    %% transport tag.
     scheme => http | https,
+    %% Per-route handler state attached at compile time via the
+    %% 3-tuple route shape `{Path, Handler, State}` or the map
+    %% shape's `state` key (and the listener's `{Module, State}`
+    %% single-handler form). `undefined` when no state was attached.
     state => term(),
-    body_state => term(),
+    %% Body-read state attached by `roadrunner_conn` in
+    %% `body_buffering => manual` mode. Threaded through
+    %% `roadrunner_req:read_body/1,2`. Never present in `auto` mode
+    %% or in manually-constructed request maps.
+    body_state => roadrunner_conn:body_state(),
+    %% Per-request correlation token attached by `roadrunner_conn`
+    %% once the headers parse. 16 lowercase hex chars (8 bytes of
+    %% CSPRNG output). Mirrored into `logger:set_process_metadata/1`
+    %% so any `?LOG_*` call from middleware or the handler picks it
+    %% up automatically.
     request_id => binary(),
+    %% Registered name of the owning `roadrunner_listener`. Set
+    %% once per conn from `proto_opts.listener_name`. Surfaced in
+    %% `roadrunner_telemetry` event metadata so subscribers can
+    %% filter by listener in multi-listener deployments.
     listener_name => atom()
 }.
 

--- a/src/roadrunner_resp.erl
+++ b/src/roadrunner_resp.erl
@@ -1,12 +1,17 @@
 -module(roadrunner_resp).
 -moduledoc """
-Convenience builders for the `{Status, Headers, Body}` triple roadrunner
-handlers return.
+Convenience builders for the buffered `{Status, Headers, Body}`
+triple — one of the five shapes a roadrunner handler can return.
 
-Each helper sets `Content-Type` and `Content-Length` so handlers don't
-repeat the boilerplate. Body framing (`Connection: close`,
-`Transfer-Encoding`, etc.) is still the connection layer's job — these
-helpers only fill in what the handler can know.
+Each helper sets `Content-Type` and `Content-Length` so handlers
+don't repeat the boilerplate. Body framing (`Connection: close`,
+`Transfer-Encoding`, etc.) is still the connection layer's job —
+these helpers only fill in what the handler can know.
+
+These helpers only construct the buffered form
+(`t:buffered_response/0`). Streaming, loop, sendfile, and
+WebSocket-upgrade handlers build their own tuple directly; see
+`t:roadrunner_handler:response/0` for the full union.
 """.
 
 -export([
@@ -25,12 +30,12 @@ helpers only fill in what the handler can know.
     status/1
 ]).
 
--export_type([response/0]).
+-export_type([buffered_response/0]).
 
--type response() :: {roadrunner_http:status(), roadrunner_http:headers(), iodata()}.
+-type buffered_response() :: {roadrunner_http:status(), roadrunner_http:headers(), iodata()}.
 
 -doc "Plain-text response with `text/plain; charset=utf-8`.".
--spec text(StatusCode :: roadrunner_http:status(), Body :: iodata()) -> response().
+-spec text(StatusCode :: roadrunner_http:status(), Body :: iodata()) -> buffered_response().
 text(Status, Body) ->
     with_length(Status, ~"text/plain; charset=utf-8", Body).
 
@@ -51,7 +56,7 @@ roadrunner_resp:add_header(
 
 `add_header/3` prepends, so the bare value wins on header lookup.
 """.
--spec html(StatusCode :: roadrunner_http:status(), Body :: iodata()) -> response().
+-spec html(StatusCode :: roadrunner_http:status(), Body :: iodata()) -> buffered_response().
 html(Status, Body) ->
     with_length(Status, ~"text/html; charset=utf-8", Body).
 
@@ -59,7 +64,7 @@ html(Status, Body) ->
 JSON response — the term is encoded via the stdlib `json` module
 (OTP 27+) and `Content-Type` is set to `application/json`.
 """.
--spec json(StatusCode :: roadrunner_http:status(), Term :: term()) -> response().
+-spec json(StatusCode :: roadrunner_http:status(), Term :: term()) -> buffered_response().
 json(Status, Term) ->
     Body = json:encode(Term),
     with_length(Status, ~"application/json", Body).
@@ -69,7 +74,7 @@ Redirect response — sets the `Location` header and an empty body.
 Use a 3xx status (typically 301, 302, 303, 307, or 308).
 """.
 -spec redirect(StatusCode :: roadrunner_http:redirect_status(), Location :: binary()) ->
-    response().
+    buffered_response().
 redirect(Status, Location) when is_binary(Location) ->
     {Status,
         [
@@ -78,7 +83,7 @@ redirect(Status, Location) when is_binary(Location) ->
         ],
         ~""}.
 
--spec with_length(roadrunner_http:status(), binary(), iodata()) -> response().
+-spec with_length(roadrunner_http:status(), binary(), iodata()) -> buffered_response().
 with_length(Status, ContentType, Body) ->
     {Status,
         [
@@ -94,7 +99,7 @@ The header is added to the front of the list — last-write-wins for
 any subsequent lookup. `Value` may be iodata; it is flattened into a
 binary so the wire encoder doesn't have to.
 """.
--spec add_header(response(), Name :: binary(), Value :: iodata()) -> response().
+-spec add_header(buffered_response(), Name :: binary(), Value :: iodata()) -> buffered_response().
 add_header({Status, Headers, Body}, Name, Value) when is_binary(Name) ->
     {Status, [{Name, iolist_to_binary(Value)} | Headers], Body}.
 
@@ -103,43 +108,43 @@ Add a `Set-Cookie` header to a response — wraps `roadrunner_cookie:serialize/3
 so handlers don't have to.
 """.
 -spec set_cookie(
-    response(), Name :: binary(), Value :: binary(), roadrunner_cookie:serialize_opts()
+    buffered_response(), Name :: binary(), Value :: binary(), roadrunner_cookie:serialize_opts()
 ) ->
-    response().
+    buffered_response().
 set_cookie(Resp, Name, Value, Opts) ->
     add_header(Resp, ~"set-cookie", roadrunner_cookie:serialize(Name, Value, Opts)).
 
 -doc "Empty 204 No Content response.".
--spec no_content() -> response().
+-spec no_content() -> buffered_response().
 no_content() -> empty_status(204).
 
 -doc "Empty 400 Bad Request response.".
--spec bad_request() -> response().
+-spec bad_request() -> buffered_response().
 bad_request() -> empty_status(400).
 
 -doc "Empty 401 Unauthorized response.".
--spec unauthorized() -> response().
+-spec unauthorized() -> buffered_response().
 unauthorized() -> empty_status(401).
 
 -doc "Empty 403 Forbidden response.".
--spec forbidden() -> response().
+-spec forbidden() -> buffered_response().
 forbidden() -> empty_status(403).
 
 -doc "Empty 404 Not Found response.".
--spec not_found() -> response().
+-spec not_found() -> buffered_response().
 not_found() -> empty_status(404).
 
 -doc "Empty 500 Internal Server Error response.".
--spec internal_error() -> response().
+-spec internal_error() -> buffered_response().
 internal_error() -> empty_status(500).
 
 -doc """
 Empty-body response with an arbitrary status code — handy for
 statuses outside the named shortcut set (e.g., 418, 503).
 """.
--spec status(roadrunner_http:status()) -> response().
+-spec status(roadrunner_http:status()) -> buffered_response().
 status(Code) -> empty_status(Code).
 
--spec empty_status(roadrunner_http:status()) -> response().
+-spec empty_status(roadrunner_http:status()) -> buffered_response().
 empty_status(Status) ->
     {Status, [{~"content-length", ~"0"}], ~""}.

--- a/src/roadrunner_resp.erl
+++ b/src/roadrunner_resp.erl
@@ -27,10 +27,10 @@ helpers only fill in what the handler can know.
 
 -export_type([response/0]).
 
--type response() :: {roadrunner_req:status(), roadrunner_req:headers(), iodata()}.
+-type response() :: {roadrunner_http:status(), roadrunner_http:headers(), iodata()}.
 
 -doc "Plain-text response with `text/plain; charset=utf-8`.".
--spec text(StatusCode :: roadrunner_req:status(), Body :: iodata()) -> response().
+-spec text(StatusCode :: roadrunner_http:status(), Body :: iodata()) -> response().
 text(Status, Body) ->
     with_length(Status, ~"text/plain; charset=utf-8", Body).
 
@@ -51,7 +51,7 @@ roadrunner_resp:add_header(
 
 `add_header/3` prepends, so the bare value wins on header lookup.
 """.
--spec html(StatusCode :: roadrunner_req:status(), Body :: iodata()) -> response().
+-spec html(StatusCode :: roadrunner_http:status(), Body :: iodata()) -> response().
 html(Status, Body) ->
     with_length(Status, ~"text/html; charset=utf-8", Body).
 
@@ -59,7 +59,7 @@ html(Status, Body) ->
 JSON response — the term is encoded via the stdlib `json` module
 (OTP 27+) and `Content-Type` is set to `application/json`.
 """.
--spec json(StatusCode :: roadrunner_req:status(), Term :: term()) -> response().
+-spec json(StatusCode :: roadrunner_http:status(), Term :: term()) -> response().
 json(Status, Term) ->
     Body = json:encode(Term),
     with_length(Status, ~"application/json", Body).
@@ -68,7 +68,7 @@ json(Status, Term) ->
 Redirect response — sets the `Location` header and an empty body.
 Use a 3xx status (typically 301, 302, 303, 307, or 308).
 """.
--spec redirect(StatusCode :: roadrunner_req:redirect_status(), Location :: binary()) ->
+-spec redirect(StatusCode :: roadrunner_http:redirect_status(), Location :: binary()) ->
     response().
 redirect(Status, Location) when is_binary(Location) ->
     {Status,
@@ -78,7 +78,7 @@ redirect(Status, Location) when is_binary(Location) ->
         ],
         ~""}.
 
--spec with_length(roadrunner_req:status(), binary(), iodata()) -> response().
+-spec with_length(roadrunner_http:status(), binary(), iodata()) -> response().
 with_length(Status, ContentType, Body) ->
     {Status,
         [
@@ -137,9 +137,9 @@ internal_error() -> empty_status(500).
 Empty-body response with an arbitrary status code — handy for
 statuses outside the named shortcut set (e.g., 418, 503).
 """.
--spec status(roadrunner_req:status()) -> response().
+-spec status(roadrunner_http:status()) -> response().
 status(Code) -> empty_status(Code).
 
--spec empty_status(roadrunner_req:status()) -> response().
+-spec empty_status(roadrunner_http:status()) -> response().
 empty_status(Status) ->
     {Status, [{~"content-length", ~"0"}], ~""}.

--- a/src/roadrunner_stream_response.erl
+++ b/src/roadrunner_stream_response.erl
@@ -31,8 +31,8 @@ decision).
 """.
 -spec run(
     roadrunner_transport:socket(),
-    roadrunner_req:status(),
-    roadrunner_req:headers(),
+    roadrunner_http:status(),
+    roadrunner_http:headers(),
     roadrunner_handler:stream_fun()
 ) -> ok | {error, term()}.
 run(Socket, Status, UserHeaders, Fun) ->
@@ -56,7 +56,7 @@ run(Socket, Status, UserHeaders, Fun) ->
 %% emits nothing, `Send(<<>>, fin)` emits just the terminator (no
 %% leading chunk), and `Send(<<>>, {fin, Trailers})` emits just the
 %% terminator + trailers.
--spec stream_frame(iodata(), nofin | fin | {fin, roadrunner_req:headers()}) -> iodata().
+-spec stream_frame(iodata(), nofin | fin | {fin, roadrunner_http:headers()}) -> iodata().
 stream_frame(Data, nofin) ->
     case iolist_size(Data) of
         0 -> [];
@@ -74,7 +74,7 @@ chunk_or_empty(Data) ->
         N -> [integer_to_binary(N, 16), ~"\r\n", Data, ~"\r\n"]
     end.
 
--spec encode_trailers(roadrunner_req:headers()) -> iodata().
+-spec encode_trailers(roadrunner_http:headers()) -> iodata().
 encode_trailers(Trailers) ->
     %% Trailers go on the wire after the size-0 chunk; the same
     %% header-injection defense the response-line headers get applies

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -158,8 +158,8 @@ accept_key(Key) when is_binary(Key) ->
 %% The session uses this to set up zlib state. The agreed extension's
 %% response header is already in `Headers`.
 -doc false.
--spec handshake_response(roadrunner_req:headers()) ->
-    {ok, roadrunner_req:status(), roadrunner_req:headers(), iodata(), negotiated()}
+-spec handshake_response(roadrunner_http:headers()) ->
+    {ok, roadrunner_http:status(), roadrunner_http:headers(), iodata(), negotiated()}
     | {error,
         missing_websocket_upgrade
         | missing_connection_upgrade
@@ -178,7 +178,7 @@ handshake_response(Headers) when is_list(Headers) ->
             Err
     end.
 
--spec build_handshake_headers(binary(), negotiated()) -> roadrunner_req:headers().
+-spec build_handshake_headers(binary(), negotiated()) -> roadrunner_http:headers().
 build_handshake_headers(Accept, none) ->
     [
         {~"upgrade", ~"websocket"},
@@ -193,7 +193,7 @@ build_handshake_headers(Accept, {permessage_deflate, _, ResponseValue}) ->
         {~"sec-websocket-extensions", ResponseValue}
     ].
 
--spec validate_upgrade(roadrunner_req:headers()) ->
+-spec validate_upgrade(roadrunner_http:headers()) ->
     {ok, binary()}
     | {error,
         missing_websocket_upgrade
@@ -229,7 +229,7 @@ validate_upgrade(Headers) ->
 %% Single-pass extraction. Missing headers come back as `undefined`,
 %% matching `header_lookup/2`'s contract so the validators above stay
 %% untouched.
--spec collect_upgrade_headers(roadrunner_req:headers()) ->
+-spec collect_upgrade_headers(roadrunner_http:headers()) ->
     {binary() | undefined, binary() | undefined, binary() | undefined, binary() | undefined}.
 collect_upgrade_headers([]) ->
     {undefined, undefined, undefined, undefined};
@@ -270,7 +270,7 @@ has_upgrade_token(Value) ->
     binary:match(roadrunner_bin:ascii_lowercase(Value), persistent_term:get(?UPGRADE_CP_KEY)) =/=
         nomatch.
 
--spec header_lookup(binary(), roadrunner_req:headers()) -> binary() | undefined.
+-spec header_lookup(binary(), roadrunner_http:headers()) -> binary() | undefined.
 header_lookup(Name, Headers) ->
     case lists:keyfind(Name, 1, Headers) of
         {_, V} -> V;

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -146,7 +146,7 @@ socket. Returns `ok` once the session has ended (or the
 handshake check fails — in which case 400 has been sent and
 the gen_statem is never started).
 """.
--spec run(roadrunner_transport:socket(), roadrunner_http1:request(), module(), term()) -> ok.
+-spec run(roadrunner_transport:socket(), roadrunner_req:request(), module(), term()) -> ok.
 run(Socket, Req, Mod, State) ->
     case roadrunner_ws:handshake_response(roadrunner_req:headers(Req)) of
         {ok, Status, RespHeaders, _, Negotiated} ->
@@ -166,7 +166,7 @@ run(Socket, Req, Mod, State) ->
 
 -spec run_session(
     roadrunner_transport:socket(),
-    roadrunner_http1:request(),
+    roadrunner_req:request(),
     module(),
     term(),
     iodata(),
@@ -927,7 +927,7 @@ close_payload(Code, Reason) ->
 
 %% --- helpers ---
 
--spec ws_context(roadrunner_http1:request(), module()) -> map().
+-spec ws_context(roadrunner_req:request(), module()) -> map().
 ws_context(Req, Mod) ->
     #{
         listener_name => maps:get(listener_name, Req, undefined),

--- a/test/roadrunner_autobahn_handler.erl
+++ b/test/roadrunner_autobahn_handler.erl
@@ -19,7 +19,7 @@ behaviour — only loaded under the test profile.
 
 -export([handle/1, handle_frame/2]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     {{websocket, ?MODULE, no_state}, Req}.
 

--- a/test/roadrunner_bench_cookies_handler.erl
+++ b/test/roadrunner_bench_cookies_handler.erl
@@ -11,7 +11,7 @@ header with N pairs separated by `; `).
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Cookies = roadrunner_req:parse_cookies(Req),
     AckBody = integer_to_binary(length(Cookies)),

--- a/test/roadrunner_bench_cors_handler.erl
+++ b/test/roadrunner_bench_cors_handler.erl
@@ -11,7 +11,7 @@ request, so it's a real hot path for SPAs.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Resp =
         {204,

--- a/test/roadrunner_bench_drain_handler.erl
+++ b/test/roadrunner_bench_drain_handler.erl
@@ -4,7 +4,7 @@ Roadrunner handler for `scripts/bench.escript --scenarios large_post_streaming`.
 
 Manual-mode body read: loops `roadrunner_req:read_body/2` with
 `length => 64 KB` until the body is fully drained, then returns a
-2-byte ack. Exercises the manual body_state machine + `recv_phase_bytes`
+2-byte ack. Exercises the manual body_reader machine + `recv_phase_bytes`
 rate-limit interaction — paths with unit coverage but no bench coverage.
 """.
 

--- a/test/roadrunner_bench_drain_handler.erl
+++ b/test/roadrunner_bench_drain_handler.erl
@@ -14,7 +14,7 @@ rate-limit interaction — paths with unit coverage but no bench coverage.
 
 -define(CHUNK_LIMIT, 65536).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Final = drain(Req),
     Resp =

--- a/test/roadrunner_bench_echo_handler.erl
+++ b/test/roadrunner_bench_echo_handler.erl
@@ -10,7 +10,7 @@ back in the response with `Content-Type: application/octet-stream`.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(#{body := Body} = Req) ->
     Resp =
         {200,

--- a/test/roadrunner_bench_etag_handler.erl
+++ b/test/roadrunner_bench_etag_handler.erl
@@ -20,7 +20,7 @@ browsers, varnish) hit constantly.
     """
 ).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     case roadrunner_req:header(~"if-none-match", Req) of
         ?ETAG ->

--- a/test/roadrunner_bench_form_handler.erl
+++ b/test/roadrunner_bench_form_handler.erl
@@ -12,7 +12,7 @@ coverage but no bench coverage.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(#{body := Body} = Req) ->
     %% The auto-buffered body is `iodata()`; qs:parse requires a binary.
     Pairs = roadrunner_qs:parse(iolist_to_binary(Body)),

--- a/test/roadrunner_bench_gzip_handler.erl
+++ b/test/roadrunner_bench_gzip_handler.erl
@@ -19,7 +19,7 @@ The compress middleware (configured at the listener level) adds
 
 -define(BODY_KEY, {?MODULE, body}).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Body = persistent_term:get(?BODY_KEY),
     Resp =

--- a/test/roadrunner_bench_httparena_baseline_handler.erl
+++ b/test/roadrunner_bench_httparena_baseline_handler.erl
@@ -11,7 +11,7 @@ parsing, integer parsing, and small plaintext response framing.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     A = qs_int(~"a", Req, 0),
     B = qs_int(~"b", Req, 0),

--- a/test/roadrunner_bench_httparena_json_handler.erl
+++ b/test/roadrunner_bench_httparena_json_handler.erl
@@ -29,7 +29,7 @@ size to expect.
 -define(BENCH_COUNT, 50).
 -define(BENCH_MULTIPLIER, 1).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Count = binding_int(~"count", Req, 0),
     M = qs_int(~"m", Req, 1),

--- a/test/roadrunner_bench_httparena_upload_handler.erl
+++ b/test/roadrunner_bench_httparena_upload_handler.erl
@@ -27,7 +27,7 @@ peak on the 20 MB upload validator.
 
 -define(CHUNK_LIMIT, 65536).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(#{body := Body} = Req) ->
     ack(iolist_size(Body), Req);
 handle(Req) ->

--- a/test/roadrunner_bench_json_handler.erl
+++ b/test/roadrunner_bench_json_handler.erl
@@ -28,7 +28,7 @@ wire framing + dispatch, not body construction.
     """
 ).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Resp =
         {200,

--- a/test/roadrunner_bench_large_handler.erl
+++ b/test/roadrunner_bench_large_handler.erl
@@ -18,7 +18,7 @@ behavior, not body construction.
 -define(BODY_KEY, {?MODULE, body}).
 -define(BODY_SIZE, 65536).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Body = persistent_term:get(?BODY_KEY),
     Resp =

--- a/test/roadrunner_bench_redirect_handler.erl
+++ b/test/roadrunner_bench_redirect_handler.erl
@@ -10,7 +10,7 @@ flows, deprecated-URL forwarding, etc.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Resp =
         {302,

--- a/test/roadrunner_bench_small_chunks_handler.erl
+++ b/test/roadrunner_bench_small_chunks_handler.erl
@@ -19,7 +19,7 @@ the payload size.
 -define(CHUNK_SIZE, 64).
 -define(NUM_CHUNKS, 100).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Chunk = persistent_term:get(?CHUNK_KEY),
     Fun = fun(Send) ->

--- a/test/roadrunner_bench_sse_handler.erl
+++ b/test/roadrunner_bench_sse_handler.erl
@@ -16,7 +16,7 @@ callback drives event emission via the `Push` fun.
 
 -define(NUM_EVENTS, 100).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     self() ! {emit, ?NUM_EVENTS},
     Resp =

--- a/test/roadrunner_bench_streaming_handler.erl
+++ b/test/roadrunner_bench_streaming_handler.erl
@@ -23,7 +23,7 @@ fragmentation cost, not body construction.
 -define(CHUNK_SIZE, 4096).
 -define(NUM_CHUNKS, 4).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Chunk = persistent_term:get(?CHUNK_KEY),
     Fun = fun(Send) ->

--- a/test/roadrunner_bench_url_qs_handler.erl
+++ b/test/roadrunner_bench_url_qs_handler.erl
@@ -12,7 +12,7 @@ form-decode path the form handler measures).
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Pairs = roadrunner_req:parse_qs(Req),
     AckBody = integer_to_binary(length(Pairs)),

--- a/test/roadrunner_bindings_handler.erl
+++ b/test/roadrunner_bindings_handler.erl
@@ -9,7 +9,7 @@ Used to verify router bindings reach the handler via
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Bindings = roadrunner_req:bindings(Req),
     Id = maps:get(~"id", Bindings, ~"<unbound>"),

--- a/test/roadrunner_conn_loop_lazy_manual_handler.erl
+++ b/test/roadrunner_conn_loop_lazy_manual_handler.erl
@@ -13,7 +13,7 @@ conn must exit cleanly. Covers
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Resp = {200, [{~"content-length", ~"2"}], ~"ok"},
     {Resp, Req}.

--- a/test/roadrunner_conn_loop_lazy_manual_handler.erl
+++ b/test/roadrunner_conn_loop_lazy_manual_handler.erl
@@ -3,7 +3,7 @@
 Test fixture — manual-mode handler that returns 200 immediately
 WITHOUT reading the request body. The conn's `finishing_phase`
 must then `drain_body/1` the unread bytes from the
-`body_state`. When the recv during drain fails (test sink replies
+`body_reader`. When the recv during drain fails (test sink replies
 `{error, closed}`), `drain_body` returns `{error, _}` and the
 conn must exit cleanly. Covers
 `roadrunner_conn_loop:buffered_finish/4`'s drain-failure branch.

--- a/test/roadrunner_conn_loop_sendfile_handler.erl
+++ b/test/roadrunner_conn_loop_sendfile_handler.erl
@@ -11,7 +11,7 @@ single-handler dispatch helper that stashes state there) or from
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Path = persistent_term:get({?MODULE, file}),
     {ok, Info} = file:read_file_info(Path),

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -600,8 +600,8 @@ body_recv_error_writes_400_test() ->
     ?assertMatch(<<"HTTP/1.1 400", _/binary>>, Sent),
     Sink ! stop.
 
-manual_mode_dispatches_with_body_state_test() ->
-    %% Manual mode skips the auto-buffer read and hands a body_state to
+manual_mode_dispatches_with_body_reader_test() ->
+    %% Manual mode skips the auto-buffer read and hands a body_reader to
     %% the handler. The manual handler reads the body explicitly,
     %% returning 200 ok. Use `Connection: close` so the conn closes
     %% after the single request rather than looping back keep-alive
@@ -741,7 +741,7 @@ keep_alive_max_cap_closes_after_max_test() ->
 
 manual_mode_drain_failure_closes_cleanly_test() ->
     %% Manual handler returns 200 without reading the body. drain_body/1
-    %% then has to consume the body_state's unread bytes — when the
+    %% then has to consume the body_reader's unread bytes — when the
     %% recv in that drain returns `{error, closed}`, drain_body returns
     %% `{error, _}` and the conn must exit cleanly without crashing.
     ensure_pg(),
@@ -778,7 +778,7 @@ manual_mode_pipelined_leftover_uses_manual_drain_test() ->
     %% headers + body. After dispatch 1, drain_body returns
     %% `{ok, ManualLeftover}` where ManualLeftover is request 2.
     %% `pipelined_leftover/3` MUST take the manual-mode branch (the
-    %% req has `body_state` set) and feed ManualLeftover to the next
+    %% req has `body_reader` set) and feed ManualLeftover to the next
     %% iteration's read_request_phase. Covers the manual-mode clause
     %% of pipelined_leftover/3.
     ensure_pg(),

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -1208,12 +1208,12 @@ conn_handler_crash_returns_500_test_() ->
             end}
         end}.
 
-%% --- consume_body_state/2 — pure unit tests ---
+%% --- consume_body_reader/2 — pure unit tests ---
 
 consume_state_no_framing_returns_empty_test() ->
     %% No framing → zero-length body per RFC 7230 §3.3.3. The
     %% `buffered` bytes are pipelined-leftover, not body — preserved
-    %% in the body_state so `roadrunner_conn_loop`'s finishing phase can
+    %% in the body_reader so `roadrunner_conn_loop`'s finishing phase can
     %% thread them into the next reading_request parse.
     State = #{
         framing => none,
@@ -1222,7 +1222,7 @@ consume_state_no_framing_returns_empty_test() ->
         recv => fun() -> error(unused) end,
         max => 1000
     },
-    ?assertMatch({ok, <<>>, #{buffered := ~"hi"}}, roadrunner_conn:consume_body_state(State, all)).
+    ?assertMatch({ok, <<>>, #{buffered := ~"hi"}}, roadrunner_conn:consume_body_reader(State, all)).
 
 consume_state_already_drained_returns_empty_test() ->
     State = #{
@@ -1232,7 +1232,7 @@ consume_state_already_drained_returns_empty_test() ->
         recv => fun() -> error(unused) end,
         max => 1000
     },
-    ?assertMatch({ok, <<>>, _}, roadrunner_conn:consume_body_state(State, all)).
+    ?assertMatch({ok, <<>>, _}, roadrunner_conn:consume_body_reader(State, all)).
 
 consume_state_length_returns_more_then_ok_test() ->
     State0 = #{
@@ -1242,9 +1242,9 @@ consume_state_length_returns_more_then_ok_test() ->
         recv => fun() -> error(unused) end,
         max => 1000
     },
-    {more, First, State1} = roadrunner_conn:consume_body_state(State0, {length, 4}),
+    {more, First, State1} = roadrunner_conn:consume_body_reader(State0, {length, 4}),
     ?assertEqual(~"abcd", First),
-    {ok, Last, _State2} = roadrunner_conn:consume_body_state(State1, {length, 4}),
+    {ok, Last, _State2} = roadrunner_conn:consume_body_reader(State1, {length, 4}),
     ?assertEqual(~"ef", Last).
 
 consume_state_length_recv_error_propagates_test() ->
@@ -1255,7 +1255,7 @@ consume_state_length_recv_error_propagates_test() ->
         recv => fun() -> {error, closed} end,
         max => 1000
     },
-    ?assertEqual({error, closed}, roadrunner_conn:consume_body_state(State, all)).
+    ?assertEqual({error, closed}, roadrunner_conn:consume_body_reader(State, all)).
 
 %% Exercise `fill_n` / `fill_iolist`'s recursive branch where one
 %% recv returns less than `Need` and a SECOND recv has to land
@@ -1282,7 +1282,7 @@ consume_state_length_multi_recv_test() ->
         recv => Recv,
         max => 1000
     },
-    {more, Bytes, State1} = roadrunner_conn:consume_body_state(State0, {length, 8}),
+    {more, Bytes, State1} = roadrunner_conn:consume_body_reader(State0, {length, 8}),
     ?assertEqual(~"abcdefgh", iolist_to_binary(Bytes)),
     %% State1's buffered should now hold the leftover "ij".
     ?assertMatch(#{buffered := ~"ij"}, State1).
@@ -1309,7 +1309,7 @@ consume_state_length_multi_recv_error_test() ->
     },
     ?assertEqual(
         {error, closed},
-        roadrunner_conn:consume_body_state(State, {length, 8})
+        roadrunner_conn:consume_body_reader(State, {length, 8})
     ).
 
 consume_state_request_too_large_test() ->
@@ -1322,26 +1322,26 @@ consume_state_request_too_large_test() ->
     },
     ?assertEqual(
         {error, content_length_too_large},
-        roadrunner_conn:consume_body_state(State, all)
+        roadrunner_conn:consume_body_reader(State, all)
     ).
 
 consume_state_chunked_full_drain_test() ->
     State = chunked_state(~"5\r\nhello\r\n0\r\n\r\n", fun() -> error(unused) end),
-    {ok, Bytes, _} = roadrunner_conn:consume_body_state(State, all),
+    {ok, Bytes, _} = roadrunner_conn:consume_body_reader(State, all),
     ?assertEqual(~"hello", iolist_to_binary(Bytes)).
 
 consume_state_chunked_error_propagates_test() ->
     State = chunked_state(~"xyz\r\nhello\r\n", fun() -> error(unused) end),
-    ?assertEqual({error, bad_chunk_size}, roadrunner_conn:consume_body_state(State, all)).
+    ?assertEqual({error, bad_chunk_size}, roadrunner_conn:consume_body_reader(State, all)).
 
 consume_state_chunked_length_streams_within_chunk_test() ->
     %% Chunk decodes to "hello"; reading with length=2 yields he/ll/o.
     State = chunked_state(~"5\r\nhello\r\n0\r\n\r\n", fun() -> error(unused) end),
-    {more, B1, S1} = roadrunner_conn:consume_body_state(State, {length, 2}),
+    {more, B1, S1} = roadrunner_conn:consume_body_reader(State, {length, 2}),
     ?assertEqual(~"he", iolist_to_binary(B1)),
-    {more, B2, S2} = roadrunner_conn:consume_body_state(S1, {length, 2}),
+    {more, B2, S2} = roadrunner_conn:consume_body_reader(S1, {length, 2}),
     ?assertEqual(~"ll", iolist_to_binary(B2)),
-    {ok, B3, _S3} = roadrunner_conn:consume_body_state(S2, {length, 2}),
+    {ok, B3, _S3} = roadrunner_conn:consume_body_reader(S2, {length, 2}),
     ?assertEqual(~"o", iolist_to_binary(B3)).
 
 consume_state_chunked_length_crosses_chunk_boundary_test() ->
@@ -1350,11 +1350,11 @@ consume_state_chunked_length_crosses_chunk_boundary_test() ->
         ~"3\r\nhel\r\n8\r\nlo world\r\n0\r\n\r\n",
         fun() -> error(unused) end
     ),
-    {more, B1, S1} = roadrunner_conn:consume_body_state(State, {length, 4}),
+    {more, B1, S1} = roadrunner_conn:consume_body_reader(State, {length, 4}),
     ?assertEqual(~"hell", iolist_to_binary(B1)),
-    {more, B2, S2} = roadrunner_conn:consume_body_state(S1, {length, 4}),
+    {more, B2, S2} = roadrunner_conn:consume_body_reader(S1, {length, 4}),
     ?assertEqual(~"o wo", iolist_to_binary(B2)),
-    {ok, B3, _S3} = roadrunner_conn:consume_body_state(S2, {length, 4}),
+    {ok, B3, _S3} = roadrunner_conn:consume_body_reader(S2, {length, 4}),
     ?assertEqual(~"rld", iolist_to_binary(B3)).
 
 consume_state_chunked_length_recvs_more_test() ->
@@ -1364,7 +1364,7 @@ consume_state_chunked_length_recvs_more_test() ->
         Self ! recv_called,
         {ok, ~"llo\r\n0\r\n\r\n"}
     end),
-    {ok, Bytes, _S2} = roadrunner_conn:consume_body_state(State, {length, 100}),
+    {ok, Bytes, _S2} = roadrunner_conn:consume_body_reader(State, {length, 100}),
     ?assertEqual(~"hello", iolist_to_binary(Bytes)),
     receive
         recv_called -> ok
@@ -1373,24 +1373,24 @@ consume_state_chunked_length_recvs_more_test() ->
 
 consume_state_chunked_length_recv_error_test() ->
     State = chunked_state(~"5\r\nhe", fun() -> {error, closed} end),
-    ?assertEqual({error, closed}, roadrunner_conn:consume_body_state(State, {length, 4})).
+    ?assertEqual({error, closed}, roadrunner_conn:consume_body_reader(State, {length, 4})).
 
 consume_state_chunked_length_after_done_returns_empty_test() ->
     %% Drain the body fully via the all path, then try to read more.
     State0 = chunked_state(~"3\r\nhel\r\n0\r\n\r\n", fun() -> error(unused) end),
-    {ok, Drained, State1} = roadrunner_conn:consume_body_state(State0, all),
+    {ok, Drained, State1} = roadrunner_conn:consume_body_reader(State0, all),
     ?assertEqual(~"hel", iolist_to_binary(Drained)),
-    {ok, MoreBytes, _} = roadrunner_conn:consume_body_state(State1, {length, 4}),
+    {ok, MoreBytes, _} = roadrunner_conn:consume_body_reader(State1, {length, 4}),
     ?assertEqual(<<>>, iolist_to_binary(MoreBytes)).
 
 consume_state_next_chunk_returns_one_chunk_test() ->
     %% Two chunks "hel" and "lo"; next_chunk yields each one in turn.
     State0 = chunked_state(~"3\r\nhel\r\n2\r\nlo\r\n0\r\n\r\n", fun() -> error(unused) end),
-    {more, B1, S1} = roadrunner_conn:consume_body_state(State0, next_chunk),
+    {more, B1, S1} = roadrunner_conn:consume_body_reader(State0, next_chunk),
     ?assertEqual(~"hel", B1),
-    {more, B2, S2} = roadrunner_conn:consume_body_state(S1, next_chunk),
+    {more, B2, S2} = roadrunner_conn:consume_body_reader(S1, next_chunk),
     ?assertEqual(~"lo", B2),
-    {ok, B3, _S3} = roadrunner_conn:consume_body_state(S2, next_chunk),
+    {ok, B3, _S3} = roadrunner_conn:consume_body_reader(S2, next_chunk),
     ?assertEqual(<<>>, B3).
 
 consume_state_next_chunk_drains_pending_first_test() ->
@@ -1399,7 +1399,7 @@ consume_state_next_chunk_drains_pending_first_test() ->
     State = (chunked_state(~"3\r\nfoo\r\n0\r\n\r\n", fun() -> error(unused) end))#{
         pending := ~"leftover"
     },
-    {more, B, _S} = roadrunner_conn:consume_body_state(State, next_chunk),
+    {more, B, _S} = roadrunner_conn:consume_body_reader(State, next_chunk),
     ?assertEqual(~"leftover", B).
 
 consume_state_next_chunk_recvs_more_test() ->
@@ -1408,7 +1408,7 @@ consume_state_next_chunk_recvs_more_test() ->
         Self ! recv_called,
         {ok, ~"llo\r\n0\r\n\r\n"}
     end),
-    {more, B, _S} = roadrunner_conn:consume_body_state(State, next_chunk),
+    {more, B, _S} = roadrunner_conn:consume_body_reader(State, next_chunk),
     ?assertEqual(~"hello", B),
     receive
         recv_called -> ok
@@ -1417,7 +1417,7 @@ consume_state_next_chunk_recvs_more_test() ->
 
 consume_state_next_chunk_recv_error_test() ->
     State = chunked_state(~"5\r\nhe", fun() -> {error, closed} end),
-    ?assertEqual({error, closed}, roadrunner_conn:consume_body_state(State, next_chunk)).
+    ?assertEqual({error, closed}, roadrunner_conn:consume_body_reader(State, next_chunk)).
 
 consume_state_next_chunk_exceeds_max_test() ->
     State = (chunked_state(~"5\r\nhello\r\n0\r\n\r\n", fun() -> error(unused) end))#{
@@ -1425,14 +1425,14 @@ consume_state_next_chunk_exceeds_max_test() ->
     },
     ?assertEqual(
         {error, content_length_too_large},
-        roadrunner_conn:consume_body_state(State, next_chunk)
+        roadrunner_conn:consume_body_reader(State, next_chunk)
     ).
 
 consume_state_next_chunk_bad_chunk_test() ->
     State = chunked_state(~"xyz\r\nhello\r\n", fun() -> error(unused) end),
     ?assertEqual(
         {error, bad_chunk_size},
-        roadrunner_conn:consume_body_state(State, next_chunk)
+        roadrunner_conn:consume_body_reader(State, next_chunk)
     ).
 
 join_drain_group_undefined_listener_test() ->
@@ -1457,13 +1457,13 @@ consume_state_next_chunk_for_content_length_drains_fully_test() ->
         recv => fun() -> error(unused) end,
         max => 1000
     },
-    ?assertMatch({ok, ~"hello", _}, roadrunner_conn:consume_body_state(State, next_chunk)).
+    ?assertMatch({ok, ~"hello", _}, roadrunner_conn:consume_body_reader(State, next_chunk)).
 
 consume_state_next_chunk_after_done_returns_empty_test() ->
     %% Calling next_chunk on a state where the size-0 last chunk has
     %% already been seen returns `{ok, <<>>, _}` without parsing more.
     State = (chunked_state(<<>>, fun() -> error(unused) end))#{done := true},
-    ?assertMatch({ok, <<>>, _}, roadrunner_conn:consume_body_state(State, next_chunk)).
+    ?assertMatch({ok, <<>>, _}, roadrunner_conn:consume_body_reader(State, next_chunk)).
 
 consume_state_chunked_exceeds_max_test() ->
     %% Single chunk of 5 bytes, max=2 — must reject before pending swells.
@@ -1472,7 +1472,7 @@ consume_state_chunked_exceeds_max_test() ->
     },
     ?assertEqual(
         {error, content_length_too_large},
-        roadrunner_conn:consume_body_state(State, all)
+        roadrunner_conn:consume_body_reader(State, all)
     ).
 
 chunked_state(Buf, Recv) ->
@@ -1500,7 +1500,7 @@ consume_state_recvs_more_when_buffer_short_test() ->
         end,
         max => 1000
     },
-    {ok, Bytes, _} = roadrunner_conn:consume_body_state(State, all),
+    {ok, Bytes, _} = roadrunner_conn:consume_body_reader(State, all),
     ?assertEqual(~"hello", iolist_to_binary(Bytes)),
     receive
         recv_called -> ok
@@ -1583,7 +1583,7 @@ conn_manual_body_buffering_drain_error_forces_close_test_() ->
                     {127, 0, 0, 1}, Port, [binary, {active, false}], 1000
                 ),
                 %% Handler skips body, conn drains. The chunk size `xyz` is
-                %% non-hex — `consume_body_state` returns `{error, ...}`
+                %% non-hex — `consume_body_reader` returns `{error, ...}`
                 %% and `drain_body` collapses the keep_alive into a close.
                 ok = gen_tcp:send(
                     Sock,

--- a/test/roadrunner_crashing_handler.erl
+++ b/test/roadrunner_crashing_handler.erl
@@ -9,6 +9,6 @@ with 500 instead of leaving the client hanging.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> no_return().
+-spec handle(roadrunner_req:request()) -> no_return().
 handle(_Req) ->
     error(boom).

--- a/test/roadrunner_echo_body_handler.erl
+++ b/test/roadrunner_echo_body_handler.erl
@@ -9,7 +9,7 @@ body into the handler's request map.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Body = roadrunner_req:body(Req),
     Resp =

--- a/test/roadrunner_explicit_date_handler.erl
+++ b/test/roadrunner_explicit_date_handler.erl
@@ -10,7 +10,7 @@ handler-supplied values.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Headers = [
         {~"content-type", ~"text/plain; charset=utf-8"},

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -11,8 +11,8 @@ shape.
 
 -export([handle_info/3]).
 
--spec handle(roadrunner_http1:request()) ->
-    {roadrunner_handler:response(), roadrunner_http1:request()}.
+-spec handle(roadrunner_req:request()) ->
+    {roadrunner_handler:response(), roadrunner_req:request()}.
 handle(#{target := ~"/empty"} = Req) ->
     {{200, [], ~""}, Req};
 handle(#{target := ~"/stream"} = Req) ->

--- a/test/roadrunner_http2_request_tests.erl
+++ b/test/roadrunner_http2_request_tests.erl
@@ -12,7 +12,7 @@ minimal_get_test() ->
         {~":authority", ~"example.com"},
         {~":path", ~"/"}
     ],
-    {ok, Req} = roadrunner_http2_request:from_headers(Headers, <<>>, conn_info()),
+    {ok, Req} = roadrunner_http2_request:from_headers(Headers, <<>>, request_context()),
     ?assertEqual(~"GET", maps:get(method, Req)),
     ?assertEqual(~"/", maps:get(target, Req)),
     ?assertEqual({2, 0}, maps:get(version, Req)),
@@ -27,7 +27,7 @@ post_with_body_test() ->
         {~"content-type", ~"application/json"}
     ],
     Body = ~"{\"hello\":\"world\"}",
-    {ok, Req} = roadrunner_http2_request:from_headers(Headers, Body, conn_info()),
+    {ok, Req} = roadrunner_http2_request:from_headers(Headers, Body, request_context()),
     ?assertEqual(~"POST", maps:get(method, Req)),
     ?assertEqual(Body, maps:get(body, Req)),
     ?assertEqual(
@@ -44,7 +44,7 @@ regular_headers_preserved_in_order_test() ->
         {~"x-2", ~"b"},
         {~"x-3", ~"c"}
     ],
-    {ok, Req} = roadrunner_http2_request:from_headers(Headers, <<>>, conn_info()),
+    {ok, Req} = roadrunner_http2_request:from_headers(Headers, <<>>, request_context()),
     %% No `:authority` so no synthesised `host` header is prepended.
     ?assertEqual(
         [{~"x-1", ~"a"}, {~"x-2", ~"b"}, {~"x-3", ~"c"}],
@@ -58,7 +58,7 @@ missing_method_is_error_test() ->
     ],
     ?assertEqual(
         {error, missing_pseudo_header},
-        roadrunner_http2_request:from_headers(Headers, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(Headers, <<>>, request_context())
     ).
 
 missing_path_is_error_test() ->
@@ -68,7 +68,7 @@ missing_path_is_error_test() ->
     ],
     ?assertEqual(
         {error, missing_pseudo_header},
-        roadrunner_http2_request:from_headers(Headers, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(Headers, <<>>, request_context())
     ).
 
 empty_path_is_error_test() ->
@@ -79,7 +79,7 @@ empty_path_is_error_test() ->
     ],
     ?assertEqual(
         {error, empty_path},
-        roadrunner_http2_request:from_headers(Headers, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(Headers, <<>>, request_context())
     ).
 
 duplicate_pseudo_is_error_test() ->
@@ -91,7 +91,7 @@ duplicate_pseudo_is_error_test() ->
     ],
     ?assertEqual(
         {error, duplicate_pseudo_header},
-        roadrunner_http2_request:from_headers(Headers, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(Headers, <<>>, request_context())
     ).
 
 unknown_pseudo_is_error_test() ->
@@ -103,7 +103,7 @@ unknown_pseudo_is_error_test() ->
     ],
     ?assertEqual(
         {error, unknown_pseudo_header},
-        roadrunner_http2_request:from_headers(Headers, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(Headers, <<>>, request_context())
     ).
 
 pseudo_after_regular_is_error_test() ->
@@ -115,7 +115,7 @@ pseudo_after_regular_is_error_test() ->
     ],
     ?assertEqual(
         {error, pseudo_after_regular},
-        roadrunner_http2_request:from_headers(Headers, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(Headers, <<>>, request_context())
     ).
 
 pseudo_after_multiple_regulars_is_error_test() ->
@@ -133,7 +133,7 @@ pseudo_after_multiple_regulars_is_error_test() ->
     ],
     ?assertEqual(
         {error, pseudo_after_regular},
-        roadrunner_http2_request:from_headers(Headers, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(Headers, <<>>, request_context())
     ).
 
 connection_specific_header_is_error_test() ->
@@ -149,7 +149,7 @@ connection_specific_header_is_error_test() ->
                     {Banned, ~"x"}
                 ],
                 <<>>,
-                conn_info()
+                request_context()
             )
         )
      || Banned <- [
@@ -168,7 +168,9 @@ te_only_trailers_allowed_test() ->
         {~":path", ~"/"},
         {~"te", ~"trailers"}
     ],
-    ?assertMatch({ok, _}, roadrunner_http2_request:from_headers(GoodHeaders, <<>>, conn_info())),
+    ?assertMatch(
+        {ok, _}, roadrunner_http2_request:from_headers(GoodHeaders, <<>>, request_context())
+    ),
     BadHeaders = [
         {~":method", ~"GET"},
         {~":scheme", ~"https"},
@@ -177,12 +179,12 @@ te_only_trailers_allowed_test() ->
     ],
     ?assertEqual(
         {error, connection_specific_header},
-        roadrunner_http2_request:from_headers(BadHeaders, <<>>, conn_info())
+        roadrunner_http2_request:from_headers(BadHeaders, <<>>, request_context())
     ).
 
 %% --- helpers ---
 
-conn_info() ->
+request_context() ->
     #{
         peer => {{127, 0, 0, 1}, 12345},
         scheme => https,

--- a/test/roadrunner_keepalive_handler.erl
+++ b/test/roadrunner_keepalive_handler.erl
@@ -8,7 +8,7 @@ header, so the conn layer's keep-alive logic can engage.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Body = ~"alive\r\n",
     Resp =

--- a/test/roadrunner_manual_keepalive_handler.erl
+++ b/test/roadrunner_manual_keepalive_handler.erl
@@ -10,7 +10,7 @@ response (no `Connection: close`).
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     {ok, _Body, Req2} = roadrunner_req:read_body(Req),
     Resp = {200, [{~"content-length", ~"2"}], ~"ok"},

--- a/test/roadrunner_manual_keepalive_handler.erl
+++ b/test/roadrunner_manual_keepalive_handler.erl
@@ -2,7 +2,7 @@
 -moduledoc """
 Test fixture for the manual-mode keep-alive finishing path:
 explicitly reads the body via `roadrunner_req:read_body/1` so the
-`body_state` is fully drained, and emits a keep-alive-friendly
+`body_reader` is fully drained, and emits a keep-alive-friendly
 response (no `Connection: close`).
 """.
 

--- a/test/roadrunner_peer_handler.erl
+++ b/test/roadrunner_peer_handler.erl
@@ -9,7 +9,7 @@ populates the peer field for accepted connections.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Body =
         case roadrunner_req:peer(Req) of

--- a/test/roadrunner_redbot_handler.erl
+++ b/test/roadrunner_redbot_handler.erl
@@ -23,7 +23,7 @@ Routes:
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(#{target := ~"/"} = Req) ->
     plain(Req, ~"hello\n", []);
 handle(#{target := ~"/json"} = Req) ->

--- a/test/roadrunner_req_tests.erl
+++ b/test/roadrunner_req_tests.erl
@@ -3,7 +3,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% =============================================================================
-%% Pure accessors over a roadrunner_http1:request() map.
+%% Pure accessors over a roadrunner_req:request() map.
 %% =============================================================================
 
 method_test() ->

--- a/test/roadrunner_req_tests.erl
+++ b/test/roadrunner_req_tests.erl
@@ -142,7 +142,7 @@ read_body_manual_state_full_drain_test() ->
         recv => fun() -> error(unused) end,
         max => 1000
     },
-    Req = (sample_req())#{body_state => BS},
+    Req = (sample_req())#{body_reader => BS},
     {ok, Bytes, Req2} = roadrunner_req:read_body(Req),
     ?assertEqual(~"hello", Bytes),
     ?assertEqual(~"hello", roadrunner_req:body(Req2)).
@@ -155,7 +155,7 @@ read_body_manual_state_partial_returns_more_test() ->
         recv => fun() -> error(unused) end,
         max => 1000
     },
-    Req = (sample_req())#{body_state => BS},
+    Req = (sample_req())#{body_reader => BS},
     {more, First, Req2} = roadrunner_req:read_body(Req, #{length => 4}),
     ?assertEqual(~"abcd", First),
     {ok, Last, _Req3} = roadrunner_req:read_body(Req2, #{length => 4}),
@@ -169,7 +169,7 @@ read_body_manual_state_error_propagates_test() ->
         recv => fun() -> {error, closed} end,
         max => 1000
     },
-    Req = (sample_req())#{body_state => BS},
+    Req = (sample_req())#{body_reader => BS},
     ?assertEqual({error, closed}, roadrunner_req:read_body(Req)).
 
 %% --- read_body_chunked/1 ---
@@ -188,7 +188,7 @@ read_body_chunked_manual_state_yields_one_chunk_test() ->
         recv => fun() -> error(unused) end,
         max => 1000
     },
-    Req = (sample_req())#{body_state => BS},
+    Req = (sample_req())#{body_reader => BS},
     {more, Bytes, _Req2} = roadrunner_req:read_body_chunked(Req),
     ?assertEqual(~"foo", Bytes).
 
@@ -342,7 +342,7 @@ read_form_urlencoded_body_read_error_propagates_test() ->
     },
     Req = (sample_req())#{
         headers => [{~"content-type", ~"application/x-www-form-urlencoded"}],
-        body_state => BS
+        body_reader => BS
     },
     ?assertEqual({error, closed}, roadrunner_req:read_form(Req)).
 
@@ -358,7 +358,7 @@ read_form_multipart_body_read_error_propagates_test() ->
     },
     Req = (sample_req())#{
         headers => [{~"content-type", ~"multipart/form-data; boundary=B"}],
-        body_state => BS
+        body_reader => BS
     },
     ?assertEqual({error, closed}, roadrunner_req:read_form(Req)).
 
@@ -379,7 +379,7 @@ read_body_chunked_manual_state_error_propagates_test() ->
         recv => fun() -> {error, closed} end,
         max => 1000
     },
-    Req = (sample_req())#{body_state => BS},
+    Req = (sample_req())#{body_reader => BS},
     ?assertEqual({error, closed}, roadrunner_req:read_body_chunked(Req)).
 
 %% Pending bytes don't satisfy the requested length, recursion needs
@@ -398,7 +398,7 @@ read_body_chunked_manual_pending_then_recv_error_test() ->
         recv => fun() -> {error, closed} end,
         max => 1000
     },
-    Req = (sample_req())#{body_state => BS},
+    Req = (sample_req())#{body_reader => BS},
     ?assertEqual(
         {error, closed},
         roadrunner_req:read_body(Req, #{length => 5})

--- a/test/roadrunner_stream_handler.erl
+++ b/test/roadrunner_stream_handler.erl
@@ -9,7 +9,7 @@ size-0 terminator. Used to verify `roadrunner_conn` honors the
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Resp =
         {stream, 200, [{~"content-type", ~"text/plain; charset=utf-8"}], fun(Send) ->

--- a/test/roadrunner_test_handler.erl
+++ b/test/roadrunner_test_handler.erl
@@ -9,7 +9,7 @@ actually reaches the user-supplied handler module.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     Body = ~"custom handler response",
     Resp =

--- a/test/roadrunner_ws_upgrade_handler.erl
+++ b/test/roadrunner_ws_upgrade_handler.erl
@@ -8,6 +8,6 @@ to a WebSocket session driven by `roadrunner_ws_echo_handler`.
 
 -export([handle/1]).
 
--spec handle(roadrunner_http1:request()) -> roadrunner_handler:result().
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
 handle(Req) ->
     {{websocket, roadrunner_ws_echo_handler, no_state}, Req}.


### PR DESCRIPTION
# Description

- `version/0`, `headers/0`, `status/0`, `redirect_status/0` exported only from `roadrunner_http`; `roadrunner_http1` and `roadrunner_req` no longer re-export them
- `body_reader/0` (renamed from `body_state/0`, including the req field + helper-function suffixes) and `cached_decisions/0` now live in `roadrunner_req` alongside `request/0`, the public type that carries them; `roadrunner_conn` and `roadrunner_http1` reference them across modules
- `roadrunner_resp:response/0` renamed to `buffered_response/0` so it no longer collides with `roadrunner_handler:response/0` (the full 5-way handler-return union)
- `roadrunner_http2_hpack:header/0` and `roadrunner_http2_hpack_huffman:decode_error/0` dropped from exports — both were either redundant with existing types or HPACK-internal
- `roadrunner_http2_request:conn_info/0` renamed to `request_context/0` to clarify it's a builder input, not connection state

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
