### PR TITLE
Cap request bodies at max_content_length on the chunked h1 and h2 paths

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -26,10 +26,14 @@ tuned under `{http1, #{...}}` in the `protocols` list, with the keys
 `max_header_count`. A chunked body's trailer block obeys the same header
 caps and is rejected the same way.
 
-The body cap is enforced the same way for both `Content-Length` and
-`Transfer-Encoding: chunked` requests: the cap is checked as the body is
-read, so an oversized chunked body is rejected without buffering the
-whole thing.
+The body cap is enforced across all three protocols. For HTTP/1.1 it
+covers both `Content-Length` and `Transfer-Encoding: chunked` requests:
+the cap is checked as the body is read (a chunked body on its declared
+size line), so an oversized body is rejected without buffering the whole
+thing. HTTP/2 and HTTP/3 accumulate DATA frames against the same cap; an
+over-cap body answers `413 Payload Too Large` and resets the stream
+(`RST_STREAM(NO_ERROR)` on h2, `STOP_SENDING` on h3) so the client stops
+sending.
 
 ## WebSocket limits
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -620,7 +620,10 @@ read_body_until_io(N, RecvFun) ->
 ) ->
     {ok, binary(), binary()} | {error, content_length_too_large | term()}.
 read_chunked(Buf, RecvFun, MaxCL, Decoded, TrailerLimits) ->
-    case roadrunner_http1:parse_chunk(Buf, TrailerLimits) of
+    %% `parse_chunk/3` rejects a declared chunk size over the remaining
+    %% budget on its size line, so an oversized chunk can't buffer past
+    %% the cap before this loop sees it.
+    case roadrunner_http1:parse_chunk(Buf, TrailerLimits, MaxCL - Decoded) of
         {ok, last, _Trailers, Leftover} ->
             %% Bytes after the size-0 last-chunk + trailer block are
             %% pipelined-next-request leftover; thread them up so the
@@ -628,16 +631,11 @@ read_chunked(Buf, RecvFun, MaxCL, Decoded, TrailerLimits) ->
             {ok, <<>>, Leftover};
         {ok, Data, Rest} ->
             NewDecoded = Decoded + byte_size(Data),
-            if
-                NewDecoded > MaxCL ->
-                    {error, content_length_too_large};
-                true ->
-                    case read_chunked(Rest, RecvFun, MaxCL, NewDecoded, TrailerLimits) of
-                        {ok, More, Leftover} ->
-                            {ok, <<Data/binary, More/binary>>, Leftover};
-                        {error, _} = E ->
-                            E
-                    end
+            case read_chunked(Rest, RecvFun, MaxCL, NewDecoded, TrailerLimits) of
+                {ok, More, Leftover} ->
+                    {ok, <<Data/binary, More/binary>>, Leftover};
+                {error, _} = E ->
+                    E
             end;
         {more, _} ->
             case RecvFun() of
@@ -785,16 +783,11 @@ chunked_collect(
     } = BS,
     Want
 ) ->
-    case roadrunner_http1:parse_chunk(Buf, TrailerLimits) of
+    case roadrunner_http1:parse_chunk(Buf, TrailerLimits, Max - Read) of
         {ok, Data, Rest} ->
             NewRead = Read + byte_size(Data),
-            case NewRead > Max of
-                true ->
-                    {error, content_length_too_large};
-                false ->
-                    BS2 = BS#{buffered := Rest, bytes_read := NewRead, pending := Data},
-                    chunked_collect(BS2, Want)
-            end;
+            BS2 = BS#{buffered := Rest, bytes_read := NewRead, pending := Data},
+            chunked_collect(BS2, Want);
         {ok, last, _Trailers, Rest} ->
             chunked_collect(BS#{buffered := Rest, done := true}, Want);
         {more, _} ->
@@ -829,15 +822,10 @@ next_chunk(
         trailer_limits := TrailerLimits
     } = BS
 ) ->
-    case roadrunner_http1:parse_chunk(Buf, TrailerLimits) of
+    case roadrunner_http1:parse_chunk(Buf, TrailerLimits, Max - Read) of
         {ok, Data, Rest} ->
             NewRead = Read + byte_size(Data),
-            case NewRead > Max of
-                true ->
-                    {error, content_length_too_large};
-                false ->
-                    {more, Data, BS#{buffered := Rest, bytes_read := NewRead}}
-            end;
+            {more, Data, BS#{buffered := Rest, bytes_read := NewRead}};
         {ok, last, _Trailers, Rest} ->
             {ok, <<>>, BS#{buffered := Rest, done := true}};
         {more, _} ->

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -112,6 +112,11 @@
 %% RST_STREAM(REFUSED_STREAM) on the over-limit HEADERS.
 -define(MAX_CONCURRENT_STREAMS, 100).
 
+%% Request-body cap fallback when proto_opts omits `max_content_length`
+%% (only test harnesses do; the listener always sets it). Matches the
+%% listener default.
+-define(DEFAULT_MAX_CONTENT_LENGTH, 10_485_760).
+
 -define(GOAWAY(LastStreamId, ErrorCode),
     roadrunner_http2_frame:encode({goaway, (LastStreamId), (ErrorCode), <<>>})
 ).
@@ -199,6 +204,10 @@
     %% Cumulative HEADERS+CONTINUATION block cap (CONTINUATION-flood guard).
     %% Read from proto_opts at `enter/5`.
     max_header_block = ?MAX_HEADER_BLOCK :: pos_integer(),
+    %% Request-body cap (`max_content_length` listener opt); an over-cap
+    %% body answers 413 + RST_STREAM(NO_ERROR). Read from proto_opts at
+    %% `enter/5`.
+    max_content_length = ?DEFAULT_MAX_CONTENT_LENGTH :: non_neg_integer(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -249,6 +258,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
     ),
     MaxStreams = maps:get(http2_max_concurrent_streams, ProtoOpts, ?MAX_CONCURRENT_STREAMS),
     MaxHeaderBlock = maps:get(http2_max_header_block, ProtoOpts, ?MAX_HEADER_BLOCK),
+    MaxContentLength = maps:get(max_content_length, ProtoOpts, ?DEFAULT_MAX_CONTENT_LENGTH),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -265,7 +275,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         stream_recv_window_peak = StreamPeak,
         recv_window_threshold = Threshold,
         max_concurrent_streams = MaxStreams,
-        max_header_block = MaxHeaderBlock
+        max_header_block = MaxHeaderBlock,
+        max_content_length = MaxContentLength
     },
     handshake(State).
 
@@ -865,28 +876,48 @@ on_data(StreamId, _Flags, _Payload, #loop{streams = Streams} = State) when
     %% RST_STREAM rather than ignoring.
     _ = send_rst_stream(State, StreamId, stream_closed),
     frame_loop(State);
-on_data(StreamId, Flags, Payload, #loop{streams = Streams} = State) ->
+on_data(StreamId, Flags, Payload, #loop{streams = Streams, max_content_length = MaxCL} = State) ->
     case Streams of
         #{
             StreamId :=
                 #{state := open, body := Body, body_len := Len, recv_window := RW} = Stream
         } ->
-            EndStream = (Flags band 16#01) =/= 0,
             PayloadLen = byte_size(Payload),
-            Stream1 = Stream#{
-                body := [Body, Payload],
-                body_len := Len + PayloadLen,
-                end_stream_seen := EndStream,
-                recv_window := RW - PayloadLen
-            },
-            State1 = State#loop{
-                streams = Streams#{StreamId := Stream1},
-                conn_recv_window = State#loop.conn_recv_window - PayloadLen
-            },
-            State2 = maybe_refill_recv_windows(State1, StreamId),
-            case EndStream of
-                true -> dispatch_stream(StreamId, State2);
-                false -> frame_loop(State2)
+            case Len + PayloadLen > MaxCL of
+                true ->
+                    %% RFC 9113 §8.1: the request body exceeds
+                    %% `max_content_length`. Answer 413 before the full
+                    %% request, then RST_STREAM(NO_ERROR) to ask the client to
+                    %% stop sending the rest, and drop the stream (no worker
+                    %% was dispatched — dispatch is at END_STREAM).
+                    Resp = ~"Payload Too Large",
+                    State1 = encode_and_send_response_atomic(
+                        State,
+                        StreamId,
+                        413,
+                        [{~"content-type", ~"text/plain"}],
+                        Resp,
+                        byte_size(Resp)
+                    ),
+                    _ = send_rst_stream(State1, StreamId, no_error),
+                    frame_loop(remove_stream(State1, StreamId));
+                false ->
+                    EndStream = (Flags band 16#01) =/= 0,
+                    Stream1 = Stream#{
+                        body := [Body, Payload],
+                        body_len := Len + PayloadLen,
+                        end_stream_seen := EndStream,
+                        recv_window := RW - PayloadLen
+                    },
+                    State1 = State#loop{
+                        streams = Streams#{StreamId := Stream1},
+                        conn_recv_window = State#loop.conn_recv_window - PayloadLen
+                    },
+                    State2 = maybe_refill_recv_windows(State1, StreamId),
+                    case EndStream of
+                        true -> dispatch_stream(StreamId, State2);
+                        false -> frame_loop(State2)
+                    end
             end;
         #{StreamId := _} ->
             %% RFC 9113 §5.1: the peer already sent END_STREAM (the

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -17,6 +17,7 @@
     parse_request/2,
     parse_chunk/1,
     parse_chunk/2,
+    parse_chunk/3,
     check_header_safe/2,
     response/3,
     compute_cached_decisions/1
@@ -723,17 +724,50 @@ headers; `parse_chunk/1` passes the `?MAX_*` defaults.
         | header_block_too_long
         | too_many_headers
         | conflicting_framing}.
-parse_chunk(Bin, Limits) when is_binary(Bin) ->
+parse_chunk(Bin, Limits) ->
+    parse_chunk(Bin, Limits, infinity).
+
+-doc """
+Like `parse_chunk/2`, but caps the *declared* chunk size against `Budget`
+(the caller's remaining `max_content_length` allowance) so an oversized
+chunk is rejected on its size line, before its data is buffered.
+
+`Budget` is a `non_neg_integer()` (the cap) or `infinity` (no cap, the
+`parse_chunk/1,2` behaviour). A declared size over `Budget` returns
+`{error, content_length_too_large}` without waiting for or buffering the
+chunk body, so a `7fffffff\r\n` size line can't drive the connection's
+heap up before the cap fires.
+""".
+-spec parse_chunk(
+    binary(),
+    {pos_integer(), pos_integer(), pos_integer()},
+    non_neg_integer() | infinity
+) ->
+    {ok, Data :: binary(), Rest :: binary()}
+    | {ok, last, Trailers :: headers(), Rest :: binary()}
+    | {more, undefined}
+    | {error,
+        bad_chunk_size
+        | bad_chunk
+        | bad_header
+        | header_too_long
+        | header_block_too_long
+        | too_many_headers
+        | conflicting_framing
+        | content_length_too_large}.
+parse_chunk(Bin, Limits, Budget) when is_binary(Bin) ->
     %% Fetch the compiled CRLF + semicolon patterns ONCE here and
     %% thread them into `parse_chunk_size_line/3` (and onward to
     %% `parse_size_line/3`) so the chunked-decode loop in
-    %% `roadrunner_conn:read_chunked/4` doesn't pay two
+    %% `roadrunner_conn:read_chunked/5` doesn't pay two
     %% `persistent_term:get/1` per chunk through this entry.
     CrlfCp = persistent_term:get(?CRLF_KEY),
     SemiCp = persistent_term:get(?SEMICOLON_KEY),
     case parse_chunk_size_line(Bin, CrlfCp, SemiCp) of
         {ok, 0, AfterSize} ->
             parse_last_chunk(AfterSize, Limits);
+        {ok, Size, _AfterSize} when is_integer(Budget), Size > Budget ->
+            {error, content_length_too_large};
         {ok, Size, AfterSize} ->
             parse_chunk_data(Size, AfterSize);
         Other ->

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -100,8 +100,9 @@ Routing (pick one):
 
 Optional middleware and timing knobs (durations in milliseconds):
 - `middlewares` — listener-wide pipeline applied to every request.
-- `max_content_length` — request-body cap; over-cap reads return
-  `payload_too_large`. Default 10 MB.
+- `max_content_length` — request-body cap across HTTP/1.1, HTTP/2, and
+  HTTP/3; an over-cap body answers `413 Payload Too Large` (and resets
+  the stream on h2/h3). Default 10 MB.
 - `ws` — WebSocket inbound size caps as a nested map (see
   `t:ws_opts/0`): `max_frame_size` (per-frame payload cap) and
   `max_message_size` (reassembled + decompressed message cap). Both

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -112,6 +112,7 @@ all_test_() ->
         fun max_frame_size_too_large_protocol_error/0,
         fun initial_window_size_change_overflows_flow_control_error/0,
         fun content_length_mismatch_rst_stream/0,
+        fun oversized_body_413_then_rst/0,
         fun request_trailers_dispatched/0,
         fun request_trailers_via_continuation/0,
         fun awaiting_continuation_blocks_other_frames/0,
@@ -2772,6 +2773,63 @@ content_length_mismatch_rst_stream() ->
     serve_recv(ConnPid, Data),
     Out = expect_send(),
     ?assertMatch(<<_:24, 3, _/binary>>, Out),
+    cleanup(Pid, Ref).
+
+oversized_body_413_then_rst() ->
+    %% RFC 9113 §8.1: a request body over `max_content_length` is
+    %% answered with a 413 from the conn before END_STREAM, then
+    %% RST_STREAM(NO_ERROR) to stop the upload; the connection stays
+    %% usable. The worker is never dispatched (dispatch is at
+    %% END_STREAM), so the conn emits the 413 directly, mirroring h3.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(#{max_content_length => 8}),
+    _ = expect_send(),
+    serve_recv(ConnPid, ?PREFACE),
+    serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+    _ = expect_send(),
+    Enc = roadrunner_http2_hpack:new_encoder(4096),
+    {Hpack, _} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"POST"},
+            {~":scheme", ~"https"},
+            {~":authority", ~"x"},
+            {~":path", ~"/"}
+        ],
+        Enc
+    ),
+    HpackBin = iolist_to_binary(Hpack),
+    %% HEADERS with END_HEADERS but NOT END_STREAM: a body follows.
+    HeadersF = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 16#04, undefined, HpackBin})
+    ),
+    serve_recv(ConnPid, HeadersF),
+    %% A 10-byte DATA frame exceeds max_content_length (8).
+    DataF = iolist_to_binary(
+        roadrunner_http2_frame:encode({data, 1, 0, ~"helloworld"})
+    ),
+    serve_recv(ConnPid, DataF),
+    %% Conn answers HEADERS+DATA (the 413), then RST_STREAM(no_error).
+    Resp1 = expect_send(),
+    Resp2 = drain_send(50),
+    AllResponse =
+        case Resp2 of
+            undefined -> Resp1;
+            _ -> <<Resp1/binary, Resp2/binary>>
+        end,
+    Dec0 = roadrunner_http2_hpack:new_decoder(4096),
+    {ok, {headers, 1, _, _, RespHpack}, AfterHeaders} =
+        roadrunner_http2_frame:parse(AllResponse, 16384),
+    {ok, RespHeaders, _} = roadrunner_http2_hpack:decode(RespHpack, Dec0),
+    ?assertEqual(~"413", proplists:get_value(~":status", RespHeaders)),
+    {ok, {data, 1, DataFlags, _Body}, AfterData} =
+        roadrunner_http2_frame:parse(AfterHeaders, 16384),
+    ?assertNotEqual(0, DataFlags band 16#01),
+    ?assertMatch(
+        {ok, {rst_stream, 1, no_error}, _},
+        roadrunner_http2_frame:parse(AfterData, 16384)
+    ),
+    ?assert(is_process_alive(Pid)),
     cleanup(Pid, Ref).
 
 request_trailers_dispatched() ->

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -222,6 +222,18 @@ read_body_chunked_second_chunk_exceeds_max_test() ->
         )
     ).
 
+read_body_chunked_declared_size_over_max_rejected_before_buffering_test() ->
+    %% A chunk that DECLARES a huge size but supplies no body bytes is
+    %% rejected on its size line, before any recv. `NoRecv` proves the
+    %% cap fires from the declared size alone: pre-fix this looped into
+    %% RecvFun asking for the ~2GB body before any 413.
+    Req = req_with_headers([{~"transfer-encoding", ~"chunked"}]),
+    NoRecv = fun() -> error(should_not_be_called) end,
+    ?assertEqual(
+        {error, content_length_too_large},
+        roadrunner_conn:read_body(Req, ~"7fffffff\r\n", NoRecv, 100, {8192, 10240, 100})
+    ).
+
 read_body_chunked_bad_chunk_size_test() ->
     Req = req_with_headers([{~"transfer-encoding", ~"chunked"}]),
     NoRecv = fun() -> error(should_not_be_called) end,


### PR DESCRIPTION
# Description

`max_content_length` was only enforced for HTTP/1.1 requests with a fixed `Content-Length` (checked before reading). Two paths buffered the whole body first, an OOM/DoS surface (h3 was already capped):

- **HTTP/1.1 chunked**: a chunk declares its size in hex, bounded only by the 8192-byte size *line*, so `7fffffff\r\n` declares ~2 GB. The decoder buffered the whole chunk before the cap check. Now `parse_chunk/3` carries the remaining budget and rejects an oversized *declared* size on the size line, before any body bytes are read.
- **HTTP/2**: `on_data` accumulated DATA frames with no cap. Now, when the body exceeds `max_content_length`, the conn answers `413 Payload Too Large` and then `RST_STREAM(NO_ERROR)` to ask the client to stop sending (RFC 9113 §8.1), mirroring the existing h3 413 path. The stream is never dispatched (dispatch is at END_STREAM), so the conn responds directly.

```erlang
%% a chunk that declares a huge size but sends no body is now rejected on its size line:
{error, content_length_too_large} = roadrunner_conn:read_body(Req, <<"7fffffff\r\n">>, NoRecv, 100, Limits)
```

Regression tests prove both: the h1 case rejects without ever calling `RecvFun` (so it never buffers the declared body), and the h2 case asserts a `413` `:status` + `RST_STREAM` with the connection still alive.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)