### PR TITLE
Split SSE data on CR and CRLF so a bare CR can't inject event fields

### DIFF
--- a/src/roadrunner_sse.erl
+++ b/src/roadrunner_sse.erl
@@ -45,7 +45,7 @@ Per the SSE spec ([WHATWG HTML §9.2](https://html.spec.whatwg.org/multipage/ser
 
 -on_load(init_patterns/0).
 
--define(LF_CP_KEY, {?MODULE, lf_cp}).
+-define(DATA_SPLIT_CP_KEY, {?MODULE, data_split_cp}).
 -define(LINE_BREAK_CP_KEY, {?MODULE, line_break_cp}).
 
 -export([
@@ -108,19 +108,23 @@ after a connection drop.
 retry(Ms) when is_integer(Ms), Ms >= 0 ->
     [~"retry: ", integer_to_binary(Ms), ~"\n\n"].
 
-%% Encode `Data` as one or more `data:` lines (split on each `\n`),
-%% each terminated by a single newline. The caller appends the
-%% trailing blank line that ends the event.
+%% Encode `Data` as one or more `data:` lines, each terminated by a
+%% single newline. `data` is allowed to span multiple lines, but the
+%% split must cover every separator the client recognises — the
+%% event-stream spec treats CR, LF, and CRLF as line breaks — so a bare
+%% `\r` in untrusted data becomes a new `data:` line rather than
+%% injecting an `event:` / `id:` / `retry:` field. The caller appends
+%% the trailing blank line that ends the event.
 -spec data_lines(binary()) -> iodata().
 data_lines(Data) ->
     [
         [~"data: ", Line, $\n]
-     || Line <- binary:split(Data, persistent_term:get(?LF_CP_KEY), [global])
+     || Line <- binary:split(Data, persistent_term:get(?DATA_SPLIT_CP_KEY), [global])
     ].
 
 %% `-on_load` callback. See `feedback_compile_pattern_convention`.
 -spec init_patterns() -> ok.
 init_patterns() ->
-    persistent_term:put(?LF_CP_KEY, binary:compile_pattern(~"\n")),
+    persistent_term:put(?DATA_SPLIT_CP_KEY, binary:compile_pattern([~"\r\n", ~"\r", ~"\n"])),
     persistent_term:put(?LINE_BREAK_CP_KEY, binary:compile_pattern([~"\r", ~"\n"])),
     ok.

--- a/test/roadrunner_sse_tests.erl
+++ b/test/roadrunner_sse_tests.erl
@@ -45,6 +45,28 @@ event_with_name_and_multiline_data_test() ->
         iolist_to_binary(roadrunner_sse:event(~"log", ~"hello\nworld"))
     ).
 
+%% Security: a bare `\r` in `data` must split into its own `data:` line,
+%% not pass through to inject an `event:` / `id:` / `retry:` field — the
+%% client treats CR, LF, and CRLF as line breaks.
+event_data_with_cr_splits_test() ->
+    ?assertEqual(
+        ~"data: line one\ndata: event: steal\n\n",
+        iolist_to_binary(roadrunner_sse:event(~"line one\revent: steal"))
+    ).
+
+event_data_with_crlf_splits_once_test() ->
+    %% CRLF is a single separator: no empty `data:` line between the two.
+    ?assertEqual(
+        ~"data: line one\ndata: line two\n\n",
+        iolist_to_binary(roadrunner_sse:event(~"line one\r\nline two"))
+    ).
+
+event_data_mixed_line_breaks_test() ->
+    ?assertEqual(
+        ~"data: a\ndata: b\ndata: c\ndata: d\n\n",
+        iolist_to_binary(roadrunner_sse:event(~"a\rb\nc\r\nd"))
+    ).
+
 comment_test() ->
     ?assertEqual(
         ~": keepalive\n\n",


### PR DESCRIPTION
# Description

`roadrunner_sse:data_lines/1` split the `data` payload only on `\n`, but a browser's `EventSource` treats a bare `\r`, `\n`, or `\r\n` as a line break. So a `\r` in untrusted data slipped through inside a `data:` line and let the client re-parse it as a new `event:` / `id:` / `retry:` field (the event name/id/comment fields were already guarded against line breaks; `data` was the gap).

The fix splits `data` on CR, LF, and CRLF (CRLF as a single separator, verified) so each segment becomes its own `data:` line. `data` legitimately spans multiple lines, so the right fix is to split, not reject.

```erlang
%% a bare CR in data is now neutralised into another data: line, not an injected field
roadrunner_sse:event(~"line one\revent: steal")
%% => "data: line one\ndata: event: steal\n\n"
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)