### PR TITLE
Sync the resource-limits doc and roadmap with the configurable protocol caps

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -14,11 +14,17 @@ This page is an operator reference. For the reporting policy, see
 
 | Limit | Default | Configurable | Over-limit behavior |
 |---|---|---|---|
-| Request line | 8 KB | no (fixed) | 400, connection closed |
-| Header line | 8 KB | no (fixed) | 400, connection closed |
-| Header block (cumulative) | 10 KB | no (fixed) | 400, connection closed |
-| Header count | 100 | no (fixed) | 400, connection closed |
+| Request line | 8 KB | yes | 414 URI Too Long, connection closed |
+| Header line | 8 KB | yes | 431 Request Header Fields Too Large, connection closed |
+| Header block (cumulative) | 10 KB | yes | 431 Request Header Fields Too Large, connection closed |
+| Header count | 100 | yes | 431 Request Header Fields Too Large, connection closed |
 | Body (`max_content_length`) | 10 MB | yes | 413 Payload Too Large |
+
+The request line, header line, header block, and header count caps are
+tuned under `{http1, #{...}}` in the `protocols` list, with the keys
+`max_request_line`, `max_header_line`, `max_header_block`, and
+`max_header_count`. A chunked body's trailer block obeys the same header
+caps and is rejected the same way.
 
 The body cap is enforced the same way for both `Content-Length` and
 `Transfer-Encoding: chunked` requests: the cap is checked as the body is
@@ -57,25 +63,43 @@ When a cap closes a connection, roadrunner emits
 
 ## HTTP/2 framing limits
 
-These are advertised to the peer in the initial `SETTINGS` frame and
-enforced by the framing layer.
+The framing layer enforces these. The ones with a `SETTINGS` counterpart
+are advertised to the peer in the initial `SETTINGS` frame.
 
 | Limit | Default | Configurable |
 |---|---|---|
 | `SETTINGS_MAX_FRAME_SIZE` | 16 KB | no (fixed) |
-| `SETTINGS_MAX_CONCURRENT_STREAMS` | 100 | no (fixed) |
+| `SETTINGS_MAX_CONCURRENT_STREAMS` | 100 | yes |
 | HPACK decoder table | 4 KB | no (fixed) |
+| Header block (HEADERS + CONTINUATION) | 16 KB | yes |
 | Connection receive window (`conn_window`) | 65535 | yes |
 | Stream receive window (`stream_window`) | 65535 | yes |
 
 A frame whose declared length exceeds the negotiated max frame size is
 rejected on its 9-byte header, before the body is buffered. Streams over
-the concurrency limit are refused.
+the concurrency limit are refused. The cumulative header block has no
+`SETTINGS` counterpart yet, so it is enforced silently: a peer that
+overruns it gets `GOAWAY(ENHANCE_YOUR_CALM)`. The concurrency and
+header-block caps are tuned under `{http2, #{...}}` in the `protocols`
+list, with the keys `max_concurrent_streams` and `max_header_block`.
+
+## HTTP/3 framing limits
+
+| Limit | Default | Configurable |
+|---|---|---|
+| Field section block (encoded HEADERS) | 16 KB | yes |
+
+The encoded request field section is capped before it reaches the
+handler; an overrun answers `431 Request Header Fields Too Large`. It is
+tuned under `{http3, #{...}}` in the `protocols` list, with the key
+`max_header_block`. QPACK runs static-table only, so there is no
+dynamic-table memory to bound yet.
 
 ## Connection and slow-client guards
 
 | Limit | Default | Configurable | Purpose |
 |---|---|---|---|
+| `socket_backlog` | 1024 | yes | TCP listen backlog (kernel SYN/accept queue depth) |
 | `max_clients` | 150 | yes | concurrent connection cap per listener |
 | `request_timeout` | 30 s | yes | header-read timeout on a fresh connection |
 | `keep_alive_timeout` | 60 s | yes | idle timeout between requests |
@@ -90,7 +114,13 @@ Pass any configurable limit in the listener options map:
 roadrunner:start_listener(my_api, #{
     port => 8080,
     routes => my_handler,
+    socket_backlog => 4096,
     max_content_length => 5_242_880,
+    protocols => [
+        {http1, #{max_header_count => 200}},
+        {http2, #{max_concurrent_streams => 250, max_header_block => 32_768}},
+        {http3, #{max_header_block => 32_768}}
+    ],
     ws => #{max_frame_size => 1_048_576, max_message_size => 8_388_608}
 }).
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,10 +49,11 @@ only). Remaining work:
   needs the same conn-loop→worker inbound routing WebSocket would, so
   do it alongside that work, not standalone
 - Advertise `SETTINGS_MAX_FIELD_SECTION_SIZE` (RFC 9114 §7.2.4.1). The
-  encoded request header block is now capped (16384 bytes, 431 on
-  overflow, as h1's MAX_HEADER_BLOCK does); advertising the decoded-size
-  limit would let conformant clients avoid sending an oversized field
-  section in the first place rather than learning via the 431
+  encoded request header block is now capped (16384-byte default, 431 on
+  overflow, as the h1 and h2 `max_header_block` caps do); advertising the
+  decoded-size limit would let conformant clients avoid sending an
+  oversized field section in the first place rather than learning via the
+  431
 - WebSocket over h3 (`websocket` shape, still `501`) — RFC 9220
   Extended CONNECT; do WebSocket over h2 (RFC 8441) first, since it's
   the more common transport and h2 has no WebSocket either
@@ -177,7 +178,7 @@ their handshake fixture).
 
 **What:** Advertise `SETTINGS_MAX_HEADER_LIST_SIZE` (RFC 9113 §6.5.2,
 id 0x06) in the server's SETTINGS frame. The cumulative HEADERS +
-CONTINUATION block is now capped (16384 bytes, GOAWAY(ENHANCE_YOUR_CALM)
+CONTINUATION block is now capped (16384-byte default, GOAWAY(ENHANCE_YOUR_CALM)
 on overflow, the same way h1 and h3 bound it), which closes the
 CONTINUATION-flood memory gap. Advertising the decoded-size limit lets
 conformant clients avoid sending an oversized block in the first place
@@ -195,7 +196,7 @@ exists defaulted to `infinity` in `roadrunner_http2_settings.erl` and the
 encoder skips `infinity`, so advertising it meaningfully needs a concrete
 value to ship and (to be truthful) decode-side enforcement, since today we
 only parse the peer's value and bound inbound via the encoded
-`?MAX_HEADER_BLOCK`. The ~50 handshake fixtures that drain the server
+`max_header_block` cap. The ~50 handshake fixtures that drain the server
 SETTINGS need to tolerate the extra entry.
 
 ### Sync headline scenarios in comparison.md + resource_results.md


### PR DESCRIPTION
# Description

The configurable-limits work shipped, but `docs/resource_limits.md` still listed the h1 request/header caps and h2 `max_concurrent_streams` as fixed and showed a flat `400` for over-limit requests. This updates the doc to match: the five h1 caps and the h2 concurrency/header-block caps are now marked configurable, over-limit answers are `414`/`431`, and new rows cover the h2 header block, a fresh HTTP/3 section, and `socket_backlog`. The configuring example shows the `protocols` tuning shape.

The roadmap loses two stale asides that referenced the old `MAX_HEADER_BLOCK` macro as if the caps were still fixed; the deferred SETTINGS-advertisement TODOs stay.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)