### PR TITLE
Make max_clients connection rejection observable

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,15 +120,17 @@ lot of them.
 
 ### Connection-process memory tuning follow-ups
 
-**What:** The `conn_spawn` listener opt already exposes the full
+**What:** The `handler_spawn` listener opt already exposes the full
 `proc_lib:start/5` spawn config (`opts` + `start_timeout`) for every
 handler-running process, defaulting to `[{fullsweep_after, 0}]`.
 Remaining polish:
 - a named convenience opt (e.g. a top-level `max_heap_size`) if the
   raw `opts` passthrough proves clumsy in practice
-- ship a recommended `vm.args` carrying `+MHacul 0 +MBacul 0` so the
-  allocator returns freed carriers to the OS (the opt's doc points at
-  this today, but nothing packages it)
+- characterize the `+MHacul 0 +MBacul 0` allocator-carrier-release
+  tradeoff before recommending it anywhere: it lowers resident memory
+  but raises allocator↔OS traffic and can hurt throughput at high core
+  counts, so it is workload-dependent, not a blanket win (the
+  `handler_spawn` doc now says as much)
 - revisit whether `fullsweep_after, 0` should stay the default: it is
   free on allocation-heavy handlers but costs ~3-4% on trivial
   passthrough, so an adaptive policy (or a different default) may be
@@ -137,9 +139,10 @@ Remaining polish:
   stream-worker processes under load (validated so far on the h1
   connection process)
 
-**Why deferred:** the passthrough plus default already capture the
-~72% process-memory reduction; these are refinements that each want
-their own measurement before shipping.
+**Why deferred:** the passthrough plus default already capture a
+substantial, workload-dependent process-memory reduction on
+allocation-heavy handlers; these are refinements that each want their
+own measurement before shipping.
 
 **Scope:** small.
 

--- a/src/roadrunner_acceptor.erl
+++ b/src/roadrunner_acceptor.erl
@@ -52,7 +52,17 @@ handle_accepted(Socket, ProtoOpts) ->
             ConnPid ! shoot,
             ok;
         false ->
-            %% Over max_clients — drop the new connection on the floor.
+            %% Over max_clients — drop the new connection on the floor, but
+            %% make the drop observable: bump the cumulative reject counter
+            %% (surfaced via `roadrunner_listener:info/1`) and emit
+            %% `[roadrunner, listener, conn_rejected]`. No `peername` lookup
+            %% here — this is the floodable path, so it stays cheap.
+            #{rejected_counter := RejectedCounter} = ProtoOpts,
+            ok = atomics:add(RejectedCounter, 1, 1),
+            ok = roadrunner_telemetry:listener_conn_rejected(#{
+                listener_name => maps:get(listener_name, ProtoOpts, undefined),
+                reason => max_clients
+            }),
             _ = roadrunner_transport:close(Socket),
             ok
     end.

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -97,6 +97,7 @@
     max_clients := pos_integer(),
     client_counter := counters:counters_ref(),
     requests_counter := atomics:atomics_ref(),
+    rejected_counter := atomics:atomics_ref(),
     min_bytes_per_second := non_neg_integer(),
     body_buffering := auto | manual,
     listener_name => atom(),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -108,7 +108,14 @@ Optional middleware and timing knobs (durations in milliseconds):
 - `num_acceptors` — size of the acceptor pool. Default 10.
 - `max_keep_alive_requests` — requests served per conn before
   forced close. Default 1000.
-- `max_clients` — concurrent connection cap. Default 150.
+- `max_clients` — concurrent connection cap. Default 150. Connections
+  accepted while already at the cap are closed immediately without a
+  response. The default bounds memory (the recv `buffer` alone is
+  `max_clients × 64 KB`), so high-concurrency deployments should raise
+  it. Rejections are observable: each one emits
+  `[roadrunner, listener, conn_rejected]` and increments the `rejected`
+  count from `info/1`, so a rising `rejected` is the signal that the
+  cap is the binding limit.
 - `min_bytes_per_second` — slow-loris guard on the request-read
   phase (0 disables). Default 100.
 - `rate_check_interval` — how often the rate guard re-checks
@@ -130,8 +137,11 @@ Optional middleware and timing knobs (durations in milliseconds):
   `[{fullsweep_after, 0}]` so the per-conn response heap is reclaimed
   instead of hoarding it as old-gen garbage across keep-alive
   requests) and `start_timeout` (init-ack deadline, default
-  `infinity`). Pair with `+MHacul 0 +MBacul 0` in `vm.args` to return
-  freed allocator carriers to the OS for the lowest resident memory.
+  `infinity`). For the lowest *resident* memory you can also add
+  `+MHacul 0 +MBacul 0` to `vm.args` to return freed allocator carriers
+  to the OS, but that is a tradeoff, not a free win: it raises
+  allocator↔OS traffic and can hurt throughput at high core counts, so
+  measure it for your workload rather than enabling it blindly.
 - `protocols` — list of `t:protocol_entry/0`. Default `[http1]`.
   On TLS this drives `alpn_preferred_protocols` automatically.
 - `tls` — `[ssl:tls_server_option()]` for HTTPS. Empty / absent
@@ -202,8 +212,11 @@ ops-tuning rationale.
     %% `Time`: how long to wait for a started process to ack init before
     %% killing it with `{error, timeout}` (default `infinity`); it applies to
     %% the connection process and the WebSocket session (the fire-and-forget
-    %% HTTP/3 conn and stream-worker spawns have no init handshake). For lowest
-    %% OS-resident memory also set `+MHacul 0 +MBacul 0` in `vm.args`.
+    %% HTTP/3 conn and stream-worker spawns have no init handshake). For lower
+    %% OS-resident memory `+MHacul 0 +MBacul 0` in `vm.args` returns freed
+    %% allocator carriers to the OS, but it trades throughput for RSS (more
+    %% allocator↔OS traffic, costly at high core counts) — measure it, don't
+    %% enable it blindly.
     handler_spawn => #{
         opts => [proc_lib:start_spawn_option()],
         start_timeout => timeout()
@@ -431,6 +444,10 @@ Return runtime introspection for a listener:
   responses from the router (404) and the body-size pre-check (413);
   excludes wire-level parse failures, idle keep-alive timeouts, and
   silent slow-client closes.
+- `rejected` — cumulative count of connections dropped because the
+  listener was at its `max_clients` cap when they arrived. A rising
+  `rejected` means the cap is the binding limit and should be raised.
+  Also emitted in real time as `[roadrunner, listener, conn_rejected]`.
 
 Useful for ops dashboards / health endpoints.
 """.
@@ -438,7 +455,8 @@ Useful for ops dashboards / health endpoints.
     #{
         active_clients := non_neg_integer(),
         max_clients := pos_integer(),
-        requests_served := non_neg_integer()
+        requests_served := non_neg_integer(),
+        rejected := non_neg_integer()
     }.
 info(Name) ->
     gen_server:call(Name, info).
@@ -820,15 +838,18 @@ build_proto_opts(Opts, ListenerName) ->
     %% a single `maps:get/2` instead of a nested map dive.
     {Protocols, ProtoFlats} = normalize_protocols(Opts),
     %% Per-listener counters: live-connection counter (acceptors bump on
-    %% accept; conns decrement on exit) and a cumulative requests-served
-    %% counter (conn bumps on each handler dispatch). `client_counter`
-    %% uses the `counters` module with `write_concurrency` so each
-    %% scheduler bumps a private sub-counter (lock-free, no cache-line
-    %% ping-pong across cores). `counters:get/2` returns an
-    %% eventually-consistent sum, which matches the bounded-overshoot
-    %% contract `try_acquire_slot/1` already documents.
+    %% accept; conns decrement on exit), a cumulative requests-served
+    %% counter (conn bumps on each handler dispatch), and a cumulative
+    %% rejected-connections counter (acceptor bumps when a connection is
+    %% dropped at the `max_clients` cap). `client_counter` uses the
+    %% `counters` module with `write_concurrency` so each scheduler bumps a
+    %% private sub-counter (lock-free, no cache-line ping-pong across
+    %% cores). `counters:get/2` returns an eventually-consistent sum, which
+    %% matches the bounded-overshoot contract `try_acquire_slot/1` already
+    %% documents.
     ClientCounter = counters:new(1, [write_concurrency]),
     RequestsCounter = atomics:new(1, [{signed, false}]),
+    RejectedCounter = atomics:new(1, [{signed, false}]),
     %% Public `ws` opts are a nested map; flatten to the `ws_*`
     %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
     %% → `http2_*` flattening above.
@@ -853,6 +874,7 @@ build_proto_opts(Opts, ListenerName) ->
             max_clients => maps:get(max_clients, Opts, ?DEFAULT_MAX_CLIENTS),
             client_counter => ClientCounter,
             requests_counter => RequestsCounter,
+            rejected_counter => RejectedCounter,
             min_bytes_per_second =>
                 maps:get(min_bytes_per_second, Opts, ?DEFAULT_MIN_BYTES_PER_SECOND),
             body_buffering => maps:get(body_buffering, Opts, auto),
@@ -1212,12 +1234,14 @@ handle_call(info, _From, #state{proto_opts = ProtoOpts} = State) ->
     #{
         client_counter := ClientCounter,
         requests_counter := RequestsCounter,
+        rejected_counter := RejectedCounter,
         max_clients := MaxClients
     } = ProtoOpts,
     Reply = #{
         active_clients => counters:get(ClientCounter, 1),
         max_clients => MaxClients,
-        requests_served => atomics:get(RequestsCounter, 1)
+        requests_served => atomics:get(RequestsCounter, 1),
+        rejected => atomics:get(RejectedCounter, 1)
     },
     {reply, Reply, State}.
 

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -64,6 +64,18 @@
 %%   - **Measurements:** `duration` in `native` time units.
 %%   - **Metadata:** `listener_name`, `peer`, `requests_served`.
 %%
+%% - `[roadrunner, listener, conn_rejected]` — fired in the acceptor when a
+%%   freshly-accepted connection is dropped because the listener is at its
+%%   `max_clients` cap. Lets operators see they've hit the connection
+%%   ceiling instead of mistaking the rejections for slowness; pair it
+%%   with the cumulative `rejected` count from `roadrunner_listener:info/1`.
+%%   Carries no `peer` (unlike `accept`): the reject path is the floodable
+%%   one, so it skips the `peername` lookup to stay cheap under a connection
+%%   flood.
+%%
+%%   - **Measurements:** `system_time`.
+%%   - **Metadata:** `listener_name`, `reason` (`max_clients`).
+%%
 %% - `[roadrunner, ws, upgrade]` — fired in the conn process once the
 %%   WebSocket handshake response has been written. Marks the
 %%   transition from HTTP/1.1 keep-alive into the WS frame loop.
@@ -125,8 +137,9 @@
 %% All other events listed above (`request, start`,
 %% `request, exception`, `response, send_failed`,
 %% `listener, accept`, `listener, conn_close`,
-%% `request, rejected`, `listener, slots_reconciled`,
-%% `drain, acknowledged`, `ws, frame_in`, `ws, frame_rejected`) are **unstable**: their
+%% `listener, conn_rejected`, `request, rejected`,
+%% `listener, slots_reconciled`, `drain, acknowledged`,
+%% `ws, frame_in`, `ws, frame_rejected`) are **unstable**: their
 %% event name, measurement keys, or metadata schema may change in
 %% any minor release. Production subscribers depending on those
 %% events should pin a roadrunner version.
@@ -141,6 +154,7 @@
     response_send/2,
     listener_accept/1,
     listener_conn_close/2,
+    listener_conn_rejected/1,
     request_rejected/1,
     slots_reconciled/1,
     drain_acknowledged/1,
@@ -256,6 +270,22 @@ listener_conn_close(StartMono, Metadata) ->
     telemetry:execute(
         [roadrunner, listener, conn_close],
         #{duration => erlang:monotonic_time() - StartMono},
+        Metadata
+    ),
+    ok.
+
+-doc """
+Emit `[roadrunner, listener, conn_rejected]` when a freshly-accepted
+connection is dropped at the `max_clients` cap. `Metadata` should
+include `listener_name` and `reason` (`max_clients`). Carries no `peer`:
+the reject path is the floodable one, so it skips the `peername` lookup
+to stay cheap under a connection flood.
+""".
+-spec listener_conn_rejected(map()) -> ok.
+listener_conn_rejected(Metadata) ->
+    telemetry:execute(
+        [roadrunner, listener, conn_rejected],
+        #{system_time => erlang:system_time()},
         Metadata
     ),
     ok.

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -182,6 +182,7 @@ proto_opts(ListenerName, Counter) ->
         max_clients => 1000,
         client_counter => Counter,
         requests_counter => atomics:new(1, [{signed, false}]),
+        rejected_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
         listener_name => ListenerName,

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -432,6 +432,7 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
         handler_start_timeout => infinity,
         client_counter => Counter,
         requests_counter => RequestsCounter,
+        rejected_counter => atomics:new(1, [{signed, false}]),
         listener_name => h2c_dispatch_test,
         dispatch =>
             {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
@@ -484,6 +485,7 @@ plaintext_listener_without_h2c_stays_h1() ->
         handler_start_timeout => infinity,
         client_counter => Counter,
         requests_counter => RequestsCounter,
+        rejected_counter => atomics:new(1, [{signed, false}]),
         listener_name => h1_dispatch_test,
         dispatch =>
             {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1278,6 +1278,7 @@ fake_opts(ListenerName) ->
         max_clients => 10,
         client_counter => counters:new(1, [write_concurrency]),
         requests_counter => atomics:new(1, [{signed, false}]),
+        rejected_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
         listener_name => ListenerName,

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -478,7 +478,65 @@ listener_info_initial_zero_test() ->
     ?assertEqual(0, maps:get(active_clients, Info)),
     ?assertEqual(42, maps:get(max_clients, Info)),
     ?assertEqual(0, maps:get(requests_served, Info)),
+    ?assertEqual(0, maps:get(rejected, Info)),
     ok = roadrunner_listener:stop(Name).
+
+over_cap_connection_rejected_fires_event_and_counts_test() ->
+    %% A listener at `max_clients` drops the next connection on the floor.
+    %% That used to be silent; assert it now bumps `info/1`'s `rejected`
+    %% and emits `[roadrunner, listener, conn_rejected]` with
+    %% `reason => max_clients`.
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    HandlerId = make_ref(),
+    ok = telemetry:attach(
+        HandlerId,
+        [roadrunner, listener, conn_rejected],
+        fun(Event, M, Md, _) -> Self ! {ev, Event, M, Md} end,
+        undefined
+    ),
+    Name = listener_test_over_cap,
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0, max_clients => 1, routes => roadrunner_hello_handler
+    }),
+    Port = roadrunner_listener:port(Name),
+    try
+        %% Hold one connection open to occupy the single slot. The slot is
+        %% taken on accept (before any request is read), so an idle socket
+        %% that sends nothing keeps it — the hello handler answers with
+        %% `Connection: close`, so sending a request would free the slot.
+        {ok, Hold} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        %% Wait until the slot is actually accounted for before probing.
+        ok = wait_active_clients(Name, 1, 50),
+        %% A second connection must be rejected at the cap.
+        {ok, Rejected} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        %% The server closes it without a response — recv hits EOF.
+        ?assertMatch({error, closed}, gen_tcp:recv(Rejected, 0, 1000)),
+        ok = gen_tcp:close(Rejected),
+        receive
+            {ev, [roadrunner, listener, conn_rejected], M, Md} ->
+                ?assert(is_integer(maps:get(system_time, M))),
+                ?assertEqual(Name, maps:get(listener_name, Md)),
+                ?assertEqual(max_clients, maps:get(reason, Md))
+        after 1000 -> error(no_conn_rejected_event)
+        end,
+        ?assertEqual(1, maps:get(rejected, roadrunner_listener:info(Name))),
+        ok = gen_tcp:close(Hold)
+    after
+        telemetry:detach(HandlerId),
+        ok = roadrunner_listener:stop(Name)
+    end.
+
+wait_active_clients(_Name, _Want, 0) ->
+    error(active_clients_never_reached);
+wait_active_clients(Name, Want, Tries) ->
+    case maps:get(active_clients, roadrunner_listener:info(Name)) of
+        Want ->
+            ok;
+        _ ->
+            timer:sleep(20),
+            wait_active_clients(Name, Want, Tries - 1)
+    end.
 
 listener_info_counts_served_requests_test_() ->
     {setup,

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -130,6 +130,7 @@ request_rejected_event_fires_on_bad_request_line_test() ->
             max_clients => 10,
             client_counter => counters:new(1, [write_concurrency]),
             requests_counter => atomics:new(1, [{signed, false}]),
+            rejected_counter => atomics:new(1, [{signed, false}]),
             min_bytes_per_second => 0,
             body_buffering => auto,
             listener_name => probe_listener_rej,

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -566,6 +566,7 @@ fake_proto_opts(Handler) ->
         max_clients => 10,
         client_counter => counters:new(1, [write_concurrency]),
         requests_counter => atomics:new(1, [{signed, false}]),
+        rejected_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
         handler_spawn_opts => [{fullsweep_after, 0}],


### PR DESCRIPTION
Connections accepted while a listener is already at `max_clients` were dropped silently (no log, no event, no counter), so hitting the cap looked like the server being slow.

Now each rejection emits `[roadrunner, listener, conn_rejected]` (`reason => max_clients`) and increments a cumulative `rejected` count surfaced via `roadrunner_listener:info/1`. The reject path carries no `peername` lookup so it stays cheap under a connection flood. The default cap stays 150; its doc now names both signals and points high-concurrency deployments at raising it.

```erlang
#{active_clients := 150, max_clients := 150, rejected := 1234} = roadrunner_listener:info(my_listener).
```