### PR TITLE
Raise the static-test recv deadline to 5s to stop cover-slowed CI flakes

### DIFF
--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -676,7 +676,7 @@ recv_response_with_body_loop(Sock, Buf, BodyLen) ->
             <<Trim:(byte_size(Head) + 4 + BodyLen)/binary, _/binary>> = Buf,
             Trim;
         _ ->
-            {ok, Data} = gen_tcp:recv(Sock, 0, 1000),
+            {ok, Data} = gen_tcp:recv(Sock, 0, 5000),
             recv_response_with_body_loop(
                 Sock, <<Buf/binary, Data/binary>>, BodyLen
             )
@@ -806,7 +806,7 @@ http_request(Port, Method, Path, ExtraHeaders) ->
     Reply.
 
 recv_until_closed(Sock, Acc) ->
-    case gen_tcp:recv(Sock, 0, 1000) of
+    case gen_tcp:recv(Sock, 0, 5000) of
         {ok, Data} -> recv_until_closed(Sock, <<Acc/binary, Data/binary>>);
         {error, _} -> Acc
     end.


### PR DESCRIPTION
# Description

The pipelined-sendfile static test flakes on CI with `{badmatch, {error, timeout}}`. Its blocking `gen_tcp:recv` used a 1000ms deadline, which a loaded 2-vCPU runner with cover instrumentation on (every BEAM reduction runs 2 to 5x slower) can miss before the second response lands. The test passes locally and on rerun, so it is a deadline flake, not a logic bug.

Both blocking-recv helpers in the file go to 5000ms, matching `roadrunner_bench_client`. The normal path still returns the moment data or socket-close arrives, so the larger value only absorbs scheduler jitter and never adds latency to a healthy run.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)