### PR TITLE
Add the max_header_block http3 listener option

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -131,6 +131,9 @@
     http2_window_refill_threshold => 1..16#7FFFFFFF,
     http2_max_concurrent_streams => 1..16#7FFFFFFF,
     http2_max_header_block => 1..16#7FFFFFFF,
+    %% HTTP/3 tuning, flattened from `{http3, #{...}}` when http3 is enabled.
+    http3_listeners => 1..1024,
+    http3_max_header_block => 1..16#7FFFFFFF,
     %% Optional fields the listener injects only when the user
     %% supplies them — see `roadrunner_listener:build_proto_opts/2`.
     %% Declared here so dialyzer accepts pattern matches like

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -53,7 +53,9 @@
 %% Exported for unit testing of the pure request-stream frame folding
 %% and the pure peer-uni-stream state machine; not part of any public
 %% surface.
--export([decode_request_frames/3, new_request_stream/0, uni_event/4, uni_reset/1]).
+-export([
+    decode_request_frames/3, decode_request_frames/4, new_request_stream/0, uni_event/4, uni_reset/1
+]).
 
 %% RFC 9114 §8.1 / RFC 9204 §8.3 error codes.
 -define(H3_NO_ERROR, 16#0100).
@@ -68,10 +70,12 @@
 -define(H3_MESSAGE_ERROR, 16#010E).
 -define(H3_QPACK_DECOMPRESSION_FAILED, 16#0200).
 
-%% Cap on the encoded request field section (the HEADERS block). The body
-%% is bounded by `max_content_length`; this bounds header memory the same
-%% way h1 does (`roadrunner_http1` MAX_HEADER_BLOCK), so a peer cannot make
-%% the conn buffer an unbounded header block. Over-cap answers 431.
+%% Default cap on the encoded request field section (the HEADERS block).
+%% The body is bounded by `max_content_length`; this bounds header memory
+%% so a peer cannot make the conn buffer an unbounded header block.
+%% Over-cap answers 431. Overridable per listener via the `max_header_block`
+%% http3 opt. h1 and h2 have their own header-block caps (each separately
+%% configurable; h1 defaults to 10240, h2 to 16384).
 -define(MAX_HEADER_BLOCK, 16384).
 
 %% A critical stream role can be claimed at most once per connection.
@@ -115,7 +119,10 @@
     %% sent. While set, the connection is draining and request streams at
     %% or beyond it are refused. `undefined` means not draining.
     goaway_id = undefined :: non_neg_integer() | undefined,
-    max_content_length :: non_neg_integer()
+    max_content_length :: non_neg_integer(),
+    %% Cap on the encoded request field section (HEADERS block). Read from
+    %% proto_opts at conn start; defaults to `?MAX_HEADER_BLOCK`.
+    max_header_block = ?MAX_HEADER_BLOCK :: pos_integer()
 }).
 
 -doc """
@@ -169,7 +176,8 @@ init(Conn, ProtoOpts) ->
         listener_name = ListenerName,
         peer = Peer,
         start_mono = StartMono,
-        max_content_length = maps:get(max_content_length, ProtoOpts)
+        max_content_length = maps:get(max_content_length, ProtoOpts),
+        max_header_block = maps:get(http3_max_header_block, ProtoOpts, ?MAX_HEADER_BLOCK)
     }).
 
 -spec loop(#h3{}) -> ok.
@@ -293,7 +301,8 @@ handle_request_stream(#h3{goaway_id = GoawayId} = State, StreamId, _Data, _Fin) 
     %% will not be processed — reject it with H3_REQUEST_REJECTED.
     reset_and_drop(State, StreamId, ?H3_REQUEST_REJECTED);
 handle_request_stream(State0, StreamId, Data, Fin) ->
-    #h3{streams = Streams, max_content_length = MaxLen} = State = note_request_id(State0, StreamId),
+    #h3{streams = Streams, max_content_length = MaxLen, max_header_block = MaxHdrBlock} =
+        State = note_request_id(State0, StreamId),
     Stream0 = maps:get(StreamId, Streams, new_request_stream()),
     case maps:get(frame_state, Stream0) of
         discarding ->
@@ -309,7 +318,9 @@ handle_request_stream(State0, StreamId, Data, Fin) ->
             end;
         _ ->
             #{buf := Buf0} = Stream0,
-            case decode_request_frames(<<Buf0/binary, Data/binary>>, Stream0, MaxLen) of
+            case
+                decode_request_frames(<<Buf0/binary, Data/binary>>, Stream0, MaxLen, MaxHdrBlock)
+            of
                 {ok, Stream1} ->
                     State1 = State#h3{streams = Streams#{StreamId => Stream1}},
                     case Fin of
@@ -425,10 +436,14 @@ new_request_stream() ->
 %% the next `stream_data` message.
 -spec decode_request_frames(binary(), map(), non_neg_integer()) -> decode_result().
 decode_request_frames(Buf, Stream, MaxLen) ->
+    decode_request_frames(Buf, Stream, MaxLen, ?MAX_HEADER_BLOCK).
+
+-spec decode_request_frames(binary(), map(), non_neg_integer(), pos_integer()) -> decode_result().
+decode_request_frames(Buf, Stream, MaxLen, MaxHdrBlock) ->
     case quic_h3_frame:decode(Buf) of
         {ok, Frame, Rest} ->
-            case apply_frame(Frame, Stream, MaxLen) of
-                {ok, Stream1} -> decode_request_frames(Rest, Stream1, MaxLen);
+            case apply_frame(Frame, Stream, MaxLen, MaxHdrBlock) of
+                {ok, Stream1} -> decode_request_frames(Rest, Stream1, MaxLen, MaxHdrBlock);
                 Other -> Other
             end;
         {more, _} ->
@@ -436,7 +451,7 @@ decode_request_frames(Buf, Stream, MaxLen) ->
             %% oversized field section: reject now instead of buffering more.
             %% Once in `expecting_data` the body cap governs the buffer.
             case Stream of
-                #{frame_state := expecting_headers} when byte_size(Buf) > ?MAX_HEADER_BLOCK ->
+                #{frame_state := expecting_headers} when byte_size(Buf) > MaxHdrBlock ->
                     headers_too_large;
                 _ ->
                     {ok, Stream#{buf := Buf}}
@@ -454,26 +469,26 @@ decode_request_frames(Buf, Stream, MaxLen) ->
 %% H3_FRAME_UNEXPECTED (§4.1, §7.2.4); unknown/reserved frames are
 %% ignored (§9). Trailers (a HEADERS after the body) are accepted but
 %% not surfaced by the buffered path.
--spec apply_frame(quic_h3_frame:frame(), map(), non_neg_integer()) ->
+-spec apply_frame(quic_h3_frame:frame(), map(), non_neg_integer(), pos_integer()) ->
     {ok, map()} | too_large | headers_too_large | {conn_error, non_neg_integer(), binary()}.
-apply_frame({headers, Block}, #{frame_state := expecting_headers}, _MaxLen) when
-    byte_size(Block) > ?MAX_HEADER_BLOCK
+apply_frame({headers, Block}, #{frame_state := expecting_headers}, _MaxLen, MaxHdrBlock) when
+    byte_size(Block) > MaxHdrBlock
 ->
     headers_too_large;
-apply_frame({headers, Block}, #{frame_state := expecting_headers} = Stream, _MaxLen) ->
+apply_frame({headers, Block}, #{frame_state := expecting_headers} = Stream, _MaxLen, _MaxHdrBlock) ->
     {ok, Stream#{header_block := Block, frame_state := expecting_data}};
-apply_frame({headers, _Trailers}, #{frame_state := expecting_data} = Stream, _MaxLen) ->
+apply_frame({headers, _Trailers}, #{frame_state := expecting_data} = Stream, _MaxLen, _MaxHdrBlock) ->
     {ok, Stream#{frame_state := expecting_done}};
-apply_frame({data, Payload}, #{frame_state := expecting_data} = Stream, MaxLen) ->
+apply_frame({data, Payload}, #{frame_state := expecting_data} = Stream, MaxLen, _MaxHdrBlock) ->
     #{body := Body, body_len := Len} = Stream,
     NewLen = Len + byte_size(Payload),
     case NewLen > MaxLen of
         true -> too_large;
         false -> {ok, Stream#{body := [Body, Payload], body_len := NewLen}}
     end;
-apply_frame({unknown, _Type, _Payload}, Stream, _MaxLen) ->
+apply_frame({unknown, _Type, _Payload}, Stream, _MaxLen, _MaxHdrBlock) ->
     {ok, Stream};
-apply_frame(_Frame, _Stream, _MaxLen) ->
+apply_frame(_Frame, _Stream, _MaxLen, _MaxHdrBlock) ->
     %% DATA before HEADERS, a frame after trailers, or a control-stream
     %% frame (SETTINGS / GOAWAY / MAX_PUSH_ID / CANCEL_PUSH / PUSH_PROMISE)
     %% on a request stream — RFC 9114 §4.1 / §7.2: H3_FRAME_UNEXPECTED.

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -351,9 +351,15 @@ HTTP/3 listener tunables (under `{http3, ThisMap}` in `protocols`).
   connection registry; the kernel spreads inbound datagrams across
   them, so inbound demux parallelizes across cores. Default 8.
   `1` disables pooling (a single listener, no `SO_REUSEPORT`).
+- `max_header_block` — cap on the encoded request field section (the
+  HEADERS block); over-cap answers `431`. Default `16384`. The h3
+  counterpart to the `{http1, ...}` / `{http2, ...}` `max_header_block`
+  opts; the three are independent (h1 defaults to `10240`, h2/h3 to
+  `16384`).
 """.
 -type http3_opts() :: #{
-    listeners => 1..?MAX_H3_LISTENERS
+    listeners => 1..?MAX_H3_LISTENERS,
+    max_header_block => 1..16#7FFFFFFF
 }.
 
 -doc """
@@ -1142,16 +1148,24 @@ flatten_http2_opts(Entries) ->
 
 -spec http3_defaults() -> http3_opts().
 http3_defaults() ->
-    #{listeners => ?DEFAULT_H3_LISTENERS}.
+    #{listeners => ?DEFAULT_H3_LISTENERS, max_header_block => 16384}.
 
 -spec validate_http3_opts(map(), term()) -> http3_opts().
 validate_http3_opts(Opts, Raw) ->
     Defaults = http3_defaults(),
     maps:fold(
         fun(K, V, Acc) ->
+            %% `listeners` caps at the reuseport-pool limit; `max_header_block`
+            %% is a byte size up to the 31-bit ceiling.
+            Max =
+                case K of
+                    listeners -> ?MAX_H3_LISTENERS;
+                    max_header_block -> 16#7FFFFFFF;
+                    _ -> 0
+                end,
             case is_map_key(K, Defaults) of
                 false -> error({invalid_listener_opt, protocols, Raw});
-                true when is_integer(V, 1, ?MAX_H3_LISTENERS) -> Acc#{K => V};
+                true when is_integer(V, 1, Max) -> Acc#{K => V};
                 true -> error({invalid_listener_opt, protocols, Raw})
             end
         end,
@@ -1160,15 +1174,15 @@ validate_http3_opts(Opts, Raw) ->
     ).
 
 %% Flatten the http3 sub-opts onto proto_opts top-level (`http3_*`) so
-%% `start_quic/4` reads the listener count with a single `maps:get/2`.
-%% Returns an empty map when http3 isn't in the list.
+%% the conn loop reads each knob with a single `maps:get/2`. Returns an
+%% empty map when http3 isn't in the list.
 -spec flatten_http3_opts([protocol_entry_norm(), ...]) -> #{atom() => term()}.
 flatten_http3_opts(Entries) ->
     case lists:keyfind(http3, 1, Entries) of
         false ->
             #{};
-        {http3, #{listeners := Listeners}} ->
-            #{http3_listeners => Listeners}
+        {http3, #{listeners := Listeners, max_header_block := MaxHeaderBlock}} ->
+            #{http3_listeners => Listeners, http3_max_header_block => MaxHeaderBlock}
     end.
 
 -spec ws_defaults() ->

--- a/test/roadrunner_conn_loop_http3_tests.erl
+++ b/test/roadrunner_conn_loop_http3_tests.erl
@@ -15,6 +15,9 @@ new() ->
 decode(Buf, MaxLen) ->
     roadrunner_conn_loop_http3:decode_request_frames(Buf, new(), MaxLen).
 
+decode(Buf, MaxLen, MaxHdrBlock) ->
+    roadrunner_conn_loop_http3:decode_request_frames(Buf, new(), MaxLen, MaxHdrBlock).
+
 %% A HEADERS frame wrapping an arbitrary field block (the block is only
 %% QPACK-decoded later, in the conn loop's dispatch, not here).
 hf(Block) -> quic_h3_frame:encode_headers(Block).
@@ -97,3 +100,18 @@ dribbled_header_block_test() ->
     Frame = hf(binary:copy(<<"x">>, 20000)),
     Partial = binary:part(Frame, 0, 17000),
     ?assertEqual(headers_too_large, decode(Partial, 1000000)).
+
+configured_max_header_block_complete_test() ->
+    %% A complete 300-byte HEADERS block (well under the default 16384) is
+    %% rejected when the configured `max_header_block` is 200, accepted at
+    %% the default. Proves the configured cap, not the macro, is enforced.
+    Block = binary:copy(<<"x">>, 300),
+    ?assertEqual(headers_too_large, decode(hf(Block), 1000000, 200)),
+    ?assertMatch({ok, _}, decode(hf(Block), 1000000, 16384)).
+
+configured_max_header_block_dribbled_test() ->
+    %% The `{more}` dribble guard also honors the configured cap: a partial
+    %% HEADERS frame already past a 200-byte cap is rejected.
+    Frame = hf(binary:copy(<<"x">>, 1000)),
+    Partial = binary:part(Frame, 0, 400),
+    ?assertEqual(headers_too_large, decode(Partial, 1000000, 200)).

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -448,7 +448,9 @@ certfile_keyfile(Config) ->
     Name = listener_name(certfile_keyfile),
     {ok, _} = roadrunner_listener:start_link(Name, #{
         port => 0,
-        protocols => [http3],
+        %% Exercise the `{http3, #{...}}` tuple form + the
+        %% `max_header_block` flatten path through a real boot.
+        protocols => [{http3, #{max_header_block => 32768}}],
         tls => [{certfile, CertFile}, {keyfile, KeyFile}],
         routes => roadrunner_h3_test_handler
     }),

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -388,6 +388,28 @@ listener_rejects_invalid_protocols_value_test() ->
         [[], [bogus], [http1, http1], not_a_list]
     ).
 
+listener_rejects_invalid_http3_opt_test() ->
+    %% Unknown keys and out-of-range values in `{http3, _}` reject at
+    %% `init/1` (the protocol-entry normalizer runs before the
+    %% http3-requires-tls check, so a bad opt fails without needing TLS).
+    process_flag(trap_exit, true),
+    lists:foreach(
+        fun(Bad) ->
+            R = roadrunner_listener:start_link(listener_test_http3_invalid, #{
+                port => 0,
+                protocols => [{http3, Bad}],
+                routes => roadrunner_hello_handler
+            }),
+            ?assertMatch({error, {{invalid_listener_opt, protocols, _}, _Stack}}, R)
+        end,
+        [
+            #{bogus_key => 1},
+            #{max_header_block => 0},
+            #{max_header_block => not_an_integer},
+            #{listeners => 16#80000000}
+        ]
+    ).
+
 listener_rejects_ws_message_cap_below_frame_cap_test() ->
     %% A reassembled message is built from frames, so a single
     %% unfragmented frame is also a whole message — `max_message_size`


### PR DESCRIPTION
# Description

Makes the HTTP/3 request field-section (HEADERS block) cap configurable via `{http3, #{max_header_block => N}}`. Over-cap still answers 431; default stays 16384. This is the h3 counterpart to the `{http1, ...}` / `{http2, ...}` header-block caps, independent and defaulting separately (h1 10240, h2/h3 16384).

```erlang
roadrunner:start_listener(my_listener, #{
    port => 8443, routes => my_router, tls => TlsOpts,
    protocols => [{http3, #{max_header_block => 32768}}]
}).
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)