### PR TITLE
Add configurable http1 request and header size limits

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -30,7 +30,7 @@
 -export([
     start/2,
     parse_loop/2,
-    read_body/4,
+    read_body/5,
     peer/1,
     try_acquire_slot/1,
     release_slot/1,
@@ -53,7 +53,7 @@
     maybe_send_continue/3,
     refine_conn_label/2,
     scheme/1,
-    make_body_reader/4,
+    make_body_reader/5,
     drain_body/1,
     keep_alive_decision/2,
     send_request_timeout/1,
@@ -377,7 +377,8 @@ resolve_handler({router, ListenerName}, Req) ->
     roadrunner_req:request(),
     binary(),
     fun(() -> {ok, binary()} | {error, term()}),
-    non_neg_integer()
+    non_neg_integer(),
+    {pos_integer(), pos_integer(), pos_integer()}
 ) ->
     {ok, Body :: iodata(), Leftover :: binary()}
     | {error,
@@ -385,7 +386,7 @@ resolve_handler({router, ListenerName}, Req) ->
         | bad_content_length
         | bad_transfer_encoding
         | term()}.
-read_body(Req, Buffered, RecvFun, MaxCL) ->
+read_body(Req, Buffered, RecvFun, MaxCL, TrailerLimits) ->
     case body_framing(Req) of
         none ->
             %% Per RFC 9112 §6.3: a request without `Content-Length`
@@ -395,7 +396,7 @@ read_body(Req, Buffered, RecvFun, MaxCL) ->
             %% can feed them into the next `reading_request` parse.
             {ok, <<>>, Buffered};
         chunked ->
-            read_chunked(Buffered, RecvFun, MaxCL, 0);
+            read_chunked(Buffered, RecvFun, MaxCL, 0, TrailerLimits);
         {content_length, N} when N > MaxCL ->
             {error, content_length_too_large};
         {content_length, N} ->
@@ -438,9 +439,10 @@ has_continue_expectation(Req) ->
     none | chunked | {content_length, non_neg_integer()},
     binary(),
     fun(() -> {ok, binary()} | {error, term()}),
-    non_neg_integer()
+    non_neg_integer(),
+    {pos_integer(), pos_integer(), pos_integer()}
 ) -> roadrunner_req:body_reader().
-make_body_reader(Framing, Buffered, Recv, Max) ->
+make_body_reader(Framing, Buffered, Recv, Max, TrailerLimits) ->
     #{
         framing => Framing,
         buffered => Buffered,
@@ -448,7 +450,8 @@ make_body_reader(Framing, Buffered, Recv, Max) ->
         pending => <<>>,
         done => false,
         recv => Recv,
-        max => Max
+        max => Max,
+        trailer_limits => TrailerLimits
     }.
 
 -doc false.
@@ -547,11 +550,12 @@ read_body_until_io(N, RecvFun) ->
     binary(),
     fun(() -> {ok, binary()} | {error, term()}),
     non_neg_integer(),
-    non_neg_integer()
+    non_neg_integer(),
+    {pos_integer(), pos_integer(), pos_integer()}
 ) ->
     {ok, binary(), binary()} | {error, content_length_too_large | term()}.
-read_chunked(Buf, RecvFun, MaxCL, Decoded) ->
-    case roadrunner_http1:parse_chunk(Buf) of
+read_chunked(Buf, RecvFun, MaxCL, Decoded, TrailerLimits) ->
+    case roadrunner_http1:parse_chunk(Buf, TrailerLimits) of
         {ok, last, _Trailers, Leftover} ->
             %% Bytes after the size-0 last-chunk + trailer block are
             %% pipelined-next-request leftover; thread them up so the
@@ -563,7 +567,7 @@ read_chunked(Buf, RecvFun, MaxCL, Decoded) ->
                 NewDecoded > MaxCL ->
                     {error, content_length_too_large};
                 true ->
-                    case read_chunked(Rest, RecvFun, MaxCL, NewDecoded) of
+                    case read_chunked(Rest, RecvFun, MaxCL, NewDecoded, TrailerLimits) of
                         {ok, More, Leftover} ->
                             {ok, <<Data/binary, More/binary>>, Leftover};
                         {error, _} = E ->
@@ -573,7 +577,9 @@ read_chunked(Buf, RecvFun, MaxCL, Decoded) ->
         {more, _} ->
             case RecvFun() of
                 {ok, More} ->
-                    read_chunked(<<Buf/binary, More/binary>>, RecvFun, MaxCL, Decoded);
+                    read_chunked(
+                        <<Buf/binary, More/binary>>, RecvFun, MaxCL, Decoded, TrailerLimits
+                    );
                 {error, _} = E ->
                     E
             end;
@@ -704,8 +710,17 @@ chunked_collect(#{pending := Pending} = BS, Want) when byte_size(Pending) > 0 ->
     end;
 chunked_collect(#{done := true} = BS, _Want) ->
     {ok, [], BS};
-chunked_collect(#{buffered := Buf, recv := Recv, max := Max, bytes_read := Read} = BS, Want) ->
-    case roadrunner_http1:parse_chunk(Buf) of
+chunked_collect(
+    #{
+        buffered := Buf,
+        recv := Recv,
+        max := Max,
+        bytes_read := Read,
+        trailer_limits := TrailerLimits
+    } = BS,
+    Want
+) ->
+    case roadrunner_http1:parse_chunk(Buf, TrailerLimits) of
         {ok, Data, Rest} ->
             NewRead = Read + byte_size(Data),
             case NewRead > Max of
@@ -740,8 +755,16 @@ next_chunk(#{pending := Pending} = BS) when byte_size(Pending) > 0 ->
     {more, Pending, BS#{pending := <<>>}};
 next_chunk(#{done := true} = BS) ->
     {ok, <<>>, BS};
-next_chunk(#{buffered := Buf, recv := Recv, max := Max, bytes_read := Read} = BS) ->
-    case roadrunner_http1:parse_chunk(Buf) of
+next_chunk(
+    #{
+        buffered := Buf,
+        recv := Recv,
+        max := Max,
+        bytes_read := Read,
+        trailer_limits := TrailerLimits
+    } = BS
+) ->
+    case roadrunner_http1:parse_chunk(Buf, TrailerLimits) of
         {ok, Data, Rest} ->
             NewRead = Read + byte_size(Data),
             case NewRead > Max of

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -134,6 +134,11 @@
     %% HTTP/3 tuning, flattened from `{http3, #{...}}` when http3 is enabled.
     http3_listeners => 1..1024,
     http3_max_header_block => 1..16#7FFFFFFF,
+    %% HTTP/1 inbound size limits, flattened from `{http1, #{...}}`.
+    http1_max_request_line => 1..16#7FFFFFFF,
+    http1_max_header_line => 1..16#7FFFFFFF,
+    http1_max_header_block => 1..16#7FFFFFFF,
+    http1_max_header_count => 1..16#7FFFFFFF,
     %% Optional fields the listener injects only when the user
     %% supplies them — see `roadrunner_listener:build_proto_opts/2`.
     %% Declared here so dialyzer accepts pattern matches like

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -511,7 +511,8 @@ read_body_phase(
     #loop_state{
         socket = Socket,
         proto_opts = ProtoOpts,
-        max_content_length = MaxCL
+        max_content_length = MaxCL,
+        http1_limits = {_ReqLine, MaxHdrLine, MaxHdrBlock, MaxHdrCount}
     } = S,
     Req,
     Deadline
@@ -519,9 +520,12 @@ read_body_phase(
     MinRate = maps:get(min_bytes_per_second, ProtoOpts),
     Recv = roadrunner_conn:make_recv(Socket, Deadline, MinRate),
     Buffered = S#loop_state.buffered,
+    %% Trailer headers (chunked bodies) obey the same caps as request
+    %% headers; the request-line cap doesn't apply to a trailer block.
+    TrailerLimits = {MaxHdrLine, MaxHdrBlock, MaxHdrCount},
     case maps:get(body_buffering, ProtoOpts) of
         auto ->
-            case roadrunner_conn:read_body(Req, Buffered, Recv, MaxCL) of
+            case roadrunner_conn:read_body(Req, Buffered, Recv, MaxCL, TrailerLimits) of
                 {ok, Body, Leftover} ->
                     %% Leftover is bytes past the body — feed it
                     %% back to the next read_request_phase iteration
@@ -550,7 +554,7 @@ read_body_phase(
                     exit_normal(S);
                 Framing ->
                     BodyState = roadrunner_conn:make_body_reader(
-                        Framing, Buffered, Recv, MaxCL
+                        Framing, Buffered, Recv, MaxCL, TrailerLimits
                     ),
                     dispatch_phase(S, Req#{body_reader => BodyState})
             end

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -95,6 +95,13 @@
     middlewares = [] :: roadrunner_middleware:middleware_list(),
     max_content_length = 0 :: non_neg_integer(),
     max_keep_alive_requests = 1 :: pos_integer(),
+    %% HTTP/1 inbound size limits as the
+    %% `{max_request_line, max_header_line, max_header_block, max_header_count}`
+    %% tuple `roadrunner_http1:parse_request/2` takes. Cached from the
+    %% `http1_*` proto_opts keys at `shoot` (defaults match the parser's
+    %% own `?MAX_*` macros).
+    http1_limits = {8192, 8192, 10240, 100} ::
+        {pos_integer(), pos_integer(), pos_integer(), pos_integer()},
     %% Anti-slowloris on the request-read phase. `min_rate` is cached
     %% from `proto_opts.min_bytes_per_second` at `shoot`. When > 0,
     %% `recv_passive/2` tracks bytes received since `recv_phase_start`
@@ -166,7 +173,13 @@ awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
                         middlewares = maps:get(middlewares, ProtoOpts),
                         max_content_length = maps:get(max_content_length, ProtoOpts),
                         max_keep_alive_requests = maps:get(max_keep_alive_requests, ProtoOpts),
-                        min_rate = maps:get(min_bytes_per_second, ProtoOpts)
+                        min_rate = maps:get(min_bytes_per_second, ProtoOpts),
+                        http1_limits = {
+                            maps:get(http1_max_request_line, ProtoOpts, 8192),
+                            maps:get(http1_max_header_line, ProtoOpts, 8192),
+                            maps:get(http1_max_header_block, ProtoOpts, 10240),
+                            maps:get(http1_max_header_count, ProtoOpts, 100)
+                        }
                     },
                     read_request_phase(S)
             end;
@@ -440,12 +453,13 @@ handle_request_bytes(
         listener_name = ListenerName,
         peer = Peer,
         scheme = Scheme,
-        requests_counter = ReqCounter
+        requests_counter = ReqCounter,
+        http1_limits = Http1Limits
     } = S,
     Deadline
 ) ->
     Buf = S#loop_state.buffered,
-    case roadrunner_http1:parse_request(Buf) of
+    case roadrunner_http1:parse_request(Buf, Http1Limits) of
         {ok, Req0, Rest} ->
             _ = atomics:add(ReqCounter, 1, 1),
             {RequestId, NewBuffer} = roadrunner_conn:generate_request_id(

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -16,6 +16,7 @@
     parse_request/1,
     parse_request/2,
     parse_chunk/1,
+    parse_chunk/2,
     check_header_safe/2,
     response/3,
     compute_cached_decisions/1
@@ -699,7 +700,30 @@ header line is capped at 8192 bytes.
         | header_block_too_long
         | too_many_headers
         | conflicting_framing}.
-parse_chunk(Bin) when is_binary(Bin) ->
+parse_chunk(Bin) ->
+    parse_chunk(Bin, {?MAX_HEADER_LINE, ?MAX_HEADER_BLOCK, ?MAX_HEADER_COUNT}).
+
+-doc """
+Like `parse_chunk/1`, but with caller-supplied trailer-header limits as a
+`{MaxHeaderLine, MaxHeaderBlock, MaxHeaderCount}` tuple (the same shape
+`parse_headers/2` takes; there is no request-line in a trailer block). The
+conn loop passes the listener's configured `http1_*` header limits so a
+chunked request's trailer headers obey the same caps as its request
+headers; `parse_chunk/1` passes the `?MAX_*` defaults.
+""".
+-spec parse_chunk(binary(), {pos_integer(), pos_integer(), pos_integer()}) ->
+    {ok, Data :: binary(), Rest :: binary()}
+    | {ok, last, Trailers :: headers(), Rest :: binary()}
+    | {more, undefined}
+    | {error,
+        bad_chunk_size
+        | bad_chunk
+        | bad_header
+        | header_too_long
+        | header_block_too_long
+        | too_many_headers
+        | conflicting_framing}.
+parse_chunk(Bin, Limits) when is_binary(Bin) ->
     %% Fetch the compiled CRLF + semicolon patterns ONCE here and
     %% thread them into `parse_chunk_size_line/3` (and onward to
     %% `parse_size_line/3`) so the chunked-decode loop in
@@ -709,14 +733,14 @@ parse_chunk(Bin) when is_binary(Bin) ->
     SemiCp = persistent_term:get(?SEMICOLON_KEY),
     case parse_chunk_size_line(Bin, CrlfCp, SemiCp) of
         {ok, 0, AfterSize} ->
-            parse_last_chunk(AfterSize);
+            parse_last_chunk(AfterSize, Limits);
         {ok, Size, AfterSize} ->
             parse_chunk_data(Size, AfterSize);
         Other ->
             Other
     end.
 
--spec parse_last_chunk(binary()) ->
+-spec parse_last_chunk(binary(), {pos_integer(), pos_integer(), pos_integer()}) ->
     {ok, last, headers(), binary()}
     | {more, undefined}
     | {error,
@@ -725,8 +749,8 @@ parse_chunk(Bin) when is_binary(Bin) ->
         | header_block_too_long
         | too_many_headers
         | conflicting_framing}.
-parse_last_chunk(AfterSize) ->
-    case parse_headers(AfterSize) of
+parse_last_chunk(AfterSize, Limits) ->
+    case parse_headers(AfterSize, Limits) of
         {ok, Trailers, Rest} -> {ok, last, Trailers, Rest};
         {more, _} = More -> More;
         {error, _} = Err -> Err

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -14,6 +14,7 @@
     parse_header/1,
     parse_headers/1,
     parse_request/1,
+    parse_request/2,
     parse_chunk/1,
     check_header_safe/2,
     response/3,
@@ -76,34 +77,48 @@ Bare LF terminators are rejected as `bad_request_line` per RFC 9112 §2.2.
 %% optional leading `\r\n` and then parse normally. Two consecutive
 %% leading CRLFs still fail (the second one becomes a malformed
 %% request-line) so this doesn't open a slowloris-style padding vector.
-parse_request_line(<<"\r\n", Rest/binary>>) ->
-    do_parse_request_line(Rest, persistent_term:get(?LF_KEY), persistent_term:get(?SPACE_KEY));
-parse_request_line(Bin) when is_binary(Bin) ->
-    do_parse_request_line(Bin, persistent_term:get(?LF_KEY), persistent_term:get(?SPACE_KEY)).
+parse_request_line(Bin) ->
+    parse_request_line(Bin, ?MAX_REQUEST_LINE).
 
--spec do_parse_request_line(binary(), binary:cp(), binary:cp()) ->
+%% Internal — `MaxReqLine` caps the request-line length. `parse_request/2`
+%% threads the listener's configured limit; the public `parse_request_line/1`
+%% above passes the `?MAX_REQUEST_LINE` default.
+-spec parse_request_line(binary(), pos_integer()) ->
     {ok, Method :: binary(), Target :: binary(), version(), Rest :: binary()}
     | {more, undefined}
     | {error, bad_request_line | bad_version | request_line_too_long}.
-do_parse_request_line(Bin, LfCp, SpaceCp) ->
+parse_request_line(<<"\r\n", Rest/binary>>, MaxReqLine) ->
+    do_parse_request_line(
+        Rest, persistent_term:get(?LF_KEY), persistent_term:get(?SPACE_KEY), MaxReqLine
+    );
+parse_request_line(Bin, MaxReqLine) when is_binary(Bin) ->
+    do_parse_request_line(
+        Bin, persistent_term:get(?LF_KEY), persistent_term:get(?SPACE_KEY), MaxReqLine
+    ).
+
+-spec do_parse_request_line(binary(), binary:cp(), binary:cp(), pos_integer()) ->
+    {ok, Method :: binary(), Target :: binary(), version(), Rest :: binary()}
+    | {more, undefined}
+    | {error, bad_request_line | bad_version | request_line_too_long}.
+do_parse_request_line(Bin, LfCp, SpaceCp, MaxReqLine) ->
     case binary:match(Bin, LfCp) of
-        nomatch when byte_size(Bin) > ?MAX_REQUEST_LINE ->
+        nomatch when byte_size(Bin) > MaxReqLine ->
             {error, request_line_too_long};
         nomatch ->
             {more, undefined};
         {0, 1} ->
             {error, bad_request_line};
         {LfPos, 1} ->
-            extract_line(Bin, LfPos, SpaceCp)
+            extract_line(Bin, LfPos, SpaceCp, MaxReqLine)
     end.
 
--spec extract_line(binary(), pos_integer(), binary:cp()) ->
+-spec extract_line(binary(), pos_integer(), binary:cp(), pos_integer()) ->
     {ok, binary(), binary(), version(), binary()}
     | {error, bad_request_line | bad_version | request_line_too_long}.
-extract_line(Bin, LfPos, SpaceCp) ->
+extract_line(Bin, LfPos, SpaceCp, MaxReqLine) ->
     LineLen = LfPos - 1,
     case Bin of
-        <<Line:LineLen/binary, "\r\n", Rest/binary>> when LineLen =< ?MAX_REQUEST_LINE ->
+        <<Line:LineLen/binary, "\r\n", Rest/binary>> when LineLen =< MaxReqLine ->
             parse_line(Line, Rest, SpaceCp);
         <<_:LineLen/binary, "\r\n", _/binary>> ->
             {error, request_line_too_long};
@@ -220,25 +235,34 @@ parse_header(Bin) when is_binary(Bin) ->
     | {more, undefined}
     | {error, bad_header | header_too_long}.
 parse_header(Bin, LfCp, ColonCp) ->
+    parse_header(Bin, LfCp, ColonCp, ?MAX_HEADER_LINE).
+
+%% Internal — `MaxLine` caps the per-header-line length.
+-spec parse_header(binary(), binary:cp(), binary:cp(), pos_integer()) ->
+    {ok, binary(), binary(), binary()}
+    | {end_of_headers, binary()}
+    | {more, undefined}
+    | {error, bad_header | header_too_long}.
+parse_header(Bin, LfCp, ColonCp, MaxLine) ->
     case binary:match(Bin, LfCp) of
-        nomatch when byte_size(Bin) > ?MAX_HEADER_LINE ->
+        nomatch when byte_size(Bin) > MaxLine ->
             {error, header_too_long};
         nomatch ->
             {more, undefined};
         {0, 1} ->
             {error, bad_header};
         {LfPos, 1} ->
-            extract_header_line(Bin, LfPos, ColonCp)
+            extract_header_line(Bin, LfPos, ColonCp, MaxLine)
     end.
 
--spec extract_header_line(binary(), pos_integer(), binary:cp()) ->
+-spec extract_header_line(binary(), pos_integer(), binary:cp(), pos_integer()) ->
     {ok, binary(), binary(), binary()}
     | {end_of_headers, binary()}
     | {error, bad_header | header_too_long}.
-extract_header_line(Bin, LfPos, ColonCp) ->
+extract_header_line(Bin, LfPos, ColonCp, MaxLine) ->
     LineLen = LfPos - 1,
     case Bin of
-        <<Line:LineLen/binary, "\r\n", Rest/binary>> when LineLen =< ?MAX_HEADER_LINE ->
+        <<Line:LineLen/binary, "\r\n", Rest/binary>> when LineLen =< MaxLine ->
             case Line of
                 <<>> -> {end_of_headers, Rest};
                 _ -> parse_header_line(Line, Rest, ColonCp)
@@ -387,14 +411,30 @@ Enforces three hardening limits per OTP PR #11073:
         | header_block_too_long
         | too_many_headers
         | conflicting_framing}.
-parse_headers(Bin) when is_binary(Bin) ->
+parse_headers(Bin) ->
+    parse_headers(Bin, {?MAX_HEADER_LINE, ?MAX_HEADER_BLOCK, ?MAX_HEADER_COUNT}).
+
+%% Internal — `Limits` is `{MaxLine, MaxBlock, MaxCount}`, bundled into
+%% one tuple so the per-header loop carries a single extra arg rather than
+%% three. `parse_request/2` threads the listener's configured limits;
+%% `parse_headers/1` above passes the macro defaults.
+-spec parse_headers(binary(), {pos_integer(), pos_integer(), pos_integer()}) ->
+    {ok, headers(), Rest :: binary()}
+    | {more, undefined}
+    | {error,
+        bad_header
+        | header_too_long
+        | header_block_too_long
+        | too_many_headers
+        | conflicting_framing}.
+parse_headers(Bin, {MaxLine, MaxBlock, MaxCount}) when is_binary(Bin) ->
     %% Fetch the compiled LF + colon patterns ONCE here and thread
     %% them through the per-header loop. Saves two
     %% `persistent_term:get/1` calls per header (was ~12 per parse on
     %% a typical request; now 2).
     LfCp = persistent_term:get(?LF_KEY),
     ColonCp = persistent_term:get(?COLON_KEY),
-    case parse_headers_loop(Bin, 0, 0, LfCp, ColonCp) of
+    case parse_headers_loop(Bin, 0, 0, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount) of
         {ok, Headers, Rest} ->
             case check_framing(Headers) of
                 ok -> {ok, Headers, Rest};
@@ -405,7 +445,14 @@ parse_headers(Bin) when is_binary(Bin) ->
     end.
 
 -spec parse_headers_loop(
-    binary(), non_neg_integer(), non_neg_integer(), binary:cp(), binary:cp()
+    binary(),
+    non_neg_integer(),
+    non_neg_integer(),
+    binary:cp(),
+    binary:cp(),
+    pos_integer(),
+    pos_integer(),
+    pos_integer()
 ) ->
     {ok, headers(), binary()}
     | {more, undefined}
@@ -414,15 +461,23 @@ parse_headers(Bin) when is_binary(Bin) ->
         | header_too_long
         | header_block_too_long
         | too_many_headers}.
-parse_headers_loop(_Bin, Count, _Consumed, _LfCp, _ColonCp) when Count > ?MAX_HEADER_COUNT ->
+parse_headers_loop(_Bin, Count, _Consumed, _LfCp, _ColonCp, _MaxLine, _MaxBlock, MaxCount) when
+    Count > MaxCount
+->
     {error, too_many_headers};
-parse_headers_loop(_Bin, _Count, Consumed, _LfCp, _ColonCp) when Consumed > ?MAX_HEADER_BLOCK ->
+parse_headers_loop(_Bin, _Count, Consumed, _LfCp, _ColonCp, _MaxLine, MaxBlock, _MaxCount) when
+    Consumed > MaxBlock
+->
     {error, header_block_too_long};
-parse_headers_loop(Bin, Count, Consumed, LfCp, ColonCp) ->
-    case parse_header(Bin, LfCp, ColonCp) of
+parse_headers_loop(Bin, Count, Consumed, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount) ->
+    case parse_header(Bin, LfCp, ColonCp, MaxLine) of
         {ok, Name, Value, Rest} ->
             Used = byte_size(Bin) - byte_size(Rest),
-            case parse_headers_loop(Rest, Count + 1, Consumed + Used, LfCp, ColonCp) of
+            case
+                parse_headers_loop(
+                    Rest, Count + 1, Consumed + Used, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount
+                )
+            of
                 {ok, Tail, FinalRest} -> {ok, [{Name, Value} | Tail], FinalRest};
                 Other -> Other
             end;
@@ -562,10 +617,36 @@ a record, so callers don't need to include a header file.
         | too_many_headers
         | conflicting_framing
         | missing_host}.
-parse_request(Bin) when is_binary(Bin) ->
+parse_request(Bin) ->
+    parse_request(
+        Bin, {?MAX_REQUEST_LINE, ?MAX_HEADER_LINE, ?MAX_HEADER_BLOCK, ?MAX_HEADER_COUNT}
+    ).
+
+-doc """
+Like `parse_request/1`, but with caller-supplied size limits as a
+`{MaxRequestLine, MaxHeaderLine, MaxHeaderBlock, MaxHeaderCount}` tuple.
+The conn loop passes the listener's configured `http1_*` limits;
+`parse_request/1` passes the `?MAX_*` defaults.
+""".
+-spec parse_request(
+    binary(), {pos_integer(), pos_integer(), pos_integer(), pos_integer()}
+) ->
+    {ok, roadrunner_req:request(), Rest :: binary()}
+    | {more, undefined}
+    | {error,
+        bad_request_line
+        | bad_version
+        | request_line_too_long
+        | bad_header
+        | header_too_long
+        | header_block_too_long
+        | too_many_headers
+        | conflicting_framing
+        | missing_host}.
+parse_request(Bin, {MaxReqLine, MaxHdrLine, MaxHdrBlock, MaxHdrCount}) when is_binary(Bin) ->
     maybe
-        {ok, Method, Target, Version, Rest} ?= parse_request_line(Bin),
-        {ok, Headers, Rest2} ?= parse_headers(Rest),
+        {ok, Method, Target, Version, Rest} ?= parse_request_line(Bin, MaxReqLine),
+        {ok, Headers, Rest2} ?= parse_headers(Rest, {MaxHdrLine, MaxHdrBlock, MaxHdrCount}),
         Decisions = compute_cached_decisions(Headers),
         ok ?= validate_host(Version, Decisions),
         Req = #{

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -247,8 +247,10 @@ ops-tuning rationale.
     %% `init/1` — roadrunner has no `Upgrade: h2c` implementation,
     %% so the two cannot share a plaintext port.
     %%
-    %% HTTP/1 currently has no tunables; its opts map must be empty
-    %% (room reserved for future additions without an API break).
+    %% HTTP/1 tunables live under the `http1` tuple's opts map (see
+    %% `t:http1_opts/0`): `max_request_line`, `max_header_line`,
+    %% `max_header_block`, `max_header_count` — the inbound request-size
+    %% caps. An empty map keeps the defaults.
     %%
     %% HTTP/2 tunables live under the `http2` tuple's opts map:
     %%
@@ -288,9 +290,9 @@ ops-tuning rationale.
 -doc """
 One protocol entry in the listener's `protocols` list. Either a
 bare atom (`http1` / `http2` / `http3`) for default opts, or a tuple
-`{Proto, ProtoOpts}` carrying protocol-specific tuning. HTTP/1 has no
-tunables (its opts map must be empty); HTTP/2 tunables live under
-`t:http2_opts/0` and HTTP/3 under `t:http3_opts/0`.
+`{Proto, ProtoOpts}` carrying protocol-specific tuning. HTTP/1 tunables
+live under `t:http1_opts/0`, HTTP/2 under `t:http2_opts/0`, and HTTP/3
+under `t:http3_opts/0`.
 
 On TLS the list drives `alpn_preferred_protocols` for the TCP
 protocols. On plain TCP, `[http2]` means prior-knowledge h2c (client
@@ -305,7 +307,31 @@ same port. The QUIC handshake advertises the `h3` ALPN itself, so
 `http3` does not appear in the TCP `alpn_preferred_protocols`.
 """.
 -type protocol_entry() ::
-    http1 | http2 | http3 | {http1, #{}} | {http2, http2_opts()} | {http3, http3_opts()}.
+    http1 | http2 | http3 | {http1, http1_opts()} | {http2, http2_opts()} | {http3, http3_opts()}.
+
+-doc """
+HTTP/1.1 listener tunables (under `{http1, ThisMap}` in `protocols`).
+
+All four cap inbound request sizes; oversized input is rejected before
+the handler runs (414 for the request line, 431 for headers). Raise them
+for clients that send large headers (long JWTs / cookies / tracing
+metadata); lower them to tighten the attack surface.
+
+- `max_request_line` — request-line byte cap (method + target +
+  version). Over-cap → `414 URI Too Long`. Default `8192`.
+- `max_header_line` — per-header-line byte cap. Over-cap → `431`.
+  Default `8192`.
+- `max_header_block` — cumulative header-block byte cap. Over-cap →
+  `431`. Default `10240`.
+- `max_header_count` — maximum number of header lines. Over-cap →
+  `431`. Default `100`.
+""".
+-type http1_opts() :: #{
+    max_request_line => 1..16#7FFFFFFF,
+    max_header_line => 1..16#7FFFFFFF,
+    max_header_block => 1..16#7FFFFFFF,
+    max_header_count => 1..16#7FFFFFFF
+}.
 
 -doc """
 HTTP/2 listener tunables (under `{http2, ThisMap}` in `protocols`).
@@ -1056,7 +1082,11 @@ normalize_protocols(Opts) ->
         [http2, http1] when not HasTls ->
             error({listener_opt_conflict, protocols, Raw, no_h2c_upgrade});
         _ ->
-            {Names, maps:merge(flatten_http2_opts(Entries), flatten_http3_opts(Entries))}
+            {Names,
+                maps:merge(
+                    flatten_http1_opts(Entries),
+                    maps:merge(flatten_http2_opts(Entries), flatten_http3_opts(Entries))
+                )}
     end.
 
 -spec require_tls_for_h3([http1 | http2 | http3, ...], boolean(), term()) -> ok.
@@ -1068,7 +1098,8 @@ require_tls_for_h3(Names, HasTls, Raw) ->
             ok
     end.
 
--type protocol_entry_norm() :: {http1, #{}} | {http2, http2_opts()} | {http3, http3_opts()}.
+-type protocol_entry_norm() ::
+    {http1, http1_opts()} | {http2, http2_opts()} | {http3, http3_opts()}.
 
 -spec normalize_protocols_list(term()) -> [protocol_entry_norm(), ...].
 normalize_protocols_list(L) when is_list(L), L =/= [] ->
@@ -1083,11 +1114,11 @@ normalize_protocols_list(L) ->
 
 -spec normalize_protocol_entry(term(), term()) -> protocol_entry_norm().
 normalize_protocol_entry(http1, _Raw) ->
-    {http1, #{}};
+    {http1, http1_defaults()};
 normalize_protocol_entry(http2, _Raw) ->
     {http2, http2_defaults()};
-normalize_protocol_entry({http1, Opts}, _Raw) when is_map(Opts), map_size(Opts) =:= 0 ->
-    {http1, #{}};
+normalize_protocol_entry({http1, Opts}, Raw) when is_map(Opts) ->
+    {http1, validate_http1_opts(Opts, Raw)};
 normalize_protocol_entry({http2, Opts}, Raw) when is_map(Opts) ->
     {http2, validate_http2_opts(Opts, Raw)};
 normalize_protocol_entry(http3, _Raw) ->
@@ -1096,6 +1127,52 @@ normalize_protocol_entry({http3, Opts}, Raw) when is_map(Opts) ->
     {http3, validate_http3_opts(Opts, Raw)};
 normalize_protocol_entry(_, Raw) ->
     error({invalid_listener_opt, protocols, Raw}).
+
+-spec http1_defaults() -> http1_opts().
+http1_defaults() ->
+    #{
+        max_request_line => 8192,
+        max_header_line => 8192,
+        max_header_block => 10240,
+        max_header_count => 100
+    }.
+
+-spec validate_http1_opts(map(), term()) -> http1_opts().
+validate_http1_opts(Opts, Raw) ->
+    Defaults = http1_defaults(),
+    maps:fold(
+        fun(K, V, Acc) ->
+            case is_map_key(K, Defaults) of
+                false -> error({invalid_listener_opt, protocols, Raw});
+                true when is_integer(V, 1, 16#7FFFFFFF) -> Acc#{K => V};
+                true -> error({invalid_listener_opt, protocols, Raw})
+            end
+        end,
+        Defaults,
+        Opts
+    ).
+
+%% Flatten the http1 sub-opts onto proto_opts top-level with an `http1_`
+%% prefix so the conn loop reads each limit with a single `maps:get/2`.
+%% Returns an empty map when http1 isn't in the list.
+-spec flatten_http1_opts([protocol_entry_norm(), ...]) -> #{atom() => term()}.
+flatten_http1_opts(Entries) ->
+    case lists:keyfind(http1, 1, Entries) of
+        false ->
+            #{};
+        {http1, #{
+            max_request_line := ReqLine,
+            max_header_line := HdrLine,
+            max_header_block := HdrBlock,
+            max_header_count := HdrCount
+        }} ->
+            #{
+                http1_max_request_line => ReqLine,
+                http1_max_header_line => HdrLine,
+                http1_max_header_block => HdrBlock,
+                http1_max_header_count => HdrCount
+            }
+    end.
 
 -spec http2_defaults() -> http2_opts().
 http2_defaults() ->

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -127,7 +127,10 @@ to absorb a chunk's payload across multiple length-bounded calls.
     pending := binary(),
     done := boolean(),
     recv := fun(() -> {ok, binary()} | {error, term()}),
-    max := non_neg_integer()
+    max := non_neg_integer(),
+    %% Trailer-header limits `{max_header_line, max_header_block,
+    %% max_header_count}` threaded to `roadrunner_http1:parse_chunk/2`.
+    trailer_limits := {pos_integer(), pos_integer(), pos_integer()}
 }.
 
 -export([

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -45,7 +45,7 @@ read_body_no_content_length_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {ok, <<>>, ~"leftover bytes"},
-        roadrunner_conn:read_body(Req, ~"leftover bytes", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"leftover bytes", NoRecv, 1000, {8192, 10240, 100})
     ).
 
 read_body_cl_within_buffer_test() ->
@@ -53,13 +53,13 @@ read_body_cl_within_buffer_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {ok, ~"hello", ~" world"},
-        roadrunner_conn:read_body(Req, ~"hello world", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"hello world", NoRecv, 1000, {8192, 10240, 100})
     ).
 
 read_body_cl_needs_more_recv_test() ->
     Req = req_with_headers([{~"content-length", ~"11"}]),
     Recv = fun() -> {ok, ~" world"} end,
-    {ok, Body, Leftover} = roadrunner_conn:read_body(Req, ~"hello", Recv, 1000),
+    {ok, Body, Leftover} = roadrunner_conn:read_body(Req, ~"hello", Recv, 1000, {8192, 10240, 100}),
     ?assertEqual(~"hello world", iolist_to_binary(Body)),
     ?assertEqual(<<>>, Leftover).
 
@@ -69,7 +69,7 @@ read_body_cl_multi_chunk_recv_test() ->
     %% iolist accumulator in `read_body_until_io/2`.
     Req = req_with_headers([{~"content-length", ~"15"}]),
     Recv = chunked_recv([~"abc", ~"defgh", ~"ijklmnop"]),
-    {ok, Body, Leftover} = roadrunner_conn:read_body(Req, <<>>, Recv, 1000),
+    {ok, Body, Leftover} = roadrunner_conn:read_body(Req, <<>>, Recv, 1000, {8192, 10240, 100}),
     ?assertEqual(~"abcdefghijklmno", iolist_to_binary(Body)),
     ?assertEqual(~"p", Leftover).
 
@@ -79,7 +79,7 @@ read_body_cl_recv_error_test() ->
     Recv = fun() -> {error, closed} end,
     ?assertEqual(
         {error, closed},
-        roadrunner_conn:read_body(Req, <<>>, Recv, 1000)
+        roadrunner_conn:read_body(Req, <<>>, Recv, 1000, {8192, 10240, 100})
     ).
 
 read_body_cl_too_large_test() ->
@@ -87,7 +87,7 @@ read_body_cl_too_large_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {error, content_length_too_large},
-        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000, {8192, 10240, 100})
     ).
 
 drain_oversized_body_caps_at_2x_max_test() ->
@@ -153,7 +153,7 @@ read_body_bad_cl_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {error, bad_content_length},
-        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000, {8192, 10240, 100})
     ).
 
 read_body_negative_cl_test() ->
@@ -161,7 +161,7 @@ read_body_negative_cl_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {error, bad_content_length},
-        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000, {8192, 10240, 100})
     ).
 
 read_body_recv_error_test() ->
@@ -169,7 +169,7 @@ read_body_recv_error_test() ->
     Recv = fun() -> {error, closed} end,
     ?assertEqual(
         {error, closed},
-        roadrunner_conn:read_body(Req, ~"hi", Recv, 1000)
+        roadrunner_conn:read_body(Req, ~"hi", Recv, 1000, {8192, 10240, 100})
     ).
 
 %% --- chunked transfer-encoding ---
@@ -179,7 +179,7 @@ read_body_chunked_single_in_buffer_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {ok, ~"hello", <<>>},
-        roadrunner_conn:read_body(Req, ~"5\r\nhello\r\n0\r\n\r\n", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"5\r\nhello\r\n0\r\n\r\n", NoRecv, 1000, {8192, 10240, 100})
     ).
 
 read_body_chunked_multiple_in_buffer_test() ->
@@ -187,7 +187,9 @@ read_body_chunked_multiple_in_buffer_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {ok, ~"hellofoo", <<>>},
-        roadrunner_conn:read_body(Req, ~"5\r\nhello\r\n3\r\nfoo\r\n0\r\n\r\n", NoRecv, 1000)
+        roadrunner_conn:read_body(
+            Req, ~"5\r\nhello\r\n3\r\nfoo\r\n0\r\n\r\n", NoRecv, 1000, {8192, 10240, 100}
+        )
     ).
 
 read_body_chunked_needs_more_recv_test() ->
@@ -196,7 +198,7 @@ read_body_chunked_needs_more_recv_test() ->
     Recv = fun() -> {ok, ~"0\r\n\r\n"} end,
     ?assertEqual(
         {ok, ~"hi", <<>>},
-        roadrunner_conn:read_body(Req, ~"2\r\nhi\r\n", Recv, 1000)
+        roadrunner_conn:read_body(Req, ~"2\r\nhi\r\n", Recv, 1000, {8192, 10240, 100})
     ).
 
 read_body_chunked_exceeds_max_test() ->
@@ -205,7 +207,7 @@ read_body_chunked_exceeds_max_test() ->
     %% MaxCL=3 but the single chunk is 5 bytes.
     ?assertEqual(
         {error, content_length_too_large},
-        roadrunner_conn:read_body(Req, ~"5\r\nhello\r\n0\r\n\r\n", NoRecv, 3)
+        roadrunner_conn:read_body(Req, ~"5\r\nhello\r\n0\r\n\r\n", NoRecv, 3, {8192, 10240, 100})
     ).
 
 read_body_chunked_second_chunk_exceeds_max_test() ->
@@ -215,7 +217,9 @@ read_body_chunked_second_chunk_exceeds_max_test() ->
     %% the error must propagate out of the recursive read_chunked call.
     ?assertEqual(
         {error, content_length_too_large},
-        roadrunner_conn:read_body(Req, ~"3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n", NoRecv, 4)
+        roadrunner_conn:read_body(
+            Req, ~"3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n", NoRecv, 4, {8192, 10240, 100}
+        )
     ).
 
 read_body_chunked_bad_chunk_size_test() ->
@@ -223,7 +227,7 @@ read_body_chunked_bad_chunk_size_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {error, bad_chunk_size},
-        roadrunner_conn:read_body(Req, ~"xyz\r\nhello\r\n", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"xyz\r\nhello\r\n", NoRecv, 1000, {8192, 10240, 100})
     ).
 
 read_body_chunked_recv_error_test() ->
@@ -231,7 +235,7 @@ read_body_chunked_recv_error_test() ->
     Recv = fun() -> {error, closed} end,
     ?assertEqual(
         {error, closed},
-        roadrunner_conn:read_body(Req, ~"5\r\nhel", Recv, 1000)
+        roadrunner_conn:read_body(Req, ~"5\r\nhel", Recv, 1000, {8192, 10240, 100})
     ).
 
 read_body_unknown_transfer_encoding_rejected_test() ->
@@ -239,7 +243,39 @@ read_body_unknown_transfer_encoding_rejected_test() ->
     NoRecv = fun() -> error(should_not_be_called) end,
     ?assertEqual(
         {error, bad_transfer_encoding},
-        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000)
+        roadrunner_conn:read_body(Req, ~"", NoRecv, 1000, {8192, 10240, 100})
+    ).
+
+read_body_chunked_trailer_limits_enforced_test() ->
+    %% A chunked body with a ~40-byte trailer block: rejected when the
+    %% configured trailer `max_header_block` is 16, accepted at the
+    %% default 10240. Proves the configured limits reach the trailer
+    %% parser (not just request headers).
+    Req = req_with_headers([{~"transfer-encoding", ~"chunked"}]),
+    NoRecv = fun() -> error(should_not_be_called) end,
+    Body = ~"5\r\nhello\r\n0\r\nX-Trace: 0123456789abcdef\r\n\r\n",
+    ?assertEqual(
+        {error, header_block_too_long},
+        roadrunner_conn:read_body(Req, Body, NoRecv, 1000, {8192, 16, 100})
+    ),
+    ?assertEqual(
+        {ok, ~"hello", <<>>},
+        roadrunner_conn:read_body(Req, Body, NoRecv, 1000, {8192, 10240, 100})
+    ).
+
+read_body_chunked_trailer_count_enforced_test() ->
+    %% Two trailer headers: rejected when the trailer `max_header_count`
+    %% is 1, accepted at 100.
+    Req = req_with_headers([{~"transfer-encoding", ~"chunked"}]),
+    NoRecv = fun() -> error(should_not_be_called) end,
+    Body = ~"5\r\nhello\r\n0\r\nA: 1\r\nB: 2\r\n\r\n",
+    ?assertEqual(
+        {error, too_many_headers},
+        roadrunner_conn:read_body(Req, Body, NoRecv, 1000, {8192, 10240, 1})
+    ),
+    ?assertEqual(
+        {ok, ~"hello", <<>>},
+        roadrunner_conn:read_body(Req, Body, NoRecv, 1000, {8192, 10240, 100})
     ).
 
 read_body_chunked_case_insensitive_test() ->
@@ -253,7 +289,8 @@ read_body_chunked_case_insensitive_test() ->
                 req_with_headers([{~"transfer-encoding", V}]),
                 ~"2\r\nhi\r\n0\r\n\r\n",
                 NoRecv,
-                1000
+                1000,
+                {8192, 10240, 100}
             )
         )
      || V <- [~"chunked", ~"Chunked", ~"CHUNKED", ~"ChUnKeD"]
@@ -1220,7 +1257,8 @@ consume_state_no_framing_returns_empty_test() ->
         buffered => ~"hi",
         bytes_read => 0,
         recv => fun() -> error(unused) end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     ?assertMatch({ok, <<>>, #{buffered := ~"hi"}}, roadrunner_conn:consume_body_reader(State, all)).
 
@@ -1230,7 +1268,8 @@ consume_state_already_drained_returns_empty_test() ->
         buffered => <<>>,
         bytes_read => 5,
         recv => fun() -> error(unused) end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     ?assertMatch({ok, <<>>, _}, roadrunner_conn:consume_body_reader(State, all)).
 
@@ -1240,7 +1279,8 @@ consume_state_length_returns_more_then_ok_test() ->
         buffered => ~"abcdef",
         bytes_read => 0,
         recv => fun() -> error(unused) end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     {more, First, State1} = roadrunner_conn:consume_body_reader(State0, {length, 4}),
     ?assertEqual(~"abcd", First),
@@ -1253,7 +1293,8 @@ consume_state_length_recv_error_propagates_test() ->
         buffered => <<>>,
         bytes_read => 0,
         recv => fun() -> {error, closed} end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     ?assertEqual({error, closed}, roadrunner_conn:consume_body_reader(State, all)).
 
@@ -1280,7 +1321,8 @@ consume_state_length_multi_recv_test() ->
         buffered => <<>>,
         bytes_read => 0,
         recv => Recv,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     {more, Bytes, State1} = roadrunner_conn:consume_body_reader(State0, {length, 8}),
     ?assertEqual(~"abcdefgh", iolist_to_binary(Bytes)),
@@ -1305,7 +1347,8 @@ consume_state_length_multi_recv_error_test() ->
         buffered => <<>>,
         bytes_read => 0,
         recv => Recv,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     ?assertEqual(
         {error, closed},
@@ -1318,7 +1361,8 @@ consume_state_request_too_large_test() ->
         buffered => <<>>,
         bytes_read => 0,
         recv => fun() -> error(unused) end,
-        max => 10
+        max => 10,
+        trailer_limits => {8192, 10240, 100}
     },
     ?assertEqual(
         {error, content_length_too_large},
@@ -1488,7 +1532,8 @@ consume_state_next_chunk_for_content_length_drains_fully_test() ->
         pending => <<>>,
         done => false,
         recv => fun() -> error(unused) end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     ?assertMatch({ok, ~"hello", _}, roadrunner_conn:consume_body_reader(State, next_chunk)).
 
@@ -1516,7 +1561,8 @@ chunked_state(Buf, Recv) ->
         pending => <<>>,
         done => false,
         recv => Recv,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     }.
 
 consume_state_recvs_more_when_buffer_short_test() ->
@@ -1531,7 +1577,8 @@ consume_state_recvs_more_when_buffer_short_test() ->
             Self ! recv_called,
             {ok, ~"llo"}
         end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     {ok, Bytes, _} = roadrunner_conn:consume_body_reader(State, all),
     ?assertEqual(~"hello", iolist_to_binary(Bytes)),

--- a/test/roadrunner_http1_tests.erl
+++ b/test/roadrunner_http1_tests.erl
@@ -987,3 +987,67 @@ response_rejects_nul_in_header_name_test() ->
         {header_injection, name, _},
         roadrunner_http1:response(200, [{<<"x-name", 0, "bad">>, ~"v"}], ~"")
     ).
+
+%% --- parse_request/2 configurable limits ---
+
+%% Each limit's reject path flips when the configured limit changes:
+%% the same request is rejected under a tight limit and accepted under a
+%% loose one. `Limits` is
+%% `{max_request_line, max_header_line, max_header_block, max_header_count}`.
+
+config_max_request_line_enforced_test() ->
+    %% A 40-byte request line: rejected at a 16-byte cap, accepted at 8192.
+    Req = ~"GET /a-fairly-long-path HTTP/1.1\r\nHost: x\r\n\r\n",
+    ?assertEqual(
+        {error, request_line_too_long},
+        roadrunner_http1:parse_request(Req, {16, 8192, 10240, 100})
+    ),
+    ?assertMatch(
+        {ok, #{method := ~"GET"}, _},
+        roadrunner_http1:parse_request(Req, {8192, 8192, 10240, 100})
+    ).
+
+config_max_header_line_enforced_test() ->
+    %% A ~60-byte header line: rejected at a 20-byte cap, accepted at 8192.
+    Req = ~"GET / HTTP/1.1\r\nHost: x\r\nX-Trace: 0123456789abcdef0123456789\r\n\r\n",
+    ?assertEqual(
+        {error, header_too_long},
+        roadrunner_http1:parse_request(Req, {8192, 20, 10240, 100})
+    ),
+    ?assertMatch(
+        {ok, _, _},
+        roadrunner_http1:parse_request(Req, {8192, 8192, 10240, 100})
+    ).
+
+config_max_header_count_enforced_test() ->
+    %% Three headers: rejected when the count cap is 2, accepted at 100.
+    Req = ~"GET / HTTP/1.1\r\nHost: x\r\nA: 1\r\nB: 2\r\n\r\n",
+    ?assertEqual(
+        {error, too_many_headers},
+        roadrunner_http1:parse_request(Req, {8192, 8192, 10240, 2})
+    ),
+    ?assertMatch(
+        {ok, _, _},
+        roadrunner_http1:parse_request(Req, {8192, 8192, 10240, 100})
+    ).
+
+config_max_header_block_enforced_test() ->
+    %% The cumulative header block is ~30 bytes: rejected at a 20-byte
+    %% block cap, accepted at 10240.
+    Req = ~"GET / HTTP/1.1\r\nHost: x\r\nA: 1\r\nB: 2\r\n\r\n",
+    ?assertEqual(
+        {error, header_block_too_long},
+        roadrunner_http1:parse_request(Req, {8192, 8192, 20, 100})
+    ),
+    ?assertMatch(
+        {ok, _, _},
+        roadrunner_http1:parse_request(Req, {8192, 8192, 10240, 100})
+    ).
+
+config_defaults_match_parse_request_1_test() ->
+    %% parse_request/1 must equal parse_request/2 with the default tuple.
+    Req = ~"GET /x HTTP/1.1\r\nHost: x\r\nAccept: */*\r\n\r\n",
+    ?assertEqual(
+        roadrunner_http1:parse_request(Req),
+        roadrunner_http1:parse_request(Req, {8192, 8192, 10240, 100})
+    ).

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -337,10 +337,9 @@ listener_threads_custom_handler_spawn_into_proto_opts_test() ->
     ok = roadrunner_listener:stop(Name).
 
 listener_accepts_http1_tuple_form_test() ->
-    %% `{http1, #{}}` is the explicit tuple shape — accepted but
-    %% currently must be empty (no http1 tunables yet; reserved for
-    %% future additions). Normalizes to the same internal `[http1]`
-    %% atom list as the bare-atom form.
+    %% `{http1, #{}}` is the explicit tuple shape — an empty map keeps
+    %% the defaults. Normalizes to the same internal `[http1]` atom list
+    %% as the bare-atom form.
     Name = listener_test_protocols_http1_tuple,
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
         port => 0,
@@ -351,6 +350,65 @@ listener_accepts_http1_tuple_form_test() ->
     ProtoOpts = element(4, State),
     ?assertEqual([http1], maps:get(protocols, ProtoOpts)),
     ok = roadrunner_listener:stop(Name).
+
+listener_threads_http1_limits_into_proto_opts_test() ->
+    %% Custom `{http1, #{...}}` limits flatten to the `http1_*` proto_opts
+    %% keys the conn loop reads.
+    Name = listener_test_http1_limits,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => [
+            {http1, #{
+                max_request_line => 16384,
+                max_header_line => 16384,
+                max_header_block => 65536,
+                max_header_count => 250
+            }}
+        ],
+        routes => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual(16384, maps:get(http1_max_request_line, ProtoOpts)),
+    ?assertEqual(16384, maps:get(http1_max_header_line, ProtoOpts)),
+    ?assertEqual(65536, maps:get(http1_max_header_block, ProtoOpts)),
+    ?assertEqual(250, maps:get(http1_max_header_count, ProtoOpts)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_http1_defaults_thread_into_proto_opts_test() ->
+    %% Bare `http1` (no tuple) fills the default limits into proto_opts.
+    Name = listener_test_http1_defaults,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => [http1],
+        routes => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual(8192, maps:get(http1_max_request_line, ProtoOpts)),
+    ?assertEqual(100, maps:get(http1_max_header_count, ProtoOpts)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_rejects_invalid_http1_opt_test() ->
+    %% Unknown keys and out-of-range / non-integer values in `{http1, _}`
+    %% reject at `init/1` (mirrors the `{http2, _}` sub-opt validation).
+    process_flag(trap_exit, true),
+    lists:foreach(
+        fun(Bad) ->
+            R = roadrunner_listener:start_link(listener_test_http1_invalid, #{
+                port => 0,
+                protocols => [{http1, Bad}],
+                routes => roadrunner_hello_handler
+            }),
+            ?assertMatch({error, {{invalid_listener_opt, protocols, _}, _Stack}}, R)
+        end,
+        [
+            #{bogus_key => 1},
+            #{max_header_count => 0},
+            #{max_header_count => -1},
+            #{max_request_line => not_an_integer}
+        ]
+    ).
 
 listener_rejects_h1_and_h2_on_plain_tcp_test() ->
     %% `[http1, http2]` (and the reverse order) on plain TCP needs

--- a/test/roadrunner_req_tests.erl
+++ b/test/roadrunner_req_tests.erl
@@ -140,7 +140,8 @@ read_body_manual_state_full_drain_test() ->
         buffered => ~"hello",
         bytes_read => 0,
         recv => fun() -> error(unused) end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{body_reader => BS},
     {ok, Bytes, Req2} = roadrunner_req:read_body(Req),
@@ -153,7 +154,8 @@ read_body_manual_state_partial_returns_more_test() ->
         buffered => ~"abcdef",
         bytes_read => 0,
         recv => fun() -> error(unused) end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{body_reader => BS},
     {more, First, Req2} = roadrunner_req:read_body(Req, #{length => 4}),
@@ -167,7 +169,8 @@ read_body_manual_state_error_propagates_test() ->
         buffered => <<>>,
         bytes_read => 0,
         recv => fun() -> {error, closed} end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{body_reader => BS},
     ?assertEqual({error, closed}, roadrunner_req:read_body(Req)).
@@ -186,7 +189,8 @@ read_body_chunked_manual_state_yields_one_chunk_test() ->
         pending => <<>>,
         done => false,
         recv => fun() -> error(unused) end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{body_reader => BS},
     {more, Bytes, _Req2} = roadrunner_req:read_body_chunked(Req),
@@ -338,7 +342,8 @@ read_form_urlencoded_body_read_error_propagates_test() ->
         pending => <<>>,
         done => false,
         recv => fun() -> {error, closed} end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{
         headers => [{~"content-type", ~"application/x-www-form-urlencoded"}],
@@ -354,7 +359,8 @@ read_form_multipart_body_read_error_propagates_test() ->
         pending => <<>>,
         done => false,
         recv => fun() -> {error, closed} end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{
         headers => [{~"content-type", ~"multipart/form-data; boundary=B"}],
@@ -377,7 +383,8 @@ read_body_chunked_manual_state_error_propagates_test() ->
         pending => <<>>,
         done => false,
         recv => fun() -> {error, closed} end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{body_reader => BS},
     ?assertEqual({error, closed}, roadrunner_req:read_body_chunked(Req)).
@@ -396,7 +403,8 @@ read_body_chunked_manual_pending_then_recv_error_test() ->
         pending => ~"hi",
         done => false,
         recv => fun() -> {error, closed} end,
-        max => 1000
+        max => 1000,
+        trailer_limits => {8192, 10240, 100}
     },
     Req = (sample_req())#{body_reader => BS},
     ?assertEqual(


### PR DESCRIPTION
# Description

Makes the HTTP/1 inbound size limits configurable via `{http1, #{...}}`: `max_request_line`, `max_header_line`, `max_header_block`, `max_header_count` (over-cap answers 414 / 431). They were hardcoded (8192 / 8192 / 10240 / 100); defaults unchanged. The limits apply to both request headers and chunked-body trailer headers. Threaded through the parser as bound integers, perf-checked flat against the macro path.

```erlang
roadrunner:start_listener(my_listener, #{
    port => 8080, routes => my_router,
    protocols => [{http1, #{max_header_line => 16384, max_header_count => 200}}]
}).
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)