### PR TITLE
Bump the README install snippet to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Add to `rebar.config`:
 
 ```erlang
 {deps, [
-    {roadrunner, "0.2.0"}
+    {roadrunner, "0.2.1"}
 ]}.
 ```
 


### PR DESCRIPTION
# Description

Bumps the README `rebar.config` example to `{roadrunner, "0.2.1"}` for the 0.2.1 release. Docs only.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
