### PR TITLE
Add the max_concurrent_requests listener option for an aggregate in-flight ceiling

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -101,10 +101,25 @@ dynamic-table memory to bound yet.
 |---|---|---|---|
 | `socket_backlog` | 1024 | yes | TCP listen backlog (kernel SYN/accept queue depth) |
 | `max_clients` | 150 | yes | concurrent connection cap per listener |
+| `max_concurrent_requests` | `infinity` | yes | concurrent in-flight request cap per listener (HTTP/2 and HTTP/3) |
 | `request_timeout` | 30 s | yes | header-read timeout on a fresh connection |
 | `keep_alive_timeout` | 60 s | yes | idle timeout between requests |
 | `max_keep_alive_requests` | 1000 | yes | requests served per connection before close |
 | `min_bytes_per_second` | 100 | yes (0 disables) | slow-loris guard on the request-read phase |
+
+`max_clients` bounds connections and the HTTP/2 / HTTP/3
+`max_concurrent_streams` bounds streams per connection, but their product
+(the worst-case number of concurrent handler processes) is otherwise
+unbounded. A high `max_clients`, set for burst tolerance, can let
+concurrent handler memory grow without limit under heavy multiplexing.
+`max_concurrent_requests` caps that product directly: a listener-wide
+ceiling on live handler processes for the multiplexed protocols. Over the
+ceiling, a new HTTP/2 or HTTP/3 stream is refused with `REFUSED_STREAM` /
+`H3_REQUEST_REJECTED` (both retry-safe per RFC 9113 §8.7) before any
+handler runs, and the refusal emits `[roadrunner, request, throttled]` and
+increments the `throttled` count from `roadrunner_listener:info/1`. HTTP/1
+is unaffected: it serves one request per connection, so `max_clients`
+already bounds it.
 
 ## Configuring
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -34,6 +34,9 @@
     peer/1,
     try_acquire_slot/1,
     release_slot/1,
+    try_acquire_request_slot/1,
+    release_request_slot/1,
+    release_request_slots/2,
     consume_body_reader/2,
     join_drain_group/2,
     join_drain_group_for/2
@@ -100,6 +103,16 @@
     client_counter := counters:counters_ref(),
     requests_counter := atomics:atomics_ref(),
     rejected_counter := atomics:atomics_ref(),
+    %% Aggregate in-flight ceiling for the multiplexed protocols (h2/h3):
+    %% a cap on concurrent live stream-worker processes across the whole
+    %% listener, independent of `max_clients` and `max_concurrent_streams`.
+    %% `infinity` (default) disables it. `inflight_counter` is the live
+    %% gauge (acquired before a worker spawns, released on its `DOWN`);
+    %% `throttled_counter` is the cumulative count of streams refused at
+    %% the ceiling. h1 is bounded by `max_clients` and does not use these.
+    max_concurrent_requests := infinity | pos_integer(),
+    inflight_counter := counters:counters_ref(),
+    throttled_counter := atomics:atomics_ref(),
     min_bytes_per_second := non_neg_integer(),
     body_buffering := auto | manual,
     listener_name => atom(),
@@ -254,6 +267,56 @@ try_acquire_slot(#{client_counter := Ref, max_clients := Max}) ->
 -spec release_slot(proto_opts()) -> ok.
 release_slot(#{client_counter := Ref}) ->
     ok = counters:sub(Ref, 1, 1),
+    ok.
+
+-doc """
+Try to bump the live in-flight-request counter under
+`max_concurrent_requests`. Returns `true` if a worker may be spawned,
+`false` if the listener is already at the ceiling (caller must refuse the
+stream). `infinity` short-circuits to `true` with no counter touch, so an
+unconfigured listener pays nothing on the hot path.
+
+Same eventually-consistent overshoot contract as `try_acquire_slot/1`: the
+`counters` ref uses `write_concurrency`, so a brief read slightly above the
+cap is possible before rollbacks reconcile, bounded by in-flight admissions.
+Paired with `release_request_slot/1`, which must run exactly once per
+successfully-acquired worker (tie it to the worker monitor-ref removal so a
+worker is released by its `DOWN` or by the conn's clean exit, never both).
+""".
+-spec try_acquire_request_slot(proto_opts()) -> boolean().
+try_acquire_request_slot(#{max_concurrent_requests := infinity}) ->
+    true;
+try_acquire_request_slot(#{inflight_counter := Ref, max_concurrent_requests := Max}) ->
+    ok = counters:add(Ref, 1, 1),
+    case counters:get(Ref, 1) of
+        N when N =< Max ->
+            true;
+        _ ->
+            ok = counters:sub(Ref, 1, 1),
+            false
+    end.
+
+-doc "Decrement the in-flight-request counter, paired with `try_acquire_request_slot/1`.".
+-spec release_request_slot(proto_opts()) -> ok.
+release_request_slot(#{max_concurrent_requests := infinity}) ->
+    ok;
+release_request_slot(#{inflight_counter := Ref}) ->
+    ok = counters:sub(Ref, 1, 1),
+    ok.
+
+-doc """
+Release `N` in-flight slots at once. Used by the conn clean-exit path to
+account for stream workers still live at teardown (each held one slot), so
+their slots are not leaked until the listener restarts. `N = 0` and
+`infinity` are no-ops.
+""".
+-spec release_request_slots(proto_opts(), non_neg_integer()) -> ok.
+release_request_slots(_ProtoOpts, 0) ->
+    ok;
+release_request_slots(#{max_concurrent_requests := infinity}, _N) ->
+    ok;
+release_request_slots(#{inflight_counter := Ref}, N) ->
+    ok = counters:sub(Ref, 1, N),
     ok.
 
 -doc false.

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -975,21 +975,33 @@ dispatch_stream(
             },
             case roadrunner_http2_request:from_headers(Headers, BodyIolist, RequestContext) of
                 {ok, Req} ->
-                    {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
-                        self(), StreamId, Req, ProtoOpts
-                    ),
-                    Stream1 = Stream#{
-                        worker_pid := WorkerPid,
-                        worker_ref := MonRef,
-                        state := half_closed_remote,
-                        body := []
-                    },
-                    State1 = State#loop{
-                        streams = Streams#{StreamId := Stream1},
-                        worker_refs = (State#loop.worker_refs)#{MonRef => StreamId},
-                        req_id_buffer = NewBuf
-                    },
-                    frame_loop(State1);
+                    case roadrunner_conn:try_acquire_request_slot(ProtoOpts) of
+                        true ->
+                            {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
+                                self(), StreamId, Req, ProtoOpts
+                            ),
+                            Stream1 = Stream#{
+                                worker_pid := WorkerPid,
+                                worker_ref := MonRef,
+                                state := half_closed_remote,
+                                body := []
+                            },
+                            State1 = State#loop{
+                                streams = Streams#{StreamId := Stream1},
+                                worker_refs = (State#loop.worker_refs)#{MonRef => StreamId},
+                                req_id_buffer = NewBuf
+                            },
+                            frame_loop(State1);
+                        false ->
+                            %% Listener-wide in-flight ceiling reached — refuse
+                            %% the stream (retry-safe REFUSED_STREAM) without
+                            %% spawning a worker.
+                            ok = throttle_stream(State, ListenerName),
+                            _ = send_rst_stream(State, StreamId, refused_stream),
+                            frame_loop(
+                                remove_stream(State#loop{req_id_buffer = NewBuf}, StreamId)
+                            )
+                    end;
                 {error, _Reason} ->
                     _ = send_rst_stream(State, StreamId, protocol_error),
                     frame_loop(remove_stream(State#loop{req_id_buffer = NewBuf}, StreamId))
@@ -1117,6 +1129,10 @@ handle_send_trailers(State, From, Ref, StreamId, Trailers) ->
 handle_worker_down(#loop{worker_refs = Refs} = State, MonRef, Reason) ->
     case Refs of
         #{MonRef := StreamId} ->
+            %% Release the in-flight slot exactly once, tied to removing the
+            %% worker ref so a worker is accounted for by its `DOWN` here or
+            %% by the conn's clean exit, never both.
+            ok = roadrunner_conn:release_request_slot(State#loop.proto_opts),
             State1 = State#loop{worker_refs = maps:remove(MonRef, Refs)},
             case Reason of
                 normal -> remove_stream(State1, StreamId);
@@ -1423,6 +1439,11 @@ reset_stream(#loop{streams = Streams, worker_refs = Refs} = State, StreamId) ->
             MonRef ->
                 _ = (WorkerPid ! {h2_stream_reset, StreamId}),
                 true = demonitor(MonRef, [flush]),
+                %% The worker held an in-flight slot. We demonitor it (so no
+                %% `DOWN` fires) and drop its ref here, so this is the only
+                %% place that can release the slot — `handle_worker_down`
+                %% never runs and `exit_clean` no longer sees the ref.
+                ok = roadrunner_conn:release_request_slot(State#loop.proto_opts),
                 maps:remove(MonRef, Refs)
         end,
     State#loop{
@@ -1550,19 +1571,34 @@ send_goaway(#loop{last_stream_id = LastId} = State, ErrorCode) ->
 send_rst_stream(State, StreamId, ErrorCode) ->
     send(State, roadrunner_http2_frame:encode({rst_stream, StreamId, ErrorCode})).
 
+%% Bump the cumulative throttled counter and emit the throttled telemetry
+%% when a stream is refused at the `max_concurrent_requests` ceiling.
+-spec throttle_stream(#loop{}, atom()) -> ok.
+throttle_stream(#loop{proto_opts = #{throttled_counter := Counter}}, ListenerName) ->
+    ok = atomics:add(Counter, 1, 1),
+    roadrunner_telemetry:request_throttled(#{
+        listener_name => ListenerName,
+        reason => max_concurrent_requests
+    }).
+
 -spec exit_clean(#loop{}) -> no_return().
 exit_clean(#loop{
     socket = Socket,
     proto_opts = ProtoOpts,
     listener_name = ListenerName,
     peer = Peer,
-    start_mono = StartMono
+    start_mono = StartMono,
+    worker_refs = Refs
 }) ->
     roadrunner_telemetry:listener_conn_close(StartMono, #{
         listener_name => ListenerName,
         peer => Peer,
         requests_served => 0
     }),
+    %% Account for any stream workers still live at teardown (each holds one
+    %% in-flight slot). Workers whose `DOWN` already fired were removed from
+    %% `worker_refs`, so this releases each remaining worker exactly once.
+    ok = roadrunner_conn:release_request_slots(ProtoOpts, map_size(Refs)),
     ok = roadrunner_conn:release_slot(ProtoOpts),
     ok = roadrunner_transport:close(Socket),
     exit(normal).

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -700,16 +700,25 @@ dispatch_decoded(#h3{streams = Streams} = State, StreamId, Headers, Body) ->
             %% stream error H3_MESSAGE_ERROR.
             reset_and_drop(State1, StreamId, ?H3_MESSAGE_ERROR);
         {ok, Req} ->
-            {_WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
-                State1#h3.conn, StreamId, Req, State1#h3.proto_opts
-            ),
-            %% The worker owns the response now, tracked by its monitor
-            %% ref; drop the (no-longer-needed) frame-accumulation entry
-            %% so the streams map only ever holds in-progress requests.
-            State1#h3{
-                streams = maps:remove(StreamId, Streams),
-                worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId}
-            }
+            case roadrunner_conn:try_acquire_request_slot(State1#h3.proto_opts) of
+                true ->
+                    {_WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
+                        State1#h3.conn, StreamId, Req, State1#h3.proto_opts
+                    ),
+                    %% The worker owns the response now, tracked by its monitor
+                    %% ref; drop the (no-longer-needed) frame-accumulation entry
+                    %% so the streams map only ever holds in-progress requests.
+                    State1#h3{
+                        streams = maps:remove(StreamId, Streams),
+                        worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId}
+                    };
+                false ->
+                    %% Listener-wide in-flight ceiling reached — refuse the
+                    %% stream (retry-safe H3_REQUEST_REJECTED) without spawning
+                    %% a worker.
+                    ok = throttle_stream(State1),
+                    reset_and_drop(State1, StreamId, ?H3_REQUEST_REJECTED)
+            end
     end.
 
 %% A worker exit: normal means it sent its response with the stream FIN
@@ -721,6 +730,10 @@ handle_worker_down(#h3{worker_refs = WorkerRefs} = State, MonRef, Reason) ->
     %% Every monitor the loop holds is a stream worker (the QUIC conn is
     %% linked, not monitored), so the ref is always present.
     {StreamId, WorkerRefs1} = maps:take(MonRef, WorkerRefs),
+    %% Release the in-flight slot exactly once, tied to removing the worker
+    %% ref so it is accounted for by this `DOWN` or by the conn's clean
+    %% exit, never both.
+    ok = roadrunner_conn:release_request_slot(State#h3.proto_opts),
     State1 = State#h3{worker_refs = WorkerRefs1},
     case Reason of
         normal ->
@@ -735,6 +748,16 @@ handle_worker_down(#h3{worker_refs = WorkerRefs} = State, MonRef, Reason) ->
 reset_and_drop(#h3{conn = Conn} = State, StreamId, ErrorCode) ->
     _ = quic:reset_stream(Conn, StreamId, ErrorCode),
     drop_stream(State, StreamId).
+
+%% Bump the cumulative throttled counter and emit the throttled telemetry
+%% when a stream is refused at the `max_concurrent_requests` ceiling.
+-spec throttle_stream(#h3{}) -> ok.
+throttle_stream(#h3{proto_opts = #{throttled_counter := Counter}, listener_name = ListenerName}) ->
+    ok = atomics:add(Counter, 1, 1),
+    roadrunner_telemetry:request_throttled(#{
+        listener_name => ListenerName,
+        reason => max_concurrent_requests
+    }).
 
 %% A connection error (RFC 9114 §8): close the QUIC connection with the
 %% h3 error code + reason, then run the normal teardown. The peer sees
@@ -752,11 +775,19 @@ drop_stream(#h3{streams = Streams} = State, StreamId) ->
 
 -spec terminate(#h3{}) -> ok.
 terminate(#h3{
-    proto_opts = ProtoOpts, listener_name = ListenerName, peer = Peer, start_mono = StartMono
+    proto_opts = ProtoOpts,
+    listener_name = ListenerName,
+    peer = Peer,
+    start_mono = StartMono,
+    worker_refs = Refs
 }) ->
     ok = roadrunner_telemetry:listener_conn_close(StartMono, #{
         listener_name => ListenerName,
         peer => Peer,
         requests_served => 0
     }),
+    %% Account for any stream workers still live at teardown (each holds one
+    %% in-flight slot); workers whose `DOWN` already fired were removed from
+    %% `worker_refs`, so this releases each remaining worker exactly once.
+    ok = roadrunner_conn:release_request_slots(ProtoOpts, map_size(Refs)),
     ok = roadrunner_conn:release_slot(ProtoOpts).

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -44,6 +44,7 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_NUM_ACCEPTORS, 10).
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
 -define(DEFAULT_MAX_CLIENTS, 150).
+-define(DEFAULT_MAX_CONCURRENT_REQUESTS, infinity).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
 %% TCP listen backlog (kernel SYN/accept queue depth). OTP defaults to 5,
 %% which a burst of concurrent connects overflows; 1024 matches cowboy.
@@ -120,6 +121,19 @@ Optional middleware and timing knobs (durations in milliseconds):
   `[roadrunner, listener, conn_rejected]` and increments the `rejected`
   count from `info/1`, so a rising `rejected` is the signal that the
   cap is the binding limit.
+- `max_concurrent_requests` — cap on concurrent in-flight requests
+  (live handler processes) across the whole listener, for the
+  multiplexed protocols (HTTP/2 and HTTP/3). Default `infinity` (off).
+  `max_clients` bounds connections and `max_concurrent_streams` bounds
+  streams per connection, but their product (the worst-case live-handler
+  count) is otherwise unbounded; a high `max_clients` set for burst
+  tolerance can let concurrent handler memory grow without limit under
+  heavy multiplexing. This caps the product directly. Over-limit streams
+  are refused with `REFUSED_STREAM` (h2) / `H3_REQUEST_REJECTED` (h3),
+  which RFC 9113 §8.7 marks safe to retry; each refusal emits
+  `[roadrunner, request, throttled]` and increments the `throttled`
+  count from `info/1`. HTTP/1 is unaffected (one request per connection,
+  already bounded by `max_clients`).
 - `socket_backlog` — TCP listen backlog (kernel SYN/accept queue
   depth). Default 1024. Raise it for connection bursts (load tests,
   health-check storms); Linux clamps the effective value at
@@ -177,6 +191,7 @@ ops-tuning rationale.
     num_acceptors => pos_integer(),
     max_keep_alive_requests => pos_integer(),
     max_clients => pos_integer(),
+    max_concurrent_requests => infinity | pos_integer(),
     socket_backlog => pos_integer(),
     min_bytes_per_second => non_neg_integer(),
     %% How often `reading_request` re-checks the running
@@ -508,6 +523,12 @@ Return runtime introspection for a listener:
   listener was at its `max_clients` cap when they arrived. A rising
   `rejected` means the cap is the binding limit and should be raised.
   Also emitted in real time as `[roadrunner, listener, conn_rejected]`.
+- `max_concurrent_requests` — the configured in-flight ceiling
+  (`infinity` when off).
+- `throttled` — cumulative count of streams refused because the listener
+  was at its `max_concurrent_requests` ceiling. A rising `throttled`
+  means the in-flight cap is binding. Also emitted in real time as
+  `[roadrunner, request, throttled]`.
 
 Useful for ops dashboards / health endpoints.
 """.
@@ -516,7 +537,9 @@ Useful for ops dashboards / health endpoints.
         active_clients := non_neg_integer(),
         max_clients := pos_integer(),
         requests_served := non_neg_integer(),
-        rejected := non_neg_integer()
+        rejected := non_neg_integer(),
+        max_concurrent_requests := infinity | pos_integer(),
+        throttled := non_neg_integer()
     }.
 info(Name) ->
     gen_server:call(Name, info).
@@ -911,6 +934,13 @@ build_proto_opts(Opts, ListenerName) ->
     ClientCounter = counters:new(1, [write_concurrency]),
     RequestsCounter = atomics:new(1, [{signed, false}]),
     RejectedCounter = atomics:new(1, [{signed, false}]),
+    %% `inflight_counter` is the live in-flight-request gauge (h2/h3 stream
+    %% workers acquire before spawn, release on `DOWN`), same lock-free
+    %% `write_concurrency` shape as `client_counter`. `throttled_counter`
+    %% is the cumulative count of streams refused at the
+    %% `max_concurrent_requests` ceiling, mirroring `rejected_counter`.
+    InflightCounter = counters:new(1, [write_concurrency]),
+    ThrottledCounter = atomics:new(1, [{signed, false}]),
     %% Public `ws` opts are a nested map; flatten to the `ws_*`
     %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
     %% → `http2_*` flattening above.
@@ -933,9 +963,13 @@ build_proto_opts(Opts, ListenerName) ->
             max_keep_alive_requests =>
                 maps:get(max_keep_alive_requests, Opts, ?DEFAULT_MAX_KEEP_ALIVE),
             max_clients => maps:get(max_clients, Opts, ?DEFAULT_MAX_CLIENTS),
+            max_concurrent_requests =>
+                maps:get(max_concurrent_requests, Opts, ?DEFAULT_MAX_CONCURRENT_REQUESTS),
             client_counter => ClientCounter,
             requests_counter => RequestsCounter,
             rejected_counter => RejectedCounter,
+            inflight_counter => InflightCounter,
+            throttled_counter => ThrottledCounter,
             min_bytes_per_second =>
                 maps:get(min_bytes_per_second, Opts, ?DEFAULT_MIN_BYTES_PER_SECOND),
             body_buffering => maps:get(body_buffering, Opts, auto),
@@ -1365,13 +1399,17 @@ handle_call(info, _From, #state{proto_opts = ProtoOpts} = State) ->
         client_counter := ClientCounter,
         requests_counter := RequestsCounter,
         rejected_counter := RejectedCounter,
-        max_clients := MaxClients
+        throttled_counter := ThrottledCounter,
+        max_clients := MaxClients,
+        max_concurrent_requests := MaxConcurrentRequests
     } = ProtoOpts,
     Reply = #{
         active_clients => counters:get(ClientCounter, 1),
         max_clients => MaxClients,
         requests_served => atomics:get(RequestsCounter, 1),
-        rejected => atomics:get(RejectedCounter, 1)
+        rejected => atomics:get(RejectedCounter, 1),
+        max_concurrent_requests => MaxConcurrentRequests,
+        throttled => atomics:get(ThrottledCounter, 1)
     },
     {reply, Reply, State}.
 

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -156,6 +156,7 @@
     listener_conn_close/2,
     listener_conn_rejected/1,
     request_rejected/1,
+    request_throttled/1,
     slots_reconciled/1,
     drain_acknowledged/1,
     ws_upgrade/1,
@@ -303,6 +304,25 @@ debug logs. `Metadata` should include `listener_name`, `peer`, and
 request_rejected(Metadata) ->
     telemetry:execute(
         [roadrunner, request, rejected],
+        #{system_time => erlang:system_time()},
+        Metadata
+    ),
+    ok.
+
+-doc """
+Emit `[roadrunner, request, throttled]` when an HTTP/2 or HTTP/3 stream is
+refused because the listener is at its `max_concurrent_requests` in-flight
+ceiling. The stream is reset (`REFUSED_STREAM` / `H3_REQUEST_REJECTED`,
+both retry-safe per RFC 9113 §8.7) before any handler runs. Lets ops see
+the in-flight cap is binding instead of mistaking the refusals for errors;
+pair it with the cumulative `throttled` count from
+`roadrunner_listener:info/1`. `Metadata` should include `listener_name`
+and `reason` (`max_concurrent_requests`).
+""".
+-spec request_throttled(map()) -> ok.
+request_throttled(Metadata) ->
+    telemetry:execute(
+        [roadrunner, request, throttled],
         #{system_time => erlang:system_time()},
         Metadata
     ),

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -180,6 +180,7 @@ proto_opts(ListenerName, Counter) ->
         keep_alive_timeout => 200,
         max_keep_alive_requests => 100,
         max_clients => 1000,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         requests_counter => atomics:new(1, [{signed, false}]),
         rejected_counter => atomics:new(1, [{signed, false}]),

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -86,6 +86,8 @@ all_test_() ->
         fun handler_returning_invalid_shape_resets_stream/0,
         fun unrelated_down_ignored/0,
         fun over_max_concurrent_streams_refused/0,
+        fun over_inflight_ceiling_refused_and_throttled/0,
+        fun reset_stream_releases_inflight_slot/0,
         fun rst_during_stream_response_unwinds_worker/0,
         fun drain_with_no_streams_exits_immediately/0,
         fun drain_refuses_new_streams/0,
@@ -366,6 +368,7 @@ concurrent_streams_both_dispatch() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_concurrent_test,
         dispatch =>
@@ -431,6 +434,7 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         requests_counter => RequestsCounter,
         rejected_counter => atomics:new(1, [{signed, false}]),
@@ -484,6 +488,7 @@ plaintext_listener_without_h2c_stays_h1() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         requests_counter => RequestsCounter,
         rejected_counter => atomics:new(1, [{signed, false}]),
@@ -1077,6 +1082,7 @@ middleware_chain_runs() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_mw_test,
         dispatch =>
@@ -1141,6 +1147,7 @@ router_404_returns_not_found() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_404_listener,
         dispatch => {router, h2_404_listener},
@@ -1846,6 +1853,140 @@ over_max_concurrent_streams_refused() ->
         roadrunner_http2_frame:parse(Rst, 16384),
     cleanup(Pid, Ref).
 
+over_inflight_ceiling_refused_and_throttled() ->
+    %% Listener-wide in-flight ceiling of 1. The first complete request
+    %% dispatches a long-lived `{loop, _}` worker that holds the only slot;
+    %% the second complete request is refused with RST_STREAM(refused_stream),
+    %% bumps the `throttled_counter`, and emits `[roadrunner, request,
+    %% throttled]`. Releasing the worker frees the slot again.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    Self = self(),
+    HandlerId = make_ref(),
+    ok = telemetry:attach(
+        HandlerId,
+        [roadrunner, request, throttled],
+        fun(Event, M, Md, _) -> Self ! {ev, Event, M, Md} end,
+        undefined
+    ),
+    Inflight = counters:new(1, [write_concurrency]),
+    Throttled = atomics:new(1, [{signed, false}]),
+    {Pid, Ref, ConnPid} = start_http2_conn(#{
+        max_concurrent_requests => 1,
+        inflight_counter => Inflight,
+        throttled_counter => Throttled,
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined}
+    }),
+    try
+        _ = expect_send(),
+        serve_recv(ConnPid, ?PREFACE),
+        serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+        _ = expect_send(),
+        %% Stream 1: GET /loop — the handler registers itself and parks,
+        %% so its worker stays alive holding the single in-flight slot.
+        serve_recv(ConnPid, complete_get_headers(1, ~"/loop")),
+        _ = wait_for_register(roadrunner_h2_loop_test, 1000),
+        _ = drain_send(50),
+        ?assertEqual(1, counters:get(Inflight, 1)),
+        %% Stream 3: a second complete request is over the ceiling.
+        serve_recv(ConnPid, complete_get_headers(3, ~"/empty")),
+        Rst = expect_send(),
+        ?assertMatch(
+            {ok, {rst_stream, 3, refused_stream}, _},
+            roadrunner_http2_frame:parse(Rst, 16384)
+        ),
+        ?assertEqual(1, atomics:get(Throttled, 1)),
+        receive
+            {ev, [roadrunner, request, throttled], M, Md} ->
+                ?assert(is_integer(maps:get(system_time, M))),
+                ?assertEqual(http2_test, maps:get(listener_name, Md)),
+                ?assertEqual(max_concurrent_requests, maps:get(reason, Md))
+        after 1000 -> error(no_throttled_event)
+        end,
+        %% The slot is still held by the parked loop worker.
+        ?assertEqual(1, counters:get(Inflight, 1)),
+        %% Stop the loop worker; its `DOWN` releases the slot.
+        roadrunner_h2_loop_test ! stop,
+        ok = wait_inflight(Inflight, 0, 50)
+    after
+        telemetry:detach(HandlerId),
+        cleanup(Pid, Ref)
+    end.
+
+reset_stream_releases_inflight_slot() ->
+    %% A peer RST_STREAM for a dispatched stream must release the in-flight
+    %% slot the worker held. `reset_stream/2` demonitors the worker (so no
+    %% `DOWN` fires) and drops the worker ref, so without an explicit release
+    %% on that path the slot leaks: the gauge would never return to 0 and a
+    %% later request would be wrongly refused.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    Inflight = counters:new(1, [write_concurrency]),
+    Throttled = atomics:new(1, [{signed, false}]),
+    {Pid, Ref, ConnPid} = start_http2_conn(#{
+        max_concurrent_requests => 1,
+        inflight_counter => Inflight,
+        throttled_counter => Throttled,
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined}
+    }),
+    try
+        _ = expect_send(),
+        serve_recv(ConnPid, ?PREFACE),
+        serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+        _ = expect_send(),
+        %% Stream 1: a long-lived `/loop` worker takes the only slot.
+        serve_recv(ConnPid, complete_get_headers(1, ~"/loop")),
+        _ = wait_for_register(roadrunner_h2_loop_test, 1000),
+        _ = drain_send(50),
+        ?assertEqual(1, counters:get(Inflight, 1)),
+        %% Peer cancels stream 1. `reset_stream/2` tears the worker down
+        %% and must free the slot.
+        Rst = iolist_to_binary(roadrunner_http2_frame:encode({rst_stream, 1, cancel})),
+        serve_recv(ConnPid, Rst),
+        ok = wait_inflight(Inflight, 0, 50),
+        %% The slot is genuinely free again: stream 3 is admitted (worker
+        %% spawns), not refused.
+        serve_recv(ConnPid, complete_get_headers(3, ~"/empty")),
+        _ = drain_send(100),
+        ?assertEqual(0, atomics:get(Throttled, 1))
+    after
+        cleanup(Pid, Ref)
+    end.
+
+%% Build a complete (END_HEADERS + END_STREAM) GET HEADERS frame for `Path`
+%% on `StreamId`, so dispatch fires immediately (no body to wait for).
+complete_get_headers(StreamId, Path) ->
+    Enc = roadrunner_http2_hpack:new_encoder(4096),
+    {Hpack, _} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"https"},
+            {~":authority", ~"x"},
+            {~":path", Path}
+        ],
+        Enc
+    ),
+    iolist_to_binary(
+        roadrunner_http2_frame:encode(
+            {headers, StreamId, 16#04 bor 16#01, undefined, iolist_to_binary(Hpack)}
+        )
+    ).
+
+wait_inflight(_Ref, _Want, 0) ->
+    error(inflight_never_reached);
+wait_inflight(Ref, Want, Tries) ->
+    case counters:get(Ref, 1) of
+        Want ->
+            ok;
+        _ ->
+            timer:sleep(20),
+            wait_inflight(Ref, Want, Tries - 1)
+    end.
+
 rst_during_stream_response_unwinds_worker() ->
     %% A `{stream, _}` handler pauses mid-response. Peer sends
     %% RST_STREAM during the pause. Conn's `reset_stream/2` tells
@@ -1863,6 +2004,7 @@ rst_during_stream_response_unwinds_worker() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_rst_during_stream,
         dispatch =>
@@ -1943,6 +2085,7 @@ drain_refuses_new_streams() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_drain_test,
         dispatch =>
@@ -1998,6 +2141,7 @@ drain_with_in_flight_stream_waits() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_drain_inflight_test,
         dispatch =>
@@ -2060,6 +2204,7 @@ drain_message_is_idempotent() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_drain_dup_test,
         dispatch =>
@@ -2112,6 +2257,7 @@ drain_then_peer_rst_exits_via_frame_loop() ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_drain_rst_test,
         dispatch =>
@@ -2207,6 +2353,7 @@ telemetry_request_stop_fires_for_router_404() ->
         ProtoOpts = #{
             handler_spawn_opts => [{fullsweep_after, 0}],
             handler_start_timeout => infinity,
+            max_concurrent_requests => infinity,
             client_counter => Counter,
             listener_name => h2_telem_404,
             dispatch => {router, h2_telem_404},
@@ -2290,6 +2437,7 @@ run_h2_with_compress_middleware(Path, ExtraHeaders) ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_compress_test,
         dispatch =>
@@ -3028,6 +3176,7 @@ post_handshake_handler(Handler) ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_strict_test,
         dispatch => {handler, Handler, fun Handler:handle/1, undefined},
@@ -3153,6 +3302,7 @@ start_http2_conn(Extra) ->
     %% (e.g. `hibernate_after` for the idle-hibernation tests).
     ProtoOpts = maps:merge(
         #{
+            max_concurrent_requests => infinity,
             client_counter => Counter,
             listener_name => http2_test,
             handler_spawn_opts => [{fullsweep_after, 0}],
@@ -3282,6 +3432,7 @@ run_h2_request_with_handler(Handler, Path) ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_handler_test,
         dispatch => {handler, Handler, fun Handler:handle/1, undefined},
@@ -3340,6 +3491,7 @@ run_stream_request(Path, PrefaceSettings) ->
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_stream_test,
         dispatch =>

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1322,6 +1322,7 @@ fake_opts(ListenerName) ->
         keep_alive_timeout => 5000,
         max_keep_alive_requests => 100,
         max_clients => 10,
+        max_concurrent_requests => infinity,
         client_counter => counters:new(1, [write_concurrency]),
         requests_counter => atomics:new(1, [{signed, false}]),
         rejected_counter => atomics:new(1, [{signed, false}]),

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -2129,3 +2129,44 @@ parse_error_status_other_is_400_test() ->
     ?assertEqual(400, roadrunner_conn:parse_error_status(bad_request_line)),
     ?assertEqual(400, roadrunner_conn:parse_error_status(bad_version)),
     ?assertEqual(400, roadrunner_conn:parse_error_status(missing_host)).
+
+%% =============================================================================
+%% try_acquire_request_slot/1 + release_request_slot[s] — pure unit tests
+%% =============================================================================
+
+request_slot_infinity_is_noop_test() ->
+    %% `infinity` short-circuits before touching any counter, so the map
+    %% needs no `inflight_counter`. Acquire always succeeds; release is a
+    %% no-op.
+    Opts = #{max_concurrent_requests => infinity},
+    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slot(Opts)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(Opts, 5)).
+
+request_slot_admits_up_to_cap_then_refuses_test() ->
+    Ref = counters:new(1, [write_concurrency]),
+    Opts = #{max_concurrent_requests => 2, inflight_counter => Ref},
+    %% Two admits up to the cap, the third is refused and rolls back so the
+    %% gauge stays at the cap.
+    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assertNot(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assertEqual(2, counters:get(Ref, 1)),
+    %% Releasing one frees a slot; the next acquire succeeds again.
+    ?assertEqual(ok, roadrunner_conn:release_request_slot(Opts)),
+    ?assertEqual(1, counters:get(Ref, 1)),
+    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assertEqual(2, counters:get(Ref, 1)).
+
+request_slot_release_many_test() ->
+    Ref = counters:new(1, [write_concurrency]),
+    Opts = #{max_concurrent_requests => 10, inflight_counter => Ref},
+    [?assert(roadrunner_conn:try_acquire_request_slot(Opts)) || _ <- lists:seq(1, 4)],
+    ?assertEqual(4, counters:get(Ref, 1)),
+    %% Bulk release (conn teardown with N live workers) drops the gauge by N;
+    %% N = 0 is a no-op.
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(Opts, 0)),
+    ?assertEqual(4, counters:get(Ref, 1)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(Opts, 4)),
+    ?assertEqual(0, counters:get(Ref, 1)).

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -241,6 +241,7 @@ start_conn(H2Opts) ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_window_test,
         dispatch =>

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -351,6 +351,7 @@ start_conn(Handler) ->
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
+        max_concurrent_requests => infinity,
         client_counter => Counter,
         listener_name => h2_flow_test,
         dispatch => {handler, Handler, fun Handler:handle/1, undefined},

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -47,6 +47,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     co_listen/1,
     rejects_http3_without_tls/1,
     max_clients_refuse/1,
+    max_concurrent_requests_refuse/1,
     stream_cancel/1,
     response_to_cancelled_stream/1,
     badheaders_reset/1,
@@ -106,6 +107,7 @@ all() ->
         co_listen,
         rejects_http3_without_tls,
         max_clients_refuse,
+        max_concurrent_requests_refuse,
         stream_cancel,
         response_to_cancelled_stream,
         badheaders_reset,
@@ -179,6 +181,7 @@ init_per_testcase(Case, Config) when
     Case =:= co_listen;
     Case =:= rejects_http3_without_tls;
     Case =:= max_clients_refuse;
+    Case =:= max_concurrent_requests_refuse;
     Case =:= extra_data_after_413
 ->
     Config;
@@ -610,6 +613,53 @@ max_clients_refuse(_Config) ->
     after
         close(Conn1),
         roadrunner_listener:stop(Name)
+    end.
+
+max_concurrent_requests_refuse(_Config) ->
+    %% A listener with an in-flight ceiling of 1. A `/loop` request parks a
+    %% long-lived worker holding the only slot; a second request on the same
+    %% connection is refused (H3_REQUEST_REJECTED) and bumps the `throttled`
+    %% count from `info/1`. Stopping the loop worker frees the slot.
+    Name = listener_name(max_concurrent_requests_refuse),
+    {ok, _} = start_h3(Name, #{max_concurrent_requests => 1}),
+    Port = roadrunner_listener:port(Name),
+    Conn = connect(Port),
+    try
+        {ok, _StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/loop")),
+        Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
+        %% The parked worker holds the single in-flight slot, so the next
+        %% request is over the ceiling and gets no response.
+        ?assertEqual(error, try_get(Conn, ~"/")),
+        ?assert(maps:get(throttled, roadrunner_listener:info(Name)) >= 1),
+        %% Releasing the worker frees the slot; a fresh request succeeds once
+        %% the worker's `DOWN` has run (the slot release is async, so retry).
+        WorkerRef = monitor(process, Worker),
+        Worker ! stop,
+        receive
+            {'DOWN', WorkerRef, process, Worker, _} -> ok
+        after 5000 -> ct:fail(loop_worker_did_not_exit)
+        end,
+        ?assertEqual({200, ~"ok"}, status_body(retry_get(Conn, ~"/", 50)))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+%% Retry a GET until it succeeds: the in-flight slot is released on the
+%% worker's `DOWN`, which is processed by the conn loop slightly after the
+%% monitor fires here, so the first follow-up request can still race it.
+retry_get(_Conn, _Path, 0) ->
+    error(retry_get_exhausted);
+retry_get(Conn, Path, Tries) ->
+    case get(Conn, Path) of
+        {error, _} ->
+            timer:sleep(20),
+            retry_get(Conn, Path, Tries - 1);
+        timeout ->
+            timer:sleep(20),
+            retry_get(Conn, Path, Tries - 1);
+        Response ->
+            Response
     end.
 
 stream_cancel(Config) ->

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -578,6 +578,20 @@ listener_info_initial_zero_test() ->
     ?assertEqual(42, maps:get(max_clients, Info)),
     ?assertEqual(0, maps:get(requests_served, Info)),
     ?assertEqual(0, maps:get(rejected, Info)),
+    %% `max_concurrent_requests` defaults to `infinity` (off); the
+    %% cumulative `throttled` gauge starts at zero.
+    ?assertEqual(infinity, maps:get(max_concurrent_requests, Info)),
+    ?assertEqual(0, maps:get(throttled, Info)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_info_reports_configured_max_concurrent_requests_test() ->
+    Name = listener_test_info_mcr,
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0, max_concurrent_requests => 256, routes => roadrunner_hello_handler
+    }),
+    Info = roadrunner_listener:info(Name),
+    ?assertEqual(256, maps:get(max_concurrent_requests, Info)),
+    ?assertEqual(0, maps:get(throttled, Info)),
     ok = roadrunner_listener:stop(Name).
 
 over_cap_connection_rejected_fires_event_and_counts_test() ->

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -128,6 +128,7 @@ request_rejected_event_fires_on_bad_request_line_test() ->
             keep_alive_timeout => 200,
             max_keep_alive_requests => 100,
             max_clients => 10,
+            max_concurrent_requests => infinity,
             client_counter => counters:new(1, [write_concurrency]),
             requests_counter => atomics:new(1, [{signed, false}]),
             rejected_counter => atomics:new(1, [{signed, false}]),

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -564,6 +564,7 @@ fake_proto_opts(Handler) ->
         keep_alive_timeout => 5000,
         max_keep_alive_requests => 100,
         max_clients => 10,
+        max_concurrent_requests => infinity,
         client_counter => counters:new(1, [write_concurrency]),
         requests_counter => atomics:new(1, [{signed, false}]),
         rejected_counter => atomics:new(1, [{signed, false}]),


### PR DESCRIPTION
# Description

Adds a per-listener cap on total concurrent in-flight requests, enforced independently of `max_clients` and `max_concurrent_streams`. Their product (the worst-case number of concurrent handler processes) was otherwise unbounded, so a high `max_clients` set for burst tolerance could let concurrent handler memory grow without limit under heavy HTTP/2 or HTTP/3 multiplexing. `max_concurrent_requests` bounds that product directly.

Default is `infinity` (off, no behaviour change). Over the ceiling, a new h2/h3 stream is refused with `REFUSED_STREAM` / `H3_REQUEST_REJECTED` (both retry-safe per RFC 9113 §8.7) before any handler runs; the refusal emits `[roadrunner, request, throttled]` and increments the `throttled` count from `roadrunner_listener:info/1`. HTTP/1 is unaffected (one request per connection, already bounded by `max_clients`).

This is the right axis rather than lowering the per-connection `max_concurrent_streams` default below the RFC-recommended 100: that knob protects a single client's parallelism, while this bounds the actual unbounded quantity (total concurrent work) listener-wide.

```erlang
roadrunner:start_listener(my_api, #{
    port => 8080,
    routes => my_handler,
    max_concurrent_requests => 10_000
}).
```

The live gauge is a shared `counters` ref acquired before a worker spawns and released on its exit; the release is tied to the worker monitor-ref removal so each worker is accounted for exactly once (a peer `RST_STREAM` releases on the reset path, normal completion on the `DOWN` path, and conn teardown releases any still-live workers).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)