### PR TITLE
Answer 414/431 for over-limit http1 request lines and headers

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -58,6 +58,8 @@
     keep_alive_decision/2,
     send_request_timeout/1,
     send_bad_request/1,
+    send_status/2,
+    parse_error_status/1,
     send_payload_too_large/1,
     drain_oversized_body/3,
     send_internal_error/1,
@@ -988,12 +990,32 @@ header_value(Name, Headers) ->
 -doc false.
 -spec send_bad_request(roadrunner_transport:socket()) -> ok | {error, term()}.
 send_bad_request(Socket) ->
+    send_status(Socket, 400).
+
+%% Send a bare status line (empty body, `Connection: close`) for a request
+%% rejected before any handler runs.
+-doc false.
+-spec send_status(roadrunner_transport:socket(), roadrunner_http:status()) ->
+    ok | {error, term()}.
+send_status(Socket, Status) ->
     Resp = roadrunner_http1:response(
-        400,
+        Status,
         [{~"content-length", ~"0"}, {~"connection", ~"close"}],
         ~""
     ),
     roadrunner_transport:send(Socket, Resp).
+
+%% Map an `roadrunner_http1:parse_request/2` error reason to its HTTP
+%% status. Size-limit overruns get the RFC-specific codes (414 URI Too
+%% Long per RFC 9110 §15.5.15, 431 Request Header Fields Too Large per
+%% RFC 6585 §5); every other malformed-input reason is a generic 400.
+-doc false.
+-spec parse_error_status(atom()) -> roadrunner_http:status().
+parse_error_status(request_line_too_long) -> 414;
+parse_error_status(header_too_long) -> 431;
+parse_error_status(header_block_too_long) -> 431;
+parse_error_status(too_many_headers) -> 431;
+parse_error_status(_) -> 400.
 
 %% Drain up to `2 * MaxCL` bytes from the socket (counting the
 %% already-buffered bytes), discarding them. Used to flush an

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -496,7 +496,10 @@ handle_request_bytes(
                 peer => Peer,
                 reason => Reason
             }),
-            _ = roadrunner_conn:send_bad_request(Socket),
+            %% Size-limit overruns get the RFC-specific status (414 for an
+            %% over-long request line, 431 for oversized/too-many headers);
+            %% other malformed input is a generic 400.
+            _ = roadrunner_conn:send_status(Socket, roadrunner_conn:parse_error_status(Reason)),
             exit_normal(S)
     end.
 
@@ -543,7 +546,12 @@ read_body_phase(
                     exit_normal(S);
                 {error, BodyReason} ->
                     ok = rejection(S, BodyReason),
-                    _ = roadrunner_conn:send_bad_request(Socket),
+                    %% A chunked body's trailer block obeys the same header
+                    %% limits as request headers, so an oversized/too-many
+                    %% trailer reason maps to 431 the same way.
+                    _ = roadrunner_conn:send_status(
+                        Socket, roadrunner_conn:parse_error_status(BodyReason)
+                    ),
                     exit_normal(S)
             end;
         manual ->

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -145,6 +145,52 @@ bad_request_writes_400_then_exits_test() ->
     ?assertMatch(<<"HTTP/1.1 400", _/binary>>, Sent),
     Sink ! stop.
 
+oversized_request_line_writes_414_then_exits_test() ->
+    %% A request line past the 8192-byte cap is `request_line_too_long`,
+    %% which answers 414 URI Too Long (RFC 9110 §15.5.15), not a generic
+    %% 400.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    LongTarget = binary:copy(~"a", 9000),
+    Sink = spawn_active_sink_with_send_log(
+        Self, Tag, <<"GET /", LongTarget/binary, " HTTP/1.1\r\nHost: x\r\n\r\n">>
+    ),
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, fake_opts(uri_414)),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertMatch(<<"HTTP/1.1 414", _/binary>>, Sent),
+    Sink ! stop.
+
+too_many_headers_writes_431_then_exits_test() ->
+    %% More than 100 header lines is `too_many_headers`, which answers
+    %% 431 Request Header Fields Too Large (RFC 6585 §5), not a 400.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Headers = iolist_to_binary([
+        [~"X-", integer_to_binary(N), ~": v\r\n"]
+     || N <- lists:seq(1, 150)
+    ]),
+    Sink = spawn_active_sink_with_send_log(
+        Self, Tag, <<"GET / HTTP/1.1\r\nHost: x\r\n", Headers/binary, "\r\n">>
+    ),
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, fake_opts(hdr_431)),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertMatch(<<"HTTP/1.1 431", _/binary>>, Sent),
+    Sink ! stop.
+
 request_timeout_writes_408_then_exits_test() ->
     %% No bytes — the request_timeout `after` clause should fire and
     %% the conn should write 408 before exiting.

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -2108,3 +2108,24 @@ recv_response_with_body(Sock, BodyLen) ->
                 <<BodySoFar/binary, More/binary>>
         end,
     <<Head/binary, "\r\n\r\n", Body/binary>>.
+
+%% =============================================================================
+%% parse_error_status/1 — pure unit tests
+%% =============================================================================
+
+parse_error_status_request_line_too_long_test() ->
+    ?assertEqual(414, roadrunner_conn:parse_error_status(request_line_too_long)).
+
+parse_error_status_header_too_long_test() ->
+    ?assertEqual(431, roadrunner_conn:parse_error_status(header_too_long)).
+
+parse_error_status_header_block_too_long_test() ->
+    ?assertEqual(431, roadrunner_conn:parse_error_status(header_block_too_long)).
+
+parse_error_status_too_many_headers_test() ->
+    ?assertEqual(431, roadrunner_conn:parse_error_status(too_many_headers)).
+
+parse_error_status_other_is_400_test() ->
+    ?assertEqual(400, roadrunner_conn:parse_error_status(bad_request_line)),
+    ?assertEqual(400, roadrunner_conn:parse_error_status(bad_version)),
+    ?assertEqual(400, roadrunner_conn:parse_error_status(missing_host)).


### PR DESCRIPTION
# Description

HTTP/1 rejected every oversized request the same way, with a flat `400 Bad Request`. Now the size-limit reasons map to their RFC status: an over-long request line answers `414 URI Too Long` (RFC 9110 §15.5.15), and an oversized or too-numerous header block (including chunked trailers) answers `431 Request Header Fields Too Large` (RFC 6585 §5). Every other malformed-input reason still answers `400`.

This makes the behavior the `{http1, ...}` listener docs already describe accurate.

```erlang
%% request line over the cap
> HTTP/1.1 414 URI Too Long
%% header block over the cap
> HTTP/1.1 431 Request Header Fields Too Large
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)