### PR TITLE
Bound the HTTP/2 request header block to prevent CONTINUATION-flood denial-of-service

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -255,6 +255,28 @@ workloads (server-side, large-POST upload patterns) before shipping.
 have to drain the new SETTINGS entry + early WINDOW_UPDATE in
 their handshake fixture).
 
+### Advertise SETTINGS_MAX_HEADER_LIST_SIZE
+
+**What:** Advertise `SETTINGS_MAX_HEADER_LIST_SIZE` (RFC 9113 §6.5.2,
+id 0x06) in the server's SETTINGS frame. The cumulative HEADERS +
+CONTINUATION block is now capped (16384 bytes, GOAWAY(ENHANCE_YOUR_CALM)
+on overflow, the same bound h1 and h3 use), which closes the
+CONTINUATION-flood memory gap. Advertising the decoded-size limit lets
+conformant clients avoid sending an oversized block in the first place
+rather than learning via the connection close.
+
+**Why deferred:** The setting bounds the *decoded* header-list size, a
+different unit from the encoded-block cap that does the real memory
+bounding, so it is an advisory courtesy rather than the load-bearing
+fix. The h3 sibling (`SETTINGS_MAX_FIELD_SECTION_SIZE`, under the
+HTTP/3 follow-ups above) wants the same treatment.
+
+**Scope:** small (`server_settings_frame/1` in
+`roadrunner_conn_loop_http2.erl` prepends `{6, Limit}`; the setting
+already exists defaulted to `infinity` in
+`roadrunner_http2_settings.erl`; the ~50 handshake fixtures that drain
+the server SETTINGS need to tolerate the extra entry).
+
 ### Sendfile chunk size tracks the peer's negotiated MAX_FRAME_SIZE
 
 **What:** Today `?SENDFILE_CHUNK_SIZE` in

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -73,6 +73,14 @@
 %% RFC 9113 §6.5.2 default `MAX_FRAME_SIZE`.
 -define(MAX_FRAME_SIZE, 16_384).
 
+%% Cumulative cap on an assembled HEADERS+CONTINUATION block. Each frame
+%% is already bounded to MAX_FRAME_SIZE, but the number of CONTINUATION
+%% frames is not, so without this a peer can flood CONTINUATION frames and
+%% grow the block without bound (the HTTP/2 CONTINUATION Flood). h1 and h3
+%% bound the same way (`roadrunner_http1` / `roadrunner_conn_loop_http3`
+%% MAX_HEADER_BLOCK).
+-define(MAX_HEADER_BLOCK, 16_384).
+
 %% RFC 9113 §6.9.2 initial window size for both the connection and
 %% each stream.
 -define(INITIAL_WINDOW, 65535).
@@ -122,7 +130,14 @@
 
 -type stream_entry() :: #{
     state := stream_state(),
-    header_fragment := binary(),
+    %% Field block fragments (the HEADERS frame plus any CONTINUATIONs):
+    %% a bare binary for a single frame, an iolist once CONTINUATIONs
+    %% append, flattened once at finalize (like `body` accumulates DATA).
+    header_fragment := iodata(),
+    %% Running byte count of `header_fragment`, so the CONTINUATION-flood
+    %% cap can compare against a counter instead of re-measuring the
+    %% accumulated block on every frame.
+    header_len := non_neg_integer(),
     end_headers := boolean(),
     end_stream_seen := boolean(),
     headers := undefined | roadrunner_http:headers(),
@@ -620,6 +635,7 @@ on_headers(StreamId, Flags, _Priority, Fragment, #loop{streams = Streams} = Stat
             EndHeaders = (Flags band 16#04) =/= 0,
             Stream1 = Stream#{
                 header_fragment := Fragment,
+                header_len := byte_size(Fragment),
                 end_headers := EndHeaders,
                 end_stream_seen := true
             },
@@ -689,6 +705,7 @@ new_stream(Fragment, EndHeaders, EndStream, SendWindow, RecvWindow) ->
     #{
         state => open,
         header_fragment => Fragment,
+        header_len => byte_size(Fragment),
         end_headers => EndHeaders,
         end_stream_seen => EndStream,
         headers => undefined,
@@ -707,28 +724,50 @@ on_continuation(StreamId, Flags, Fragment, #loop{streams = Streams} = State) ->
             StreamId :=
                 #{
                     end_headers := false,
-                    header_fragment := Existing,
+                    header_fragment := Frags,
+                    header_len := Len,
                     headers := PriorHeaders
                 } = Stream
         } ->
-            Combined = <<Existing/binary, Fragment/binary>>,
+            FragLen = byte_size(Fragment),
+            NewLen = Len + FragLen,
             EndHeaders = (Flags band 16#04) =/= 0,
-            Stream1 = Stream#{header_fragment := Combined, end_headers := EndHeaders},
-            Streams1 = Streams#{StreamId := Stream1},
-            %% Set streams + awaiting_continuation in one record update on
-            %% the END_HEADERS path — two sequential `#loop{}` updates
-            %% would copy the record twice.
-            State2 =
-                case EndHeaders of
-                    true ->
-                        State#loop{streams = Streams1, awaiting_continuation = undefined};
-                    false ->
-                        State#loop{streams = Streams1}
-                end,
-            case {EndHeaders, PriorHeaders =:= undefined} of
-                {true, true} -> finalize_headers(StreamId, State2);
-                {true, false} -> finalize_trailers(StreamId, State2);
-                {false, _} -> frame_loop(State2)
+            %% CONTINUATION-flood guard, both variants. The assembled
+            %% block crossed the cap (memory exhaustion), or a non-final
+            %% empty CONTINUATION made no forward progress (an endless
+            %% stream of those pins the conn in header assembly without
+            %% ever growing the byte total). Each frame is bounded by
+            %% MAX_FRAME_SIZE but neither the cumulative size nor the
+            %% frame count is otherwise limited. The per-connection HPACK
+            %% context can't be resynced if we skip the block, so this is
+            %% a connection error rather than a per-stream reject.
+            %% ENHANCE_YOUR_CALM is the RFC 9113 §6.5.2 resource-limit code.
+            case NewLen > ?MAX_HEADER_BLOCK orelse (FragLen =:= 0 andalso not EndHeaders) of
+                true ->
+                    _ = send_goaway(State, enhance_your_calm),
+                    exit_clean(State);
+                false ->
+                    Stream1 = Stream#{
+                        header_fragment := [Frags, Fragment],
+                        header_len := NewLen,
+                        end_headers := EndHeaders
+                    },
+                    Streams1 = Streams#{StreamId := Stream1},
+                    %% Set streams + awaiting_continuation in one record update on
+                    %% the END_HEADERS path — two sequential `#loop{}` updates
+                    %% would copy the record twice.
+                    State2 =
+                        case EndHeaders of
+                            true ->
+                                State#loop{streams = Streams1, awaiting_continuation = undefined};
+                            false ->
+                                State#loop{streams = Streams1}
+                        end,
+                    case {EndHeaders, PriorHeaders =:= undefined} of
+                        {true, true} -> finalize_headers(StreamId, State2);
+                        {true, false} -> finalize_trailers(StreamId, State2);
+                        {false, _} -> frame_loop(State2)
+                    end
             end;
         _ ->
             _ = send_goaway(State, protocol_error),
@@ -742,7 +781,7 @@ on_continuation(StreamId, Flags, Fragment, #loop{streams = Streams} = State) ->
 %% pending request (END_STREAM was already set by `on_headers/5`).
 finalize_trailers(StreamId, #loop{streams = Streams, hpack_dec = Dec} = State) ->
     #{StreamId := #{header_fragment := Fragment} = Stream} = Streams,
-    case roadrunner_http2_hpack:decode(Fragment, Dec) of
+    case roadrunner_http2_hpack:decode(iolist_to_binary(Fragment), Dec) of
         {ok, _Trailers, Dec1} ->
             Stream1 = Stream#{header_fragment := <<>>},
             State1 = State#loop{
@@ -765,7 +804,7 @@ finalize_headers(StreamId, #loop{streams = Streams, hpack_dec = Dec} = State) ->
             end_stream_seen := EndStreamSeen
         } = Stream
     } = Streams,
-    case roadrunner_http2_hpack:decode(Fragment, Dec) of
+    case roadrunner_http2_hpack:decode(iolist_to_binary(Fragment), Dec) of
         {ok, Headers, Dec1} ->
             Stream1 = Stream#{headers := Headers, header_fragment := <<>>},
             State1 = State#loop{

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -33,6 +33,8 @@ all_test_() ->
         fun push_promise_from_client_triggers_goaway/0,
         fun even_stream_id_triggers_goaway/0,
         fun continuation_without_pending_triggers_goaway/0,
+        fun continuation_flood_triggers_goaway/0,
+        fun continuation_empty_frame_flood_triggers_goaway/0,
         fun data_on_unknown_stream_triggers_goaway/0,
         fun malformed_hpack_block_triggers_goaway/0,
         fun missing_pseudo_header_rst_stream/0,
@@ -643,6 +645,65 @@ continuation_without_pending_triggers_goaway() ->
     Cf = iolist_to_binary(roadrunner_http2_frame:encode({continuation, 1, 16#04, <<>>})),
     serve_recv(ConnPid, Cf),
     _ = expect_send(),
+    expect_close(),
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 500 -> error(no_exit)
+    end.
+
+continuation_flood_triggers_goaway() ->
+    %% HEADERS without END_HEADERS, then a CONTINUATION that pushes the
+    %% assembled block past ?MAX_HEADER_BLOCK. Each frame is within
+    %% MAX_FRAME_SIZE but the cumulative block is not (the HTTP/2
+    %% CONTINUATION Flood), so the conn is torn down with
+    %% GOAWAY(ENHANCE_YOUR_CALM). The fragments are never HPACK-decoded.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(),
+    _ = expect_send(),
+    serve_recv(ConnPid, ?PREFACE),
+    serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+    _ = expect_send(),
+    HeadersF = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 0, undefined, binary:copy(~"x", 100)})
+    ),
+    serve_recv(ConnPid, HeadersF),
+    ContinuationF = iolist_to_binary(
+        roadrunner_http2_frame:encode({continuation, 1, 0, binary:copy(~"x", 16384)})
+    ),
+    serve_recv(ConnPid, ContinuationF),
+    Out = expect_send(),
+    %% GOAWAY (type 7) carrying ENHANCE_YOUR_CALM (0x0B): after the 9-byte
+    %% frame header the payload is Last-Stream-Id (32 bits) then the error
+    %% code (32 bits).
+    ?assertMatch(<<_:24, 7:8, _:8, _:32, _:32, 16#0B:32, _/binary>>, Out),
+    expect_close(),
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 500 -> error(no_exit)
+    end.
+
+continuation_empty_frame_flood_triggers_goaway() ->
+    %% HEADERS without END_HEADERS, then a non-final empty CONTINUATION.
+    %% It makes no forward progress and never grows the byte total, so the
+    %% size cap alone would never catch an endless stream of them. Treated
+    %% as a flood: GOAWAY(ENHANCE_YOUR_CALM). An empty CONTINUATION that
+    %% carries END_HEADERS, the only sane empty case, is still accepted.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(),
+    _ = expect_send(),
+    serve_recv(ConnPid, ?PREFACE),
+    serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+    _ = expect_send(),
+    HeadersF = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 0, undefined, binary:copy(~"x", 100)})
+    ),
+    serve_recv(ConnPid, HeadersF),
+    EmptyF = iolist_to_binary(roadrunner_http2_frame:encode({continuation, 1, 0, <<>>})),
+    serve_recv(ConnPid, EmptyF),
+    Out = expect_send(),
+    ?assertMatch(<<_:24, 7:8, _:8, _:32, _:32, 16#0B:32, _/binary>>, Out),
     expect_close(),
     receive
         {'DOWN', Ref, process, Pid, normal} -> ok


### PR DESCRIPTION
# Description

HTTP/2 didn't bound the request header block, so a peer could flood CONTINUATION frames and exhaust the server's memory (the HTTP/2 CONTINUATION Flood). This caps the assembled block and closes the connection on overflow, the way h1 and h3 already do.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
