### PR TITLE
Add the max_streams_bidi http3 listener option

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -88,12 +88,16 @@ list, with the keys `max_concurrent_streams` and `max_header_block`.
 | Limit | Default | Configurable |
 |---|---|---|
 | Field section block (encoded HEADERS) | 16 KB | yes |
+| `initial_max_streams_bidi` | 100 | yes |
 
 The encoded request field section is capped before it reaches the
-handler; an overrun answers `431 Request Header Fields Too Large`. It is
-tuned under `{http3, #{...}}` in the `protocols` list, with the key
-`max_header_block`. QPACK runs static-table only, so there is no
-dynamic-table memory to bound yet.
+handler; an overrun answers `431 Request Header Fields Too Large`. The
+concurrent client-initiated bidirectional (request) stream count is
+advertised to the peer in the QUIC transport parameters, the h3
+counterpart to HTTP/2's `max_concurrent_streams`. Both are tuned under
+`{http3, #{...}}` in the `protocols` list, with the keys
+`max_header_block` and `max_streams_bidi`. QPACK runs static-table only,
+so there is no dynamic-table memory to bound yet.
 
 ## Connection and slow-client guards
 
@@ -134,7 +138,7 @@ roadrunner:start_listener(my_api, #{
     protocols => [
         {http1, #{max_header_count => 200}},
         {http2, #{max_concurrent_streams => 250, max_header_block => 32_768}},
-        {http3, #{max_header_block => 32_768}}
+        {http3, #{max_header_block => 32_768, max_streams_bidi => 250}}
     ],
     ws => #{max_frame_size => 1_048_576, max_message_size => 8_388_608}
 }).

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -397,10 +397,15 @@ HTTP/3 listener tunables (under `{http3, ThisMap}` in `protocols`).
   counterpart to the `{http1, ...}` / `{http2, ...}` `max_header_block`
   opts; the three are independent (h1 defaults to `10240`, h2/h3 to
   `16384`).
+- `max_streams_bidi` — cap on concurrent client-initiated bidirectional
+  (request) streams, advertised to the peer in the QUIC transport
+  parameters. Default `100`. The h3 counterpart to the `{http2, ...}`
+  `max_concurrent_streams` opt.
 """.
 -type http3_opts() :: #{
     listeners => 1..?MAX_H3_LISTENERS,
-    max_header_block => 1..16#7FFFFFFF
+    max_header_block => 1..16#7FFFFFFF,
+    max_streams_bidi => 1..16#7FFFFFFF
 }.
 
 -doc """
@@ -670,12 +675,13 @@ start_quic(Port, Opts, Protocols, ProtoOpts) ->
             %% the probe (the pool listeners keep the port via reuseport).
             {QuicPort, Probe} = resolve_quic_port(Port),
             Listeners = maps:get(http3_listeners, ProtoOpts, ?DEFAULT_H3_LISTENERS),
+            MaxStreamsBidi = maps:get(http3_max_streams_bidi, ProtoOpts, ?H3_MAX_STREAMS_BIDI),
             Res = start_quic_pool(QuicPort, #{
                 cert => Cert,
                 key => Key,
                 cert_chain => CertChain,
                 alpn => [~"h3"],
-                max_streams_bidi => ?H3_MAX_STREAMS_BIDI,
+                max_streams_bidi => MaxStreamsBidi,
                 connection_handler => Handler,
                 pool_size => Listeners - 1
             }),
@@ -1261,7 +1267,11 @@ flatten_http2_opts(Entries) ->
 
 -spec http3_defaults() -> http3_opts().
 http3_defaults() ->
-    #{listeners => ?DEFAULT_H3_LISTENERS, max_header_block => 16384}.
+    #{
+        listeners => ?DEFAULT_H3_LISTENERS,
+        max_header_block => 16384,
+        max_streams_bidi => ?H3_MAX_STREAMS_BIDI
+    }.
 
 -spec validate_http3_opts(map(), term()) -> http3_opts().
 validate_http3_opts(Opts, Raw) ->
@@ -1269,11 +1279,13 @@ validate_http3_opts(Opts, Raw) ->
     maps:fold(
         fun(K, V, Acc) ->
             %% `listeners` caps at the reuseport-pool limit; `max_header_block`
-            %% is a byte size up to the 31-bit ceiling.
+            %% (a byte size) and `max_streams_bidi` (a stream count) go up to
+            %% the 31-bit ceiling.
             Max =
                 case K of
                     listeners -> ?MAX_H3_LISTENERS;
                     max_header_block -> 16#7FFFFFFF;
+                    max_streams_bidi -> 16#7FFFFFFF;
                     _ -> 0
                 end,
             case is_map_key(K, Defaults) of
@@ -1294,8 +1306,16 @@ flatten_http3_opts(Entries) ->
     case lists:keyfind(http3, 1, Entries) of
         false ->
             #{};
-        {http3, #{listeners := Listeners, max_header_block := MaxHeaderBlock}} ->
-            #{http3_listeners => Listeners, http3_max_header_block => MaxHeaderBlock}
+        {http3, #{
+            listeners := Listeners,
+            max_header_block := MaxHeaderBlock,
+            max_streams_bidi := MaxStreamsBidi
+        }} ->
+            #{
+                http3_listeners => Listeners,
+                http3_max_header_block => MaxHeaderBlock,
+                http3_max_streams_bidi => MaxStreamsBidi
+            }
     end.
 
 -spec ws_defaults() ->

--- a/test/roadrunner_h3_listener_pool_tests.erl
+++ b/test/roadrunner_h3_listener_pool_tests.erl
@@ -1,17 +1,20 @@
 -module(roadrunner_h3_listener_pool_tests).
 -include_lib("eunit/include/eunit.hrl").
 
-%% Tests the listener-level HTTP/3 reuseport-pool knob, nested under
-%% `protocols => [{http3, #{listeners => N}}]`: the validator's reject
-%% path (a bad count fails listener start fast) and accept path (a tuned
-%% count boots a listener cleanly). The pooling behaviour itself
-%% (parallel inbound demux) is a perf property measured by the bench, not
-%% asserted here.
+%% Tests the listener-level HTTP/3 sub-opts, nested under
+%% `protocols => [{http3, #{...}}]`: the reuseport-pool `listeners` knob
+%% and the `max_streams_bidi` cap. Covers the validator's reject path (a
+%% bad value fails listener start fast), the accept path (a tuned value
+%% boots a listener cleanly), and that a custom `max_streams_bidi`
+%% threads through to proto_opts. The pooling behaviour itself (parallel
+%% inbound demux) is a perf property measured by the bench, not asserted
+%% here.
 
 all_test_() ->
     Tests = [
         fun invalid_listeners_opt_fails_listener_start/0,
-        fun valid_listeners_opt_lets_listener_boot/0
+        fun valid_listeners_opt_lets_listener_boot/0,
+        fun custom_max_streams_bidi_threads_into_proto_opts/0
     ],
     [{spawn, T} || T <- Tests].
 
@@ -59,6 +62,27 @@ valid_listeners_opt_lets_listener_boot() ->
         tls => roadrunner_test_certs:server_opts(),
         routes => roadrunner_keepalive_handler
     }),
+    ok = roadrunner_listener:stop(Name).
+
+custom_max_streams_bidi_threads_into_proto_opts() ->
+    %% A tuned `max_streams_bidi` flattens to the `http3_max_streams_bidi`
+    %% proto_opts key the QUIC pool reads when advertising the peer's
+    %% bidirectional-stream cap in the transport parameters.
+    {ok, _} = application:ensure_all_started(ssl),
+    {ok, _} = application:ensure_all_started(quic),
+    ensure_pg(),
+    Name = list_to_atom(
+        "h3_max_streams_bidi_test_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => [{http3, #{max_streams_bidi => 256}}],
+        tls => roadrunner_test_certs:server_opts(),
+        routes => roadrunner_keepalive_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual(256, maps:get(http3_max_streams_bidi, ProtoOpts)),
     ok = roadrunner_listener:stop(Name).
 
 ensure_pg() ->

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -464,7 +464,10 @@ listener_rejects_invalid_http3_opt_test() ->
             #{bogus_key => 1},
             #{max_header_block => 0},
             #{max_header_block => not_an_integer},
-            #{listeners => 16#80000000}
+            #{listeners => 16#80000000},
+            #{max_streams_bidi => 0},
+            #{max_streams_bidi => 16#80000000},
+            #{max_streams_bidi => not_an_integer}
         ]
     ).
 


### PR DESCRIPTION
# Description

`H3_MAX_STREAMS_BIDI` was the last hardcoded h3 limit (fixed at 100) while h2's `max_concurrent_streams` was already configurable. This makes it a listener option, the h3 counterpart to `max_concurrent_streams`: a cap on concurrent client-initiated bidirectional (request) streams, advertised to the peer as the `initial_max_streams_bidi` QUIC transport parameter. Plumbed through the same five sites as the existing `max_header_block`/`listeners` h3 opts (type+doc, defaults, validate, flatten, consume); default stays 100.

```erlang
protocols => [{http3, #{max_streams_bidi => 250}}]
```

A test boots a real h3 listener with a tuned value and asserts it threads to `http3_max_streams_bidi` in proto_opts; full precommit green (100% cover).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)