### PR TITLE
Drop the pinned version from the README install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,12 @@ means out of scope for that server.
 
 ## Quickstart
 
-Add to `rebar.config`:
+Add to `rebar.config` (latest version on
+[Hex](https://hex.pm/packages/roadrunner)):
 
 ```erlang
 {deps, [
-    {roadrunner, "0.2.2"}
+    roadrunner
 ]}.
 ```
 


### PR DESCRIPTION
# Description

The Quickstart now uses a bare-atom dep `{deps, [roadrunner]}` (rebar3 resolves the latest from Hex) instead of a hardcoded version, so the install snippet no longer needs a bump every release. The version link points to [Hex](https://hex.pm/packages/roadrunner).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the contributing guidelines