### PR TITLE
Wake an h2 stream worker blocked in a frame sync when the conn dies

### DIFF
--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -32,10 +32,10 @@ Returns when the handler's `handle_info/3` returns `{stop, _}`.
 ) -> ok.
 run(ConnPid, StreamId, Status, Headers, {Handler, State}) ->
     sync_send_headers(ConnPid, StreamId, Status, Headers, false),
-    %% Stop looping if the conn process dies — otherwise an idle loop
-    %% worker (blocked in `info_loop` waiting for a message) leaks
-    %% forever once the conn is gone.
-    _ = monitor(process, ConnPid),
+    %% The worker already monitors the conn (see
+    %% `roadrunner_http2_stream_worker:init/4`), so an idle `info_loop`
+    %% blocked waiting for a message wakes on the conn's `DOWN` instead
+    %% of leaking once the conn is gone.
     Push = make_push(ConnPid, StreamId),
     info_loop(ConnPid, StreamId, Handler, Push, State).
 
@@ -88,11 +88,8 @@ make_push(ConnPid, StreamId) ->
         end
     end.
 
-%% Sync helpers: send a frame request to the conn and block on its
-%% ack. Duplicated from `roadrunner_http2_stream_response`. Two
-%% callers is the threshold for extracting a shared module; a third
-%% caller (e.g. a future `{loop, _}` middleware path) would justify
-%% factoring them out into `roadrunner_http2_worker_sync`.
+%% Sync helpers: send a frame request to the conn and block on its ack
+%% via the shared `roadrunner_http2_worker_sync`.
 
 -spec sync_send_headers(
     pid(),
@@ -102,7 +99,7 @@ make_push(ConnPid, StreamId) ->
     boolean()
 ) -> ok.
 sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->
-    sync(fun(Ref) ->
+    roadrunner_http2_worker_sync:sync(ConnPid, fun(Ref) ->
         _ =
             (ConnPid !
                 {h2_send_headers, self(), Ref, StreamId, Status, Headers, EndStream}),
@@ -111,18 +108,9 @@ sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->
 
 -spec sync_send_data(pid(), pos_integer(), iodata(), boolean()) -> ok.
 sync_send_data(ConnPid, StreamId, Data, EndStream) ->
-    sync(fun(Ref) ->
+    roadrunner_http2_worker_sync:sync(ConnPid, fun(Ref) ->
         _ =
             (ConnPid !
                 {h2_send_data, self(), Ref, StreamId, Data, EndStream}),
         ok
     end).
-
--spec sync(fun((reference()) -> ok)) -> ok.
-sync(SendFun) ->
-    Ref = make_ref(),
-    ok = SendFun(Ref),
-    receive
-        {h2_send_ack, Ref} -> ok;
-        {h2_stream_reset, _StreamId} -> exit(stream_reset)
-    end.

--- a/src/roadrunner_http2_stream_response.erl
+++ b/src/roadrunner_http2_stream_response.erl
@@ -76,27 +76,19 @@ do_send(ConnPid, StreamId, Data, {fin, Trailers}) ->
     ok.
 
 sync_send_headers(ConnPid, StreamId, Status, Headers, EndStream) ->
-    sync(fun(Ref) ->
+    roadrunner_http2_worker_sync:sync(ConnPid, fun(Ref) ->
         _ = (ConnPid ! {h2_send_headers, self(), Ref, StreamId, Status, Headers, EndStream}),
         ok
     end).
 
 sync_send_data(ConnPid, StreamId, Data, EndStream) ->
-    sync(fun(Ref) ->
+    roadrunner_http2_worker_sync:sync(ConnPid, fun(Ref) ->
         _ = (ConnPid ! {h2_send_data, self(), Ref, StreamId, Data, EndStream}),
         ok
     end).
 
 sync_send_trailers(ConnPid, StreamId, Trailers) ->
-    sync(fun(Ref) ->
+    roadrunner_http2_worker_sync:sync(ConnPid, fun(Ref) ->
         _ = (ConnPid ! {h2_send_trailers, self(), Ref, StreamId, Trailers}),
         ok
     end).
-
-sync(SendFun) ->
-    Ref = make_ref(),
-    ok = SendFun(Ref),
-    receive
-        {h2_send_ack, Ref} -> ok;
-        {h2_stream_reset, _StreamId} -> exit(stream_reset)
-    end.

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -71,6 +71,11 @@ init(ConnPid, StreamId, Req, ProtoOpts) ->
     %% `request_id`. The conn process can't do this for us — the
     %% handler runs in this worker, not on the conn.
     ok = roadrunner_conn:set_request_logger_metadata(Req),
+    %% Monitor the conn once for the worker's whole life so any sync
+    %% round-trip (buffered, stream, or loop mode) wakes if the conn
+    %% dies, instead of blocking on an ack that never comes until TCP
+    %% teardown reaps the worker.
+    _ = roadrunner_http2_worker_sync:monitor_conn(ConnPid),
     run_handler(ConnPid, StreamId, Req, ProtoOpts),
     %% No explicit completion message: the worker is spawn_monitored by
     %% the conn, which finalises the stream on the worker's `DOWN`
@@ -243,15 +248,7 @@ emit_501(ConnPid, StreamId) ->
 %% or constrained windows; the worker still sees a single sync
 %% round-trip in either case.
 send_buffered(ConnPid, StreamId, Status, Headers, Body) ->
-    sync(fun(Ref) ->
+    roadrunner_http2_worker_sync:sync(ConnPid, fun(Ref) ->
         _ = (ConnPid ! {h2_send_response, self(), Ref, StreamId, Status, Headers, Body}),
         ok
     end).
-
-sync(SendFun) ->
-    Ref = make_ref(),
-    ok = SendFun(Ref),
-    receive
-        {h2_send_ack, Ref} -> ok;
-        {h2_stream_reset, _StreamId} -> exit(stream_reset)
-    end.

--- a/src/roadrunner_http2_worker_sync.erl
+++ b/src/roadrunner_http2_worker_sync.erl
@@ -1,0 +1,34 @@
+-module(roadrunner_http2_worker_sync).
+-moduledoc false.
+
+%% Worker -> conn synchronous frame round-trip, shared by the h2 stream
+%% worker (buffered responses) and the stream / loop response emitters.
+%% `sync/2` sends a frame request to the conn (via `SendFun`) and blocks
+%% for the conn's `{h2_send_ack, Ref}`; a conn-side stream reset
+%% (`{h2_stream_reset, _}`) exits the worker with `stream_reset`.
+%%
+%% `monitor_conn/1` is called once per worker, before the first sync, so
+%% a `sync/2` blocked on an ack also wakes if the conn process dies. The
+%% ack never arrives once the conn is gone, so without the monitor the
+%% worker would block until the conn's TCP teardown reaped it; the
+%% monitor turns that into a prompt `conn_down` exit. The worker is
+%% monitored (not linked) by the conn, so on a conn crash it is
+%% otherwise orphaned with no signal of its own.
+
+-export([monitor_conn/1, sync/2]).
+
+-doc false.
+-spec monitor_conn(pid()) -> reference().
+monitor_conn(ConnPid) ->
+    monitor(process, ConnPid).
+
+-doc false.
+-spec sync(pid(), fun((reference()) -> ok)) -> ok.
+sync(ConnPid, SendFun) ->
+    Ref = make_ref(),
+    ok = SendFun(Ref),
+    receive
+        {h2_send_ack, Ref} -> ok;
+        {h2_stream_reset, _StreamId} -> exit(stream_reset);
+        {'DOWN', _MonRef, process, ConnPid, _Reason} -> exit(conn_down)
+    end.

--- a/test/roadrunner_http2_worker_sync_tests.erl
+++ b/test/roadrunner_http2_worker_sync_tests.erl
@@ -1,0 +1,70 @@
+-module(roadrunner_http2_worker_sync_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% `sync/2` returns ok once the conn acks the frame.
+ack_returns_ok_test() ->
+    Parent = self(),
+    Worker = spawn(fun() ->
+        Res = roadrunner_http2_worker_sync:sync(Parent, fun(Ref) ->
+            Parent ! {sent, self(), Ref},
+            ok
+        end),
+        Parent ! {worker_result, self(), Res}
+    end),
+    Ref =
+        receive
+            {sent, Worker, R0} -> R0
+        after 1000 -> error(send_fun_not_called)
+        end,
+    Worker ! {h2_send_ack, Ref},
+    receive
+        {worker_result, Worker, Res} -> ?assertEqual(ok, Res)
+    after 1000 -> error(no_worker_result)
+    end.
+
+%% A conn-side stream reset exits the worker with `stream_reset`.
+stream_reset_exits_worker_test() ->
+    Parent = self(),
+    Worker = spawn(fun() ->
+        _ = roadrunner_http2_worker_sync:sync(Parent, fun(_Ref) ->
+            Parent ! {sent, self()},
+            ok
+        end)
+    end),
+    WorkerRef = monitor(process, Worker),
+    receive
+        {sent, Worker} -> ok
+    after 1000 -> error(send_fun_not_called)
+    end,
+    Worker ! {h2_stream_reset, 1},
+    receive
+        {'DOWN', WorkerRef, process, Worker, Reason} ->
+            ?assertEqual(stream_reset, Reason)
+    after 1000 -> error(worker_did_not_exit)
+    end.
+
+%% A worker that monitored the conn and is blocked in `sync/2` wakes
+%% with `conn_down` when the conn dies, instead of hanging on an ack
+%% that will never come until TCP teardown reaps it.
+conn_death_exits_worker_test() ->
+    Parent = self(),
+    Conn = spawn(fun() -> timer:sleep(infinity) end),
+    Worker = spawn(fun() ->
+        _ = roadrunner_http2_worker_sync:monitor_conn(Conn),
+        Parent ! {ready, self()},
+        %% The SendFun never triggers an ack: the conn is a black hole,
+        %% so only its death can release the sync.
+        _ = roadrunner_http2_worker_sync:sync(Conn, fun(_Ref) -> ok end)
+    end),
+    WorkerRef = monitor(process, Worker),
+    receive
+        {ready, Worker} -> ok
+    after 1000 -> error(worker_not_ready)
+    end,
+    exit(Conn, kill),
+    receive
+        {'DOWN', WorkerRef, process, Worker, Reason} ->
+            ?assertEqual(conn_down, Reason)
+    after 1000 -> error(worker_did_not_wake)
+    end.


### PR DESCRIPTION
# Description

An h2 stream worker blocked in a worker-to-conn frame sync (waiting on the conn's `h2_send_ack`) only matched the ack and a stream reset, so if the conn process died mid-frame the worker hung until TCP teardown reaped it. h3 has no such gap. This consolidates the three duplicated sync round-trips (stream worker, stream response, loop response) into the `roadrunner_http2_worker_sync` module the existing comments already called for, and that shared `sync/2` now also returns on the conn's `DOWN`, exiting the worker promptly with `conn_down`. The worker monitors the conn once in `init` (covering buffered, stream, and loop modes), so `loop_response`'s own monitor is removed and its idle-loop teardown rides the same single monitor.

Worker-side monitoring is deliberate: a monitor catches a conn crash too, which a conn-side "kill the workers on teardown" approach would miss.

```erlang
%% worker blocked here when the conn dies now exits conn_down instead of hanging
roadrunner_http2_worker_sync:sync(ConnPid, fun(Ref) -> ConnPid ! {h2_send_data, self(), Ref, ...}, ok end)
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)