### PR TITLE
Drop the redundant HTTP/2 h2_worker_done message

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -29,7 +29,6 @@
 %% {h2_send_headers, Worker, Ref, StreamId, Status, Headers, EndStream}
 %% {h2_send_data,    Worker, Ref, StreamId, Data,   EndStream}
 %% {h2_send_trailers, Worker, Ref, StreamId, Trailers}
-%% {h2_worker_done,  StreamId}
 %% ```
 %%
 %% The conn replies `{h2_send_ack, Ref}` once the corresponding
@@ -405,8 +404,6 @@ recv_more(
             recv_more(handle_send_trailers(State, From, Ref, StreamId, Trailers));
         {h2_send_response, From, Ref, StreamId, Status, Headers, Body} ->
             recv_more(handle_send_response(State, From, Ref, StreamId, Status, Headers, Body));
-        {h2_worker_done, StreamId} ->
-            recv_more(handle_worker_done(State, StreamId));
         {'DOWN', MonRef, process, _Pid, Reason} ->
             recv_more(maybe_exit_when_drained(handle_worker_down(State, MonRef, Reason)));
         {roadrunner_drain, _Deadline} ->
@@ -1086,12 +1083,6 @@ handle_send_trailers(State, From, Ref, StreamId, Trailers) ->
             _ = (From ! {h2_send_ack, Ref}),
             State1
     end.
-
-handle_worker_done(State, StreamId) ->
-    %% The worker exits after this message; the DOWN cleanup will
-    %% remove the stream. Nothing to do here.
-    _ = StreamId,
-    State.
 
 handle_worker_down(#loop{worker_refs = Refs} = State, MonRef, Reason) ->
     case Refs of

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -26,9 +26,10 @@
 %%
 %% Worker → Conn: {h2_send_trailers, Worker, Ref, StreamId, Trailers}
 %% Conn   → Worker: {h2_send_ack, Ref}
-%%
-%% Worker → Conn: {h2_worker_done, StreamId}                 %% normal exit
 %% ```
+%%
+%% The worker has no explicit "done" message: it is spawn_monitored, so
+%% the conn finalises the stream on the worker's `DOWN`.
 %%
 %% If the peer cancels the stream (`RST_STREAM` or worker-level error
 %% on the conn side), the conn sends `{h2_stream_reset, StreamId}` —
@@ -70,7 +71,9 @@ init(ConnPid, StreamId, Req, ProtoOpts) ->
     %% handler runs in this worker, not on the conn.
     ok = roadrunner_conn:set_request_logger_metadata(Req),
     run_handler(ConnPid, StreamId, Req, ProtoOpts),
-    ConnPid ! {h2_worker_done, StreamId},
+    %% No explicit completion message: the worker is spawn_monitored by
+    %% the conn, which finalises the stream on the worker's `DOWN`
+    %% (`normal` -> clean removal, anything else -> RST_STREAM).
     ok.
 
 run_handler(ConnPid, StreamId, Req, ProtoOpts) ->

--- a/test/roadrunner_http2_stream_worker_tests.erl
+++ b/test/roadrunner_http2_stream_worker_tests.erl
@@ -32,11 +32,11 @@ logger_metadata_set_in_h2_worker_test_() ->
                     fun roadrunner_logger_probe_handler:handle/1, undefined},
             middlewares => []
         },
-        {_WorkerPid, _MonRef} = roadrunner_http2_stream_worker:start(
+        {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
             ConnPid, StreamId, Req, ProtoOpts
         ),
         Body = recv_response_body(StreamId),
-        ok = recv_worker_done(StreamId),
+        ok = recv_worker_exit(MonRef, WorkerPid),
         Probe = binary_to_term(Body, [safe]),
         Md = maps:get(logger_metadata, Probe),
         ?assertEqual(~"deadbeefdeadbeef", maps:get(request_id, Md)),
@@ -54,9 +54,9 @@ recv_response_body(StreamId) ->
         error(no_h2_send_response)
     end.
 
-recv_worker_done(StreamId) ->
+recv_worker_exit(MonRef, WorkerPid) ->
     receive
-        {h2_worker_done, StreamId} -> ok
+        {'DOWN', MonRef, process, WorkerPid, normal} -> ok
     after 1000 ->
-        error(no_h2_worker_done)
+        error(no_worker_exit)
     end.


### PR DESCRIPTION
# Description

The conn's handler for `h2_worker_done` was a no-op, since stream cleanup and the drain check already run on the worker's monitored `DOWN`, so dropping the message removes one worker-to-conn message and one conn-loop iteration per h2 request and leaves the worker protocol as just the send/ack round-trips plus the monitored exit.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)