### PR TITLE
Send STREAM_CLOSED for DATA on a half-closed-remote h2 stream

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -866,26 +866,38 @@ on_data(StreamId, _Flags, _Payload, #loop{streams = Streams} = State) when
     _ = send_rst_stream(State, StreamId, stream_closed),
     frame_loop(State);
 on_data(StreamId, Flags, Payload, #loop{streams = Streams} = State) ->
-    #{
-        StreamId :=
-            #{body := Body, body_len := Len, recv_window := RW} = Stream
-    } = Streams,
-    EndStream = (Flags band 16#01) =/= 0,
-    PayloadLen = byte_size(Payload),
-    Stream1 = Stream#{
-        body := [Body, Payload],
-        body_len := Len + PayloadLen,
-        end_stream_seen := EndStream,
-        recv_window := RW - PayloadLen
-    },
-    State1 = State#loop{
-        streams = Streams#{StreamId := Stream1},
-        conn_recv_window = State#loop.conn_recv_window - PayloadLen
-    },
-    State2 = maybe_refill_recv_windows(State1, StreamId),
-    case EndStream of
-        true -> dispatch_stream(StreamId, State2);
-        false -> frame_loop(State2)
+    case Streams of
+        #{
+            StreamId :=
+                #{state := open, body := Body, body_len := Len, recv_window := RW} = Stream
+        } ->
+            EndStream = (Flags band 16#01) =/= 0,
+            PayloadLen = byte_size(Payload),
+            Stream1 = Stream#{
+                body := [Body, Payload],
+                body_len := Len + PayloadLen,
+                end_stream_seen := EndStream,
+                recv_window := RW - PayloadLen
+            },
+            State1 = State#loop{
+                streams = Streams#{StreamId := Stream1},
+                conn_recv_window = State#loop.conn_recv_window - PayloadLen
+            },
+            State2 = maybe_refill_recv_windows(State1, StreamId),
+            case EndStream of
+                true -> dispatch_stream(StreamId, State2);
+                false -> frame_loop(State2)
+            end;
+        #{StreamId := _} ->
+            %% RFC 9113 §5.1: the peer already sent END_STREAM (the
+            %% stream is half-closed remote, with a worker dispatched),
+            %% so any further DATA is a STREAM_CLOSED stream error.
+            %% Reset the peer and unwind the in-flight worker rather
+            %% than appending to a request body that was already
+            %% delivered (which would also re-dispatch on a second
+            %% END_STREAM).
+            _ = send_rst_stream(State, StreamId, stream_closed),
+            frame_loop(reset_stream(State, StreamId))
     end.
 
 %% Refill the conn-level + stream-level recv windows whenever they

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -102,6 +102,7 @@ all_test_() ->
         fun data_on_stream_zero_protocol_error/0,
         fun data_on_idle_stream_protocol_error/0,
         fun data_on_closed_stream_rst/0,
+        fun data_after_end_stream_on_half_closed_remote_rst/0,
         fun headers_self_dependency_rst_stream/0,
         fun priority_self_dependency_rst_stream/0,
         fun enable_push_invalid_value_protocol_error/0,
@@ -2553,6 +2554,57 @@ data_on_closed_stream_rst() ->
     serve_recv(ConnPid, <<1:24, 0, 0, 0:1, 1:31, 0>>),
     Out = expect_send(),
     ?assertMatch(<<_:24, 3, _/binary>>, Out),
+    cleanup(Pid, Ref).
+
+data_after_end_stream_on_half_closed_remote_rst() ->
+    %% RFC 9113 §5.1: once the peer sends END_STREAM the stream is
+    %% half-closed (remote); a later DATA frame is STREAM_CLOSED. Unlike
+    %% `data_on_closed_stream_rst/0` (stream already removed from the
+    %% map), here the worker is still in flight — a blocking handler
+    %% keeps the stream half-closed-remote in the map — so this
+    %% exercises the state-guarded `on_data` path. Without the guard the
+    %% DATA was silently appended (no reset) and the handler's response
+    %% raced the violation, the h2spec §5.1 / §6.1 flake.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(#{
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined}
+    }),
+    _ = expect_send(),
+    serve_recv(ConnPid, ?PREFACE),
+    serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+    _ = expect_send(),
+    Enc = roadrunner_http2_hpack:new_encoder(4096),
+    {Hpack, _} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"https"},
+            {~":authority", ~"x"},
+            {~":path", ~"/block"}
+        ],
+        Enc
+    ),
+    HpackBin = iolist_to_binary(Hpack),
+    %% HEADERS with END_HEADERS + END_STREAM: request complete, the
+    %% stream goes half-closed-remote and the worker is dispatched.
+    HeadersF = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 16#04 bor 16#01, undefined, HpackBin})
+    ),
+    serve_recv(ConnPid, HeadersF),
+    %% Park until the worker is in `handle/1`: the stream is still in
+    %% the map, half-closed-remote.
+    Worker = wait_for_register(roadrunner_h2_block_test, 1000),
+    DataF = iolist_to_binary(roadrunner_http2_frame:encode({data, 1, 0, ~"x"})),
+    serve_recv(ConnPid, DataF),
+    ?assertMatch(
+        {ok, {rst_stream, 1, stream_closed}, _},
+        roadrunner_http2_frame:parse(expect_send(), 16384)
+    ),
+    %% The worker is parked in `handle/1`; `reset_stream/2` already
+    %% demonitored it, so drop it directly before tearing down the conn.
+    exit(Worker, kill),
     cleanup(Pid, Ref).
 
 headers_self_dependency_rst_stream() ->

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -15,6 +15,21 @@ shape.
     {roadrunner_handler:response(), roadrunner_req:request()}.
 handle(#{target := ~"/empty"} = Req) ->
     {{200, [], ~""}, Req};
+handle(#{target := ~"/block"} = Req) ->
+    %% Park the worker before responding so the stream stays
+    %% half-closed-remote while a test sends a protocol-violating DATA
+    %% frame on it. Unregister first in case a prior failed test leaked
+    %% the name (see the `/loop` clause); the test releases or kills the
+    %% worker in teardown.
+    try
+        unregister(roadrunner_h2_block_test)
+    catch
+        _:_ -> ok
+    end,
+    true = register(roadrunner_h2_block_test, self()),
+    receive
+        release -> {{200, [], ~"ok"}, Req}
+    end;
 handle(#{target := ~"/stream"} = Req) ->
     {
         {stream, 200, [{~"content-type", ~"text/plain"}], fun(Send) ->


### PR DESCRIPTION
# Description

`on_data` handled DATA on an in-map stream without checking its state, so a DATA frame arriving after END_STREAM (RFC 9113 §5.1, the stream is half-closed remote with a worker dispatched) was silently appended to an already-delivered request body, and if it carried END_STREAM it re-dispatched the worker a second time. `STREAM_CLOSED` was only sent in the other path (stream already removed from the map), which fires only when the worker happened to finish first. That timing dependency is the h2spec §5.1 / §6.1 flake: fast worker finishes, stream gone, reset sent, pass; worker still in flight, silent accept, handler response wins, fail (more often under OTP 28/29 scheduling).

The fix guards the body-append on `state := open`; any other state resets the peer with `STREAM_CLOSED` and unwinds the in-flight worker via `reset_stream/2` (worker bail, in-flight slot release, stream removal). The `open` path is byte-identical, so there is no throughput cost; only the rare violation path changed.

```erlang
%% half-closed-remote stream + a DATA frame now deterministically yields:
{ok, {rst_stream, 1, stream_closed}, _} = roadrunner_http2_frame:parse(Sent, 16384)
```

A regression test holds the stream half-closed-remote with a blocking handler so it exercises the new path specifically. A rare residual ordering (the handler response is forwarded before the violating socket frame is read) can't be eliminated without prioritizing socket reads over worker messages on the hot path; the h2spec retry wrapper covers that tail.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)