### PR TITLE
Bound WebSocket inbound memory to prevent denial-of-service

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -1,0 +1,97 @@
+# Resource limits
+
+Roadrunner bounds how much memory and CPU a single connection or peer
+can pull in before any handler runs. The goal is that no client, by
+sending oversized, malformed, or slow input, can grow a connection's
+memory without bound or pin a worker. Every limit on this page is on by
+default.
+
+This page is an operator reference. For the reporting policy, see
+`SECURITY.md`. For the exact option types, see
+`t:roadrunner_listener:opts/0`.
+
+## HTTP request limits
+
+| Limit | Default | Configurable | Over-limit behavior |
+|---|---|---|---|
+| Request line | 8 KB | no (fixed) | 400, connection closed |
+| Header line | 8 KB | no (fixed) | 400, connection closed |
+| Header block (cumulative) | 10 KB | no (fixed) | 400, connection closed |
+| Header count | 100 | no (fixed) | 400, connection closed |
+| Body (`max_content_length`) | 10 MB | yes | 413 Payload Too Large |
+
+The body cap is enforced the same way for both `Content-Length` and
+`Transfer-Encoding: chunked` requests: the cap is checked as the body is
+read, so an oversized chunked body is rejected without buffering the
+whole thing.
+
+## WebSocket limits
+
+A WebSocket message is the WS analog of a request body, so its caps
+default to the same value as `max_content_length`. Both are enforced
+before the payload reaches the handler, and crossing either closes the
+connection with RFC 6455 code 1009 (message too big).
+
+| Limit | Default | Configurable | What it bounds |
+|---|---|---|---|
+| `ws_max_frame_size` | 10 MB | yes | one frame's declared payload, checked on the frame header before the body is buffered |
+| `ws_max_message_size` | 10 MB | yes | a reassembled message: the running total across fragments, and the decompressed size when permessage-deflate is negotiated |
+
+Notes:
+
+- `ws_max_message_size` must be `>= ws_max_frame_size`; a listener
+  configured otherwise refuses to start
+- each fragment is charged at least a small fixed overhead toward
+  `ws_max_message_size`, so a flood of empty or tiny continuation frames
+  is bounded by the cap, not just the total payload bytes
+- permessage-deflate is inflated in bounded chunks against
+  `ws_max_message_size`, so a small high-ratio frame cannot expand into
+  gigabytes before the cap fires
+
+When a cap closes a connection, roadrunner emits
+`[roadrunner, ws, frame_rejected]` (metadata `reason`, measurement
+`size`) so oversize and flood attempts are visible to subscribers.
+
+## HTTP/2 framing limits
+
+These are advertised to the peer in the initial `SETTINGS` frame and
+enforced by the framing layer.
+
+| Limit | Default | Configurable |
+|---|---|---|
+| `SETTINGS_MAX_FRAME_SIZE` | 16 KB | no (fixed) |
+| `SETTINGS_MAX_CONCURRENT_STREAMS` | 100 | no (fixed) |
+| HPACK decoder table | 4 KB | no (fixed) |
+| Connection receive window (`conn_window`) | 65535 | yes |
+| Stream receive window (`stream_window`) | 65535 | yes |
+
+A frame whose declared length exceeds the negotiated max frame size is
+rejected on its 9-byte header, before the body is buffered. Streams over
+the concurrency limit are refused.
+
+## Connection and slow-client guards
+
+| Limit | Default | Configurable | Purpose |
+|---|---|---|---|
+| `max_clients` | 150 | yes | concurrent connection cap per listener |
+| `request_timeout` | 30 s | yes | header-read timeout on a fresh connection |
+| `keep_alive_timeout` | 60 s | yes | idle timeout between requests |
+| `max_keep_alive_requests` | 1000 | yes | requests served per connection before close |
+| `min_bytes_per_second` | 100 | yes (0 disables) | slow-loris guard on the request-read phase |
+
+## Configuring
+
+Pass any configurable limit in the listener options map:
+
+```erlang
+roadrunner:start_listener(my_api, #{
+    port => 8080,
+    routes => my_handler,
+    max_content_length => 5_242_880,
+    ws_max_frame_size => 1_048_576,
+    ws_max_message_size => 8_388_608
+}).
+```
+
+See `t:roadrunner_listener:opts/0` for the full list and the canonical
+defaults.

--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -32,20 +32,23 @@ default to the same value as `max_content_length`. Both are enforced
 before the payload reaches the handler, and crossing either closes the
 connection with RFC 6455 code 1009 (message too big).
 
-| Limit | Default | Configurable | What it bounds |
-|---|---|---|---|
-| `ws_max_frame_size` | 10 MB | yes | one frame's declared payload, checked on the frame header before the body is buffered |
-| `ws_max_message_size` | 10 MB | yes | a reassembled message: the running total across fragments, and the decompressed size when permessage-deflate is negotiated |
+These are configured under the `ws` listener option as a nested map,
+e.g. `ws => #{max_frame_size => N, max_message_size => N}`.
+
+| Limit | Default | What it bounds |
+|---|---|---|
+| `ws.max_frame_size` | 10 MB | one frame's declared payload, checked on the frame header before the body is buffered |
+| `ws.max_message_size` | 10 MB | a reassembled message: the running total across fragments, and the decompressed size when permessage-deflate is negotiated |
 
 Notes:
 
-- `ws_max_message_size` must be `>= ws_max_frame_size`; a listener
-  configured otherwise refuses to start
+- `max_message_size` must be `>= max_frame_size`; a listener configured
+  otherwise refuses to start
 - each fragment is charged at least a small fixed overhead toward
-  `ws_max_message_size`, so a flood of empty or tiny continuation frames
-  is bounded by the cap, not just the total payload bytes
+  `max_message_size`, so a flood of empty or tiny continuation frames is
+  bounded by the cap, not just the total payload bytes
 - permessage-deflate is inflated in bounded chunks against
-  `ws_max_message_size`, so a small high-ratio frame cannot expand into
+  `max_message_size`, so a small high-ratio frame cannot expand into
   gigabytes before the cap fires
 
 When a cap closes a connection, roadrunner emits
@@ -88,8 +91,7 @@ roadrunner:start_listener(my_api, #{
     port => 8080,
     routes => my_handler,
     max_content_length => 5_242_880,
-    ws_max_frame_size => 1_048_576,
-    ws_max_message_size => 8_388_608
+    ws => #{max_frame_size => 1_048_576, max_message_size => 8_388_608}
 }).
 ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -113,6 +113,7 @@
         "docs/resource_results.md",
         "docs/wrk2_results.md",
         "CONTRIBUTING.md",
+        "docs/resource_limits.md",
         "docs/roadmap.md",
         "CHANGELOG.md",
         "LICENSE.md"
@@ -127,6 +128,7 @@
         ]},
         {<<"Project">>, [
             <<"CONTRIBUTING.md">>,
+            <<"docs/resource_limits.md">>,
             <<"docs/roadmap.md">>,
             <<"CHANGELOG.md">>,
             <<"LICENSE.md">>

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -85,7 +85,8 @@
     %% WebSocket inbound size caps. `ws_max_frame_size` bounds a single
     %% frame's declared payload (enforced before buffering);
     %% `ws_max_message_size` bounds a reassembled message (the running
-    %% sum of fragment payloads). Both always present —
+    %% sum of fragment payloads, and the decompressed size under
+    %% permessage-deflate). Both always present —
     %% `roadrunner_listener:build_proto_opts/2` fills defaults.
     ws_max_frame_size := non_neg_integer(),
     ws_max_message_size := non_neg_integer(),

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -82,6 +82,13 @@
     dispatch := dispatch(),
     middlewares := roadrunner_middleware:middleware_list(),
     max_content_length := non_neg_integer(),
+    %% WebSocket inbound size caps. `ws_max_frame_size` bounds a single
+    %% frame's declared payload (enforced before buffering);
+    %% `ws_max_message_size` bounds a reassembled message (the running
+    %% sum of fragment payloads). Both always present —
+    %% `roadrunner_listener:build_proto_opts/2` fills defaults.
+    ws_max_frame_size := non_neg_integer(),
+    ws_max_message_size := non_neg_integer(),
     request_timeout := non_neg_integer(),
     keep_alive_timeout := non_neg_integer(),
     max_keep_alive_requests := pos_integer(),

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -547,7 +547,7 @@ read_body_phase(
 %% pipeline, run it bracketed by request_start / request_stop |
 %% request_exception telemetry. The 5 response shapes (buffered,
 %% stream, loop, sendfile, websocket) dispatch to their respective
-%% writers via `dispatch_response/4`.
+%% writers via `dispatch_response/5`.
 -spec dispatch_phase(#loop_state{}, roadrunner_req:request()) -> no_return().
 dispatch_phase(
     #loop_state{
@@ -575,7 +575,7 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     try Pipeline(Req) of
         {Response, Req2} when is_map(Req2) ->
-            _ = dispatch_response(Socket, Handler, Req2, Response),
+            _ = dispatch_response(Socket, Handler, Req2, Response, S#loop_state.proto_opts),
             ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
                 status => roadrunner_conn:response_status(Response),
                 response_kind => roadrunner_conn:response_kind(Response)
@@ -609,25 +609,26 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
     roadrunner_transport:socket(),
     module(),
     roadrunner_req:request(),
-    roadrunner_handler:response()
+    roadrunner_handler:response(),
+    roadrunner_conn:proto_opts()
 ) -> ok.
-dispatch_response(Socket, _Handler, Req, {websocket, Mod, State}) when is_atom(Mod) ->
-    _ = roadrunner_ws_session:run(Socket, Req, Mod, State),
+dispatch_response(Socket, _Handler, Req, {websocket, Mod, State}, ProtoOpts) when is_atom(Mod) ->
+    ok = roadrunner_ws_session:run(Socket, Req, Mod, State, ProtoOpts),
     ok;
-dispatch_response(Socket, _Handler, _Req, {stream, Status, Headers0, Fun}) when
+dispatch_response(Socket, _Handler, _Req, {stream, Status, Headers0, Fun}, _ProtoOpts) when
     is_function(Fun, 1)
 ->
     Headers = with_date(Headers0),
     _ = roadrunner_stream_response:run(Socket, Status, Headers, Fun),
     ok;
-dispatch_response(Socket, Handler, _Req, {loop, Status, Headers0, LoopState}) when
+dispatch_response(Socket, Handler, _Req, {loop, Status, Headers0, LoopState}, _ProtoOpts) when
     is_integer(Status)
 ->
     Headers = with_date(Headers0),
     _ = roadrunner_loop_response:run(Socket, Status, Headers, Handler, LoopState),
     ok;
 dispatch_response(
-    Socket, _Handler, Req, {sendfile, Status, Headers0, {Filename, Offset, Length}}
+    Socket, _Handler, Req, {sendfile, Status, Headers0, {Filename, Offset, Length}}, _ProtoOpts
 ) when
     is_integer(Status)
 ->
@@ -665,7 +666,9 @@ dispatch_response(
 %% include a message body — match on `method := ~"HEAD"` in the
 %% function head and emit the response with an empty body. Free
 %% pattern-match dispatch (no `maps:get(method, _)` per response).
-dispatch_response(Socket, _Handler, #{method := ~"HEAD"}, {Status, Headers0, _Body}) when
+dispatch_response(
+    Socket, _Handler, #{method := ~"HEAD"}, {Status, Headers0, _Body}, _ProtoOpts
+) when
     is_integer(Status)
 ->
     Headers = with_date(Headers0),
@@ -674,7 +677,9 @@ dispatch_response(Socket, _Handler, #{method := ~"HEAD"}, {Status, Headers0, _Bo
         roadrunner_transport:send(Socket, Resp), buffered_response
     ),
     ok;
-dispatch_response(Socket, _Handler, _Req, {Status, Headers0, Body}) when is_integer(Status) ->
+dispatch_response(Socket, _Handler, _Req, {Status, Headers0, Body}, _ProtoOpts) when
+    is_integer(Status)
+->
     Headers = with_date(Headers0),
     Resp = roadrunner_http1:response(Status, Headers, Body),
     _ = roadrunner_telemetry:response_send(

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -45,8 +45,8 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
 -define(DEFAULT_MAX_CLIENTS, 150).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
--define(DEFAULT_WS_MAX_FRAME_SIZE, 16777216).
--define(DEFAULT_WS_MAX_MESSAGE_SIZE, 16777216).
+-define(DEFAULT_WS_MAX_FRAME_SIZE, 10485760).
+-define(DEFAULT_WS_MAX_MESSAGE_SIZE, 10485760).
 
 -doc """
 Listener configuration map.
@@ -77,11 +77,11 @@ Optional middleware and timing knobs (durations in milliseconds):
   `payload_too_large`. Default 10 MB.
 - `ws_max_frame_size` — per-WebSocket-frame payload cap. An inbound
   frame declaring more bytes than this closes the connection with
-  code 1009 before the payload is buffered. Default 16 MB.
+  code 1009 before the payload is buffered. Default 10 MB.
 - `ws_max_message_size` — cap on a reassembled WebSocket message:
   the running sum of fragment payloads, and (when permessage-deflate
   is negotiated) the decompressed size. Over-cap closes with code
-  1009. Default 16 MB.
+  1009. Must be `>= ws_max_frame_size`. Default 10 MB.
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
 - `keep_alive_timeout` — idle timeout between requests on a
@@ -542,16 +542,22 @@ build_proto_opts(Opts, ListenerName) ->
     %% contract `try_acquire_slot/1` already documents.
     ClientCounter = counters:new(1, [write_concurrency]),
     RequestsCounter = atomics:new(1, [{signed, false}]),
+    %% A reassembled message is built from frames, so a single
+    %% unfragmented frame is also a whole message — `ws_max_message_size`
+    %% below `ws_max_frame_size` is contradictory (a max-size frame would
+    %% be rejected as too-big-a-message). Reject it at startup.
+    WsFrame = maps:get(ws_max_frame_size, Opts, ?DEFAULT_WS_MAX_FRAME_SIZE),
+    WsMsg = maps:get(ws_max_message_size, Opts, ?DEFAULT_WS_MAX_MESSAGE_SIZE),
+    WsMsg >= WsFrame orelse
+        error({listener_opt_conflict, ws_max_message_size, WsMsg, below_ws_max_frame_size}),
     Base = maps:merge(
         #{
             dispatch => build_dispatch(Opts, ListenerName),
             middlewares => maps:get(middlewares, Opts, []),
             max_content_length =>
                 maps:get(max_content_length, Opts, ?DEFAULT_MAX_CONTENT_LENGTH),
-            ws_max_frame_size =>
-                maps:get(ws_max_frame_size, Opts, ?DEFAULT_WS_MAX_FRAME_SIZE),
-            ws_max_message_size =>
-                maps:get(ws_max_message_size, Opts, ?DEFAULT_WS_MAX_MESSAGE_SIZE),
+            ws_max_frame_size => WsFrame,
+            ws_max_message_size => WsMsg,
             request_timeout => maps:get(request_timeout, Opts, ?DEFAULT_REQUEST_TIMEOUT),
             keep_alive_timeout =>
                 maps:get(keep_alive_timeout, Opts, ?DEFAULT_KEEP_ALIVE_TIMEOUT),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -45,6 +45,8 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
 -define(DEFAULT_MAX_CLIENTS, 150).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
+-define(DEFAULT_WS_MAX_FRAME_SIZE, 16777216).
+-define(DEFAULT_WS_MAX_MESSAGE_SIZE, 16777216).
 
 -doc """
 Listener configuration map.
@@ -73,6 +75,12 @@ Optional middleware and timing knobs (durations in milliseconds):
 - `middlewares` — listener-wide pipeline applied to every request.
 - `max_content_length` — request-body cap; over-cap reads return
   `payload_too_large`. Default 10 MB.
+- `ws_max_frame_size` — per-WebSocket-frame payload cap. An inbound
+  frame declaring more bytes than this closes the connection with
+  code 1009 before the payload is buffered. Default 16 MB.
+- `ws_max_message_size` — cap on a reassembled WebSocket message
+  (the running sum of fragment payloads). Over-cap closes with code
+  1009. Default 16 MB.
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
 - `keep_alive_timeout` — idle timeout between requests on a
@@ -117,6 +125,8 @@ ops-tuning rationale.
         | roadrunner_router:routes(),
     middlewares => roadrunner_middleware:middleware_list(),
     max_content_length => non_neg_integer(),
+    ws_max_frame_size => non_neg_integer(),
+    ws_max_message_size => non_neg_integer(),
     request_timeout => non_neg_integer(),
     keep_alive_timeout => non_neg_integer(),
     num_acceptors => pos_integer(),
@@ -537,6 +547,10 @@ build_proto_opts(Opts, ListenerName) ->
             middlewares => maps:get(middlewares, Opts, []),
             max_content_length =>
                 maps:get(max_content_length, Opts, ?DEFAULT_MAX_CONTENT_LENGTH),
+            ws_max_frame_size =>
+                maps:get(ws_max_frame_size, Opts, ?DEFAULT_WS_MAX_FRAME_SIZE),
+            ws_max_message_size =>
+                maps:get(ws_max_message_size, Opts, ?DEFAULT_WS_MAX_MESSAGE_SIZE),
             request_timeout => maps:get(request_timeout, Opts, ?DEFAULT_REQUEST_TIMEOUT),
             keep_alive_timeout =>
                 maps:get(keep_alive_timeout, Opts, ?DEFAULT_KEEP_ALIVE_TIMEOUT),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -75,13 +75,10 @@ Optional middleware and timing knobs (durations in milliseconds):
 - `middlewares` — listener-wide pipeline applied to every request.
 - `max_content_length` — request-body cap; over-cap reads return
   `payload_too_large`. Default 10 MB.
-- `ws_max_frame_size` — per-WebSocket-frame payload cap. An inbound
-  frame declaring more bytes than this closes the connection with
-  code 1009 before the payload is buffered. Default 10 MB.
-- `ws_max_message_size` — cap on a reassembled WebSocket message:
-  the running sum of fragment payloads, and (when permessage-deflate
-  is negotiated) the decompressed size. Over-cap closes with code
-  1009. Must be `>= ws_max_frame_size`. Default 10 MB.
+- `ws` — WebSocket inbound size caps as a nested map (see
+  `t:ws_opts/0`): `max_frame_size` (per-frame payload cap) and
+  `max_message_size` (reassembled + decompressed message cap). Both
+  default to 10 MB; over-cap closes the connection with code 1009.
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
 - `keep_alive_timeout` — idle timeout between requests on a
@@ -126,8 +123,7 @@ ops-tuning rationale.
         | roadrunner_router:routes(),
     middlewares => roadrunner_middleware:middleware_list(),
     max_content_length => non_neg_integer(),
-    ws_max_frame_size => non_neg_integer(),
-    ws_max_message_size => non_neg_integer(),
+    ws => ws_opts(),
     request_timeout => non_neg_integer(),
     keep_alive_timeout => non_neg_integer(),
     num_acceptors => pos_integer(),
@@ -245,6 +241,22 @@ HTTP/2 listener tunables (under `{http2, ThisMap}` in `protocols`).
     conn_window => 1..16#7FFFFFFF,
     stream_window => 1..16#7FFFFFFF,
     window_refill_threshold => 1..16#7FFFFFFF
+}.
+
+-doc """
+WebSocket inbound size caps (under `ws` in the listener opts).
+
+- `max_frame_size` — per-frame payload cap in bytes. An inbound
+  frame declaring more than this closes the connection with code
+  1009 before the payload is buffered. Default 10 MB.
+- `max_message_size` — cap on a reassembled message in bytes: the
+  running fragment total, and the decompressed size when
+  permessage-deflate is negotiated. Over-cap closes with 1009. Must
+  be `>= max_frame_size`. Default 10 MB.
+""".
+-type ws_opts() :: #{
+    max_frame_size => 0..16#7FFFFFFF,
+    max_message_size => 0..16#7FFFFFFF
 }.
 
 -record(state, {
@@ -542,14 +554,11 @@ build_proto_opts(Opts, ListenerName) ->
     %% contract `try_acquire_slot/1` already documents.
     ClientCounter = counters:new(1, [write_concurrency]),
     RequestsCounter = atomics:new(1, [{signed, false}]),
-    %% A reassembled message is built from frames, so a single
-    %% unfragmented frame is also a whole message — `ws_max_message_size`
-    %% below `ws_max_frame_size` is contradictory (a max-size frame would
-    %% be rejected as too-big-a-message). Reject it at startup.
-    WsFrame = maps:get(ws_max_frame_size, Opts, ?DEFAULT_WS_MAX_FRAME_SIZE),
-    WsMsg = maps:get(ws_max_message_size, Opts, ?DEFAULT_WS_MAX_MESSAGE_SIZE),
-    WsMsg >= WsFrame orelse
-        error({listener_opt_conflict, ws_max_message_size, WsMsg, below_ws_max_frame_size}),
+    %% Public `ws` opts are a nested map; flatten to the `ws_*`
+    %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
+    %% → `http2_*` flattening above.
+    #{max_frame_size := WsFrame, max_message_size := WsMsg} =
+        validate_ws_opts(maps:get(ws, Opts, #{})),
     Base = maps:merge(
         #{
             dispatch => build_dispatch(Opts, ListenerName),
@@ -713,6 +722,41 @@ flatten_http2_opts(Entries) ->
                 http2_window_refill_threshold => Threshold
             }
     end.
+
+-spec ws_defaults() ->
+    #{max_frame_size := non_neg_integer(), max_message_size := non_neg_integer()}.
+ws_defaults() ->
+    #{
+        max_frame_size => ?DEFAULT_WS_MAX_FRAME_SIZE,
+        max_message_size => ?DEFAULT_WS_MAX_MESSAGE_SIZE
+    }.
+
+%% Resolve the `ws` opts map against defaults, rejecting unknown keys
+%% and out-of-range values (mirroring `validate_http2_opts/2`). A
+%% reassembled message is built from frames, so a single unfragmented
+%% frame is also a whole message: `max_message_size` below
+%% `max_frame_size` is contradictory and rejected at startup.
+-spec validate_ws_opts(term()) ->
+    #{max_frame_size := non_neg_integer(), max_message_size := non_neg_integer()}.
+validate_ws_opts(Opts) when is_map(Opts) ->
+    Defaults = ws_defaults(),
+    Resolved = maps:fold(
+        fun(K, V, Acc) ->
+            case is_map_key(K, Defaults) of
+                false -> error({invalid_listener_opt, ws, Opts});
+                true when is_integer(V, 0, 16#7FFFFFFF) -> Acc#{K => V};
+                true -> error({invalid_listener_opt, ws, Opts})
+            end
+        end,
+        Defaults,
+        Opts
+    ),
+    #{max_frame_size := Frame, max_message_size := Msg} = Resolved,
+    Msg >= Frame orelse
+        error({listener_opt_conflict, ws, Opts, max_message_size_below_max_frame_size}),
+    Resolved;
+validate_ws_opts(Other) ->
+    error({invalid_listener_opt, ws, Other}).
 
 build_dispatch(#{routes := Module} = Opts, _ListenerName) when is_atom(Module) ->
     bake_dispatch(Module, Opts, [], no_state);

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -78,8 +78,9 @@ Optional middleware and timing knobs (durations in milliseconds):
 - `ws_max_frame_size` — per-WebSocket-frame payload cap. An inbound
   frame declaring more bytes than this closes the connection with
   code 1009 before the payload is buffered. Default 16 MB.
-- `ws_max_message_size` — cap on a reassembled WebSocket message
-  (the running sum of fragment payloads). Over-cap closes with code
+- `ws_max_message_size` — cap on a reassembled WebSocket message:
+  the running sum of fragment payloads, and (when permessage-deflate
+  is negotiated) the decompressed size. Over-cap closes with code
   1009. Default 16 MB.
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -3,7 +3,7 @@
 
 %% Per-connection `{loop, ...}` response — message-driven streaming.
 %%
-%% Called by `roadrunner_conn_loop:dispatch_response/4` after a handler
+%% Called by `roadrunner_conn_loop:dispatch_response/5` after a handler
 %% returns `{loop, Status, Headers, State}`. Writes the status line +
 %% chunked headers, then runs a recursive selective-receive loop that
 %% dispatches every Erlang message through `Module:handle_info/3`. The

--- a/src/roadrunner_stream_response.erl
+++ b/src/roadrunner_stream_response.erl
@@ -3,7 +3,7 @@
 
 %% Per-connection `{stream, ...}` response — chunked Transfer-Encoding.
 %%
-%% Called by `roadrunner_conn:dispatch_response/4` after a handler returns
+%% Called by `roadrunner_conn_loop:dispatch_response/5` after a handler returns
 %% `{stream, Status, Headers, Fun}`. Writes the status line + chunked
 %% headers, then calls the user's `Fun(Send)` with a `Send/2` callback
 %% that frames each emission as one chunk on the wire.

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -90,6 +90,18 @@
 %%   - **Metadata:** `listener_name`, `peer`, `request_id`, `module`,
 %%     `opcode`.
 %%
+%% - `[roadrunner, ws, frame_rejected]` — fired when the conn closes the
+%%   connection (with code 1009) because an inbound frame or
+%%   reassembled message exceeded a configured size cap. Lets operators
+%%   see oversize/flood attempts that a generic close frame doesn't
+%%   distinguish.
+%%
+%%   - **Measurements:** `system_time`, `size` (the offending byte
+%%     count: declared frame length, charged message size, or inflated
+%%     size).
+%%   - **Metadata:** `listener_name`, `peer`, `request_id`, `module`,
+%%     `reason` (`max_frame_size | max_message_size`).
+%%
 %% The `start_time` value returned by `request_start/1` must be passed
 %% back into `request_stop/3` / `request_exception/4` to compute
 %% `duration`. Subscribers can wire up via `telemetry:attach/4` in
@@ -114,7 +126,7 @@
 %% `request, exception`, `response, send_failed`,
 %% `listener, accept`, `listener, conn_close`,
 %% `request, rejected`, `listener, slots_reconciled`,
-%% `drain, acknowledged`, `ws, frame_in`) are **unstable**: their
+%% `drain, acknowledged`, `ws, frame_in`, `ws, frame_rejected`) are **unstable**: their
 %% event name, measurement keys, or metadata schema may change in
 %% any minor release. Production subscribers depending on those
 %% events should pin a roadrunner version.
@@ -134,7 +146,8 @@
     drain_acknowledged/1,
     ws_upgrade/1,
     ws_frame_in/2,
-    ws_frame_out/2
+    ws_frame_out/2,
+    ws_frame_rejected/2
 ]).
 
 -export_type([metadata/0]).
@@ -327,6 +340,16 @@ ws_frame_out(Metadata, PayloadSize) ->
     telemetry:execute(
         [roadrunner, ws, frame_out],
         #{system_time => erlang:system_time(), payload_size => PayloadSize},
+        Metadata
+    ),
+    ok.
+
+-doc "Emit `[roadrunner, ws, frame_rejected]` when an inbound size cap is exceeded.".
+-spec ws_frame_rejected(map(), non_neg_integer()) -> ok.
+ws_frame_rejected(Metadata, Size) ->
+    telemetry:execute(
+        [roadrunner, ws, frame_rejected],
+        #{system_time => erlang:system_time(), size => Size},
         Metadata
     ),
     ok.

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -412,7 +412,7 @@ process_buffer(#data{buffer = Buf, pmd_params = Pmd} = Data, HibernateAcc) ->
                     %% The header is in hand but the body isn't buffered
                     %% yet — close now (RFC 6455 §7.4 code 1009) instead
                     %% of letting the `{more, _}` re-arm keep reading.
-                    close_with(close_message_too_big(), reset_msg(Data1));
+                    close_oversize(max_frame_size, MaybeTotalLen, Data1);
                 true ->
                     process_parsed_frame(Data1, Buf, Opts, MaybeTotalLen, HibernateAcc)
             end;
@@ -685,7 +685,7 @@ accumulate_fragment(
             %% continuation flood that never sets fin=1, including one
             %% built from empty/tiny frames (each charged the per-
             %% fragment overhead so the cap bounds real memory).
-            close_with(close_message_too_big(), reset_msg(Data));
+            close_oversize(max_message_size, NewSize, Data);
         false ->
             case fragment_validate(Op, Compressed, Data#data.utf8_pending, P, Data) of
                 {ok, NewPending} ->
@@ -721,7 +721,7 @@ accumulate_fragment(
     %% The final fragment pushes the charged message size over
     %% `max_message_size` — close with 1009. (For compressed messages
     %% this bounds the wire-level accumulated payload.)
-    close_with(close_message_too_big(), reset_msg(Data));
+    close_oversize(max_message_size, Size + max(byte_size(P), ?WS_FRAGMENT_OVERHEAD), Data);
 accumulate_fragment(
     #{fin := true, payload := P} = _Frame,
     #data{
@@ -760,9 +760,9 @@ accumulate_fragment(
                         invalid_utf8 ->
                             close_with(close_invalid_payload(), Data1)
                     end;
-                {error, message_too_big} ->
+                {error, {message_too_big, Size}} ->
                     %% Inflated payload would exceed `max_message_size`.
-                    close_with(close_message_too_big(), Reset);
+                    close_oversize(max_message_size, Size, Reset);
                 {error, _} ->
                     close_with(close_protocol_error(), Reset)
             end;
@@ -922,22 +922,23 @@ finalize_message(
 %% call, so we stop and reject the moment the output would cross the cap
 %% rather than allocating the whole bomb.
 -spec bounded_inflate(zlib:zstream(), binary(), non_neg_integer()) ->
-    {ok, binary()} | {error, message_too_big}.
+    {ok, binary()} | {error, {message_too_big, non_neg_integer()}}.
 bounded_inflate(Z, Compressed, Max) ->
     bounded_inflate(zlib:safeInflate(Z, Compressed), Z, Max, 0, []).
 
 -spec bounded_inflate(
     {continue | finished, iolist()}, zlib:zstream(), non_neg_integer(), non_neg_integer(), iolist()
-) -> {ok, binary()} | {error, message_too_big}.
+) -> {ok, binary()} | {error, {message_too_big, non_neg_integer()}}.
 bounded_inflate({continue, Output}, Z, Max, Total, Acc) ->
     NewTotal = Total + iolist_size(Output),
     case NewTotal > Max of
-        true -> {error, message_too_big};
+        true -> {error, {message_too_big, NewTotal}};
         false -> bounded_inflate(zlib:safeInflate(Z, []), Z, Max, NewTotal, [Acc, Output])
     end;
 bounded_inflate({finished, Output}, _Z, Max, Total, Acc) ->
-    case Total + iolist_size(Output) > Max of
-        true -> {error, message_too_big};
+    Final = Total + iolist_size(Output),
+    case Final > Max of
+        true -> {error, {message_too_big, Final}};
         false -> {ok, iolist_to_binary([Acc, Output])}
     end.
 
@@ -974,6 +975,16 @@ close_message_too_big() ->
 close_with(StatusBin, Data) ->
     ok = send_ws_frame(Data, close, StatusBin),
     {stop, normal, Data}.
+
+%% Close with 1009 because an inbound size cap was exceeded, emitting
+%% `[roadrunner, ws, frame_rejected]` first so operators can see the
+%% rejection (and its reason + offending size) — a plain close frame
+%% doesn't distinguish a cap rejection from a normal close.
+-spec close_oversize(max_frame_size | max_message_size, non_neg_integer(), #data{}) ->
+    {stop, normal, #data{}}.
+close_oversize(Reason, Size, #data{ctx = Ctx} = Data) ->
+    ok = roadrunner_telemetry:ws_frame_rejected(Ctx#{reason => Reason}, Size),
+    close_with(close_message_too_big(), reset_msg(Data)).
 
 %% Build the payload for the close-handshake reply. RFC 6455 §5.5.1
 %% says servers typically echo the received status code back, BUT

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -106,9 +106,11 @@
     %% `init/1`). `max_frame_size` bounds a single frame's declared
     %% payload — enforced in `process_buffer/2` against the peeked
     %% header before the body is buffered. `max_message_size` bounds a
-    %% reassembled message via `msg_size`, the running sum of fragment
-    %% payloads; under permessage-deflate it also caps the decompressed
-    %% size (`finalize_message/3`). Over either cap closes with 1009.
+    %% reassembled message via `msg_size`, the running charged size of
+    %% the fragments (each charged at least `?WS_FRAGMENT_OVERHEAD` so
+    %% empty/tiny fragments can't grow `msg_acc` unbounded); under
+    %% permessage-deflate it also caps the decompressed size
+    %% (`finalize_message/3`). Over either cap closes with 1009.
     max_frame_size :: non_neg_integer(),
     max_message_size :: non_neg_integer(),
     msg_size = 0 :: non_neg_integer(),
@@ -146,6 +148,15 @@
 %% from the deflate output; receiver appends it before inflating to
 %% terminate the deflate block.
 -define(PMD_TAIL, <<0, 0, 16#FF, 16#FF>>).
+
+%% Per-fragment charge (bytes) added to the running message size on top
+%% of the payload. Each accumulated fragment costs ~32 bytes of cons
+%% cells in `msg_acc` regardless of its payload, so without a floor a
+%% flood of empty/tiny continuation frames would grow the heap while
+%% the payload-byte total stayed under `max_message_size`. Charging at
+%% least this much per fragment keeps real reassembly memory bounded by
+%% the cap (this is ~2x the actual cons-cell cost, a safe over-estimate).
+-define(WS_FRAGMENT_OVERHEAD, 64).
 
 -doc """
 Run the WebSocket session synchronously: spawn the gen_statem,
@@ -666,13 +677,14 @@ accumulate_fragment(
     } = Data,
     Hibernate
 ) ->
-    NewSize = Size + byte_size(P),
+    NewSize = Size + max(byte_size(P), ?WS_FRAGMENT_OVERHEAD),
     case NewSize > MaxMsg of
         true ->
-            %% Reassembled message (running sum of fragment payloads)
-            %% exceeds `max_message_size`. Close with 1009 instead of
-            %% buffering more — this is what stops a continuation flood
-            %% that never sets fin=1.
+            %% Charged message size exceeds `max_message_size`. Close
+            %% with 1009 instead of buffering more — this stops a
+            %% continuation flood that never sets fin=1, including one
+            %% built from empty/tiny frames (each charged the per-
+            %% fragment overhead so the cap bounds real memory).
             close_with(close_message_too_big(), reset_msg(Data));
         false ->
             case fragment_validate(Op, Compressed, Data#data.utf8_pending, P, Data) of
@@ -705,8 +717,8 @@ accumulate_fragment(
     #{fin := true, payload := P} = _Frame,
     #data{msg_size = Size, max_message_size = MaxMsg} = Data,
     _Hibernate
-) when Size + byte_size(P) > MaxMsg ->
-    %% The final fragment pushes the reassembled message over
+) when Size + max(byte_size(P), ?WS_FRAGMENT_OVERHEAD) > MaxMsg ->
+    %% The final fragment pushes the charged message size over
     %% `max_message_size` — close with 1009. (For compressed messages
     %% this bounds the wire-level accumulated payload.)
     close_with(close_message_too_big(), reset_msg(Data));

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -62,7 +62,7 @@
 
 -behaviour(gen_statem).
 
--export([run/4]).
+-export([run/5]).
 -export([init/1, callback_mode/0, terminate/3]).
 -export([awaiting_socket/3, frame_loop/3]).
 -export([unmask_slice/3]).
@@ -102,6 +102,15 @@
     msg_acc :: undefined | iodata(),
     msg_opcode :: undefined | text | binary,
     msg_compressed :: boolean(),
+    %% Inbound size caps (from listener `proto_opts`, set once in
+    %% `init/1`). `max_frame_size` bounds a single frame's declared
+    %% payload — enforced in `process_buffer/2` against the peeked
+    %% header before the body is buffered. `max_message_size` bounds a
+    %% reassembled message via `msg_size`, the running sum of fragment
+    %% payloads. Over either cap closes the connection with 1009.
+    max_frame_size :: non_neg_integer(),
+    max_message_size :: non_neg_integer(),
+    msg_size = 0 :: non_neg_integer(),
     %% Trailing UTF-8 bytes carried over from a previous fragment that
     %% form the start of a multi-byte sequence whose continuation
     %% bytes haven't arrived yet. RFC 6455 §8.1 + §5.4 require that
@@ -147,12 +156,18 @@ socket. Returns `ok` once the session has ended (or the
 handshake check fails — in which case 400 has been sent and
 the gen_statem is never started).
 """.
--spec run(roadrunner_transport:socket(), roadrunner_req:request(), module(), term()) -> ok.
-run(Socket, Req, Mod, State) ->
+-spec run(
+    roadrunner_transport:socket(),
+    roadrunner_req:request(),
+    module(),
+    term(),
+    roadrunner_conn:proto_opts()
+) -> ok.
+run(Socket, Req, Mod, State, ProtoOpts) ->
     case roadrunner_ws:handshake_response(roadrunner_req:headers(Req)) of
         {ok, Status, RespHeaders, _, Negotiated} ->
             UpgradeResp = roadrunner_http1:response(Status, RespHeaders, ~""),
-            run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated);
+            run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated, ProtoOpts);
         {error, _} ->
             _ = roadrunner_transport:send(
                 Socket,
@@ -171,9 +186,10 @@ run(Socket, Req, Mod, State) ->
     module(),
     term(),
     iodata(),
-    roadrunner_ws:negotiated()
+    roadrunner_ws:negotiated(),
+    roadrunner_conn:proto_opts()
 ) -> ok.
-run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated) ->
+run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated, ProtoOpts) ->
     Ctx = ws_context(Req, Mod),
     %% Start the gen_statem **before** writing the 101 to the wire so a
     %% start failure never leaves the upgrade response sent with no
@@ -181,7 +197,7 @@ run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated) ->
     %% conn is intentionally unlinked from its children so a session
     %% crash never propagates to the conn process. We synchronise via
     %% a monitor instead.
-    case gen_statem:start(?MODULE, {Socket, Mod, State, Ctx, Negotiated}, []) of
+    case gen_statem:start(?MODULE, {Socket, Mod, State, Ctx, Negotiated, ProtoOpts}, []) of
         {ok, Pid} ->
             ok = roadrunner_telemetry:ws_upgrade(Ctx),
             _ = roadrunner_telemetry:response_send(
@@ -227,10 +243,15 @@ wait_for_session(Ref, Pid) ->
 callback_mode() -> [state_functions, state_enter].
 
 -spec init({
-    roadrunner_transport:socket(), module(), term(), map(), roadrunner_ws:negotiated()
+    roadrunner_transport:socket(),
+    module(),
+    term(),
+    map(),
+    roadrunner_ws:negotiated(),
+    roadrunner_conn:proto_opts()
 }) ->
     {ok, awaiting_socket, #data{}} | {stop, {bad_handler, module()}}.
-init({Socket, Mod, State, Ctx, Negotiated}) ->
+init({Socket, Mod, State, Ctx, Negotiated, ProtoOpts}) ->
     %% Reject unloadable handlers up front so `gen_statem:start/3`
     %% returns `{error, _}` and the launcher's 500 fallback runs —
     %% otherwise the session would crash later inside `handle_frame`
@@ -241,6 +262,10 @@ init({Socket, Mod, State, Ctx, Negotiated}) ->
     of
         true ->
             {PmdParams, InflateZ, DeflateZ} = init_pmd(Negotiated),
+            #{
+                ws_max_frame_size := MaxFrame,
+                ws_max_message_size := MaxMsg
+            } = ProtoOpts,
             {ok, awaiting_socket, #data{
                 socket = Socket,
                 buffer = <<>>,
@@ -253,9 +278,12 @@ init({Socket, Mod, State, Ctx, Negotiated}) ->
                 pmd_params = PmdParams,
                 inflate_z = InflateZ,
                 deflate_z = DeflateZ,
+                max_frame_size = MaxFrame,
+                max_message_size = MaxMsg,
                 msg_acc = undefined,
                 msg_opcode = undefined,
                 msg_compressed = false,
+                msg_size = 0,
                 utf8_pending = <<>>,
                 frame_validated = 0,
                 unmasked_buf = <<>>
@@ -358,7 +386,7 @@ close_zlib(Z) -> zlib:close(Z).
 %% honor the hibernate flag if any handler set it.
 -spec process_buffer(#data{}, boolean()) ->
     gen_statem:event_handler_result(atom()).
-process_buffer(#data{socket = Socket, buffer = Buf, pmd_params = Pmd} = Data, HibernateAcc) ->
+process_buffer(#data{buffer = Buf, pmd_params = Pmd} = Data, HibernateAcc) ->
     Opts =
         case Pmd of
             undefined -> #{};
@@ -366,31 +394,45 @@ process_buffer(#data{socket = Socket, buffer = Buf, pmd_params = Pmd} = Data, Hi
         end,
     case early_validate_text(Data, Buf, Opts) of
         {ok, Data1, MaybeTotalLen} ->
-            ParseOpts = parse_opts_with_pre_unmasked(Opts, Data1, MaybeTotalLen),
-            case roadrunner_ws:parse_frame(Buf, ParseOpts) of
-                {ok, Frame, NewBuffer} ->
-                    ok = roadrunner_telemetry:ws_frame_in(
-                        (Data1#data.ctx)#{opcode => maps:get(opcode, Frame)},
-                        payload_size(Frame)
-                    ),
-                    %% Frame parsed. Carry `frame_validated` into
-                    %% handle_frame so accumulate_fragment can skip
-                    %% redundant per-fragment UTF-8 validation. The
-                    %% reset happens AFTER fragment-level dispatch
-                    %% (in `reset_msg/1`), so the next frame's
-                    %% wire-level cursor starts from zero.
-                    handle_frame(
-                        Frame,
-                        Data1#data{buffer = NewBuffer},
-                        HibernateAcc
-                    );
-                {more, _} ->
-                    arm_or_stop(Socket, Data1, hibernate_actions(HibernateAcc));
-                {error, _} ->
-                    {stop, normal, Data1}
+            case frame_within_cap(MaybeTotalLen, Data1) of
+                false ->
+                    %% Declared frame payload exceeds `max_frame_size`.
+                    %% The header is in hand but the body isn't buffered
+                    %% yet — close now (RFC 6455 §7.4 code 1009) instead
+                    %% of letting the `{more, _}` re-arm keep reading.
+                    close_with(close_message_too_big(), reset_msg(Data1));
+                true ->
+                    process_parsed_frame(Data1, Buf, Opts, MaybeTotalLen, HibernateAcc)
             end;
         invalid_utf8 ->
             close_with(close_invalid_payload(), reset_msg(Data))
+    end.
+
+-spec process_parsed_frame(
+    #data{}, binary(), roadrunner_ws:parse_opts(), non_neg_integer() | undefined, boolean()
+) -> gen_statem:event_handler_result(atom()).
+process_parsed_frame(#data{socket = Socket} = Data1, Buf, Opts, MaybeTotalLen, HibernateAcc) ->
+    ParseOpts = parse_opts_with_pre_unmasked(Opts, Data1, MaybeTotalLen),
+    case roadrunner_ws:parse_frame(Buf, ParseOpts) of
+        {ok, Frame, NewBuffer} ->
+            ok = roadrunner_telemetry:ws_frame_in(
+                (Data1#data.ctx)#{opcode => maps:get(opcode, Frame)},
+                payload_size(Frame)
+            ),
+            %% Frame parsed. Carry `frame_validated` into handle_frame
+            %% so accumulate_fragment can skip redundant per-fragment
+            %% UTF-8 validation. The reset happens AFTER fragment-level
+            %% dispatch (in `reset_msg/1`), so the next frame's
+            %% wire-level cursor starts from zero.
+            handle_frame(
+                Frame,
+                Data1#data{buffer = NewBuffer},
+                HibernateAcc
+            );
+        {more, _} ->
+            arm_or_stop(Socket, Data1, hibernate_actions(HibernateAcc));
+        {error, _} ->
+            {stop, normal, Data1}
     end.
 
 %% Hand the cached unmasked payload to `parse_frame` when (and only
@@ -406,6 +448,18 @@ parse_opts_with_pre_unmasked(Opts, #data{unmasked_buf = Buf}, TotalLen) when
     Opts#{pre_unmasked => Buf};
 parse_opts_with_pre_unmasked(Opts, _Data, _TotalLen) ->
     Opts.
+
+%% Per-frame size cap. The peeked header reveals the frame's declared
+%% payload length before the body is buffered, so an oversized frame is
+%% rejected on the header alone (≤14 bytes seen) rather than after the
+%% `{more, _}` re-arm reads the whole payload. `undefined` means the
+%% length isn't known yet — let parsing continue and re-check on the
+%% next pass.
+-spec frame_within_cap(non_neg_integer() | undefined, #data{}) -> boolean().
+frame_within_cap(undefined, _Data) ->
+    true;
+frame_within_cap(TotalLen, #data{max_frame_size = Max}) ->
+    TotalLen =< Max.
 
 %% Sneak-peek a partially-buffered frame and validate any NEW
 %% text-payload bytes that have arrived since the last process_buffer
@@ -460,11 +514,18 @@ early_validate_text(Data, Buf, Opts) ->
                             invalid_utf8
                     end
             end;
+        {ok, #{total_payload_len := TotalLen}, _Available} ->
+            %% Header is peekable but the in-progress frame isn't a
+            %% fresh uncompressed text frame (binary / control /
+            %% continuation / compressed). No incremental UTF-8
+            %% validation applies, but surface the declared length so
+            %% `process_buffer/2` can apply the per-frame size cap
+            %% before the body is buffered.
+            {ok, Data, TotalLen};
         _ ->
-            %% Header isn't peekable yet, OR the in-progress frame
-            %% isn't a fresh uncompressed text frame — skip early
-            %% validation. parse_frame will catch protocol errors;
-            %% UTF-8 validation happens at fragment / FIN time.
+            %% Header isn't peekable yet — not enough buffered bytes to
+            %% know the declared length. parse_frame will catch protocol
+            %% errors; UTF-8 validation happens at fragment / FIN time.
             {ok, Data, undefined}
     end.
 
@@ -595,33 +656,59 @@ classify_data_frame(#{rsv1 := Rsv1, opcode := Op}, Data) when Op =:= text orelse
     gen_statem:event_handler_result(atom()).
 accumulate_fragment(
     #{fin := false, payload := P} = _Frame,
-    #data{msg_acc = Acc, msg_opcode = Op, msg_compressed = Compressed} = Data,
+    #data{
+        msg_acc = Acc,
+        msg_opcode = Op,
+        msg_compressed = Compressed,
+        msg_size = Size,
+        max_message_size = MaxMsg
+    } = Data,
     Hibernate
 ) ->
-    case fragment_validate(Op, Compressed, Data#data.utf8_pending, P, Data) of
-        {ok, NewPending} ->
-            NewAcc =
-                case Acc of
-                    undefined -> [P];
-                    _ -> [Acc, P]
-                end,
-            process_buffer(
-                Data#data{
-                    msg_acc = NewAcc,
-                    utf8_pending = NewPending,
-                    %% Reset wire-level cursor + unmasked-buffer so
-                    %% the NEXT frame's bytes are validated and
-                    %% accumulated from scratch when they arrive.
-                    frame_validated = 0,
-                    unmasked_buf = <<>>
-                },
-                Hibernate
-            );
-        invalid_utf8 ->
-            %% RFC 6455 §8.1: close 1007 on the first invalid UTF-8
-            %% byte sequence — don't wait for FIN.
-            close_with(close_invalid_payload(), reset_msg(Data))
+    NewSize = Size + byte_size(P),
+    case NewSize > MaxMsg of
+        true ->
+            %% Reassembled message (running sum of fragment payloads)
+            %% exceeds `max_message_size`. Close with 1009 instead of
+            %% buffering more — this is what stops a continuation flood
+            %% that never sets fin=1.
+            close_with(close_message_too_big(), reset_msg(Data));
+        false ->
+            case fragment_validate(Op, Compressed, Data#data.utf8_pending, P, Data) of
+                {ok, NewPending} ->
+                    NewAcc =
+                        case Acc of
+                            undefined -> [P];
+                            _ -> [Acc, P]
+                        end,
+                    process_buffer(
+                        Data#data{
+                            msg_acc = NewAcc,
+                            msg_size = NewSize,
+                            utf8_pending = NewPending,
+                            %% Reset wire-level cursor + unmasked-buffer so
+                            %% the NEXT frame's bytes are validated and
+                            %% accumulated from scratch when they arrive.
+                            frame_validated = 0,
+                            unmasked_buf = <<>>
+                        },
+                        Hibernate
+                    );
+                invalid_utf8 ->
+                    %% RFC 6455 §8.1: close 1007 on the first invalid
+                    %% UTF-8 byte sequence — don't wait for FIN.
+                    close_with(close_invalid_payload(), reset_msg(Data))
+            end
     end;
+accumulate_fragment(
+    #{fin := true, payload := P} = _Frame,
+    #data{msg_size = Size, max_message_size = MaxMsg} = Data,
+    _Hibernate
+) when Size + byte_size(P) > MaxMsg ->
+    %% The final fragment pushes the reassembled message over
+    %% `max_message_size` — close with 1009. (For compressed messages
+    %% this bounds the wire-level accumulated payload.)
+    close_with(close_message_too_big(), reset_msg(Data));
 accumulate_fragment(
     #{fin := true, payload := P} = _Frame,
     #data{
@@ -733,6 +820,7 @@ reset_msg(Data) ->
         msg_acc = undefined,
         msg_opcode = undefined,
         msg_compressed = false,
+        msg_size = 0,
         utf8_pending = <<>>,
         frame_validated = 0,
         unmasked_buf = <<>>
@@ -826,6 +914,13 @@ close_protocol_error() ->
 -spec close_invalid_payload() -> binary().
 close_invalid_payload() ->
     <<1007:16>>.
+
+%% RFC 6455 §7.4: 1009 = message too big — a single frame's declared
+%% payload, a reassembled message, or an inflated payload exceeded the
+%% configured cap.
+-spec close_message_too_big() -> binary().
+close_message_too_big() ->
+    <<1009:16>>.
 
 -spec close_with(binary(), #data{}) -> {stop, normal, #data{}}.
 close_with(StatusBin, Data) ->

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -107,7 +107,8 @@
     %% payload — enforced in `process_buffer/2` against the peeked
     %% header before the body is buffered. `max_message_size` bounds a
     %% reassembled message via `msg_size`, the running sum of fragment
-    %% payloads. Over either cap closes the connection with 1009.
+    %% payloads; under permessage-deflate it also caps the decompressed
+    %% size (`finalize_message/3`). Over either cap closes with 1009.
     max_frame_size :: non_neg_integer(),
     max_message_size :: non_neg_integer(),
     msg_size = 0 :: non_neg_integer(),
@@ -747,6 +748,9 @@ accumulate_fragment(
                         invalid_utf8 ->
                             close_with(close_invalid_payload(), Data1)
                     end;
+                {error, message_too_big} ->
+                    %% Inflated payload would exceed `max_message_size`.
+                    close_with(close_message_too_big(), Reset);
                 {error, _} ->
                     close_with(close_protocol_error(), Reset)
             end;
@@ -880,17 +884,49 @@ incomplete_is_provably_invalid(_) -> false.
     {ok, binary(), #data{}} | {error, term()}.
 finalize_message(Data, Iolist, false) ->
     {ok, iolist_to_binary(Iolist), Data};
-finalize_message(#data{inflate_z = Z, pmd_params = Params} = Data, Iolist, true) ->
+finalize_message(
+    #data{inflate_z = Z, pmd_params = Params, max_message_size = MaxMsg} = Data, Iolist, true
+) ->
     Compressed = iolist_to_binary([Iolist, ?PMD_TAIL]),
-    try
-        Inflated = iolist_to_binary(zlib:inflate(Z, Compressed)),
-        case maps:get(client_no_context_takeover, Params, false) of
-            true -> ok = zlib:inflateReset(Z);
-            false -> ok
-        end,
-        {ok, Inflated, Data}
+    try bounded_inflate(Z, Compressed, MaxMsg) of
+        {ok, Inflated} ->
+            case maps:get(client_no_context_takeover, Params, false) of
+                true -> ok = zlib:inflateReset(Z);
+                false -> ok
+            end,
+            {ok, Inflated, Data};
+        {error, _} = Err ->
+            %% Over the decompressed cap — the connection is about to be
+            %% closed (1009), so the inflate stream isn't reset for reuse.
+            Err
     catch
         _:Reason -> {error, Reason}
+    end.
+
+%% Inflate `Compressed` in bounded chunks, enforcing `Max` on the
+%% running decompressed total. permessage-deflate (RFC 7692) lets a
+%% small high-ratio frame expand to GiB; `zlib:inflate/2` materializes
+%% all of it at once. `zlib:safeInflate/2` yields one bounded chunk per
+%% call, so we stop and reject the moment the output would cross the cap
+%% rather than allocating the whole bomb.
+-spec bounded_inflate(zlib:zstream(), binary(), non_neg_integer()) ->
+    {ok, binary()} | {error, message_too_big}.
+bounded_inflate(Z, Compressed, Max) ->
+    bounded_inflate(zlib:safeInflate(Z, Compressed), Z, Max, 0, []).
+
+-spec bounded_inflate(
+    {continue | finished, iolist()}, zlib:zstream(), non_neg_integer(), non_neg_integer(), iolist()
+) -> {ok, binary()} | {error, message_too_big}.
+bounded_inflate({continue, Output}, Z, Max, Total, Acc) ->
+    NewTotal = Total + iolist_size(Output),
+    case NewTotal > Max of
+        true -> {error, message_too_big};
+        false -> bounded_inflate(zlib:safeInflate(Z, []), Z, Max, NewTotal, [Acc, Output])
+    end;
+bounded_inflate({finished, Output}, _Z, Max, Total, Acc) ->
+    case Total + iolist_size(Output) > Max of
+        true -> {error, message_too_big};
+        false -> {ok, iolist_to_binary([Acc, Output])}
     end.
 
 %% RFC 6455 §8.1: text-message payloads MUST be valid UTF-8. Binary

--- a/test/roadrunner_conn_loop_sendfile_handler.erl
+++ b/test/roadrunner_conn_loop_sendfile_handler.erl
@@ -1,7 +1,7 @@
 -module(roadrunner_conn_loop_sendfile_handler).
 -moduledoc """
 Test fixture — emits a `{sendfile, ...}` response covering
-`roadrunner_conn_loop:dispatch_response/4`'s sendfile clause. The
+`roadrunner_conn_loop:dispatch_response/5`'s sendfile clause. The
 file path is read from the request's `state` (set by the
 single-handler dispatch helper that stashes state there) or from
 `persistent_term` under `{?MODULE, file}`.

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1008,7 +1008,7 @@ request_start_and_stop_pair_with_shared_request_id_test() ->
 
 head_method_buffered_response_omits_body_test() ->
     %% RFC 9110 §9.3.2 — HEAD must NOT include a message body even
-    %% when the handler returns one. The dispatch_response/4 fast
+    %% when the handler returns one. The dispatch_response/5 fast
     %% path in conn_loop pattern-matches on `method := ~"HEAD"` and
     %% forces the body to `~""`. Headers (including content-length)
     %% stay as-is so the framing matches what GET would have returned.
@@ -1122,7 +1122,7 @@ sendfile_response_writes_head_then_body_test() ->
 
 sendfile_response_skips_body_for_head_method_test() ->
     %% RFC 9110 §9.3.2 — HEAD must not include a message body.
-    %% Covers the `~"HEAD"` branch of dispatch_response/4's sendfile clause.
+    %% Covers the `~"HEAD"` branch of dispatch_response/5's sendfile clause.
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
@@ -1158,7 +1158,7 @@ sendfile_response_skips_body_for_head_method_test() ->
 sendfile_dispatch_closes_socket_on_error_test() ->
     %% Sendfile responses honor keep-alive (per finishing_phase/3), so a
     %% mid-write failure would otherwise leave the conn idling for a
-    %% truncated request the client will never send. dispatch_response/4
+    %% truncated request the client will never send. dispatch_response/5
     %% must force-close the socket on `roadrunner_transport:sendfile/4`
     %% errors so the keep-alive loop sees `closed` on its next recv and
     %% the conn exits normally.
@@ -1197,7 +1197,7 @@ sendfile_dispatch_closes_socket_on_error_test() ->
     Sink ! stop.
 
 websocket_dispatch_invokes_session_run_test() ->
-    %% Without proper ws upgrade headers `ws_session:run/4` writes 400
+    %% Without proper ws upgrade headers `ws_session:run/5` writes 400
     %% and returns. We're covering the dispatch_response websocket
     %% clause — a full handshake test lives in the WS suite.
     ensure_pg(),

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -109,6 +109,7 @@ listener_honors_num_acceptors_opt_test() ->
 notify_drain_reaches_pg_members_test() ->
     %% Self-join the drain group so the broadcast reaches this process,
     %% then call notify_drain and assert the message lands.
+    ok = ensure_pg_started(),
     Name = listener_test_notify_drain,
     Group = {roadrunner_drain, Name},
     ok = pg:join(Group, self()),
@@ -126,6 +127,7 @@ notify_drain_reaches_pg_members_test() ->
 
 notify_drain_with_no_members_is_noop_test() ->
     %% Empty group — just confirms the call returns ok and doesn't crash.
+    ok = ensure_pg_started(),
     ?assertEqual(
         ok,
         roadrunner_listener:notify_drain(
@@ -144,10 +146,7 @@ slot_reconciliation_releases_sustained_orphan_slots_test() ->
     %% `kill`-bypasses-`terminate` recovery. Also asserts the
     %% `[roadrunner, listener, slots_reconciled]` telemetry event fires
     %% with the released count.
-    case whereis(pg) of
-        undefined -> {ok, _} = pg:start_link();
-        _ -> ok
-    end,
+    ok = ensure_pg_started(),
     {ok, _} = application:ensure_all_started(telemetry),
     Self = self(),
     HandlerId = make_ref(),
@@ -192,10 +191,7 @@ slot_reconciliation_releases_sustained_orphan_slots_test() ->
 slot_reconciliation_only_reaps_excess_over_pg_members_test() ->
     %% Counter > pg members → only the diff is orphan; pg members
     %% themselves represent live conns and must NOT be touched.
-    case whereis(pg) of
-        undefined -> {ok, _} = pg:start_link();
-        _ -> ok
-    end,
+    ok = ensure_pg_started(),
     Name = listener_test_reap_partial,
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
         port => 0,
@@ -398,10 +394,7 @@ listener_drops_unknown_info_message_test() ->
     ok = roadrunner_listener:stop(Name).
 
 slot_reconciliation_disabled_by_default_test() ->
-    case whereis(pg) of
-        undefined -> {ok, _} = pg:start_link();
-        _ -> ok
-    end,
+    ok = ensure_pg_started(),
     Name = listener_test_no_reap,
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
         port => 0, routes => roadrunner_hello_handler
@@ -465,7 +458,7 @@ drain(Sock) ->
 drain_with_no_active_conns_returns_immediately_test_() ->
     {setup,
         fun() ->
-            ensure_pg_started(),
+            ok = ensure_pg_started(),
             Name = listener_test_drain_idle,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0, routes => roadrunner_hello_handler
@@ -483,7 +476,7 @@ drain_with_no_active_conns_returns_immediately_test_() ->
 drain_waits_for_in_flight_loop_to_close_test_() ->
     {setup,
         fun() ->
-            ensure_pg_started(),
+            ok = ensure_pg_started(),
             Name = listener_test_drain_loop,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -511,7 +504,7 @@ drain_waits_for_in_flight_loop_to_close_test_() ->
 drain_timeout_kills_unresponsive_conns_test_() ->
     {setup,
         fun() ->
-            ensure_pg_started(),
+            ok = ensure_pg_started(),
             Name = listener_test_drain_kill,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -538,7 +531,7 @@ drain_timeout_kills_unresponsive_conns_test_() ->
 drain_closes_keep_alive_conn_after_in_flight_request_test_() ->
     {setup,
         fun() ->
-            ensure_pg_started(),
+            ok = ensure_pg_started(),
             Name = listener_test_drain_ka,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0, routes => roadrunner_drain_pause_handler
@@ -616,7 +609,7 @@ parse_cl(Head) ->
 reload_routes_swaps_dispatch_table_test_() ->
     {setup,
         fun() ->
-            ensure_pg_started(),
+            ok = ensure_pg_started(),
             Name = listener_test_reload,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -648,7 +641,7 @@ reload_routes_rebakes_listener_middlewares_test_() ->
     %% middlewares on reloaded routes.
     {setup,
         fun() ->
-            ensure_pg_started(),
+            ok = ensure_pg_started(),
             Name = listener_test_reload_listener_mws,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -809,7 +802,7 @@ drain_close(Sock, Acc) ->
 status_returns_phase_test_() ->
     {setup,
         fun() ->
-            ensure_pg_started(),
+            ok = ensure_pg_started(),
             Name = listener_test_status,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0, routes => roadrunner_hello_handler
@@ -831,7 +824,8 @@ status_returns_phase_test_() ->
 ensure_pg_started() ->
     case whereis(pg) of
         undefined ->
-            {ok, _} = pg:start_link();
+            {ok, _} = pg:start_link(),
+            ok;
         _ ->
             ok
     end.

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -339,6 +339,25 @@ listener_rejects_invalid_protocols_value_test() ->
         [[], [http3], [http1, http1], not_a_list]
     ).
 
+listener_rejects_ws_message_cap_below_frame_cap_test() ->
+    %% A reassembled message is built from frames, so a single
+    %% unfragmented frame is also a whole message — `ws_max_message_size`
+    %% below `ws_max_frame_size` is contradictory and must reject at
+    %% `init/1`.
+    process_flag(trap_exit, true),
+    R = roadrunner_listener:start_link(listener_test_ws_cap_conflict, #{
+        port => 0,
+        ws_max_frame_size => 1048576,
+        ws_max_message_size => 1024,
+        routes => roadrunner_hello_handler
+    }),
+    ?assertMatch(
+        {error, {
+            {listener_opt_conflict, ws_max_message_size, 1024, below_ws_max_frame_size}, _Stack
+        }},
+        R
+    ).
+
 slot_reconciliation_disabled_drops_reconcile_slots_message_test() ->
     %% A `reconcile_slots` arriving at a listener with reconciliation
     %% disabled (race after a hypothetical config change) is just

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -341,21 +341,36 @@ listener_rejects_invalid_protocols_value_test() ->
 
 listener_rejects_ws_message_cap_below_frame_cap_test() ->
     %% A reassembled message is built from frames, so a single
-    %% unfragmented frame is also a whole message — `ws_max_message_size`
-    %% below `ws_max_frame_size` is contradictory and must reject at
+    %% unfragmented frame is also a whole message — `max_message_size`
+    %% below `max_frame_size` is contradictory and must reject at
     %% `init/1`.
     process_flag(trap_exit, true),
     R = roadrunner_listener:start_link(listener_test_ws_cap_conflict, #{
         port => 0,
-        ws_max_frame_size => 1048576,
-        ws_max_message_size => 1024,
+        ws => #{max_frame_size => 1048576, max_message_size => 1024},
         routes => roadrunner_hello_handler
     }),
     ?assertMatch(
-        {error, {
-            {listener_opt_conflict, ws_max_message_size, 1024, below_ws_max_frame_size}, _Stack
-        }},
+        {error, {{listener_opt_conflict, ws, _, max_message_size_below_max_frame_size}, _Stack}},
         R
+    ).
+
+listener_rejects_invalid_ws_opt_test() ->
+    %% Unknown keys, out-of-range / non-integer values, and non-map
+    %% shapes in `ws` all reject (mirrors the strict `{http2, #{...}}`
+    %% sub-opt validation), so a typo can't silently fall back to the
+    %% default cap.
+    process_flag(trap_exit, true),
+    lists:foreach(
+        fun(Bad) ->
+            R = roadrunner_listener:start_link(listener_test_ws_invalid, #{
+                port => 0,
+                ws => Bad,
+                routes => roadrunner_hello_handler
+            }),
+            ?assertMatch({error, {{invalid_listener_opt, ws, _}, _Stack}}, R)
+        end,
+        [#{frame_size => 1}, #{max_frame_size => -1}, #{max_frame_size => bad}, not_a_map]
     ).
 
 slot_reconciliation_disabled_drops_reconcile_slots_message_test() ->

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -1049,6 +1049,41 @@ final_fragment_over_message_cap_closes_with_1009_test() ->
     ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
     Sink ! stop.
 
+empty_continuation_flood_over_message_cap_closes_with_1009_test() ->
+    %% Empty continuation frames (payload <<>>, fin=0) carry no payload
+    %% bytes but still grow the reassembly buffer. Each fragment is
+    %% charged at least ?WS_FRAGMENT_OVERHEAD (64) toward the cap, so a
+    %% flood of empties is bounded: with cap 200, the 2-byte start
+    %% charges 64, then each empty charges 64 — the 3rd empty crosses
+    %% 200 and closes 1009.
+    Self = self(),
+    Tag = make_ref(),
+    Start = uncompressed_fragment(text, ~"ab", false),
+    Empty = uncompressed_fragment(continuation, <<>>, false),
+    Flood = <<Start/binary, Empty/binary, Empty/binary, Empty/binary, Empty/binary>>,
+    Sink = spawn_active_sink(Self, Tag, [{recv, Flood}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            ws_proto_opts(16777216, 200)
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
+    Sink ! stop.
+
 permessage_deflate_inflate_bomb_closes_with_1009_test() ->
     %% A small compressed frame whose inflated payload exceeds
     %% `ws_max_message_size` must be rejected during inflate (RFC 6455

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -1084,6 +1084,52 @@ empty_continuation_flood_over_message_cap_closes_with_1009_test() ->
     ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
     Sink ! stop.
 
+size_cap_rejection_emits_frame_rejected_telemetry_test() ->
+    %% A cap rejection emits [roadrunner, ws, frame_rejected] with the
+    %% reason and offending size before the 1009 close. Here a 50-byte
+    %% frame trips a 10-byte frame cap.
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    HandlerId = make_ref(),
+    ok = telemetry:attach(
+        HandlerId,
+        [roadrunner, ws, frame_rejected],
+        fun(Event, M, Md, _) -> Self ! {tev, Event, M, Md} end,
+        undefined
+    ),
+    try
+        Tag = make_ref(),
+        Big = frame(binary, binary:copy(<<$x>>, 50)),
+        Sink = spawn_active_sink(Self, Tag, [{recv, Big}]),
+        {ok, Pid} = gen_statem:start(
+            roadrunner_ws_session,
+            {
+                {fake, Sink},
+                roadrunner_ws_echo_handler,
+                undefined,
+                ws_ctx(),
+                none,
+                ws_proto_opts(10, 16777216)
+            },
+            []
+        ),
+        Ref = monitor(process, Pid),
+        Pid ! socket_ready,
+        receive
+            {'DOWN', Ref, process, Pid, normal} -> ok
+        after 1000 -> error(no_close)
+        end,
+        receive
+            {tev, [roadrunner, ws, frame_rejected], M, Md} ->
+                ?assertEqual(max_frame_size, maps:get(reason, Md)),
+                ?assertEqual(50, maps:get(size, M))
+        after 500 -> error(no_frame_rejected_event)
+        end,
+        Sink ! stop
+    after
+        telemetry:detach(HandlerId)
+    end.
+
 permessage_deflate_inflate_bomb_closes_with_1009_test() ->
     %% A small compressed frame whose inflated payload exceeds
     %% `ws_max_message_size` must be rejected during inflate (RFC 6455

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% `roadrunner_ws_session:run/4` must start the gen_statem **before** the
+%% `roadrunner_ws_session:run/5` must start the gen_statem **before** the
 %% 101 upgrade response is written. If `gen_statem:start/3` fails
 %% (here forced via an unknown handler module — `init/1` rejects it,
 %% turning into `{error, _}` from start), the 101 must never reach
@@ -24,7 +24,7 @@ run_with_unloadable_handler_sends_500_and_no_101_test() ->
         request_id => undefined
     },
     ok = roadrunner_ws_session:run(
-        {fake, Sink}, Req, this_module_does_not_exist_xyz_42, undefined
+        {fake, Sink}, Req, this_module_does_not_exist_xyz_42, undefined, ws_proto_opts()
     ),
     Sent = iolist_to_binary(collect_sends(Tag, 100)),
     Sink ! stop,
@@ -42,7 +42,9 @@ run_with_bad_handshake_still_returns_400_test() ->
         listener_name => undefined,
         request_id => undefined
     },
-    ok = roadrunner_ws_session:run({fake, Sink}, Req, roadrunner_ws_echo_handler, undefined),
+    ok = roadrunner_ws_session:run(
+        {fake, Sink}, Req, roadrunner_ws_echo_handler, undefined, ws_proto_opts()
+    ),
     Sent = iolist_to_binary(collect_sends(Tag, 100)),
     Sink ! stop,
     ?assertNotEqual(nomatch, binary:match(Sent, ~"400")),
@@ -50,7 +52,7 @@ run_with_bad_handshake_still_returns_400_test() ->
 
 %% =============================================================================
 %% Active-mode frame_loop — hibernate, transport error, and stray-info
-%% paths. Drives the gen_statem directly (skipping the run/4 launcher)
+%% paths. Drives the gen_statem directly (skipping the run/5 launcher)
 %% with a script-driven fake sink that delivers `roadrunner_fake_data`
 %% messages on `setopts({active, once})`.
 %% =============================================================================
@@ -68,7 +70,7 @@ frame_loop_hibernates_when_handler_returns_hibernate_opt_test() ->
     ]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_hibernate_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_hibernate_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -89,7 +91,7 @@ frame_loop_hibernates_on_ok_opt_variant_test() ->
     ]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_hibernate_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_hibernate_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -107,7 +109,7 @@ frame_loop_no_hibernate_for_3_tuple_returns_test() ->
     ]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -129,7 +131,7 @@ frame_loop_stops_on_transport_error_event_test() ->
     Sink = spawn_active_sink(Self, Tag, [{error, econnreset}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -155,7 +157,7 @@ frame_loop_closed_after_partial_frame_stops_cleanly_test() ->
     ]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -180,7 +182,7 @@ frame_loop_setopts_error_stops_cleanly_test() ->
     Sink = spawn_active_sink(Self, Tag, []),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -211,7 +213,7 @@ frame_loop_processes_multiple_frames_in_one_chunk_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, TwoFrames}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -231,7 +233,7 @@ frame_loop_drops_unexpected_info_event_test() ->
     Sink = spawn_active_sink(Self, Tag, []),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -257,7 +259,7 @@ init_callback_runs_once_at_session_start_test() ->
     State = #{sink => Self, on_init => ok},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -278,7 +280,7 @@ init_callback_can_push_priming_frames_test() ->
     State = #{sink => Self, on_init => {reply, [{text, ~"snapshot"}]}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -296,7 +298,7 @@ init_callback_can_request_hibernate_test() ->
     State = #{sink => Self, on_init => ok_hibernate},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -317,7 +319,7 @@ init_callback_close_terminates_session_test() ->
     State = #{sink => Self, on_init => close},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -340,7 +342,7 @@ handle_info_callback_forwards_stray_message_test() ->
     State = #{sink => Self, on_info => {reply, [{text, ~"forwarded"}]}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -360,7 +362,7 @@ handle_info_callback_can_request_hibernate_test() ->
     State = #{sink => Self, on_info => ok_hibernate},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -383,7 +385,7 @@ handle_info_callback_close_terminates_session_test() ->
     State = #{sink => Self, on_info => close},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -412,7 +414,7 @@ handle_drain_callback_dispatches_when_exported_test() ->
     State = #{sink => Self, on_drain => {reply, [{text, ~"draining"}]}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -437,7 +439,7 @@ handle_drain_callback_close_terminates_session_test() ->
     State = #{sink => Self, on_drain => {close, 1000, ~"draining"}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -461,7 +463,7 @@ handle_drain_drops_when_handler_does_not_export_test() ->
     Sink = spawn_active_sink(Self, Tag, []),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -498,7 +500,7 @@ run_session_forwards_drain_to_session_test() ->
     },
     Worker = spawn(fun() ->
         ok = roadrunner_ws_session:run(
-            {fake, Sink}, Req, roadrunner_ws_lifecycle_handler, State
+            {fake, Sink}, Req, roadrunner_ws_lifecycle_handler, State, ws_proto_opts()
         ),
         Self ! {worker_done, self()}
     end),
@@ -540,7 +542,7 @@ awaiting_socket_postpones_drain_until_frame_loop_test() ->
     State = #{sink => Self, on_drain => {close, 1000, ~"draining"}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -572,7 +574,7 @@ close_with_code_emits_status_and_reason_test() ->
     State = #{sink => Self, on_init => {close, 1000, ~"bye"}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -595,7 +597,7 @@ close_with_code_accepts_iodata_reason_test() ->
     State = #{sink => Self, on_init => {close, 1001, [~"hello", ~" ", ~"world"]}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -615,7 +617,7 @@ close_with_empty_reason_emits_only_code_test() ->
     State = #{sink => Self, on_init => {close, 1000, ~""}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -638,7 +640,7 @@ close_with_invalid_code_crashes_session_test() ->
     State = #{sink => Self, on_init => {close, 5000, ~"reason"}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -658,7 +660,7 @@ close_with_invalid_utf8_reason_crashes_session_test() ->
     State = #{sink => Self, on_init => {close, 1000, <<16#FF>>}},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_lifecycle_handler, State, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -694,7 +696,14 @@ pmd_inflates_compressed_inbound_text_message_test() ->
             ~"permessage-deflate"},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Pid ! socket_ready,
@@ -736,7 +745,14 @@ pmd_concatenates_compressed_fragments_before_inflate_test() ->
             ~"permessage-deflate"},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Pid ! socket_ready,
@@ -766,7 +782,14 @@ pmd_uncompressed_frame_passes_through_when_pmd_negotiated_test() ->
             ~"permessage-deflate"},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Pid ! socket_ready,
@@ -799,7 +822,14 @@ pmd_three_way_fragmented_compressed_message_test() ->
     Negotiated = pmd_negotiated(),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Pid ! socket_ready,
@@ -821,7 +851,14 @@ pmd_corrupt_compressed_payload_stops_session_test() ->
     Negotiated = pmd_negotiated(),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Ref = monitor(process, Pid),
@@ -855,7 +892,14 @@ pmd_no_context_takeover_resets_inflate_after_each_message_test() ->
             ~"permessage-deflate; server_no_context_takeover; client_no_context_takeover"},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Pid ! socket_ready,
@@ -878,7 +922,7 @@ fragmented_text_message_dispatches_complete_payload_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -897,7 +941,7 @@ continuation_outside_message_closes_with_protocol_error_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, Stray}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -911,6 +955,100 @@ continuation_outside_message_closes_with_protocol_error_test() ->
     ?assertEqual(<<16#88, 2, 1002:16>>, Sent),
     Sink ! stop.
 
+oversized_single_frame_closes_with_1009_test() ->
+    %% A single frame whose declared payload exceeds `ws_max_frame_size`
+    %% is rejected with RFC 6455 §7.4 code 1009. Cap set to 10 bytes;
+    %% the frame declares a 50-byte payload.
+    Self = self(),
+    Tag = make_ref(),
+    Big = frame(binary, binary:copy(<<$x>>, 50)),
+    Sink = spawn_active_sink(Self, Tag, [{recv, Big}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            ws_proto_opts(10, 16777216)
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
+    Sink ! stop.
+
+continuation_flood_over_message_cap_closes_with_1009_test() ->
+    %% A fragmented message that never sets fin=1 must not grow without
+    %% bound. Each 100-byte fragment is under `ws_max_frame_size` but
+    %% the running total crosses `ws_max_message_size` (150) on the
+    %% second fragment, closing with code 1009.
+    Self = self(),
+    Tag = make_ref(),
+    Chunk = binary:copy(<<$a>>, 100),
+    Start = uncompressed_fragment(text, Chunk, false),
+    Cont = uncompressed_fragment(continuation, Chunk, false),
+    Sink = spawn_active_sink(Self, Tag, [{recv, <<Start/binary, Cont/binary>>}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            ws_proto_opts(16777216, 150)
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
+    Sink ! stop.
+
+final_fragment_over_message_cap_closes_with_1009_test() ->
+    %% The cap also fires when the FINAL (fin=1) fragment is what pushes
+    %% the reassembled message over `ws_max_message_size` — close 1009.
+    Self = self(),
+    Tag = make_ref(),
+    Chunk = binary:copy(<<$a>>, 100),
+    Start = uncompressed_fragment(text, Chunk, false),
+    Final = uncompressed_fragment(continuation, Chunk, true),
+    Sink = spawn_active_sink(Self, Tag, [{recv, <<Start/binary, Final/binary>>}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            ws_proto_opts(16777216, 150)
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
+    Sink ! stop.
+
 new_data_frame_mid_message_closes_with_protocol_error_test() ->
     %% A non-FIN text frame in progress, then ANOTHER text frame
     %% (instead of a continuation) — protocol error.
@@ -921,7 +1059,7 @@ new_data_frame_mid_message_closes_with_protocol_error_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -943,7 +1081,7 @@ invalid_utf8_in_text_message_closes_1007_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, F}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -971,7 +1109,7 @@ out_of_range_utf8_at_fragment_2_closes_immediately_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary, F3/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1050,7 +1188,7 @@ empty_text_frame_round_trips_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, Empty}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -1073,7 +1211,7 @@ continuation_with_invalid_utf8_at_fin_closes_1007_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1096,7 +1234,7 @@ continuation_with_incomplete_utf8_at_fin_closes_1007_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1119,7 +1257,7 @@ overlong_3byte_e0_8x_closes_immediately_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1140,7 +1278,7 @@ overlong_4byte_f0_8x_closes_immediately_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1162,7 +1300,7 @@ invalid_leader_f5_closes_immediately_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1186,7 +1324,7 @@ incomplete_utf8_at_fin_closes_with_1007_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, F}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1212,7 +1350,14 @@ pmd_compressed_text_with_invalid_utf8_closes_1007_test() ->
     Negotiated = pmd_negotiated(),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Ref = monitor(process, Pid),
@@ -1235,7 +1380,7 @@ surrogate_pair_in_utf8_closes_immediately_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1260,7 +1405,7 @@ invalid_utf8_mid_fragment_closes_immediately_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),
@@ -1286,7 +1431,7 @@ incomplete_utf8_at_fragment_boundary_carries_forward_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -1311,7 +1456,7 @@ binary_fragments_skip_utf8_validation_test() ->
     Sink = spawn_active_sink(Self, Tag, [{recv, <<F1/binary, F2/binary>>}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_autobahn_handler, no_state, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_autobahn_handler, no_state, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Pid ! socket_ready,
@@ -1339,7 +1484,14 @@ pmd_control_frames_stay_uncompressed_test() ->
             ~"permessage-deflate"},
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), Negotiated},
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            Negotiated,
+            ws_proto_opts()
+        },
         []
     ),
     Pid ! socket_ready,
@@ -1358,6 +1510,15 @@ ws_ctx() ->
         request_id => undefined,
         module => roadrunner_ws_echo_handler
     }.
+
+%% Minimal `proto_opts` slice the session reads in `init/1`. Defaults to
+%% the production 16 MB caps so existing small-frame tests are
+%% unaffected; cap tests call `ws_proto_opts/2` with tight values.
+ws_proto_opts() ->
+    ws_proto_opts(16777216, 16777216).
+
+ws_proto_opts(MaxFrame, MaxMsg) ->
+    #{ws_max_frame_size => MaxFrame, ws_max_message_size => MaxMsg}.
 
 %% A minimal text/binary single-fragment unmasked frame. Server-side
 %% receives masked frames per the WebSocket spec, so we mark fin=true
@@ -1481,7 +1642,7 @@ run_close_test(ClosePayload) ->
     Sink = spawn_active_sink(Self, Tag, [{recv, Frame}]),
     {ok, Pid} = gen_statem:start(
         roadrunner_ws_session,
-        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none},
+        {{fake, Sink}, roadrunner_ws_echo_handler, undefined, ws_ctx(), none, ws_proto_opts()},
         []
     ),
     Ref = monitor(process, Pid),

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -1049,6 +1049,98 @@ final_fragment_over_message_cap_closes_with_1009_test() ->
     ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
     Sink ! stop.
 
+permessage_deflate_inflate_bomb_closes_with_1009_test() ->
+    %% A small compressed frame whose inflated payload exceeds
+    %% `ws_max_message_size` must be rejected during inflate (RFC 6455
+    %% §7.4 code 1009), not expanded in full. 5000 bytes deflate to a
+    %% tiny frame and inflate in a single zlib chunk; the cap is 1000.
+    Self = self(),
+    Tag = make_ref(),
+    Compressed = pmd_compress(binary:copy(<<$a>>, 5000)),
+    InboundFrame = pmd_frame(binary, Compressed),
+    Sink = spawn_active_sink(Self, Tag, [{recv, InboundFrame}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            pmd_negotiated(),
+            ws_proto_opts(16777216, 1000)
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
+    Sink ! stop.
+
+permessage_deflate_chunked_inflate_bomb_closes_with_1009_test() ->
+    %% zlib inflates in 16 KiB chunks. A payload that decompresses to
+    %% 50000 bytes crosses the 1000-byte cap on the FIRST chunk, so the
+    %% bounded loop bails mid-stream (1009) without producing the rest.
+    Self = self(),
+    Tag = make_ref(),
+    Compressed = pmd_compress(binary:copy(<<$a>>, 50000)),
+    InboundFrame = pmd_frame(binary, Compressed),
+    Sink = spawn_active_sink(Self, Tag, [{recv, InboundFrame}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            pmd_negotiated(),
+            ws_proto_opts(16777216, 1000)
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertEqual(<<16#88, 2, 1009:16>>, Sent),
+    Sink ! stop.
+
+permessage_deflate_large_message_under_cap_inflates_test() ->
+    %% A 50000-byte message inflates across several 16 KiB zlib chunks
+    %% but stays under the default cap — the bounded loop must reassemble
+    %% all chunks and dispatch the complete payload, not reject it. The
+    %% echo handler replies with a compressed text frame (0xC1), proving
+    %% the message was accepted rather than closed (0x88).
+    Self = self(),
+    Tag = make_ref(),
+    Compressed = pmd_compress(binary:copy(<<$a>>, 50000)),
+    InboundFrame = pmd_frame(text, Compressed),
+    Sink = spawn_active_sink(Self, Tag, [{recv, InboundFrame}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            pmd_negotiated(),
+            ws_proto_opts()
+        },
+        []
+    ),
+    Pid ! socket_ready,
+    Sent = iolist_to_binary(collect_sends(Tag, 300)),
+    ?assertMatch(<<16#c1, _/binary>>, Sent),
+    Sink ! stop,
+    ok = gen_statem:stop(Pid).
+
 new_data_frame_mid_message_closes_with_protocol_error_test() ->
     %% A non-FIN text frame in progress, then ANOTHER text frame
     %% (instead of a continuation) — protocol error.


### PR DESCRIPTION
# Description

Bounds the memory a single WebSocket connection can use before any handler runs, closing an unauthenticated memory-exhaustion DoS. Per-listener caps on frame size, reassembled-message size (summed across fragments), and permessage-deflate decompressed size; over-cap closes with RFC 6455 code 1009 and fires `[roadrunner, ws, frame_rejected]`. Caps default to 10 MB via a new `ws` listener option; full reference in `docs/resource_limits.md`.

- `ws => #{max_frame_size => 1_048_576, max_message_size => 8_388_608}` (new option, both default 10 MB)
- Oversized frame or message: closed with 1009 before buffering (was: unbounded)
- permessage-deflate bomb: rejected mid-inflate (was: could inflate to gigabytes)

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
