### PR TITLE
Reject inbound DATA over the h2 flow-control window as FLOW_CONTROL_ERROR

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -883,8 +883,19 @@ on_data(StreamId, Flags, Payload, #loop{streams = Streams, max_content_length = 
                 #{state := open, body := Body, body_len := Len, recv_window := RW} = Stream
         } ->
             PayloadLen = byte_size(Payload),
-            case Len + PayloadLen > MaxCL of
-                true ->
+            if
+                PayloadLen > State#loop.conn_recv_window ->
+                    %% RFC 9113 §6.9.1: more DATA than the connection-level
+                    %% receive window permits is a connection-level
+                    %% FLOW_CONTROL_ERROR.
+                    _ = send_goaway(State, flow_control_error),
+                    exit_clean(State);
+                PayloadLen > RW ->
+                    %% More DATA than the stream-level window permits is a
+                    %% stream-level FLOW_CONTROL_ERROR.
+                    _ = send_rst_stream(State, StreamId, flow_control_error),
+                    frame_loop(reset_stream(State, StreamId));
+                Len + PayloadLen > MaxCL ->
                     %% RFC 9113 §8.1: the request body exceeds
                     %% `max_content_length`. Answer 413 before the full
                     %% request, then RST_STREAM(NO_ERROR) to ask the client to
@@ -901,7 +912,7 @@ on_data(StreamId, Flags, Payload, #loop{streams = Streams, max_content_length = 
                     ),
                     _ = send_rst_stream(State1, StreamId, no_error),
                     frame_loop(remove_stream(State1, StreamId));
-                false ->
+                true ->
                     EndStream = (Flags band 16#01) =/= 0,
                     Stream1 = Stream#{
                         body := [Body, Payload],

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -22,6 +22,8 @@ reuse / scheduling races.
 -export([
     conn_window_update_overflow_triggers_goaway/1,
     stream_window_update_overflow_triggers_rst_stream/1,
+    inbound_data_over_stream_window_triggers_rst_stream/1,
+    inbound_data_over_conn_window_triggers_goaway/1,
     window_update_for_unknown_stream_ignored/1,
     stream_window_update_grows_send_window/1,
     large_response_chunks_through_send_window/1,
@@ -50,6 +52,8 @@ all() ->
     [
         conn_window_update_overflow_triggers_goaway,
         stream_window_update_overflow_triggers_rst_stream,
+        inbound_data_over_stream_window_triggers_rst_stream,
+        inbound_data_over_conn_window_triggers_goaway,
         window_update_for_unknown_stream_ignored,
         stream_window_update_grows_send_window,
         large_response_chunks_through_send_window,
@@ -106,6 +110,36 @@ stream_window_update_overflow_triggers_rst_stream(_Config) ->
     %% Conn stays alive — only the stream was reset.
     true = is_process_alive(Pid),
     cleanup(Pid, Ref).
+
+inbound_data_over_stream_window_triggers_rst_stream(_Config) ->
+    %% RFC 9113 §6.9.1: a DATA frame larger than the stream-level recv
+    %% window is a stream error. A tiny stream window (10) is overrun by
+    %% one 50-byte frame; the conn stays alive.
+    {Pid, Ref, ConnPid} = start_conn(roadrunner_hello_handler, #{http2_stream_window => 10}),
+    handshake(ConnPid),
+    HpackBin = encode_request_headers(~"POST", ~"/"),
+    serve_recv(ConnPid, encode_frame({headers, 1, 16#04, undefined, HpackBin})),
+    serve_recv(ConnPid, encode_frame({data, 1, 0, binary:copy(<<"x">>, 50)})),
+    expect_send_type(3),
+    true = is_process_alive(Pid),
+    cleanup(Pid, Ref).
+
+inbound_data_over_conn_window_triggers_goaway(_Config) ->
+    %% RFC 9113 §6.9.1: DATA exceeding the connection-level recv window
+    %% is a connection error. The conn window starts at 65535 and can
+    %% only grow, so disable refill (threshold 1) and stream four
+    %% max-size frames — the fourth overruns the drawn-down conn window.
+    {Pid, Ref, ConnPid} = start_conn(roadrunner_hello_handler, #{
+        http2_window_refill_threshold => 1
+    }),
+    handshake(ConnPid),
+    HpackBin = encode_request_headers(~"POST", ~"/"),
+    serve_recv(ConnPid, encode_frame({headers, 1, 16#04, undefined, HpackBin})),
+    Chunk = binary:copy(<<"x">>, 16384),
+    [serve_recv(ConnPid, encode_frame({data, 1, 0, Chunk})) || _ <- lists:seq(1, 4)],
+    expect_send_type(7),
+    expect_close(),
+    wait_down(Pid, Ref).
 
 window_update_for_unknown_stream_ignored(_Config) ->
     %% WINDOW_UPDATE for a stream that's not currently open is
@@ -347,18 +381,24 @@ blocked_send_idle_timeout_emits_goaway(_Config) ->
 %% `ConnPid` are the same process; the duplication mirrors the
 %% eunit suite's API for symmetry.
 start_conn(Handler) ->
+    start_conn(Handler, #{}).
+
+start_conn(Handler, Extra) ->
     Self = self(),
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
-    ProtoOpts = #{
-        max_concurrent_requests => infinity,
-        client_counter => Counter,
-        listener_name => h2_flow_test,
-        dispatch => {handler, Handler, fun Handler:handle/1, undefined},
-        middlewares => [],
-        handler_spawn_opts => [{fullsweep_after, 0}],
-        handler_start_timeout => infinity
-    },
+    ProtoOpts = maps:merge(
+        #{
+            max_concurrent_requests => infinity,
+            client_counter => Counter,
+            listener_name => h2_flow_test,
+            dispatch => {handler, Handler, fun Handler:handle/1, undefined},
+            middlewares => [],
+            handler_spawn_opts => [{fullsweep_after, 0}],
+            handler_start_timeout => infinity
+        },
+        Extra
+    ),
     Sock = {fake, Self},
     Pid = spawn(fun() ->
         receive


### PR DESCRIPTION
# Description

`on_data` debited the h2 stream and connection receive windows without checking the peer stayed within them, so they could go negative. RFC 9113 §6.9.1 requires a `FLOW_CONTROL_ERROR`: a DATA frame over the connection window now sends `GOAWAY`, one over the stream window sends `RST_STREAM`. Covered by two flow-control SUITE tests (stream → RST, conn → GOAWAY).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)