### PR TITLE
Start only the QUIC listener pool, not the whole quic application

### DIFF
--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -495,13 +495,18 @@ start_tcp(Port, Opts, Protocols, ProtoOpts) ->
     end.
 
 %% Start the QUIC listener roadrunner owns when `http3` is requested.
-%% `quic` is started on demand here (kept out of roadrunner's
-%% `applications` so HTTP/1.1/HTTP/2-only deployments never boot it).
-%% Each accepted QUIC connection is handed to a fresh
-%% `roadrunner_conn_loop_http3` owner via the arity-1
-%% `connection_handler`; the QUIC listener then transfers ownership to
-%% the returned pid. `http3` having been validated to require `tls`,
-%% the `tls` opt is always present here.
+%% Only the self-contained `quic_listener_sup` pool is started (via
+%% `start_quic_pool/2`), NOT the whole `quic` application. That app's
+%% supervisor tree backs the dep's own turnkey server (`server_registry`
+%% / `server_sup`), client (`token_cache`), and distribution
+%% (`dist_sup`) features — none of which roadrunner's owned listener
+%% uses — and `crypto` + `ssl` are already up as roadrunner's own deps.
+%% Keeping the `quic` app out of the boot path means a co-serving
+%% instance carries no idle supervisors it never uses. Each accepted
+%% QUIC connection is handed to a fresh `roadrunner_conn_loop_http3`
+%% owner via the arity-1 `connection_handler`; the QUIC listener then
+%% transfers ownership to the returned pid. `http3` having been
+%% validated to require `tls`, the `tls` opt is always present here.
 -spec start_quic(
     inet:port_number(), opts(), [http1 | http2 | http3, ...], roadrunner_conn:proto_opts()
 ) -> {ok, pid() | undefined} | {error, term()}.
@@ -510,7 +515,6 @@ start_quic(Port, Opts, Protocols, ProtoOpts) ->
         false ->
             {ok, undefined};
         true ->
-            {ok, _Started} = application:ensure_all_started(quic),
             #{tls := UserTlsOpts} = Opts,
             {Cert, CertChain, Key} = quic_cert_key(UserTlsOpts),
             Handler = fun(ConnPid) -> roadrunner_conn_loop_http3:start(ConnPid, ProtoOpts) end,

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -130,8 +130,13 @@ all() ->
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
     {ok, _} = application:ensure_all_started(ssl),
-    %% The h3 listener starts `quic` on demand, but the client needs it
-    %% too — bring it up once here for the whole suite.
+    %% roadrunner's h3 listener is self-contained and does NOT start the
+    %% `quic` app (see `roadrunner_listener:start_quic/4`); the test CLIENT
+    %% below is what needs it, so bring it up once for the whole suite.
+    %% Consequence: these cases run with `quic` already up, so they don't
+    %% exercise the server's standalone (no-app) path — that's covered
+    %% separately by `bench.escript --protocols h3`, where the server peer
+    %% serves h3 with no `quic` app running.
     {ok, _} = application:ensure_all_started(quic),
     %% Start the default `pg` scope standalone (the drain group lives
     %% there) rather than the whole roadrunner app, so this suite


### PR DESCRIPTION
# Description

roadrunner's HTTP/3 server only needs the self-contained `quic_listener_sup` pool, so `start_quic/4` no longer boots the whole `quic` application and its unused registry/server_sup/token_cache/dist_sup. Enabling http3 therefore no longer auto-starts the `quic` app, so a release that also uses quic as an outbound client must start it itself.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the contributing guidelines