### PR TITLE
Stop an h2 loop worker on stream reset rather than calling handle_info

### DIFF
--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -47,6 +47,12 @@ info_loop(ConnPid, StreamId, Handler, Push, State) ->
         {'DOWN', _MonRef, process, ConnPid, _Reason} ->
             %% Connection gone — stop looping.
             ok;
+        {h2_stream_reset, StreamId} ->
+            %% The conn reset this stream (peer RST_STREAM, or a
+            %% protocol violation on the conn side) and already dropped
+            %% it. Stop looping rather than forwarding the reset to the
+            %% handler's `handle_info/3` as if it were application data.
+            ok;
         {system, _, _} ->
             info_loop(ConnPid, StreamId, Handler, Push, State);
         {'$gen_call', _, _} ->

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -50,6 +50,7 @@ all_test_() ->
         fun loop_response_emits_data_then_closes_on_stop/0,
         fun loop_response_filters_otp_messages/0,
         fun loop_response_worker_stops_when_conn_dies/0,
+        fun loop_response_worker_stops_on_stream_reset/0,
         fun sendfile_empty_emits_empty_data/0,
         fun sendfile_small_file_emits_single_data_frame/0,
         fun sendfile_multi_frame_chunks_at_max_frame_size/0,
@@ -973,6 +974,27 @@ loop_response_worker_stops_when_conn_dies() ->
     after 1000 ->
         error(loop_worker_did_not_exit)
     end.
+
+loop_response_worker_stops_on_stream_reset() ->
+    %% A peer RST_STREAM on a live loop stream must stop the worker, not
+    %% deliver `{h2_stream_reset, _}` to the handler's `handle_info/3`
+    %% (the `/loop` handler has no clause for it, so a misdelivery would
+    %% crash with function_clause — the worker must exit `normal`).
+    {Pid, Ref} = run_stream_request(~"/loop"),
+    Worker = wait_for_register(roadrunner_h2_loop_test, 1000),
+    %% Drain the 200 HEADERS so the worker is past `sync_send_headers`
+    %% and parked in `info_loop` before the reset arrives.
+    _ = expect_send(),
+    WorkerRef = monitor(process, Worker),
+    Rst = iolist_to_binary(roadrunner_http2_frame:encode({rst_stream, 1, cancel})),
+    serve_recv(Pid, Rst),
+    receive
+        {'DOWN', WorkerRef, process, Worker, Reason} ->
+            ?assertEqual(normal, Reason)
+    after 1000 ->
+        error(loop_worker_did_not_stop)
+    end,
+    cleanup(Pid, Ref).
 
 sendfile_empty_emits_empty_data() ->
     %% Length=0: file is opened but never read. The base clause of


### PR DESCRIPTION
# Description

When the conn resets a live stream, `reset_stream/2` notifies the worker with `{h2_stream_reset, StreamId}`. A buffered or stream worker is blocked in `sync`, whose receive matches that message and exits. A `{loop, _, _, _}` (SSE) worker sits in `info_loop`, which had no clause for it, so the reset fell through to the generic `Info ->` branch and was passed to the handler's `handle_info/3` as if it were application data. Two consequences: the handler sees a protocol-internal message (a strict handler crashes with `function_clause`; a lenient one keeps looping), and an idle loop worker that never pushes again leaks until the conn dies. Reachable normally: a client cancelling an SSE stream sends `RST_STREAM`.

The fix adds a `{h2_stream_reset, StreamId} -> ok` clause to `info_loop`, above the generic `Info`, so the worker stops the same way the sync path does. It pairs with the conn-DOWN handling already there: that covers "conn died," this covers "stream reset while the conn is alive." Stream-mode and buffered workers already catch the reset via `sync`, so the fix is scoped to the loop path.

```erlang
info_loop(ConnPid, StreamId, Handler, Push, State) ->
    receive
        {'DOWN', _MonRef, process, ConnPid, _Reason} -> ok;
        {h2_stream_reset, StreamId} -> ok;   %% new: stop, don't forward to handle_info
        ...
```

A regression test drives a real `/loop` stream, waits for the response HEADERS so the worker is parked in `info_loop`, then sends a peer `RST_STREAM` and asserts the worker exits `normal`. Without the fix it exits `{function_clause, ...}` (the `/loop` handler has no `handle_info` clause for the reset).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)