### PR TITLE
Update version references to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requires **OTP 29 or newer**.
 
 Roadrunner is in `0.x`. The core is functional and covered by tests,
 but the API may change between minor versions. Pin an exact version
-in your deps (e.g. `{roadrunner, "0.1.0"}`) if you need stability
+in your deps (e.g. `{roadrunner, "0.2.0"}`) if you need stability
 across upgrades.
 
 ## ✅ Conformance
@@ -130,7 +130,7 @@ Add to `rebar.config`:
 
 ```erlang
 {deps, [
-    {roadrunner, "0.1.0"}
+    {roadrunner, "0.2.0"}
 ]}.
 ```
 


### PR DESCRIPTION
# Description

Bumps the README install and version-pin examples from `0.1.0` to `0.2.0` ahead of the 0.2.0 tag and hex publish. The package version is derived from the git tag (`{vsn, semver}` in `roadrunner.app.src`), so there is no code change. Docs only.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
