### PR TITLE
Apply the client's HTTP/2 connection-preface SETTINGS

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -315,10 +315,15 @@ handshake_phase_preface(State) ->
 -spec handshake_phase_settings(#loop{}) -> no_return().
 handshake_phase_settings(#loop{buffer = Buf} = State) ->
     case roadrunner_http2_frame:parse(Buf, ?MAX_FRAME_SIZE) of
-        {ok, {settings, Flags, _Params}, Rest} when (Flags band 1) =:= 0 ->
-            State1 = State#loop{buffer = Rest},
-            _ = send(State1, roadrunner_http2_frame:encode({settings, 1, []})),
-            frame_loop(State1);
+        {ok, {settings, Flags, Params}, Rest} when (Flags band 1) =:= 0 ->
+            %% RFC 9113 §3.4: the connection-preface SETTINGS is a normal
+            %% SETTINGS frame, so apply its parameters through the shared
+            %% handler (validate, apply INITIAL_WINDOW_SIZE, ACK, enter the
+            %% loop). Previously the parameters were dropped, pinning every
+            %% stream's send window to the 65535 default no matter what the
+            %% client advertised — forcing extra WINDOW_UPDATE round-trips
+            %% (or stalling clients that never send one) on large responses.
+            handle_frame({settings, 0, Params}, State#loop{buffer = Rest});
         {ok, _, _} ->
             _ = send_goaway(State, protocol_error),
             exit_clean(State);

--- a/test/roadrunner_bench_client.erl
+++ b/test/roadrunner_bench_client.erl
@@ -122,13 +122,16 @@ open(Host, Port, h3) ->
 %% `Sock` is the tagged transport — `{ssl, _}` or `{tcp, _}` — so the
 %% rest of the h2 path is transport-agnostic via `tsend/trecv/tclose`.
 h2_open_common(Sock, Host) ->
-    %% Preface + empty SETTINGS + a connection-level WINDOW_UPDATE that
-    %% bumps the server's `conn_send_window` from 65 535 to 2^31-1.
-    %% Without it a long-running keep-alive bench accumulates 65 535
-    %% bytes of response data and stalls. Real h2 clients all do this.
+    %% Preface + SETTINGS (raising SETTINGS_INITIAL_WINDOW_SIZE so each
+    %% stream's send window starts at the max) + a connection-level
+    %% WINDOW_UPDATE that lifts the server's `conn_send_window` to
+    %% 2^31-1. The SETTINGS covers per-stream flow control, the
+    %% WINDOW_UPDATE the connection level; without both, response data
+    %% past the 65 535 defaults stalls (a single-stream response over
+    %% 65 535 bytes, or a long keep-alive run). Real h2 clients raise both.
     BigBumpInc = 16#7FFFFFFF - 65535,
     BumpFrame = roadrunner_http2_frame:encode({window_update, 0, BigBumpInc}),
-    ok = tsend(Sock, [?PREFACE, h2_empty_settings_frame(), BumpFrame]),
+    ok = tsend(Sock, [?PREFACE, h2_settings_frame(), BumpFrame]),
     case h2_handshake(Sock, <<>>, false, false) of
         {ok, Buf} ->
             {ok, #h2_conn{
@@ -471,8 +474,10 @@ h1_content_length(Headers) ->
 %% h2 helpers
 %% =============================================================================
 
-h2_empty_settings_frame() ->
-    <<0:24, 4, 0, 0:32>>.
+h2_settings_frame() ->
+    %% SETTINGS_INITIAL_WINDOW_SIZE (0x04) = 2^31-1 so the server's
+    %% per-stream send window starts at the maximum.
+    roadrunner_http2_frame:encode({settings, 0, [{4, 16#7FFFFFFF}]}).
 
 h2_settings_ack_frame() ->
     <<0:24, 4, 1, 0:32>>.

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -122,6 +122,7 @@ all_test_() ->
         fun headers_for_closed_stream_protocol_error/0,
         fun settings_initial_window_size_shifts_stream_window/0,
         fun settings_initial_window_size_flushes_pending_data/0,
+        fun preface_settings_initial_window_applied/0,
         fun content_length_multi_valued_rst_stream/0,
         fun trailers_after_first_end_stream_protocol_error/0
     ],
@@ -2792,6 +2793,25 @@ headers_for_closed_stream_protocol_error() ->
     after 500 -> error(no_exit)
     end.
 
+preface_settings_initial_window_applied() ->
+    %% RFC 9113 §3.4: the server must apply the client's connection-
+    %% preface SETTINGS. Advertise INITIAL_WINDOW_SIZE = 20000 in the
+    %% preface, then GET a 50 KB body: the per-stream send window caps
+    %% the response at 20000 bytes (two DATA frames, neither with
+    %% END_STREAM) until a WINDOW_UPDATE that never comes. If the
+    %% preface SETTINGS were dropped (the old bug), the default 65535
+    %% window would let the whole 50 KB out with END_STREAM.
+    Preface = iolist_to_binary(
+        roadrunner_http2_frame:encode({settings, 0, [{4, 20000}]})
+    ),
+    {Pid, Ref} = run_stream_request(~"/large50k", Preface),
+    Frames = collect_response_frames(),
+    ?assertMatch([{headers, 1, false} | _], Frames),
+    DataBytes = lists:sum([byte_size(P) || {data, _, _, P} <- Frames]),
+    ?assertEqual(20000, DataBytes),
+    ?assertEqual([], [F || {data, _, true, _} = F <- Frames]),
+    cleanup(Pid, Ref).
+
 settings_initial_window_size_shifts_stream_window() ->
     %% Open a stream, then SETTINGS with a new INITIAL_WINDOW_SIZE
     %% mixed with an unrelated setting id (3, MAX_CONCURRENT_STREAMS)
@@ -3248,6 +3268,9 @@ run_h2_request_with_handler(Handler, Path) ->
 %% mailbox so the test can decode + assert on them via
 %% `collect_response_frames/0`.
 run_stream_request(Path) ->
+    run_stream_request(Path, ?EMPTY_SETTINGS_FRAME).
+
+run_stream_request(Path, PrefaceSettings) ->
     {ok, _} = application:ensure_all_started(telemetry),
     drain_mailbox(),
     Self = self(),
@@ -3274,7 +3297,7 @@ run_stream_request(Path) ->
     Pid ! ready,
     _ = expect_send(),
     serve_recv(Pid, ?PREFACE),
-    serve_recv(Pid, ?EMPTY_SETTINGS_FRAME),
+    serve_recv(Pid, PrefaceSettings),
     _ = expect_send(),
     Enc = roadrunner_http2_hpack:new_encoder(4096),
     {Hpack, _} = roadrunner_http2_hpack:encode(


### PR DESCRIPTION
# Description

The connection-preface SETTINGS frame was acknowledged but its parameters were dropped, so a peer's `SETTINGS_INITIAL_WINDOW_SIZE` never took effect and every stream's send window stayed pinned at the 65535 default (RFC 9113 §3.4); this routes the preface frame through the normal SETTINGS handler so the parameters apply. The in-tree h2 bench client now advertises a large `INITIAL_WINDOW_SIZE` like real clients, so it can drive single-stream responses larger than 65535 bytes (which previously stalled).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)