### PR TITLE
Wire graceful drain through WebSocket sessions

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -35,7 +35,8 @@
     try_acquire_slot/1,
     release_slot/1,
     consume_body_reader/2,
-    join_drain_group/2
+    join_drain_group/2,
+    join_drain_group_for/2
 ]).
 %% Internal helpers shared with `roadrunner_conn_loop`. Marked `-doc false`
 %% individually so they stay invisible to the public API surface but
@@ -159,6 +160,31 @@ join_drain_group(Name, true) ->
     case whereis(pg) of
         undefined -> ok;
         _ -> pg:join({roadrunner_drain, Name}, self())
+    end.
+
+-doc """
+Join `Pid` into the per-listener `pg` drain group on behalf of another
+process. Used by `roadrunner_ws_session:run/4` so each WS session
+pid (spawned via `gen_statem:start` and thus NOT inheriting the
+conn's `pg` membership) still receives `{roadrunner_drain, Deadline}`
+broadcasts.
+
+WS sessions always join, regardless of the conn's `graceful_drain`
+setting: that flag is documented as a perf opt-out for short-lived
+HTTP/1 conns, and WS sessions are never short-lived. Skipping the
+join here would silently strand long-lived sessions during deploys.
+
+Silently no-ops when `Name` is `undefined` (manually constructed
+requests in tests) or when the `pg` scope is absent (listener
+started without the supervision tree).
+""".
+-spec join_drain_group_for(pid(), atom()) -> ok.
+join_drain_group_for(_Pid, undefined) ->
+    ok;
+join_drain_group_for(Pid, Name) when is_pid(Pid), is_atom(Name) ->
+    case whereis(pg) of
+        undefined -> ok;
+        _ -> pg:join({roadrunner_drain, Name}, Pid)
     end.
 
 -doc """

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -24,7 +24,16 @@ All duration and interval values in `opts()` are in milliseconds —
 
 -behaviour(gen_server).
 
--export([start_link/2, stop/1, drain/2, port/1, info/1, status/1, reload_routes/2]).
+-export([
+    start_link/2,
+    stop/1,
+    drain/2,
+    notify_drain/2,
+    port/1,
+    info/1,
+    status/1,
+    reload_routes/2
+]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -export_type([opts/0]).
@@ -282,6 +291,25 @@ again to bring it back up.
     {ok, drained} | {timeout, non_neg_integer()}.
 drain(Name, Timeout) ->
     gen_server:call(Name, {drain, Timeout}, Timeout + 5000).
+
+-doc """
+Broadcast a `{roadrunner_drain, Deadline}` notification to every conn /
+WS session in the listener's `pg` drain group **without** stopping the
+listener or waiting on the counter.
+
+Use for soft-drain workflows — telling long-lived sessions to wind down
+ahead of a deploy, or in test suites that want to observe drain
+behavior without losing the listener for subsequent cases. Unlike
+`drain/2`, the listener keeps accepting new connections.
+
+Requires the `pg` scope to be running (started by `roadrunner_sup`).
+""".
+-spec notify_drain(Name :: atom(), Deadline :: integer()) -> ok.
+notify_drain(Name, Deadline) when is_atom(Name), is_integer(Deadline) ->
+    lists:foreach(
+        fun(Pid) -> Pid ! {roadrunner_drain, Deadline} end,
+        pg:get_members({roadrunner_drain, Name})
+    ).
 
 -doc "Return the actual TCP port the listener is bound to.".
 -spec port(Name :: atom()) -> inet:port_number().

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -152,7 +152,8 @@ to absorb a chunk's payload across multiple length-bounded calls.
     forwarded_for/1,
     scheme/1,
     state/1,
-    request_id/1
+    request_id/1,
+    listener_name/1
 ]).
 
 -doc "Return the request method (uppercase ASCII binary).".
@@ -579,6 +580,20 @@ the handler is automatically annotated with the same id.
 -spec request_id(request()) -> binary() | undefined.
 request_id(#{request_id := Id}) -> Id;
 request_id(_) -> undefined.
+
+-doc """
+Return the atom name of the listener that accepted this request.
+
+Set by `roadrunner_conn` from `proto_opts.listener_name` and stable
+for the lifetime of the connection. Useful for adapter code that
+needs to address the listener (e.g. `pg`-based broadcasts keyed by
+listener name).
+
+`undefined` for manually-constructed request maps used in tests.
+""".
+-spec listener_name(request()) -> atom() | undefined.
+listener_name(#{listener_name := Name}) -> Name;
+listener_name(_) -> undefined.
 
 %% `-on_load` callback. See `feedback_compile_pattern_convention`.
 -spec init_patterns() -> ok.

--- a/src/roadrunner_ws_handler.erl
+++ b/src/roadrunner_ws_handler.erl
@@ -122,6 +122,27 @@ unknown messages dropped silently.
 """.
 -callback handle_info(Info :: term(), State :: term()) -> result().
 
--optional_callbacks([init/1, handle_info/2]).
+-doc """
+Optional. Fires when the listener broadcasts `{roadrunner_drain,
+Deadline}` (typically during a deploy via
+`roadrunner_listener:drain/2` or `roadrunner_listener:notify_drain/2`).
+The session pid is auto-joined into the listener's pg drain group at
+upgrade time, so every WS session sees the broadcast.
+
+`Deadline` is the integer monotonic-time millisecond after which the
+listener will hard-kill conns that haven't wound down. Handlers can
+subtract `erlang:monotonic_time(millisecond)` to compute remaining
+grace.
+
+Returns the same shape as `handle_frame/2`: push final frames, keep
+the session open, or close gracefully (typically `{close, 1000, ~"",
+NewState}` so the client reconnects to the new server version).
+Handlers that don't export this callback let the session keep
+running until the deadline expires; the listener then sends
+`exit(Pid, shutdown)`.
+""".
+-callback handle_drain(Deadline :: integer(), State :: term()) -> result().
+
+-optional_callbacks([init/1, handle_info/2, handle_drain/2]).
 
 -export_type([opt/0, result/0]).

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -182,6 +182,11 @@ run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated) ->
     %% a monitor instead.
     case gen_statem:start(?MODULE, {Socket, Mod, State, Ctx, Negotiated}, []) of
         {ok, Pid} ->
+            %% Auto-join the session into the listener's drain `pg` group
+            %% so `roadrunner_listener:drain/2` broadcasts reach long-lived
+            %% sessions directly — the conn's membership does not carry
+            %% across the unlinked `gen_statem:start` boundary above.
+            ok = roadrunner_conn:join_drain_group_for(Pid, roadrunner_req:listener_name(Req)),
             ok = roadrunner_telemetry:ws_upgrade(Ctx),
             _ = roadrunner_telemetry:response_send(
                 roadrunner_transport:send(Socket, UpgradeResp), websocket_upgrade_response

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -80,6 +80,7 @@
     %% read).
     has_init :: boolean(),
     has_handle_info :: boolean(),
+    has_handle_drain :: boolean(),
     %% permessage-deflate (RFC 7692) state. `pmd_params = undefined`
     %% means the extension was NOT negotiated; the session bypasses
     %% all compression machinery on the hot path.
@@ -237,6 +238,7 @@ init({Socket, Mod, State, Ctx, Negotiated}) ->
                 ctx = Ctx,
                 has_init = erlang:function_exported(Mod, init, 1),
                 has_handle_info = erlang:function_exported(Mod, handle_info, 2),
+                has_handle_drain = erlang:function_exported(Mod, handle_drain, 2),
                 pmd_params = PmdParams,
                 inflate_z = InflateZ,
                 deflate_z = DeflateZ,
@@ -306,6 +308,11 @@ frame_loop(info, Msg, #data{socket = Socket} = Data) ->
             {stop, normal, Data};
         {ErrorTag, _Sock, _Reason} ->
             {stop, normal, Data};
+        {roadrunner_drain, Deadline} ->
+            %% Drain broadcast — dispatch to optional handle_drain/2 and
+            %% drop. Drain messages never reach handle_info/2 so handlers
+            %% don't have to pattern-match on a framework-internal shape.
+            handle_drain_msg(Deadline, Data, false);
         _Other ->
             %% Forward to handler's optional handle_info/2 if exported,
             %% otherwise drop. Mirrors handle_frame's reply / hibernate
@@ -869,6 +876,17 @@ dispatch_data_frame(Frame, #data{mod = Mod, mod_state = State} = Data, Hibernate
 handle_info_msg(Msg, #data{has_handle_info = true, mod = Mod, mod_state = State} = Data, Hibernate) ->
     apply_handler_result(Mod:handle_info(Msg, State), Data, Hibernate, fun continue_arm/2);
 handle_info_msg(_Msg, #data{has_handle_info = false, socket = Socket} = Data, _Hibernate) ->
+    arm_or_stop(Socket, Data, []).
+
+-spec handle_drain_msg(integer(), #data{}, boolean()) ->
+    gen_statem:event_handler_result(atom()).
+handle_drain_msg(
+    Deadline,
+    #data{has_handle_drain = true, mod = Mod, mod_state = State} = Data,
+    Hibernate
+) ->
+    apply_handler_result(Mod:handle_drain(Deadline, State), Data, Hibernate, fun continue_arm/2);
+handle_drain_msg(_Deadline, #data{has_handle_drain = false, socket = Socket} = Data, _Hibernate) ->
     arm_or_stop(Socket, Data, []).
 
 %% Named continue functions used by `apply_handler_result` — pass these

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -1445,6 +1445,24 @@ join_drain_group_disabled_skips_pg_test() ->
     %% use to skip per-conn pg overhead on short-lived workloads.
     ?assertEqual(ok, roadrunner_conn:join_drain_group(some_listener, false)).
 
+join_drain_group_for_undefined_listener_test() ->
+    %% `join_drain_group_for/2` joins on behalf of another pid (used by
+    %% roadrunner_ws_session). `undefined` listener short-circuits.
+    ?assertEqual(ok, roadrunner_conn:join_drain_group_for(self(), undefined)).
+
+join_drain_group_for_without_pg_scope_test() ->
+    %% Without the `pg` scope (test harness skips the supervision
+    %% tree), the join is silently skipped. Caller never crashes.
+    case whereis(pg) of
+        undefined ->
+            ?assertEqual(ok, roadrunner_conn:join_drain_group_for(self(), some_listener));
+        _ ->
+            %% Scope is running — join then leave so the test doesn't
+            %% pollute other suites' membership.
+            ok = roadrunner_conn:join_drain_group_for(self(), some_listener),
+            ok = pg:leave({roadrunner_drain, some_listener}, self())
+    end.
+
 consume_state_next_chunk_for_content_length_drains_fully_test() ->
     %% Non-chunked framing: `next_chunk` drains the full body in one
     %% shot — there are no chunk boundaries to honor.

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -103,6 +103,38 @@ listener_honors_num_acceptors_opt_test() ->
     ok = roadrunner_listener:stop(listener_test_pool).
 
 %% =============================================================================
+%% notify_drain/2 (soft drain — broadcast without stopping the listener)
+%% =============================================================================
+
+notify_drain_reaches_pg_members_test() ->
+    %% Self-join the drain group so the broadcast reaches this process,
+    %% then call notify_drain and assert the message lands.
+    Name = listener_test_notify_drain,
+    Group = {roadrunner_drain, Name},
+    ok = pg:join(Group, self()),
+    try
+        Deadline = erlang:monotonic_time(millisecond) + 30000,
+        ok = roadrunner_listener:notify_drain(Name, Deadline),
+        receive
+            {roadrunner_drain, Deadline} -> ok
+        after 200 ->
+            ?assert(false)
+        end
+    after
+        ok = pg:leave(Group, self())
+    end.
+
+notify_drain_with_no_members_is_noop_test() ->
+    %% Empty group — just confirms the call returns ok and doesn't crash.
+    ?assertEqual(
+        ok,
+        roadrunner_listener:notify_drain(
+            listener_test_notify_drain_empty,
+            erlang:monotonic_time(millisecond) + 30000
+        )
+    ).
+
+%% =============================================================================
 %% info/1
 %% =============================================================================
 

--- a/test/roadrunner_req_tests.erl
+++ b/test/roadrunner_req_tests.erl
@@ -456,6 +456,15 @@ request_id_present_test() ->
 request_id_absent_returns_undefined_test() ->
     ?assertEqual(undefined, roadrunner_req:request_id(sample_req())).
 
+%% --- listener_name/1 ---
+
+listener_name_present_test() ->
+    Req = (sample_req())#{listener_name => my_listener},
+    ?assertEqual(my_listener, roadrunner_req:listener_name(Req)).
+
+listener_name_absent_returns_undefined_test() ->
+    ?assertEqual(undefined, roadrunner_req:listener_name(sample_req())).
+
 %% --- fixtures ---
 
 sample_req() ->

--- a/test/roadrunner_ws_lifecycle_handler.erl
+++ b/test/roadrunner_ws_lifecycle_handler.erl
@@ -1,10 +1,10 @@
 -module(roadrunner_ws_lifecycle_handler).
 -moduledoc """
-Test fixture — exports all three callbacks (`init/1`, `handle_frame/2`,
-`handle_info/2`) and dispatches each to the return shape encoded in
-the state map. Lets a single handler module drive every optional-
-callback path in `roadrunner_ws_session_tests` without N tiny fixture
-modules.
+Test fixture — exports all four callbacks (`init/1`, `handle_frame/2`,
+`handle_info/2`, `handle_drain/2`) and dispatches each to the return
+shape encoded in the state map. Lets a single handler module drive
+every optional-callback path in `roadrunner_ws_session_tests` without
+N tiny fixture modules.
 
 Usage: pass a state map of the form
 
@@ -12,7 +12,8 @@ Usage: pass a state map of the form
         on_init  => Action,  % optional, defaults to `ok`
         on_frame => Action,  % optional, defaults to `ok`
         on_info  => Action,  % optional, defaults to `ok`
-        sink     => SinkPid  % optional — receives `{event, init|frame|info}`
+        on_drain => Action,  % optional, defaults to `ok`
+        sink     => SinkPid  % optional — receives `{event, init|frame|info|drain}`
                              % so tests can confirm a callback ran
     }
 
@@ -28,7 +29,7 @@ Usage: pass a state map of the form
 
 -behaviour(roadrunner_ws_handler).
 
--export([init/1, handle_frame/2, handle_info/2]).
+-export([init/1, handle_frame/2, handle_info/2, handle_drain/2]).
 
 -spec init(map()) -> roadrunner_ws_handler:result().
 init(#{on_init := Action} = State) ->
@@ -52,6 +53,14 @@ handle_info(_Msg, #{on_info := Action} = State) ->
     resolve(Action, State);
 handle_info(_Msg, State) ->
     notify(State, info),
+    {ok, State}.
+
+-spec handle_drain(integer(), map()) -> roadrunner_ws_handler:result().
+handle_drain(_Deadline, #{on_drain := Action} = State) ->
+    notify(State, drain),
+    resolve(Action, State);
+handle_drain(_Deadline, State) ->
+    notify(State, drain),
     {ok, State}.
 
 %% --- helpers ---

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -400,6 +400,80 @@ handle_info_callback_close_terminates_session_test() ->
     Sink ! stop.
 
 %% =============================================================================
+%% Drain dispatch (handle_drain/2).
+%% =============================================================================
+
+handle_drain_callback_dispatches_when_exported_test() ->
+    %% Handler exports handle_drain/2 — drain message must reach it and
+    %% produce wire output via the returned reply frames.
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_active_sink(Self, Tag, []),
+    State = #{sink => Self, on_drain => {reply, [{text, ~"draining"}]}},
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        []
+    ),
+    Pid ! socket_ready,
+    timer:sleep(20),
+    Pid ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 30000},
+    receive
+        {event, drain} -> ok
+    after 200 -> ?assert(false)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 200)),
+    ?assertNotEqual(nomatch, binary:match(Sent, ~"draining")),
+    Sink ! stop,
+    ok = gen_statem:stop(Pid).
+
+handle_drain_callback_close_terminates_session_test() ->
+    %% Handler returns `{close, 1000, _, _}` from handle_drain — session
+    %% sends a close frame and exits normal. Cleanest production path:
+    %% client reconnects to the new server version.
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_active_sink(Self, Tag, []),
+    State = #{sink => Self, on_drain => {close, 1000, ~"draining"}},
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    timer:sleep(20),
+    Pid ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 30000},
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 500 -> ?assert(false)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 50)),
+    ?assertMatch(<<16#88, _/binary>>, Sent),
+    Sink ! stop.
+
+handle_drain_drops_when_handler_does_not_export_test() ->
+    %% Echo handler exports only handle_frame; no handle_drain. Session
+    %% must drop the drain message silently — handler never sees it
+    %% (not even as a stray info, because drain has dedicated dispatch).
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_active_sink(Self, Tag, []),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        []
+    ),
+    Pid ! socket_ready,
+    timer:sleep(20),
+    Pid ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 30000},
+    timer:sleep(50),
+    ?assertEqual(<<>>, iolist_to_binary(collect_sends(Tag, 50))),
+    ?assert(is_process_alive(Pid)),
+    Sink ! stop,
+    ok = gen_statem:stop(Pid).
+
+%% =============================================================================
 %% Handler-driven close with status code + reason (RFC 6455 §5.5.1).
 %% =============================================================================
 


### PR DESCRIPTION
# Description

Until now `roadrunner_listener:drain/2`'s broadcast only reached conn processes; WS sessions (spawned unlinked via `gen_statem:start`) never saw it and sat idle until the listener's hard-kill deadline. This PR makes drain a first-class concern for WS handlers.

- WS sessions auto-join the listener's `pg` drain group at upgrade time.
- New optional `roadrunner_ws_handler:handle_drain(Deadline, State)` callback with the same return shape as `handle_frame/2`. Drain messages are dispatched here and never fall through to `handle_info/2`.
- New `roadrunner_listener:notify_drain(Name, Deadline)` broadcasts to the pg group without stopping the listener (soft-drain workflows + cleaner test rigs).
- New `roadrunner_req:listener_name/1` accessor so adapters don't have to peek into the request map.

WS sessions always join regardless of the conn's `graceful_drain` flag — that opt-out is for short-lived HTTP/1 perf and would silently strand long-lived sessions during deploys.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
