### PR TITLE
Add the handler_spawn listener option for handler-process spawn config

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -118,6 +118,31 @@ lot of them.
 
 ## Other
 
+### Connection-process memory tuning follow-ups
+
+**What:** The `conn_spawn` listener opt already exposes the full
+`proc_lib:start/5` spawn config (`opts` + `start_timeout`) for every
+handler-running process, defaulting to `[{fullsweep_after, 0}]`.
+Remaining polish:
+- a named convenience opt (e.g. a top-level `max_heap_size`) if the
+  raw `opts` passthrough proves clumsy in practice
+- ship a recommended `vm.args` carrying `+MHacul 0 +MBacul 0` so the
+  allocator returns freed carriers to the OS (the opt's doc points at
+  this today, but nothing packages it)
+- revisit whether `fullsweep_after, 0` should stay the default: it is
+  free on allocation-heavy handlers but costs ~3-4% on trivial
+  passthrough, so an adaptive policy (or a different default) may be
+  better once measured on more workloads
+- verify the per-process memory win extends to the HTTP/2 and HTTP/3
+  stream-worker processes under load (validated so far on the h1
+  connection process)
+
+**Why deferred:** the passthrough plus default already capture the
+~72% process-memory reduction; these are refinements that each want
+their own measurement before shipping.
+
+**Scope:** small.
+
 ### h2 receive-window defaults
 
 **What:** Bump the listener's default receive-window peaks above the

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -133,7 +133,13 @@
     %% Declared here so dialyzer accepts pattern matches like
     %% `#{hibernate_after := Ms}` against `proto_opts()`.
     hibernate_after => pos_integer(),
-    rate_check_interval => pos_integer()
+    rate_check_interval => pos_integer(),
+    %% Flattened spawn config for every handler-running process. The public
+    %% `handler_spawn => #{opts, start_timeout}` listener opt is expanded into
+    %% these top-level keys by `roadrunner_listener:build_proto_opts/2` so the
+    %% spawn sites read them with a single `maps:get/2`, never a nested lookup.
+    handler_spawn_opts => [proc_lib:start_spawn_option()],
+    handler_start_timeout => timeout()
 }.
 
 -doc """

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -115,7 +115,8 @@ start(Socket, ProtoOpts) when is_map(ProtoOpts) ->
     %% so existing acceptor handoff (`controlling_process` then `! shoot`)
     %% works without modification.
     Parent = self(),
-    proc_lib:start(?MODULE, init_loop, [Parent, Socket, ProtoOpts]).
+    #{handler_spawn_opts := SpawnOpts, handler_start_timeout := StartTimeout} = ProtoOpts,
+    proc_lib:start(?MODULE, init_loop, [Parent, Socket, ProtoOpts], StartTimeout, SpawnOpts).
 
 -doc false.
 -spec init_loop(pid(), roadrunner_transport:socket(), roadrunner_conn:proto_opts()) ->

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -138,7 +138,8 @@ start(ConnPid, ProtoOpts) ->
             _ = quic:close(ConnPid, ?H3_NO_ERROR),
             {error, max_clients};
         true ->
-            {ok, proc_lib:spawn(?MODULE, init, [ConnPid, ProtoOpts])}
+            #{handler_spawn_opts := SpawnOpts} = ProtoOpts,
+            {ok, proc_lib:spawn_opt(?MODULE, init, [ConnPid, ProtoOpts], SpawnOpts)}
     end.
 
 -doc false.

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -59,7 +59,8 @@ stream's id, leaving the other 99 streams intact.
 -spec start(pid(), pos_integer(), roadrunner_req:request(), map()) ->
     {pid(), reference()}.
 start(ConnPid, StreamId, Req, ProtoOpts) ->
-    spawn_monitor(?MODULE, init, [ConnPid, StreamId, Req, ProtoOpts]).
+    #{handler_spawn_opts := SpawnOpts} = ProtoOpts,
+    spawn_opt(?MODULE, init, [ConnPid, StreamId, Req, ProtoOpts], [monitor | SpawnOpts]).
 
 -doc false.
 -spec init(pid(), pos_integer(), roadrunner_req:request(), map()) -> ok.

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -58,7 +58,8 @@ at the connection / stream level, not by crashing this worker).
 -spec start(pid(), non_neg_integer(), roadrunner_req:request(), roadrunner_conn:proto_opts()) ->
     {pid(), reference()}.
 start(Conn, StreamId, Req, ProtoOpts) ->
-    spawn_monitor(?MODULE, init, [Conn, StreamId, Req, ProtoOpts]).
+    #{handler_spawn_opts := SpawnOpts} = ProtoOpts,
+    spawn_opt(?MODULE, init, [Conn, StreamId, Req, ProtoOpts], [monitor | SpawnOpts]).
 
 -doc false.
 -spec init(pid(), non_neg_integer(), roadrunner_req:request(), roadrunner_conn:proto_opts()) -> ok.

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -45,6 +45,13 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
 -define(DEFAULT_MAX_CLIENTS, 150).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
+%% Spawn config for every handler-running process (connection process +
+%% HTTP/2/3 stream workers). `fullsweep_after, 0` reclaims the per-connection
+%% heap that grows building a response (e.g. a JSON encoder's transient iolist)
+%% instead of hoarding it as old-gen garbage across keep-alive requests — at
+%% high connection counts the difference between hundreds of MB and a few GB.
+-define(DEFAULT_HANDLER_SPAWN_OPTS, [{fullsweep_after, 0}]).
+-define(DEFAULT_HANDLER_START_TIMEOUT, infinity).
 -define(DEFAULT_WS_MAX_FRAME_SIZE, 10485760).
 -define(DEFAULT_WS_MAX_MESSAGE_SIZE, 10485760).
 %% Per-connection concurrent client-initiated request (bidirectional)
@@ -117,6 +124,14 @@ Optional middleware and timing knobs (durations in milliseconds):
   lower per-conn overhead on short-lived workloads).
 - `hibernate_after` — when set, idle conns hibernate after this
   many milliseconds of main-loop idle time.
+- `handler_spawn` — spawn config for every handler-running process (the
+  connection process and HTTP/2/3 stream workers) as a nested map:
+  `opts` (`spawn_opt` / `proc_lib` options, default
+  `[{fullsweep_after, 0}]` so the per-conn response heap is reclaimed
+  instead of hoarding it as old-gen garbage across keep-alive
+  requests) and `start_timeout` (init-ack deadline, default
+  `infinity`). Pair with `+MHacul 0 +MBacul 0` in `vm.args` to return
+  freed allocator carriers to the OS for the lowest resident memory.
 - `protocols` — list of `t:protocol_entry/0`. Default `[http1]`.
   On TLS this drives `alpn_preferred_protocols` automatically.
 - `tls` — `[ssl:tls_server_option()]` for HTTPS. Empty / absent
@@ -172,6 +187,27 @@ ops-tuning rationale.
     %% receive's `after` clause has a window to call
     %% `erlang:hibernate/3`.
     hibernate_after => pos_integer(),
+    %% Spawn config for every handler-running process — the connection process
+    %% and the HTTP/2/3 stream workers. `opts` is a passthrough to `spawn_opt`
+    %% (default `[{fullsweep_after, 0}]`): the default reclaims the
+    %% per-connection heap that grows building a response (e.g. a JSON
+    %% encoder's transient iolist) instead of hoarding it as old-gen garbage
+    %% across keep-alive requests — at high connection counts the difference
+    %% between hundreds of MB and a few GB of resident memory. Free on
+    %% allocation-heavy handlers; ~3-4% on trivial passthrough handlers, so
+    %% pass `{fullsweep_after, 65535}` to restore the BEAM default. Also useful
+    %% here: `{max_heap_size, _}` (OOM/DoS cap), `{message_queue_data,
+    %% off_heap}`, `{min_bin_vheap_size, _}`. `link`/`monitor` are rejected —
+    %% roadrunner owns process linkage. `start_timeout` is the `proc_lib:start`
+    %% `Time`: how long to wait for a started process to ack init before
+    %% killing it with `{error, timeout}` (default `infinity`); it applies to
+    %% the connection process and the WebSocket session (the fire-and-forget
+    %% HTTP/3 conn and stream-worker spawns have no init handshake). For lowest
+    %% OS-resident memory also set `+MHacul 0 +MBacul 0` in `vm.args`.
+    handler_spawn => #{
+        opts => [proc_lib:start_spawn_option()],
+        start_timeout => timeout()
+    },
     %% Protocols this listener accepts. Each entry is either a bare
     %% atom (`http1` / `http2`) or a `{Proto, Opts}` tuple carrying
     %% protocol-specific tuning. Bare atom means "default opts".
@@ -798,6 +834,9 @@ build_proto_opts(Opts, ListenerName) ->
     %% → `http2_*` flattening above.
     #{max_frame_size := WsFrame, max_message_size := WsMsg} =
         validate_ws_opts(maps:get(ws, Opts, #{})),
+    %% Flatten the nested `handler_spawn` opt to top-level proto_opts keys the
+    %% spawn sites read directly, mirroring the `ws` / `http2` flattening above.
+    #{opts := HandlerSpawnOpts, start_timeout := HandlerStartTimeout} = resolve_handler_spawn(Opts),
     Base = maps:merge(
         maps:merge(maybe_alt_svc(Protocols, Opts), #{
             dispatch => build_dispatch(Opts, ListenerName),
@@ -819,6 +858,8 @@ build_proto_opts(Opts, ListenerName) ->
             body_buffering => maps:get(body_buffering, Opts, auto),
             listener_name => ListenerName,
             graceful_drain => maps:get(graceful_drain, Opts, true),
+            handler_spawn_opts => HandlerSpawnOpts,
+            handler_start_timeout => HandlerStartTimeout,
             protocols => Protocols
         }),
         ProtoFlats
@@ -846,6 +887,43 @@ build_proto_opts(Opts, ListenerName) ->
         #{} ->
             WithHibernate
     end.
+
+%% Resolve the public `handler_spawn` opt into the proto_opts shape the spawn
+%% sites read: `#{opts := [start_spawn_option()], start_timeout := timeout()}`.
+%% `link`/`monitor` are rejected — roadrunner owns process linkage (the conn is
+%% intentionally unlinked, stream workers are monitored), so honoring them would
+%% break that crash-isolation contract.
+resolve_handler_spawn(Opts) ->
+    case maps:get(handler_spawn, Opts, #{}) of
+        HandlerSpawn when is_map(HandlerSpawn) ->
+            SpawnOpts = maps:get(opts, HandlerSpawn, ?DEFAULT_HANDLER_SPAWN_OPTS),
+            Timeout = maps:get(start_timeout, HandlerSpawn, ?DEFAULT_HANDLER_START_TIMEOUT),
+            ok = validate_handler_spawn_opts(SpawnOpts, HandlerSpawn),
+            ok = validate_handler_start_timeout(Timeout, HandlerSpawn),
+            #{opts => SpawnOpts, start_timeout => Timeout};
+        Other ->
+            error({invalid_listener_opt, handler_spawn, Other})
+    end.
+
+validate_handler_spawn_opts(SpawnOpts, Raw) when is_list(SpawnOpts) ->
+    case lists:any(fun is_reserved_spawn_opt/1, SpawnOpts) of
+        true -> error({invalid_listener_opt, handler_spawn, Raw});
+        false -> ok
+    end;
+validate_handler_spawn_opts(_SpawnOpts, Raw) ->
+    error({invalid_listener_opt, handler_spawn, Raw}).
+
+is_reserved_spawn_opt(link) -> true;
+is_reserved_spawn_opt(monitor) -> true;
+is_reserved_spawn_opt({monitor, _}) -> true;
+is_reserved_spawn_opt(_) -> false.
+
+validate_handler_start_timeout(infinity, _Raw) ->
+    ok;
+validate_handler_start_timeout(Timeout, _Raw) when is_integer(Timeout, 0, 16#7FFFFFFF) ->
+    ok;
+validate_handler_start_timeout(_Timeout, Raw) ->
+    error({invalid_listener_opt, handler_spawn, Raw}).
 
 %% Precompute the `Alt-Svc` response-header value (RFC 7838) when the
 %% listener co-serves HTTP/3 alongside a TCP protocol on a fixed port,

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -209,7 +209,9 @@ run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated, ProtoOpts) ->
     %% conn is intentionally unlinked from its children so a session
     %% crash never propagates to the conn process. We synchronise via
     %% a monitor instead.
-    case gen_statem:start(?MODULE, {Socket, Mod, State, Ctx, Negotiated, ProtoOpts}, []) of
+    #{handler_spawn_opts := SpawnOpts, handler_start_timeout := StartTimeout} = ProtoOpts,
+    StartOpts = [{spawn_opt, SpawnOpts}, {timeout, StartTimeout}],
+    case gen_statem:start(?MODULE, {Socket, Mod, State, Ctx, Negotiated, ProtoOpts}, StartOpts) of
         {ok, Pid} ->
             ok = roadrunner_telemetry:ws_upgrade(Ctx),
             _ = roadrunner_telemetry:response_send(

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -184,7 +184,9 @@ proto_opts(ListenerName, Counter) ->
         requests_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
-        listener_name => ListenerName
+        listener_name => ListenerName,
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity
     }.
 
 spawn_recv_sink(Script) ->

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -363,6 +363,8 @@ concurrent_streams_both_dispatch() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_concurrent_test,
         dispatch =>
@@ -426,6 +428,8 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
     ok = counters:add(Counter, 1, 1),
     RequestsCounter = atomics:new(1, [{signed, false}]),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         requests_counter => RequestsCounter,
         listener_name => h2c_dispatch_test,
@@ -476,6 +480,8 @@ plaintext_listener_without_h2c_stays_h1() ->
     ok = counters:add(Counter, 1, 1),
     RequestsCounter = atomics:new(1, [{signed, false}]),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         requests_counter => RequestsCounter,
         listener_name => h1_dispatch_test,
@@ -1038,6 +1044,8 @@ middleware_chain_runs() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_mw_test,
         dispatch =>
@@ -1100,6 +1108,8 @@ router_404_returns_not_found() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_404_listener,
         dispatch => {router, h2_404_listener},
@@ -1820,6 +1830,8 @@ rst_during_stream_response_unwinds_worker() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_rst_during_stream,
         dispatch =>
@@ -1898,6 +1910,8 @@ drain_refuses_new_streams() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_drain_test,
         dispatch =>
@@ -1951,6 +1965,8 @@ drain_with_in_flight_stream_waits() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_drain_inflight_test,
         dispatch =>
@@ -2011,6 +2027,8 @@ drain_message_is_idempotent() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_drain_dup_test,
         dispatch =>
@@ -2061,6 +2079,8 @@ drain_then_peer_rst_exits_via_frame_loop() ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_drain_rst_test,
         dispatch =>
@@ -2154,6 +2174,8 @@ telemetry_request_stop_fires_for_router_404() ->
         Counter = counters:new(1, [write_concurrency]),
         ok = counters:add(Counter, 1, 1),
         ProtoOpts = #{
+            handler_spawn_opts => [{fullsweep_after, 0}],
+            handler_start_timeout => infinity,
             client_counter => Counter,
             listener_name => h2_telem_404,
             dispatch => {router, h2_telem_404},
@@ -2235,6 +2257,8 @@ run_h2_with_compress_middleware(Path, ExtraHeaders) ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_compress_test,
         dispatch =>
@@ -2971,6 +2995,8 @@ post_handshake_handler(Handler) ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_strict_test,
         dispatch => {handler, Handler, fun Handler:handle/1, undefined},
@@ -3098,6 +3124,8 @@ start_http2_conn(Extra) ->
         #{
             client_counter => Counter,
             listener_name => http2_test,
+            handler_spawn_opts => [{fullsweep_after, 0}],
+            handler_start_timeout => infinity,
             dispatch =>
                 {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1,
                     undefined},
@@ -3221,6 +3249,8 @@ run_h2_request_with_handler(Handler, Path) ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_handler_test,
         dispatch => {handler, Handler, fun Handler:handle/1, undefined},
@@ -3277,6 +3307,8 @@ run_stream_request(Path, PrefaceSettings) ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         client_counter => Counter,
         listener_name => h2_stream_test,
         dispatch =>

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -29,6 +29,18 @@ start_returns_ok_pid_test() ->
     ?assert(is_process_alive(Pid)),
     drain_then_wait(Pid).
 
+start_applies_handler_spawn_opts_to_process_test() ->
+    %% `handler_spawn_opts` must reach the spawned connection process, not
+    %% just sit in proto_opts: start a conn with a non-default
+    %% `fullsweep_after` and read it back from the live process's own
+    %% garbage-collection info.
+    ensure_pg(),
+    Opts = (fake_opts(gc_flag))#{handler_spawn_opts := [{fullsweep_after, 42}]},
+    {ok, Pid} = roadrunner_conn_loop:start({fake, spawn_sink()}, Opts),
+    {garbage_collection, GcInfo} = process_info(Pid, garbage_collection),
+    ?assertEqual(42, proplists:get_value(fullsweep_after, GcInfo)),
+    drain_then_wait(Pid).
+
 conn_start_routes_through_loop_test() ->
     ensure_pg(),
     {ok, Pid} = roadrunner_conn:start({fake, spawn_sink()}, fake_opts(dispatch)),
@@ -1268,7 +1280,9 @@ fake_opts(ListenerName) ->
         requests_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
-        listener_name => ListenerName
+        listener_name => ListenerName,
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity
     }.
 
 %% Plain sink — discards every message. Used when the test doesn't need

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -225,6 +225,8 @@ start_conn(H2Opts) ->
         dispatch =>
             {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
         protocols => [http2],
         http2_conn_window => maps:get(conn_window, H2Opts, 65535),
         http2_stream_window => maps:get(stream_window, H2Opts, 65535),

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -354,7 +354,9 @@ start_conn(Handler) ->
         client_counter => Counter,
         listener_name => h2_flow_test,
         dispatch => {handler, Handler, fun Handler:handle/1, undefined},
-        middlewares => []
+        middlewares => [],
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity
     },
     Sock = {fake, Self},
     Pid = spawn(fun() ->

--- a/test/roadrunner_http2_stream_worker_tests.erl
+++ b/test/roadrunner_http2_stream_worker_tests.erl
@@ -30,7 +30,9 @@ logger_metadata_set_in_h2_worker_test_() ->
             dispatch =>
                 {handler, roadrunner_logger_probe_handler,
                     fun roadrunner_logger_probe_handler:handle/1, undefined},
-            middlewares => []
+            middlewares => [],
+            handler_spawn_opts => [{fullsweep_after, 0}],
+            handler_start_timeout => infinity
         },
         {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
             ConnPid, StreamId, Req, ProtoOpts

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -283,6 +283,40 @@ listener_protocols_default_is_http1_only_test() ->
     ?assertEqual([http1], maps:get(protocols, ProtoOpts)),
     ok = roadrunner_listener:stop(Name).
 
+listener_threads_handler_spawn_defaults_into_proto_opts_test() ->
+    %% With no `handler_spawn` opt the listener fills the flattened
+    %% `handler_spawn_opts` / `handler_start_timeout` proto_opts keys from the
+    %% defaults: `{fullsweep_after, 0}` (reclaim the per-conn response
+    %% heap instead of hoarding it as old-gen garbage across keep-alive
+    %% requests) and `infinity` (no init-ack deadline).
+    Name = listener_test_handler_spawn_default,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        routes => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual([{fullsweep_after, 0}], maps:get(handler_spawn_opts, ProtoOpts)),
+    ?assertEqual(infinity, maps:get(handler_start_timeout, ProtoOpts)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_threads_custom_handler_spawn_into_proto_opts_test() ->
+    %% A custom `handler_spawn` map is flattened to the two top-level
+    %% proto_opts keys the spawn sites read directly (no nested lookup
+    %% on the hot path), mirroring the `ws` / `http2` flattening.
+    Name = listener_test_handler_spawn_custom,
+    SpawnOpts = [{fullsweep_after, 20}, {min_bin_vheap_size, 1024}],
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        handler_spawn => #{opts => SpawnOpts, start_timeout => 5000},
+        routes => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual(SpawnOpts, maps:get(handler_spawn_opts, ProtoOpts)),
+    ?assertEqual(5000, maps:get(handler_start_timeout, ProtoOpts)),
+    ok = roadrunner_listener:stop(Name).
+
 listener_accepts_http1_tuple_form_test() ->
     %% `{http1, #{}}` is the explicit tuple shape — accepted but
     %% currently must be empty (no http1 tunables yet; reserved for
@@ -367,6 +401,33 @@ listener_rejects_invalid_ws_opt_test() ->
             ?assertMatch({error, {{invalid_listener_opt, ws, _}, _Stack}}, R)
         end,
         [#{frame_size => 1}, #{max_frame_size => -1}, #{max_frame_size => bad}, not_a_map]
+    ).
+
+listener_rejects_invalid_handler_spawn_test() ->
+    %% `handler_spawn` must be a map; `opts` a list that does not carry the
+    %% roadrunner-owned linkage (`link` / `monitor` / `{monitor, _}`,
+    %% which would break the unlinked-conn + monitored-worker
+    %% semantics); `start_timeout` a non-negative integer or `infinity`.
+    %% Anything else rejects at `init/1` rather than per-connection.
+    process_flag(trap_exit, true),
+    lists:foreach(
+        fun(Bad) ->
+            R = roadrunner_listener:start_link(listener_test_handler_spawn_invalid, #{
+                port => 0,
+                handler_spawn => Bad,
+                routes => roadrunner_hello_handler
+            }),
+            ?assertMatch({error, {{invalid_listener_opt, handler_spawn, _}, _Stack}}, R)
+        end,
+        [
+            #{opts => [link]},
+            #{opts => [monitor]},
+            #{opts => [{monitor, []}]},
+            #{opts => not_a_list},
+            #{start_timeout => -1},
+            #{start_timeout => bad},
+            not_a_map
+        ]
     ).
 
 slot_reconciliation_disabled_drops_reconcile_slots_message_test() ->

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -132,7 +132,9 @@ request_rejected_event_fires_on_bad_request_line_test() ->
             requests_counter => atomics:new(1, [{signed, false}]),
             min_bytes_per_second => 0,
             body_buffering => auto,
-            listener_name => probe_listener_rej
+            listener_name => probe_listener_rej,
+            handler_spawn_opts => [{fullsweep_after, 0}],
+            handler_start_timeout => infinity
         },
         true = roadrunner_conn:try_acquire_slot(Opts),
         {ok, Pid} = roadrunner_conn:start({fake, Sink}, Opts),

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -567,5 +567,7 @@ fake_proto_opts(Handler) ->
         client_counter => counters:new(1, [write_concurrency]),
         requests_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
-        body_buffering => auto
+        body_buffering => auto,
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity
     }.

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -1691,7 +1691,12 @@ ws_proto_opts() ->
     ws_proto_opts(16777216, 16777216).
 
 ws_proto_opts(MaxFrame, MaxMsg) ->
-    #{ws_max_frame_size => MaxFrame, ws_max_message_size => MaxMsg}.
+    #{
+        ws_max_frame_size => MaxFrame,
+        ws_max_message_size => MaxMsg,
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity
+    }.
 
 %% A minimal text/binary single-fragment unmasked frame. Server-side
 %% receives masked frames per the WebSocket spec, so we mark fin=true


### PR DESCRIPTION
Spawns every handler-running process (the connection process, the HTTP/2 and HTTP/3 stream workers, the WebSocket session) with a configurable `proc_lib`/`spawn_opt` config, defaulting to `[{fullsweep_after, 0}]` so the per-connection response heap is reclaimed promptly instead of accumulating as old-gen garbage across keep-alive requests.

The public `handler_spawn => #{opts, start_timeout}` map is resolved and validated once at listener init, then flattened to the top-level `handler_spawn_opts` / `handler_start_timeout` proto_opts keys the spawn sites read directly.

```erlang
roadrunner:start_listener(my_listener, #{
    port => 8080,
    routes => my_router,
    handler_spawn => #{opts => [{fullsweep_after, 0}, {max_heap_size, 1000000}]}
}).
```