### PR TITLE
Polish README and hex package metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,32 @@ Diagnostic / conformance scripts under `scripts/` (`bench.escript`,
 `h2spec.sh`, `autobahn.escript`, `redbot.escript`, `wrk2_bench.sh`)
 are run directly; each script's header documents its requirements.
 
+### Test surface
+
+**PropEr properties** via `ct_property_test` cover the surfaces where
+input-shape coverage matters: `roadrunner_uri` (percent round-trip +
+encode shape), `roadrunner_qs` (round-trip), `roadrunner_cookie`
+(adversarial robustness), `roadrunner_http1` (parsers never-crash +
+incremental-feed equivalence), `roadrunner_conn_loop` (random recv /
+drain / stray inputs, clean exit + slot release), and `request_id`
+consistency between `request_start` / `request_stop` telemetry.
+
+**Malformed-input corpus:** `roadrunner_http1_corpus_tests` exercises
+HTTP/1.1 patterns lifted from the
+[llhttp](https://github.com/nodejs/llhttp) test corpus and the
+canonical request-smuggling vectors documented by
+[PortSwigger](https://portswigger.net/web-security/request-smuggling).
+
+**Conformance harnesses** (run on-demand, not part of `make precommit`):
+
+- `scripts/h2spec.sh` — HTTP/2 (RFC 9113 + RFC 7541). Strict 100 % pass.
+- `scripts/autobahn.escript` — WebSocket (RFC 6455 + RFC 7692). Strict
+  100 % across the full
+  [Autobahn|Testsuite](https://github.com/crossbario/autobahn-testsuite)
+  fuzzingclient matrix, no exclusions.
+- `scripts/redbot.escript` — HTTP/1.1 response hygiene via
+  [REDbot](https://redbot.org).
+
 ### Benchmarking notes
 
 Two complementary load drivers ship in this repo:

--- a/README.md
+++ b/README.md
@@ -198,6 +198,24 @@ roadrunner:start_listener(my_listener, #{
 }).
 ```
 
+## Configuration
+
+All listener options live in the
+[`roadrunner_listener:opts/0`](https://hexdocs.pm/roadrunner/roadrunner_listener.html#t:opts/0)
+type, with per-key defaults and tuning rationale. Beyond `port`,
+`protocols`, `tls`, and `routes` from the Quickstart, the type covers:
+
+- **DoS bounds** — `max_clients`, `max_content_length`,
+  `request_timeout`, `keep_alive_timeout`,
+  `min_bytes_per_second`, `max_keep_alive_requests`
+- **Middleware** — `middlewares`
+- **Body buffering** — `body_buffering`
+- **Graceful drain** — `graceful_drain`, `slot_reconciliation`
+- **Per-conn hibernation** — `hibernate_after`
+- **HTTP/2 tunables** (under the `{http2, Opts}` entry in
+  `protocols`) — `conn_window`, `stream_window`,
+  `window_refill_threshold`
+
 ## Features
 
 ### Handlers

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ and **strict 100 %
 (WebSocket, no exclusions). The user-facing API is a handler
 behaviour, request/response accessors, listener controls, and a
 handful of opt-in helpers (cookies, qs, multipart, SSE, WebSocket).
-Modern OTP idioms throughout, predictable per-connection lifecycle
-observability.
+Modern OTP idioms throughout, with predictable per-connection
+lifecycle observability.
 
 ## ⚠️ Requirements
 
-Requires **OTP 29**.
+Requires **OTP 29 or newer**.
 
 ## 🚧 Status
 
@@ -90,7 +90,19 @@ streaming-POST endpoint). On simple GETs and small POSTs
 Roadrunner and elli are within the bench's ~15 % variance band on
 those rows; the comparison doc has the full honest framing.
 
-### Feature matrix
+### Tail latency at sustained load
+
+Open-loop, Coordinated-Omission-corrected (wrk2, `hello`, 8 threads,
+50 connections, 3-run median): Roadrunner sustains **270 k req/s**
+at p50 1.06 ms, p99 2.26 ms, p99.99 3.34 ms. Full per-scenario
+matrix with all four rate-points per server in
+[`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md).
+
+The throughput numbers above are from `scripts/bench.escript`
+(closed-loop); the comparison doc has the full methodology
+breakdown.
+
+## Comparison
 
 If your workload needs a feature, the server has to ship it. `—`
 means achievable in user code but no helper / option built in; `✗`
@@ -98,6 +110,7 @@ means out of scope for that server.
 
 | feature                                   | roadrunner | cowboy | elli |
 |-------------------------------------------|:----------:|:------:|:----:|
+| HTTP/1.1                                  |     ✓      |   ✓    |  ✓   |
 | HTTP/2 + HPACK                            |     ✓      |   ✓    |  ✗   |
 | WebSocket (RFC 6455)                      |     ✓      |   ✓    |  —   |
 | permessage-deflate (RFC 7692)             |     ✓      |   ✓    |  ✗   |
@@ -110,18 +123,6 @@ means out of scope for that server.
 | Static handler (ETag / Range / IMS)       |     ✓      |   ✓    |  —   |
 | Graceful drain with deadline + broadcast  |     ✓      |   —    |  ✗   |
 | Per-request `request_id` in logger meta   |     ✓      |   —    |  ✗   |
-
-### Tail latency at sustained load
-
-Open-loop, Coordinated-Omission-corrected (wrk2, `hello`, 8 threads,
-50 connections, 3-run median): Roadrunner sustains **270 k req/s**
-at p50 1.06 ms, p99 2.26 ms, p99.99 3.34 ms. Full per-scenario
-matrix with all four rate-points per server in
-[`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md).
-
-The throughput numbers above are from `scripts/bench.escript`
-(closed-loop); the comparison doc has the full methodology
-breakdown.
 
 ## Quickstart
 
@@ -228,27 +229,28 @@ roadrunner:start_listener(my_listener, #{port => 8080, routes => hello_handler})
 
 ### Hardening
 
-- Strict RFC 9110 / RFC 9112 parsing — request smuggling defenses
-  (CL+TE conflict, multiple-CL), header CRLF/NUL injection rejection,
-  chunk-size leading-whitespace rejection, RFC 6265 cookie OWS handling,
-  RFC 6455 §5.5 control-frame limits, SSE event-line CRLF rejection,
-  trailer header CRLF injection rejection, sendfile path traversal +
-  symlink escape defenses.
-- TLS hardened defaults — TLS 1.2/1.3 only, `honor_cipher_order`,
-  `client_renegotiation` off, AEAD-only ECDHE-or-1.3 ciphers filtered
-  through `ssl:filter_cipher_suites/2`, OTP default `supported_groups`
-  (PQ-hybrid `x25519mlkem768` first when the OpenSSL build supports it),
-  `early_data` disabled.
+- Strict RFC 9110 / 9112 parsing, with defenses grouped by subsystem:
+    - **Request smuggling / framing:** CL+TE conflict, multiple-CL,
+      chunk-size leading-whitespace rejection.
+    - **Header / control-frame injection:** header CRLF / NUL rejection,
+      SSE event-line CRLF rejection, trailer-header CRLF rejection,
+      RFC 6455 §5.5 control-frame limits, RFC 6265 cookie OWS handling.
+    - **Sendfile path safety:** path traversal + symlink escape defenses.
+- TLS hardened defaults — TLS 1.2 / 1.3 only, AEAD-only cipher filter,
+  client renegotiation off, post-quantum hybrid `x25519mlkem768` first
+  when the OpenSSL build supports it. Full settings list in the
+  `roadrunner_listener` module docs.
 - DoS bounds — `max_clients`, `max_content_length`,
   `min_bytes_per_second`, `request_timeout`, `keep_alive_timeout`,
   `max_keep_alive_requests`.
 
 ### Observability
 
-- `telemetry` events: request `start | stop | exception | rejected`,
-  `response, send_failed`, listener `accept | conn_close |
-  slots_reconciled`, ws `upgrade | frame_in | frame_out`, `drain,
-  acknowledged` (opt-in via `roadrunner:acknowledge_drain/1`).
+- `telemetry` events covering request, response, listener
+  accept / close, slot reconciliation, ws upgrade and frames, and
+  drain ack (opt-in via `roadrunner:acknowledge_drain/1`). Full event
+  list with measurements / metadata in the `roadrunner_telemetry`
+  module docs.
 - Per-request `request_id` attached to `logger:set_process_metadata/1`
   so any `?LOG_*` from middleware/handlers is auto-correlated.
 - `roadrunner_listener:info/1` for pull-side `active_clients` /
@@ -276,6 +278,11 @@ roadrunner:start_listener(my_listener, #{port => 8080, routes => hello_handler})
   trade-offs, reproduction commands).
 - [`docs/bench_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/bench_results.md) — full per-protocol
   matrix with p50 / p99 across every scenario.
+- [`docs/bench_internals.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/bench_internals.md) — loadgen worker
+  model, latency aggregation, when the loader becomes the bottleneck.
+- [`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md) — open-loop,
+  Coordinated-Omission-corrected tail-latency tables (full per-scenario,
+  all rate-points per server).
 - [`docs/resource_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/resource_results.md) — memory + CPU
   shape per scenario.
 - [`docs/conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md)

--- a/README.md
+++ b/README.md
@@ -7,31 +7,41 @@
 
 ![roadrunner logo](https://raw.githubusercontent.com/arizona-framework/roadrunner/main/assets/logo.jpg)
 
-Pure-Erlang HTTP/1.1 + HTTP/2 + WebSocket server for OTP 29+. **Beep beep.**
+Pure-Erlang HTTP/1.1 + HTTP/2 + WebSocket server for OTP 29+.
+**Built for low tail latency at sustained load.** Beep beep.
 
-Built ground-up via TDD as the HTTP backbone for the
-[arizona-framework](https://github.com/arizona-framework/arizona). The
-user-facing API is a handler behaviour, request/response accessors,
-listener controls, and a handful of opt-in helpers (cookies, qs,
-multipart, SSE, WebSocket). RFC-correct parsing, modern OTP idioms
-throughout, and predictable per-connection lifecycle observability.
+Roadrunner is the HTTP backbone of the
+[arizona-framework](https://github.com/arizona-framework/arizona).
+Strict RFC 9110 / 9112 / 9113 parsing, with **strict 100 %
+[h2spec](https://github.com/summerwind/h2spec)** (HTTP/2 conformance)
+and **strict 100 %
+[Autobahn fuzzingclient](https://github.com/crossbario/autobahn-testsuite)**
+(WebSocket, no exclusions). The user-facing API is a handler
+behaviour, request/response accessors, listener controls, and a
+handful of opt-in helpers (cookies, qs, multipart, SSE, WebSocket).
+Modern OTP idioms throughout, predictable per-connection lifecycle
+observability.
 
 ## ⚠️ Requirements
 
-Roadrunner requires **OTP 29**. Older OTPs won't compile, and the
-throughput numbers in the [performance section](#performance-at-a-glance)
-assume 29.
+Requires **OTP 29**.
 
 ## 🚧 Status
 
 Roadrunner is in `0.x`. The core is functional and covered by tests,
-but the API may change between minor versions. Pin an exact commit
-ref in your deps (e.g. `{ref, "<sha>"}`) if you need stability
+but the API may change between minor versions. Pin an exact version
+in your deps (e.g. `{roadrunner, "0.1.0"}`) if you need stability
 across upgrades.
+
+## ✅ Conformance
 
 Eunit + Common Test (incl. PropEr) suites with **100 % line coverage**,
 dialyzer-clean, h2spec strict 100 %, Autobahn fuzzingclient strict
-100 % across the full WebSocket matrix (no exclusions).
+100 % across the full WebSocket matrix (no exclusions). HTTP/1.1
+parsers stress-tested against the
+[llhttp](https://github.com/nodejs/llhttp) test corpus and the
+canonical [PortSwigger](https://portswigger.net/web-security/request-smuggling)
+request-smuggling vectors.
 
 Standards conformance:
 
@@ -80,11 +90,38 @@ streaming-POST endpoint). On simple GETs and small POSTs
 Roadrunner and elli are within the bench's ~15 % variance band on
 those rows; the comparison doc has the full honest framing.
 
-The numbers above are throughput from `scripts/bench.escript`
-(closed-loop). For Coordinated-Omission-corrected tail latency at
-sustained rates (open-loop, via wrk2), see
-[`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md);
-the comparison doc has the methodology breakdown.
+### Feature matrix
+
+If your workload needs a feature, the server has to ship it. `—`
+means achievable in user code but no helper / option built in; `✗`
+means out of scope for that server.
+
+| feature                                   | roadrunner | cowboy | elli |
+|-------------------------------------------|:----------:|:------:|:----:|
+| HTTP/2 + HPACK                            |     ✓      |   ✓    |  ✗   |
+| WebSocket (RFC 6455)                      |     ✓      |   ✓    |  —   |
+| permessage-deflate (RFC 7692)             |     ✓      |   ✓    |  ✗   |
+| Native router                             |     ✓      |   ✓    |  ✗   |
+| gzip / deflate response negotiation       |     ✓      |   ✓    |  —   |
+| Streaming request bodies                  |     ✓      |   ✓    |  —   |
+| Native qs / cookie / multipart            |     ✓      |   ✓    |  —   |
+| Server-Sent Events helper                 |     ✓      |   —    |  —   |
+| Sendfile                                  |     ✓      |   ✓    |  ✓   |
+| Static handler (ETag / Range / IMS)       |     ✓      |   ✓    |  —   |
+| Graceful drain with deadline + broadcast  |     ✓      |   —    |  ✗   |
+| Per-request `request_id` in logger meta   |     ✓      |   —    |  ✗   |
+
+### Tail latency at sustained load
+
+Open-loop, Coordinated-Omission-corrected (wrk2, `hello`, 8 threads,
+50 connections, 3-run median): Roadrunner sustains **270 k req/s**
+at p50 1.06 ms, p99 2.26 ms, p99.99 3.34 ms. Full per-scenario
+matrix with all four rate-points per server in
+[`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md).
+
+The throughput numbers above are from `scripts/bench.escript`
+(closed-loop); the comparison doc has the full methodology
+breakdown.
 
 ## Quickstart
 
@@ -92,7 +129,7 @@ Add to `rebar.config`:
 
 ```erlang
 {deps, [
-    {roadrunner, {git, "https://github.com/arizona-framework/roadrunner.git", {branch, "main"}}}
+    {roadrunner, "0.1.0"}
 ]}.
 ```
 
@@ -232,23 +269,6 @@ roadrunner:start_listener(my_listener, #{port => 8080, routes => hello_handler})
   enable in production where you can't trust every exit path to run
   `terminate/3` (`kill` signals, OOM kills, supervisor brutal-kill).
 
-### Test surface
-
-- **PropEr properties** via `ct_property_test`: `roadrunner_uri`
-  percent round-trip + encode shape, `roadrunner_qs` round-trip,
-  `roadrunner_cookie` adversarial robustness, `roadrunner_http1`
-  parsers never-crash + incremental-feed equivalence, plus
-  `roadrunner_conn_loop` robustness over random recv/drain/stray
-  inputs (clean exit + slot release) and `request_id` consistency
-  between `request_start` / `request_stop` telemetry.
-- **Malformed-input corpus**: `roadrunner_http1_corpus_tests`
-  exercises HTTP/1.1 patterns lifted from the
-  [llhttp](https://github.com/nodejs/llhttp) test corpus and the
-  canonical request-smuggling vectors documented by Portswigger.
-- **Conformance harnesses**: `scripts/h2spec.sh` (HTTP/2),
-  `scripts/autobahn.escript` (WebSocket),
-  `scripts/redbot.escript` (HTTP/1.1 response hygiene).
-
 ## Documentation
 
 - [`docs/comparison.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/comparison.md) — full side-by-side
@@ -274,9 +294,8 @@ roadrunner:start_listener(my_listener, #{port => 8080, routes => hello_handler})
   on the way out), binary keys for wire-derived data, `-doc` /
   `-moduledoc` markdown, dialyzer-clean specs. No `binary_to_atom` on
   parsed names.
-- **Continuation-style middleware** over Plug.Conn-style transformation
-  — strictly more expressive than cowboy's deprecated `(Req, Env)`
-  shape and dramatically simpler than cowboy's stream handlers.
+- **Continuation-style middleware.** `(Req, Next) -> {Response, Req2}`,
+  composable at listener and per-route level. Outermost first.
 - **Telemetry over custom callbacks.** `telemetry` is the de facto
   standard (Phoenix, Ecto, gleam_otp); zero-overhead when no subscribers,
   integrates with prometheus / opentelemetry / datadog out of the box.

--- a/README.md
+++ b/README.md
@@ -187,11 +187,15 @@ the list to disable HTTP/2. For HTTP/2 on plain TCP (h2c
 prior-knowledge per RFC 7540 §3.4), use `protocols => [http2]` without
 the `tls` opt.
 
-For listeners that don't need routing, `routes => Mod` skips the router
-entirely and dispatches every request to `Mod:handle/1`:
+For listeners that don't need routing, `routes => Mod` (or
+`{Mod, State}` to seed handler state) skips the router entirely and
+dispatches every request to `Mod:handle/1`:
 
 ```erlang
-roadrunner:start_listener(my_listener, #{port => 8080, routes => hello_handler}).
+roadrunner:start_listener(my_listener, #{
+    port => 8080,
+    routes => {hello_handler, #{greeting => ~"hello"}}
+}).
 ```
 
 ## Features

--- a/rebar.config
+++ b/rebar.config
@@ -13,12 +13,9 @@
     {telemetry, "1.4.2"}
 ]}.
 
-%% rebar3_hex and rebar3_ex_doc come from hex (not git like the rest)
-%% because the rebar3_ex_doc git checkout doesn't include the prebuilt
-%% `ex_doc_otp_*` escripts that live in the hex tarball's priv/.
 {project_plugins, [
-    {erlfmt, {git, "https://github.com/WhatsApp/erlfmt.git", {tag, "v1.6.2"}}},
-    {rebar3_hank, {git, "https://github.com/AdRoll/rebar3_hank.git", {tag, "1.6.1"}}},
+    {erlfmt, "1.6.2"},
+    {rebar3_hank, "1.6.1"},
     {rebar3_hex, "7.1.0"},
     {rebar3_ex_doc, "0.2.31"}
 ]}.
@@ -37,14 +34,14 @@
         {erl_opts, [nowarn_export_all, nowarn_missing_spec, {d, 'PROPER'}]},
         {extra_src_dirs, [{"test", [{recursive, true}]}]},
         {deps, [
-            {proper, {git, "https://github.com/proper-testing/proper.git", {tag, "v1.5.0"}}},
+            {proper, "1.5.0"},
             %% Used only by `scripts/bench.escript` (and the
             %% `scripts/bench_matrix.sh` wrapper) so we can spin up
             %% cowboy + elli listeners in peer BEAMs and measure
             %% roadrunner against both. Test-profile-only to keep the
             %% production dep list at one entry (telemetry).
-            {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.14.2"}}},
-            {elli, {git, "https://github.com/elli-lib/elli.git", {tag, "3.3.0"}}}
+            {cowboy, "2.14.2"},
+            {elli, "3.3.0"}
         ]}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -69,20 +69,22 @@
     deprecated_functions
 ]}.
 
-%% Common Test suites and eunit setup/cleanup pairs pass contract-
-%% shaped arguments (`Config` for CT, the setup-result for
-%% `{setup, S, Cleanup, Tests}`) that the body often doesn't read.
-%% Suppress hank's `unnecessary_function_arguments` for everything
-%% under `test/` so it only flags genuine code-cleanup opportunities
-%% in `src/`.
 {hank, [
     {ignore, [
-        {"test/**", unnecessary_function_arguments},
         %% Behaviour-defining modules — `-callback` decls are abstract
         %% by design; implementors live in user code, so the rule's
         %% "no caller within the module" check is a false positive.
         {"src/roadrunner_handler.erl", unused_callbacks},
-        {"src/roadrunner_ws_handler.erl", unused_callbacks}
+        {"src/roadrunner_ws_handler.erl", unused_callbacks},
+        %% Common Test callbacks (`init_per_*`, `end_per_*`, per-testcase
+        %% `TestCase(Config)`) and eunit `{setup, S, Cleanup, Tests}`
+        %% cleanup arities are fixed by the framework — the `_Arg` style
+        %% is the convention but hank's `unnecessary_function_arguments`
+        %% rule still flags them.
+        {"test/roadrunner_http2_flow_control_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_tls_tests.erl", unnecessary_function_arguments},
+        {"test/roadrunner_conn_tests.erl", unnecessary_function_arguments}
     ]}
 ]}.
 

--- a/src/roadrunner.app.src
+++ b/src/roadrunner.app.src
@@ -1,5 +1,5 @@
 {application, roadrunner, [
-    {description, "Pure-Erlang HTTP and WebSocket server. Beep beep."},
+    {description, "Pure-Erlang HTTP/1.1, HTTP/2, and WebSocket server. Beep beep."},
     {vsn, "0.1.0"},
     {registered, []},
     {mod, {roadrunner_app, []}},

--- a/src/roadrunner.app.src
+++ b/src/roadrunner.app.src
@@ -1,6 +1,6 @@
 {application, roadrunner, [
     {description, "Pure-Erlang HTTP/1.1, HTTP/2, and WebSocket server. Beep beep."},
-    {vsn, "0.1.0"},
+    {vsn, semver},
     {registered, []},
     {mod, {roadrunner_app, []}},
     {applications, [

--- a/src/roadrunner.app.src
+++ b/src/roadrunner.app.src
@@ -14,6 +14,9 @@
     {modules, []},
     {licenses, ["Apache-2.0"]},
     {links, [
-        {"GitHub", "https://github.com/arizona-framework/roadrunner"}
+        {"GitHub", "https://github.com/arizona-framework/roadrunner"},
+        {"Docs", "https://hexdocs.pm/roadrunner"},
+        {"Issues", "https://github.com/arizona-framework/roadrunner/issues"},
+        {"Changelog", "https://github.com/arizona-framework/roadrunner/blob/main/CHANGELOG.md"}
     ]}
 ]}.

--- a/src/roadrunner.erl
+++ b/src/roadrunner.erl
@@ -6,6 +6,10 @@ Listeners are supervised by `roadrunner_sup`: starting a listener adds a
 `roadrunner_listener` child, stopping one terminates and forgets it. The
 roadrunner application must be running (typically via
 `application:ensure_all_started(roadrunner)`).
+
+Configure listeners via the `t:roadrunner_listener:opts/0` map; see
+that type for the full set of available keys, defaults, and tuning
+rationale.
 """.
 
 -export([start_listener/2, stop_listener/1, listeners/0]).
@@ -18,6 +22,9 @@ Start a listener as a supervised child of the roadrunner application.
 `stop_listener/1` later. Returns `{ok, Pid}` on success or `{error, _}`
 if a child with the same name already exists or the listen socket
 cannot be opened.
+
+`Opts` is a `t:roadrunner_listener:opts/0` map — see that type for
+the full set of keys, per-key defaults, and tuning rationale.
 """.
 -spec start_listener(Name :: atom(), roadrunner_listener:opts()) ->
     {ok, pid()} | {error, term()}.


### PR DESCRIPTION
# Description

Restructures the README around the trust signals first-time readers care about — perf headline tagline, strict-100 % h2spec + Autobahn conformance in the intro, a new Comparison section vs cowboy and elli, a Configuration breadcrumb pointing at `t:roadrunner_listener:opts/0`, and a tail-latency callout from wrk2. The hex package metadata gains the missing Docs / Issues / Changelog sidebar links and a description that mentions HTTP/2; `vsn` derives from the git tag via the semver driver to match Arizona's pattern; project plugins and bench deps move from git tags to hex versions now that the OTP 29-rc3 workaround is moot; hank config tightens to per-file ignores; and the Quickstart install switches to `{roadrunner, "0.1.0"}`.

User-visible before / after:

- Quickstart install: `{roadrunner, "0.1.0"}` (was `{roadrunner, {git, ..., {branch, "main"}}}`)
- app.src description: `"Pure-Erlang HTTP/1.1, HTTP/2, and WebSocket server. Beep beep."` (was `"Pure-Erlang HTTP and WebSocket server."`)
- README structure: new `## Comparison`, `## Configuration`, `### Tail latency at sustained load`; trimmed Hardening / Observability bullets; Test surface moved to CONTRIBUTING

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
