### PR TITLE
Add the max_header_block http2 listener option

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -129,6 +129,8 @@
     http2_conn_window => 1..16#7FFFFFFF,
     http2_stream_window => 1..16#7FFFFFFF,
     http2_window_refill_threshold => 1..16#7FFFFFFF,
+    http2_max_concurrent_streams => 1..16#7FFFFFFF,
+    http2_max_header_block => 1..16#7FFFFFFF,
     %% Optional fields the listener injects only when the user
     %% supplies them — see `roadrunner_listener:build_proto_opts/2`.
     %% Declared here so dialyzer accepts pattern matches like

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -73,12 +73,13 @@
 %% RFC 9113 §6.5.2 default `MAX_FRAME_SIZE`.
 -define(MAX_FRAME_SIZE, 16_384).
 
-%% Cumulative cap on an assembled HEADERS+CONTINUATION block. Each frame
-%% is already bounded to MAX_FRAME_SIZE, but the number of CONTINUATION
+%% Default cumulative cap on an assembled HEADERS+CONTINUATION block. Each
+%% frame is already bounded to MAX_FRAME_SIZE, but the number of CONTINUATION
 %% frames is not, so without this a peer can flood CONTINUATION frames and
-%% grow the block without bound (the HTTP/2 CONTINUATION Flood). h1 and h3
-%% bound the same way (`roadrunner_http1` / `roadrunner_conn_loop_http3`
-%% MAX_HEADER_BLOCK).
+%% grow the block without bound (the HTTP/2 CONTINUATION Flood). Overridable
+%% per listener via the `max_header_block` http2 opt. h1 and h3 have their own
+%% header-block caps (each separately configurable; h1 defaults to 10240, h3
+%% to 16384).
 -define(MAX_HEADER_BLOCK, 16_384).
 
 %% RFC 9113 §6.9.2 initial window size for both the connection and
@@ -195,6 +196,9 @@
     %% Max concurrent client-initiated streams: advertised in our SETTINGS
     %% and enforced in `on_headers/5`. Read from proto_opts at `enter/5`.
     max_concurrent_streams = ?MAX_CONCURRENT_STREAMS :: pos_integer(),
+    %% Cumulative HEADERS+CONTINUATION block cap (CONTINUATION-flood guard).
+    %% Read from proto_opts at `enter/5`.
+    max_header_block = ?MAX_HEADER_BLOCK :: pos_integer(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -244,6 +248,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         http2_window_refill_threshold, ProtoOpts, ?DEFAULT_WINDOW_REFILL_THRESHOLD
     ),
     MaxStreams = maps:get(http2_max_concurrent_streams, ProtoOpts, ?MAX_CONCURRENT_STREAMS),
+    MaxHeaderBlock = maps:get(http2_max_header_block, ProtoOpts, ?MAX_HEADER_BLOCK),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -259,7 +264,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         recv_window_peak = ConnPeak,
         stream_recv_window_peak = StreamPeak,
         recv_window_threshold = Threshold,
-        max_concurrent_streams = MaxStreams
+        max_concurrent_streams = MaxStreams,
+        max_header_block = MaxHeaderBlock
     },
     handshake(State).
 
@@ -740,7 +746,9 @@ new_stream(Fragment, EndHeaders, EndStream, SendWindow, RecvWindow) ->
         pending_sends => queue:new()
     }.
 
-on_continuation(StreamId, Flags, Fragment, #loop{streams = Streams} = State) ->
+on_continuation(
+    StreamId, Flags, Fragment, #loop{streams = Streams, max_header_block = MaxHeaderBlock} = State
+) ->
     case Streams of
         #{
             StreamId :=
@@ -764,7 +772,7 @@ on_continuation(StreamId, Flags, Fragment, #loop{streams = Streams} = State) ->
             %% context can't be resynced if we skip the block, so this is
             %% a connection error rather than a per-stream reject.
             %% ENHANCE_YOUR_CALM is the RFC 9113 §6.5.2 resource-limit code.
-            case NewLen > ?MAX_HEADER_BLOCK orelse (FragLen =:= 0 andalso not EndHeaders) of
+            case NewLen > MaxHeaderBlock orelse (FragLen =:= 0 andalso not EndHeaders) of
                 true ->
                     _ = send_goaway(State, enhance_your_calm),
                     exit_clean(State);

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -272,6 +272,9 @@ ops-tuning rationale.
     %%   streams per connection (`pos_integer`), advertised in our
     %%   SETTINGS; HEADERS that would exceed it get
     %%   RST_STREAM(REFUSED_STREAM). Default `100`.
+    %% - `max_header_block` — cumulative HEADERS+CONTINUATION block cap
+    %%   (`pos_integer`); over-cap closes the conn with
+    %%   GOAWAY(ENHANCE_YOUR_CALM). Default `16384`.
     %%
     %% Empty list, unknown protocol atoms, duplicate entries, bad
     %% tuple shape, unknown sub-option keys, or out-of-range sub-
@@ -325,12 +328,19 @@ HTTP/2 listener tunables (under `{http2, ThisMap}` in `protocols`).
   streams per connection, advertised via
   `SETTINGS_MAX_CONCURRENT_STREAMS`. HEADERS that would exceed it
   get `RST_STREAM(REFUSED_STREAM)`. Default `100`.
+- `max_header_block` — cumulative cap on an assembled
+  HEADERS+CONTINUATION block (the CONTINUATION-flood guard);
+  over-cap closes the connection with `GOAWAY(ENHANCE_YOUR_CALM)`.
+  Default `16384`. This is the h2 counterpart to the `{http1, ...}`
+  `max_header_block` opt, but the two are independent and default
+  differently (h1 `10240`, h2 `16384`).
 """.
 -type http2_opts() :: #{
     conn_window => 1..16#7FFFFFFF,
     stream_window => 1..16#7FFFFFFF,
     window_refill_threshold => 1..16#7FFFFFFF,
-    max_concurrent_streams => 1..16#7FFFFFFF
+    max_concurrent_streams => 1..16#7FFFFFFF,
+    max_header_block => 1..16#7FFFFFFF
 }.
 
 -doc """
@@ -1087,7 +1097,8 @@ http2_defaults() ->
         conn_window => 65535,
         stream_window => 65535,
         window_refill_threshold => 32768,
-        max_concurrent_streams => 100
+        max_concurrent_streams => 100,
+        max_header_block => 16384
     }.
 
 -spec validate_http2_opts(map(), term()) -> http2_opts().
@@ -1117,13 +1128,15 @@ flatten_http2_opts(Entries) ->
             conn_window := Conn,
             stream_window := Stream,
             window_refill_threshold := Threshold,
-            max_concurrent_streams := MaxStreams
+            max_concurrent_streams := MaxStreams,
+            max_header_block := MaxHeaderBlock
         }} ->
             #{
                 http2_conn_window => Conn,
                 http2_stream_window => Stream,
                 http2_window_refill_threshold => Threshold,
-                http2_max_concurrent_streams => MaxStreams
+                http2_max_concurrent_streams => MaxStreams,
+                http2_max_header_block => MaxHeaderBlock
             }
     end.
 

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -34,6 +34,7 @@ all_test_() ->
         fun even_stream_id_triggers_goaway/0,
         fun continuation_without_pending_triggers_goaway/0,
         fun continuation_flood_triggers_goaway/0,
+        fun configured_max_header_block_triggers_goaway/0,
         fun continuation_empty_frame_flood_triggers_goaway/0,
         fun data_on_unknown_stream_triggers_goaway/0,
         fun malformed_hpack_block_triggers_goaway/0,
@@ -687,6 +688,34 @@ continuation_flood_triggers_goaway() ->
     %% GOAWAY (type 7) carrying ENHANCE_YOUR_CALM (0x0B): after the 9-byte
     %% frame header the payload is Last-Stream-Id (32 bits) then the error
     %% code (32 bits).
+    ?assertMatch(<<_:24, 7:8, _:8, _:32, _:32, 16#0B:32, _/binary>>, Out),
+    expect_close(),
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 500 -> error(no_exit)
+    end.
+
+configured_max_header_block_triggers_goaway() ->
+    %% With `max_header_block => 200`, a CONTINUATION block of ~300 bytes
+    %% (well UNDER the default 16384) must still trip the flood guard and
+    %% close with GOAWAY(ENHANCE_YOUR_CALM) — proving the configured cap,
+    %% not the macro default, is what's enforced.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(#{http2_max_header_block => 200}),
+    _ = expect_send(),
+    serve_recv(ConnPid, ?PREFACE),
+    serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+    _ = expect_send(),
+    HeadersF = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 0, undefined, binary:copy(~"x", 100)})
+    ),
+    serve_recv(ConnPid, HeadersF),
+    ContinuationF = iolist_to_binary(
+        roadrunner_http2_frame:encode({continuation, 1, 0, binary:copy(~"x", 300)})
+    ),
+    serve_recv(ConnPid, ContinuationF),
+    Out = expect_send(),
     ?assertMatch(<<_:24, 7:8, _:8, _:32, _:32, 16#0B:32, _/binary>>, Out),
     expect_close(),
     receive

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -222,7 +222,8 @@ valid_window_opts_let_listener_boot() ->
                 conn_window => 1_048_576,
                 stream_window => 524_288,
                 window_refill_threshold => 65_536,
-                max_concurrent_streams => 250
+                max_concurrent_streams => 250,
+                max_header_block => 32_768
             }}
         ],
         routes => roadrunner_hello_handler


### PR DESCRIPTION
# Description

Makes the HTTP/2 cumulative HEADERS+CONTINUATION block cap (the CONTINUATION-flood guard) configurable via `{http2, #{max_header_block => N}}`. Over-cap still closes the connection with `GOAWAY(ENHANCE_YOUR_CALM)`; default stays 16384. This is the h2 counterpart to the `{http1, ...}` header-block cap, independent and defaulting separately (h1 10240, h2 16384).

Also adds the `http2_max_concurrent_streams` / `http2_max_header_block` keys to the `proto_opts()` type (the prior `max_concurrent_streams` PR read its key via `maps:get` without declaring it); both are additive optional keys.

```erlang
roadrunner:start_listener(my_listener, #{
    port => 8443, routes => my_router, tls => TlsOpts,
    protocols => [{http2, #{max_header_block => 32768}}]
}).
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)