### PR TITLE
Bump the README install snippet to 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Add to `rebar.config`:
 
 ```erlang
 {deps, [
-    {roadrunner, "0.2.1"}
+    {roadrunner, "0.2.2"}
 ]}.
 ```
 


### PR DESCRIPTION
# Description

Bumps the README install snippet to `0.2.2`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)