### PR TITLE
Sync docs with the current bench matrix and the max_concurrent_requests option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ All listener options live in the
 type, with per-key defaults and tuning rationale. Beyond `port`,
 `protocols`, `tls`, and `routes` from the Quickstart, the type covers:
 
-- **DoS bounds** — `max_clients`, `socket_backlog`,
-  `max_content_length`, `request_timeout`, `keep_alive_timeout`,
-  `min_bytes_per_second`, `max_keep_alive_requests`
+- **DoS bounds** — `max_clients`, `max_concurrent_requests`,
+  `socket_backlog`, `max_content_length`, `request_timeout`,
+  `keep_alive_timeout`, `min_bytes_per_second`, `max_keep_alive_requests`
 - **Middleware** — `middlewares`
 - **Body buffering** — `body_buffering`
 - **Graceful drain** — `graceful_drain`, `slot_reconciliation`
@@ -282,9 +282,9 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   client renegotiation off, post-quantum hybrid `x25519mlkem768` first
   when the OpenSSL build supports it. Full settings list in the
   `roadrunner_listener` module docs.
-- DoS bounds — `max_clients`, `socket_backlog`, `max_content_length`,
-  `min_bytes_per_second`, `request_timeout`, `keep_alive_timeout`,
-  `max_keep_alive_requests`.
+- DoS bounds — `max_clients`, `max_concurrent_requests`,
+  `socket_backlog`, `max_content_length`, `min_bytes_per_second`,
+  `request_timeout`, `keep_alive_timeout`, `max_keep_alive_requests`.
 
 ### Observability
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -9,7 +9,9 @@ points here for readers comparing roadrunner against the alternatives.
 `scripts/bench.escript` runs the same loadgen against each server in
 its own peer BEAM. `scripts/bench_matrix.sh` drives 30+ scenarios
 across both protocols and writes the consolidated tables that ship
-in [`bench_results.md`](bench_results.md). Numbers below are the
+in [`bench_results.md`](bench_results.md). The cross-section below is
+drawn from that same matrix run (the full per-protocol tables, plus
+roadrunner's p50 / p99, live in `bench_results.md`). Numbers are the
 median of 3 runs at 50 concurrent clients, loopback only (no NIC).
 Re-run locally to see what your hardware shows; absolute numbers
 shift, relative ordering tends to hold.
@@ -49,16 +51,18 @@ inside variance and shouldn't be read as a win.
 
 | scenario                  | roadrunner    | elli          | cowboy        |
 |---------------------------|--------------:|--------------:|--------------:|
-| `hello`                   |       285 k   |       289 k   |       196 k   |
-| `json`                    |       292 k   |       301 k   |       182 k   |
-| `echo`                    |       270 k   |       281 k   |       148 k   |
-| `large_response`          |       124 k   |       125 k   |        94 k   |
-| `headers_heavy`           |       267 k   |       241 k   |       134 k   |
-| `cookies_heavy`           |   **287 k**   |          —    |       163 k   |
-| `pipelined_h1`            |   **526 k**   |       4.9 k   |       357 k   |
-| `varied_paths_router`     |   **294 k**   |          —    |       170 k   |
-| `gzip_response`           |   **136 k**   |          —    |       108 k   |
-| `websocket_msg_throughput`|   **230 k**   |          —    |       167 k   |
+| `hello`                   |       307 k   |       299 k   |       201 k   |
+| `json`                    |       299 k   |       304 k   |       189 k   |
+| `echo`                    |       304 k   |       282 k   |       162 k   |
+| `large_response`          |       124 k   |       123 k   |        98 k   |
+| `headers_heavy`           |       257 k   |       253 k   |       141 k   |
+| `multi_request_body`      |       262 k   |       274 k   |       125 k   |
+| `pipelined_h1`            |   **580 k**   |       4.8 k   |       371 k   |
+| `varied_paths_router`     |   **290 k**   |          —    |       175 k   |
+| `post_4kb_form`           |   **193 k**   |          —    |        98 k   |
+| `large_post_streaming`    |   **20 k**    |          —    |       6.9 k   |
+| `gzip_response`           |   **138 k**   |          —    |       111 k   |
+| `websocket_msg_throughput`|   **232 k**   |          —    |       179 k   |
 
 `—` means the elli test fixture doesn't support that scenario shape
 (no h2, no WebSocket, no gzip middleware, no router, no native qs
@@ -69,17 +73,20 @@ needs any of these, elli isn't on the table.
 
 | scenario                   | roadrunner    | cowboy        |
 |----------------------------|--------------:|--------------:|
-| `hello`                    |       178 k   |       169 k   |
-| `json`                     |       170 k   |       151 k   |
-| `echo`                     |   **163 k**   |       118 k   |
-| `headers_heavy`            |   **162 k**   |        89 k   |
-| `multi_stream_h2`          |       351 k   |       331 k   |
-| `tls_handshake_throughput` |       2.7 k   |     **3.2 k** |
+| `hello`                    |       167 k   |       163 k   |
+| `json`                     |       168 k   |       153 k   |
+| `echo`                     |   **164 k**   |       112 k   |
+| `headers_heavy`            |   **161 k**   |        90 k   |
+| `multi_request_body`       |   **140 k**   |        28 k   |
+| `multi_stream_h2`          |       351 k   |       335 k   |
+| `streaming_response`       |        62 k   |        61 k   |
 
 Multi-stream and basic-req h2 line up with the h1 picture — large
-wins on bigger headers/bodies, smaller wins on the simple paths.
-`tls_handshake_throughput` is the one cowboy-wins case; documented
-honestly in
+wins on bigger headers/bodies, smaller wins on the simple paths. The
+one documented cowboy-wins case is `tls_handshake_throughput`
+(fresh-TLS-conn-per-request, runnable ad-hoc via
+`./scripts/bench.escript --scenarios tls_handshake_throughput`),
+explained in
 [`conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md).
 
 ## Latency — p50 / p99 (lower = better)
@@ -91,7 +98,6 @@ file. Spot-checks from the same run:
 |------------------------|-----------------:|----------------------:|-----------------:|
 | `hello`                | 119 µs / 1.65 ms |      117 µs / 1.53 ms | 196 µs / 1.87 ms |
 | `echo`                 | 126 µs / 1.77 ms |      119 µs / 1.70 ms | 261 µs / 2.75 ms |
-| `cookies_heavy`        | 120 µs / 1.56 ms |           —           | 235 µs / 2.62 ms |
 | `pipelined_h1`         |  74 µs / 0.71 ms |   10.35 ms / 10.67 ms | 117 µs / 0.82 ms |
 
 ## Open-loop tail latency (wrk2)
@@ -134,13 +140,12 @@ Requires Docker and a compiled test profile. See
   [`conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md)).
   Connection-storm-shape scenarios (in the full results) tie
   within variance.
-- **vs elli: tied or just ahead on simple hot-path GETs.**
-  Roadrunner now matches or slightly leads elli on `hello` /
-  `echo` (within ~7 %), and trails by ~2–7 % on `json` /
-  `large_response`. The gap (either way) is inside the bench's
-  variance band — elli's minimal surface still wins the cleanest
-  hot path some runs. Add a router / cookie parse / gzip /
-  pipeline / h2 / WebSocket and elli either falls behind or
+- **vs elli: tied on simple hot-path GETs.**
+  Roadrunner and elli trade the lead within a few percent on
+  `hello` / `echo` / `json` / `large_response` — every gap (either
+  way) sits inside the bench's ~15 % variance band, so neither
+  server has a real edge on the cleanest hot path. Add a router /
+  gzip / pipeline / h2 / WebSocket and elli either falls behind or
   drops out (no support). Elli also still wins the
   connection-storm-shape scenarios where the per-conn process
   model dominates.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -199,23 +199,25 @@ only parse the peer's value and bound inbound via the encoded
 `max_header_block` cap. The ~50 handshake fixtures that drain the server
 SETTINGS need to tolerate the extra entry.
 
-### Sync headline scenarios in comparison.md + resource_results.md
+### Refresh resource_results.md against the current headline scenarios
 
-**What:** `docs/comparison.md` and `docs/resource_results.md` still
-carry their own scenario picks predating the curated
-`?MAIN_SCENARIOS` in `scripts/bench.escript`. The README's
-quick-look table and the two bench-script-driven docs
-(`docs/bench_results.md`, `docs/wrk2_results.md`) have already
-been resynced.
+**What:** `docs/resource_results.md` still carries its own scenario
+pick (captured 2026-05-06) predating the curated `?MAIN_SCENARIOS` in
+`scripts/bench.escript`: it is missing `multi_request_body`,
+`post_4kb_form`, `large_post_streaming`, `streaming_response` and still
+lists the dropped `cookies_heavy` / `tls_handshake_throughput`.
+`comparison.md` was resynced to `?MAIN_SCENARIOS`; the README quick-look
+table and the bench-script-driven docs (`bench_results.md`,
+`wrk2_results.md`) were already current.
 
-**Why deferred:** both docs cross-reference broader investigations
-(memory shape, architectural trade-offs) — a mechanical sync isn't
-the right move, but a deliberate re-pick against `?MAIN_SCENARIOS`
-is.
+**Why deferred:** the resource doc's memory / CPU numbers are a
+single-run snapshot that can only be refreshed by re-running
+`scripts/bench.escript --with-resources` against the current 14
+scenarios, not edited by hand. Fold it into the next matrix run rather
+than re-running the bench just for this.
 
-**Scope:** small. Re-render the comparison-doc throughput tables
-and refresh the resource doc's per-scenario notes against the new
-headline.
+**Scope:** small (one `--with-resources` matrix pass + re-render the
+three tables and trim the dropped-scenario notes).
 
 ### Automate `docs/resource_results.md` regeneration
 

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -76,6 +76,15 @@
 %%   - **Measurements:** `system_time`.
 %%   - **Metadata:** `listener_name`, `reason` (`max_clients`).
 %%
+%% - `[roadrunner, request, throttled]` — fired when an HTTP/2 or HTTP/3
+%%   stream is refused because the listener is at its
+%%   `max_concurrent_requests` in-flight ceiling, before any handler runs.
+%%   The stream is reset (`REFUSED_STREAM` / `H3_REQUEST_REJECTED`); pair
+%%   with the cumulative `throttled` count from `roadrunner_listener:info/1`.
+%%
+%%   - **Measurements:** `system_time`.
+%%   - **Metadata:** `listener_name`, `reason` (`max_concurrent_requests`).
+%%
 %% - `[roadrunner, ws, upgrade]` — fired in the conn process once the
 %%   WebSocket handshake response has been written. Marks the
 %%   transition from HTTP/1.1 keep-alive into the WS frame loop.
@@ -137,7 +146,7 @@
 %% All other events listed above (`request, start`,
 %% `request, exception`, `response, send_failed`,
 %% `listener, accept`, `listener, conn_close`,
-%% `listener, conn_rejected`, `request, rejected`,
+%% `listener, conn_rejected`, `request, rejected`, `request, throttled`,
 %% `listener, slots_reconciled`, `drain, acknowledged`,
 %% `ws, frame_in`, `ws, frame_rejected`) are **unstable**: their
 %% event name, measurement keys, or metadata schema may change in


### PR DESCRIPTION
# Description

Brings the docs back in line with the current state of `main`.

- `docs/comparison.md`: the curated cowboy/elli cross-section was realigned to the canonical `docs/bench_results.md` matrix (the 2026-05-20 capture). Refreshed the stale throughput figures, dropped `cookies_heavy`, added the headline scenarios it was missing (`multi_request_body`, `post_4kb_form`, `large_post_streaming`), fixed the h2 table, and tightened the vs-elli prose to match. Every number is taken from `bench_results.md`, not re-measured.
- `README.md`: added `max_concurrent_requests` to the two DoS-bounds lists alongside the other listener caps.
- `roadrunner_telemetry`: added the `[roadrunner, request, throttled]` event to the module's event catalog and the unstable-events list.
- `docs/roadmap.md`: the scenario-sync item now reflects that `comparison.md` is done; only `resource_results.md` remains, and that one needs a `--with-resources` bench re-run (its memory numbers cannot be hand-edited), so it stays a tracked TODO.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)