### PR TITLE
Add the max_concurrent_streams http2 listener option

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -38,8 +38,9 @@
 %% Workers are spawn_monitored (NOT linked) so a handler crash
 %% resets only the affected stream — `'DOWN'` triggers
 %% `RST_STREAM(INTERNAL_ERROR)` and the other in-flight streams
-%% keep running. `MAX_CONCURRENT_STREAMS=100` is advertised; HEADERS
-%% beyond that limit get `RST_STREAM(REFUSED_STREAM)`.
+%% keep running. `MAX_CONCURRENT_STREAMS` is advertised (default 100,
+%% overridable via the `max_concurrent_streams` http2 listener opt);
+%% HEADERS beyond that limit get `RST_STREAM(REFUSED_STREAM)`.
 %%
 %% Response shapes supported:
 %%
@@ -104,8 +105,9 @@
 %% FLOW_CONTROL_ERROR.
 -define(MAX_WINDOW, 16#7FFFFFFF).
 
-%% Phase H8b: lift from 1 (serial) to 100 concurrent streams.
-%% Clients exceeding this on this connection get
+%% Default cap on concurrent client-initiated streams (Phase H8b lifted
+%% it from 1 serial to 100). Overridable per listener via the
+%% `max_concurrent_streams` http2 opt; clients exceeding the live cap get
 %% RST_STREAM(REFUSED_STREAM) on the over-limit HEADERS.
 -define(MAX_CONCURRENT_STREAMS, 100).
 
@@ -190,6 +192,9 @@
     recv_window_peak = ?DEFAULT_CONN_RECV_WINDOW :: pos_integer(),
     stream_recv_window_peak = ?DEFAULT_STREAM_RECV_WINDOW :: pos_integer(),
     recv_window_threshold = ?DEFAULT_WINDOW_REFILL_THRESHOLD :: pos_integer(),
+    %% Max concurrent client-initiated streams: advertised in our SETTINGS
+    %% and enforced in `on_headers/5`. Read from proto_opts at `enter/5`.
+    max_concurrent_streams = ?MAX_CONCURRENT_STREAMS :: pos_integer(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -238,6 +243,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
     Threshold = maps:get(
         http2_window_refill_threshold, ProtoOpts, ?DEFAULT_WINDOW_REFILL_THRESHOLD
     ),
+    MaxStreams = maps:get(http2_max_concurrent_streams, ProtoOpts, ?MAX_CONCURRENT_STREAMS),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -252,7 +258,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         hpack_enc = roadrunner_http2_hpack:new_encoder(4096),
         recv_window_peak = ConnPeak,
         stream_recv_window_peak = StreamPeak,
-        recv_window_threshold = Threshold
+        recv_window_threshold = Threshold,
+        max_concurrent_streams = MaxStreams
     },
     handshake(State).
 
@@ -262,9 +269,13 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
 
 -spec handshake(#loop{}) -> no_return().
 handshake(
-    #loop{recv_window_peak = ConnPeak, stream_recv_window_peak = StreamPeak} = State
+    #loop{
+        recv_window_peak = ConnPeak,
+        stream_recv_window_peak = StreamPeak,
+        max_concurrent_streams = MaxStreams
+    } = State
 ) ->
-    _ = send(State, server_settings_frame(StreamPeak)),
+    _ = send(State, server_settings_frame(StreamPeak, MaxStreams)),
     %% RFC 9113 §6.9.2: SETTINGS_INITIAL_WINDOW_SIZE only affects
     %% stream-level recv windows. The conn-level recv window stays
     %% at the 65535 default until an explicit `WINDOW_UPDATE(0, _)`,
@@ -280,15 +291,15 @@ handshake(
         end,
     handshake_phase_preface(State1).
 
--spec server_settings_frame(pos_integer()) -> iodata().
-server_settings_frame(StreamPeak) ->
-    %% Advertise MAX_CONCURRENT_STREAMS=100 and MAX_FRAME_SIZE.
+-spec server_settings_frame(pos_integer(), pos_integer()) -> iodata().
+server_settings_frame(StreamPeak, MaxStreams) ->
+    %% Advertise MAX_CONCURRENT_STREAMS and MAX_FRAME_SIZE.
     %% IDs from RFC 9113 §6.5.2: 3 = MAX_CONCURRENT_STREAMS,
     %% 5 = MAX_FRAME_SIZE.  When the stream-level recv peak is bigger
     %% than the RFC 65535 default, also advertise
     %% SETTINGS_INITIAL_WINDOW_SIZE (id 4) so streams the peer opens
     %% start with the larger receive allowance.
-    Base = [{3, ?MAX_CONCURRENT_STREAMS}, {5, ?MAX_FRAME_SIZE}],
+    Base = [{3, MaxStreams}, {5, ?MAX_FRAME_SIZE}],
     Settings =
         case StreamPeak > ?INITIAL_WINDOW of
             true -> [{4, StreamPeak} | Base];
@@ -676,8 +687,14 @@ on_headers(StreamId, _Flags, _Priority, _Fragment, #loop{draining = true} = Stat
     %% won't be served.
     _ = send_rst_stream(State, StreamId, refused_stream),
     frame_loop(State);
-on_headers(StreamId, _Flags, _Priority, _Fragment, #loop{streams = Streams} = State) when
-    map_size(Streams) >= ?MAX_CONCURRENT_STREAMS
+on_headers(
+    StreamId,
+    _Flags,
+    _Priority,
+    _Fragment,
+    #loop{streams = Streams, max_concurrent_streams = MaxStreams} = State
+) when
+    map_size(Streams) >= MaxStreams
 ->
     %% Over the advertised concurrency limit — refuse the stream.
     _ = send_rst_stream(State, StreamId, refused_stream),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -268,6 +268,10 @@ ops-tuning rationale.
     %%   the conn refills back to the peak. Lower threshold = fewer
     %%   `WINDOW_UPDATE` frames per byte consumed but a smaller live
     %%   window between refills. Default `32768`.
+    %% - `max_concurrent_streams` — cap on concurrent client-initiated
+    %%   streams per connection (`pos_integer`), advertised in our
+    %%   SETTINGS; HEADERS that would exceed it get
+    %%   RST_STREAM(REFUSED_STREAM). Default `100`.
     %%
     %% Empty list, unknown protocol atoms, duplicate entries, bad
     %% tuple shape, unknown sub-option keys, or out-of-range sub-
@@ -317,11 +321,16 @@ HTTP/2 listener tunables (under `{http2, ThisMap}` in `protocols`).
   the peak. Lower threshold = fewer `WINDOW_UPDATE` frames per
   byte consumed but a smaller live window between refills.
   Default `32768`.
+- `max_concurrent_streams` — cap on concurrent client-initiated
+  streams per connection, advertised via
+  `SETTINGS_MAX_CONCURRENT_STREAMS`. HEADERS that would exceed it
+  get `RST_STREAM(REFUSED_STREAM)`. Default `100`.
 """.
 -type http2_opts() :: #{
     conn_window => 1..16#7FFFFFFF,
     stream_window => 1..16#7FFFFFFF,
-    window_refill_threshold => 1..16#7FFFFFFF
+    window_refill_threshold => 1..16#7FFFFFFF,
+    max_concurrent_streams => 1..16#7FFFFFFF
 }.
 
 -doc """
@@ -1074,7 +1083,12 @@ normalize_protocol_entry(_, Raw) ->
 
 -spec http2_defaults() -> http2_opts().
 http2_defaults() ->
-    #{conn_window => 65535, stream_window => 65535, window_refill_threshold => 32768}.
+    #{
+        conn_window => 65535,
+        stream_window => 65535,
+        window_refill_threshold => 32768,
+        max_concurrent_streams => 100
+    }.
 
 -spec validate_http2_opts(map(), term()) -> http2_opts().
 validate_http2_opts(Opts, Raw) ->
@@ -1102,12 +1116,14 @@ flatten_http2_opts(Entries) ->
         {http2, #{
             conn_window := Conn,
             stream_window := Stream,
-            window_refill_threshold := Threshold
+            window_refill_threshold := Threshold,
+            max_concurrent_streams := MaxStreams
         }} ->
             #{
                 http2_conn_window => Conn,
                 http2_stream_window => Stream,
-                http2_window_refill_threshold => Threshold
+                http2_window_refill_threshold => Threshold,
+                http2_max_concurrent_streams => MaxStreams
             }
     end.
 

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -29,6 +29,8 @@ all_test_() ->
         fun bumped_stream_window_advertises_initial_window_size/0,
         fun bumped_both_emits_settings_with_size_then_window_update/0,
         fun custom_threshold_changes_refill_trigger/0,
+        fun default_advertises_100_max_concurrent_streams/0,
+        fun custom_max_concurrent_streams_advertised/0,
         fun invalid_window_opt_fails_listener_start/0,
         fun valid_window_opts_let_listener_boot/0
     ],
@@ -159,6 +161,23 @@ custom_threshold_changes_refill_trigger() ->
     ?assertEqual(60_000, Inc2),
     cleanup(Pid, Ref).
 
+default_advertises_100_max_concurrent_streams() ->
+    %% With no override the handshake SETTINGS advertises
+    %% MAX_CONCURRENT_STREAMS (id 3) = 100, the default.
+    {Pid, Ref} = start_conn(#{}),
+    Settings = expect_send(),
+    {ok, {settings, 0, Entries}, _} = roadrunner_http2_frame:parse(Settings, 16384),
+    ?assertEqual(100, proplists:get_value(3, Entries)),
+    cleanup(Pid, Ref).
+
+custom_max_concurrent_streams_advertised() ->
+    %% max_concurrent_streams = 250 must be advertised as id 3 = 250.
+    {Pid, Ref} = start_conn(#{max_concurrent_streams => 250}),
+    Settings = expect_send(),
+    {ok, {settings, 0, Entries}, _} = roadrunner_http2_frame:parse(Settings, 16384),
+    ?assertEqual(250, proplists:get_value(3, Entries)),
+    cleanup(Pid, Ref).
+
 invalid_window_opt_fails_listener_start() ->
     %% A non-positive integer (or anything outside 1..2^31-1) should
     %% surface at listener init/1 rather than mid-handshake. Each
@@ -202,7 +221,8 @@ valid_window_opts_let_listener_boot() ->
             {http2, #{
                 conn_window => 1_048_576,
                 stream_window => 524_288,
-                window_refill_threshold => 65_536
+                window_refill_threshold => 65_536,
+                max_concurrent_streams => 250
             }}
         ],
         routes => roadrunner_hello_handler
@@ -230,7 +250,8 @@ start_conn(H2Opts) ->
         protocols => [http2],
         http2_conn_window => maps:get(conn_window, H2Opts, 65535),
         http2_stream_window => maps:get(stream_window, H2Opts, 65535),
-        http2_window_refill_threshold => maps:get(window_refill_threshold, H2Opts, 32768)
+        http2_window_refill_threshold => maps:get(window_refill_threshold, H2Opts, 32768),
+        http2_max_concurrent_streams => maps:get(max_concurrent_streams, H2Opts, 100)
     },
     Sock = {fake, Self},
     Pid = spawn(fun() ->


### PR DESCRIPTION
# Description

Makes the HTTP/2 `SETTINGS_MAX_CONCURRENT_STREAMS` cap configurable via `{http2, #{max_concurrent_streams => N}}`. It was hardcoded at 100 (advertised in our SETTINGS and enforced with `RST_STREAM(REFUSED_STREAM)` on the over-limit HEADERS); the value is unchanged by default, just tunable now.

```erlang
roadrunner:start_listener(my_listener, #{
    port => 8443, routes => my_router, tls => TlsOpts,
    protocols => [{http2, #{max_concurrent_streams => 250}}]
}).
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)