### PR TITLE
Match the Connection header by token, not substring

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -77,8 +77,7 @@
 
 -on_load(init_patterns/0).
 
--define(CLOSE_CP_KEY, {?MODULE, close_cp}).
--define(KEEP_ALIVE_CP_KEY, {?MODULE, keep_alive_cp}).
+-define(CONN_COMMA_CP_KEY, {?MODULE, conn_comma_cp}).
 
 -type dispatch() ::
     {handler, module(), roadrunner_middleware:next(), State :: term()}
@@ -977,7 +976,7 @@ keep_alive_decision(Req, RespHeaders) ->
 keep_alive_decision_full(Req, RespHeaders) ->
     ReqConn = req_connection_lower(Req),
     RespConn = roadrunner_bin:ascii_lowercase(resp_connection_token(RespHeaders)),
-    CloseCp = persistent_term:get(?CLOSE_CP_KEY),
+    Close = ~"close",
     case roadrunner_req:version(Req) of
         {1, 0} ->
             %% RFC 9112 §9.3 + RFC 9110 §7.6.1: HTTP/1.0 default is close, but
@@ -986,8 +985,8 @@ keep_alive_decision_full(Req, RespHeaders) ->
             %% circuits on the keep-alive check so the response-side
             %% `has_token` only fires when the client opted in.
             case
-                has_token(ReqConn, persistent_term:get(?KEEP_ALIVE_CP_KEY)) andalso
-                    not has_token(RespConn, CloseCp)
+                has_token(ReqConn, ~"keep-alive") andalso
+                    not has_token(RespConn, Close)
             of
                 true -> keep_alive;
                 false -> close
@@ -996,7 +995,7 @@ keep_alive_decision_full(Req, RespHeaders) ->
             %% `orelse` short-circuits on ReqClose = true so the
             %% response-side `has_token` only fires when the client
             %% didn't already say `close`.
-            case has_token(ReqConn, CloseCp) orelse has_token(RespConn, CloseCp) of
+            case has_token(ReqConn, Close) orelse has_token(RespConn, Close) of
                 true -> close;
                 false -> keep_alive
             end
@@ -1021,14 +1020,28 @@ resp_connection_token(Headers) ->
         V -> V
     end.
 
--spec has_token(binary(), binary:cp()) -> boolean().
-has_token(Value, TokenCp) ->
-    binary:match(Value, TokenCp) =/= nomatch.
+%% RFC 9110 §7.6.1: `Connection` is a comma-separated list of tokens, so
+%% match `Token` against each comma-split, OWS-trimmed element, not as a
+%% substring (`Connection: enclosed` must not match the `close` token).
+%% Two fast paths skip the split/trim/persistent_term for the common
+%% values: an empty header (the response side is almost always `<<>>`)
+%% has no token, and a single-token value equals the token outright
+%% (`Connection: close` / `keep-alive`).
+-spec has_token(binary(), binary()) -> boolean().
+has_token(<<>>, _Token) ->
+    false;
+has_token(Token, Token) ->
+    true;
+has_token(Value, Token) ->
+    CommaCp = persistent_term:get(?CONN_COMMA_CP_KEY),
+    lists:any(
+        fun(Part) -> roadrunner_bin:trim_ows(Part) =:= Token end,
+        binary:split(Value, CommaCp, [global])
+    ).
 
 -spec init_patterns() -> ok.
 init_patterns() ->
-    persistent_term:put(?CLOSE_CP_KEY, binary:compile_pattern(~"close")),
-    persistent_term:put(?KEEP_ALIVE_CP_KEY, binary:compile_pattern(~"keep-alive")),
+    persistent_term:put(?CONN_COMMA_CP_KEY, binary:compile_pattern(~",")),
     ok.
 
 -spec header_value(binary(), roadrunner_http:headers()) -> binary() | undefined.

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -366,6 +366,29 @@ keep_alive_decision_without_cached_decisions_no_connection_header_keeps_alive_te
     Req = req_with_headers([]),
     ?assertEqual(keep_alive, roadrunner_conn:keep_alive_decision(Req, [])).
 
+keep_alive_decision_close_substring_is_not_the_token_test() ->
+    %% RFC 9110 §7.6.1: `Connection` is a comma-separated token list. A
+    %% value that merely contains "close" as a substring (`enclosed`) is
+    %% not the `close` token, so an HTTP/1.1 conn stays keep-alive.
+    Req = req_with_headers([{~"connection", ~"enclosed"}]),
+    ?assertEqual(keep_alive, roadrunner_conn:keep_alive_decision(Req, [])).
+
+keep_alive_decision_close_token_in_list_with_ows_test() ->
+    %% `close` as one OWS-padded token in a list still forces close.
+    Req = req_with_headers([{~"connection", ~"close , x-foo"}]),
+    ?assertEqual(close, roadrunner_conn:keep_alive_decision(Req, [])).
+
+keep_alive_decision_http10_keep_alive_substring_is_not_the_token_test() ->
+    %% HTTP/1.0 default is close; `x-keep-alive` is not the `keep-alive`
+    %% token, so it must NOT opt into keep-alive.
+    Req = req_v10([{~"connection", ~"x-keep-alive"}]),
+    ?assertEqual(close, roadrunner_conn:keep_alive_decision(Req, [])).
+
+keep_alive_decision_http10_keep_alive_token_in_list_test() ->
+    %% HTTP/1.0 + `keep-alive` as a list token opts into keep-alive.
+    Req = req_v10([{~"connection", ~"keep-alive, x-foo"}]),
+    ?assertEqual(keep_alive, roadrunner_conn:keep_alive_decision(Req, [])).
+
 %% --- peer/1 ---
 
 peer_on_closed_socket_returns_undefined_test() ->
@@ -385,6 +408,9 @@ req_with_headers(Headers) ->
         version => {1, 1},
         headers => Headers
     }.
+
+req_v10(Headers) ->
+    (req_with_headers(Headers))#{version => {1, 0}}.
 
 %% Recv closure that yields the given chunks one per call, then
 %% `{error, closed}` once exhausted. Backed by the process dictionary


### PR DESCRIPTION
# Description

`has_token/2` matched the `Connection` header with `binary:match` (a substring), so `Connection: enclosed` read as the `close` token (and `x-keep-alive` as `keep-alive`). RFC 9110 §7.6.1 defines it as a comma-separated token list — it now splits on comma, trims OWS, and compares tokens exactly.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)