### PR TITLE
Document the new configurable listener options in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,18 +217,24 @@ All listener options live in the
 type, with per-key defaults and tuning rationale. Beyond `port`,
 `protocols`, `tls`, and `routes` from the Quickstart, the type covers:
 
-- **DoS bounds** — `max_clients`, `max_content_length`,
-  `request_timeout`, `keep_alive_timeout`,
+- **DoS bounds** — `max_clients`, `socket_backlog`,
+  `max_content_length`, `request_timeout`, `keep_alive_timeout`,
   `min_bytes_per_second`, `max_keep_alive_requests`
 - **Middleware** — `middlewares`
 - **Body buffering** — `body_buffering`
 - **Graceful drain** — `graceful_drain`, `slot_reconciliation`
 - **Per-conn hibernation** — `hibernate_after`
+- **Handler spawn opts** — `handler_spawn`
+- **HTTP/1 tunables** (under the `{http1, Opts}` entry in
+  `protocols`) — `max_request_line`, `max_header_line`,
+  `max_header_block`, `max_header_count`
 - **HTTP/2 tunables** (under the `{http2, Opts}` entry in
   `protocols`) — `conn_window`, `stream_window`,
-  `window_refill_threshold`
+  `window_refill_threshold`, `max_concurrent_streams`,
+  `max_header_block`
 - **HTTP/3 tunables** (under the `{http3, Opts}` entry in
-  `protocols`) — `listeners` (reuseport pool size)
+  `protocols`) — `listeners` (reuseport pool size),
+  `max_header_block`
 
 ## Features
 
@@ -276,7 +282,7 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   client renegotiation off, post-quantum hybrid `x25519mlkem768` first
   when the OpenSSL build supports it. Full settings list in the
   `roadrunner_listener` module docs.
-- DoS bounds — `max_clients`, `max_content_length`,
+- DoS bounds — `max_clients`, `socket_backlog`, `max_content_length`,
   `min_bytes_per_second`, `request_timeout`, `keep_alive_timeout`,
   `max_keep_alive_requests`.
 


### PR DESCRIPTION
# Description

The README Configuration section never picked up the options that shipped this cycle. It now lists `socket_backlog`, `handler_spawn`, the `{http1, Opts}` request and header caps, and the new `{http2, Opts}` and `{http3, Opts}` tunables (`max_concurrent_streams`, `max_header_block`). The Hardening DoS-bounds list gains `socket_backlog` too, so the two enumerations stay in sync.

Doc-only, matching the existing bullet and separator style.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)