### PR TITLE
Send a 1002 Close on a WebSocket framing error and reject a high-bit 64-bit length

### DIFF
--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -486,7 +486,13 @@ format_pmd_kv(Name, Value, _Default) -> [~"; ", Name, ~"=", integer_to_binary(Va
 -spec parse_frame(binary()) ->
     {ok, frame(), Rest :: binary()}
     | {more, undefined}
-    | {error, bad_opcode | bad_rsv | not_masked | fragmented_control | control_frame_too_large}.
+    | {error,
+        bad_opcode
+        | bad_rsv
+        | not_masked
+        | fragmented_control
+        | control_frame_too_large
+        | bad_length}.
 parse_frame(Bin) ->
     parse_frame(Bin, #{}).
 
@@ -499,7 +505,13 @@ parse_frame(Bin) ->
 -spec parse_frame(binary(), parse_opts()) ->
     {ok, frame(), Rest :: binary()}
     | {more, undefined}
-    | {error, bad_opcode | bad_rsv | not_masked | fragmented_control | control_frame_too_large}.
+    | {error,
+        bad_opcode
+        | bad_rsv
+        | not_masked
+        | fragmented_control
+        | control_frame_too_large
+        | bad_length}.
 parse_frame(Bin, Opts) ->
     do_parse_frame(
         Bin,
@@ -510,7 +522,13 @@ parse_frame(Bin, Opts) ->
 -spec do_parse_frame(binary(), boolean(), binary() | undefined) ->
     {ok, frame(), Rest :: binary()}
     | {more, undefined}
-    | {error, bad_opcode | bad_rsv | not_masked | fragmented_control | control_frame_too_large}.
+    | {error,
+        bad_opcode
+        | bad_rsv
+        | not_masked
+        | fragmented_control
+        | control_frame_too_large
+        | bad_length}.
 do_parse_frame(<<_Fin:1, _Rsv1:1, Rsv23:2, _:4, _/bitstring>>, _AllowRsv1, _Pre) when
     Rsv23 =/= 0
 ->
@@ -551,14 +569,26 @@ do_parse_frame(_, _AllowRsv1, _Pre) ->
 -spec peek_frame_header(binary(), parse_opts()) ->
     {ok, map(), non_neg_integer()}
     | {more, undefined}
-    | {error, bad_opcode | bad_rsv | not_masked | fragmented_control | control_frame_too_large}.
+    | {error,
+        bad_opcode
+        | bad_rsv
+        | not_masked
+        | fragmented_control
+        | control_frame_too_large
+        | bad_length}.
 peek_frame_header(Bin, Opts) ->
     do_peek(Bin, maps:get(allow_rsv1, Opts, false)).
 
 -spec do_peek(binary(), boolean()) ->
     {ok, map(), non_neg_integer()}
     | {more, undefined}
-    | {error, bad_opcode | bad_rsv | not_masked | fragmented_control | control_frame_too_large}.
+    | {error,
+        bad_opcode
+        | bad_rsv
+        | not_masked
+        | fragmented_control
+        | control_frame_too_large
+        | bad_length}.
 do_peek(<<_Fin:1, _Rsv1:1, Rsv23:2, _:4, _/bitstring>>, _AllowRsv1) when Rsv23 =/= 0 ->
     {error, bad_rsv};
 do_peek(<<_Fin:1, 1:1, 0:2, _:4, _/bitstring>>, false) ->
@@ -577,11 +607,15 @@ do_peek(_, _AllowRsv1) ->
     {more, undefined}.
 
 -spec peek_extract(opcode(), 0 | 1, 0 | 1, 0 | 1, 0..127, binary()) ->
-    {ok, map(), non_neg_integer()} | {more, undefined} | {error, not_masked}.
+    {ok, map(), non_neg_integer()} | {more, undefined} | {error, not_masked | bad_length}.
 peek_extract(_Opcode, _Fin, _Rsv1, 0, _Len7, _Rest) ->
     {error, not_masked};
 peek_extract(Opcode, Fin, Rsv1, 1, 126, <<Len:16, MaskKey:4/binary, Body/binary>>) ->
     {ok, peek_header(Opcode, Fin, Rsv1, Len, MaskKey, 8), byte_size(Body)};
+peek_extract(_Opcode, _Fin, _Rsv1, 1, 127, <<Len:64, _/binary>>) when Len >= (1 bsl 63) ->
+    %% RFC 6455 §5.2: the 64-bit extended length's most significant bit
+    %% MUST be 0. A protocol error (closed 1002), not an oversize (1009).
+    {error, bad_length};
 peek_extract(Opcode, Fin, Rsv1, 1, 127, <<Len:64, MaskKey:4/binary, Body/binary>>) ->
     {ok, peek_header(Opcode, Fin, Rsv1, Len, MaskKey, 14), byte_size(Body)};
 peek_extract(Opcode, Fin, Rsv1, 1, Len7, <<MaskKey:4/binary, Body/binary>>) when Len7 < 126 ->
@@ -636,9 +670,13 @@ decode_opcode(_) -> error.
 ) ->
     {ok, frame(), binary()}
     | {more, undefined}
-    | {error, not_masked}.
+    | {error, not_masked | bad_length}.
 parse_length(126, Mask, <<Len:16, Rest/binary>>, Fin, Rsv1, Op, Pre) ->
     parse_payload(Len, Mask, Rest, Fin, Rsv1, Op, Pre);
+parse_length(127, _Mask, <<Len:64, _Rest/binary>>, _Fin, _Rsv1, _Op, _Pre) when Len >= (1 bsl 63) ->
+    %% RFC 6455 §5.2: the 64-bit extended length's most significant bit
+    %% MUST be 0.
+    {error, bad_length};
 parse_length(127, Mask, <<Len:64, Rest/binary>>, Fin, Rsv1, Op, Pre) ->
     parse_payload(Len, Mask, Rest, Fin, Rsv1, Op, Pre);
 parse_length(Len7, Mask, Rest, Fin, Rsv1, Op, Pre) when Len7 < 126 ->

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -466,7 +466,12 @@ process_parsed_frame(#data{socket = Socket} = Data1, Buf, Opts, MaybeTotalLen, H
         {more, _} ->
             arm_or_stop(Socket, Data1, hibernate_actions(HibernateAcc));
         {error, _} ->
-            {stop, normal, Data1}
+            %% RFC 6455 §5.5.1 / §7.4.1: a framing violation (bad opcode,
+            %% RSV, unmasked client frame, fragmented control, oversize
+            %% control, or a 64-bit length with the high bit set) is a
+            %% protocol error — send a 1002 Close before closing rather
+            %% than dropping the TCP connection silently.
+            close_with(close_protocol_error(), Data1)
     end.
 
 %% Hand the cached unmasked payload to `parse_frame` when (and only

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -859,10 +859,12 @@ conn_websocket_pong_silently_handled_test_() ->
 
 conn_websocket_bad_frame_closes_test_() ->
     {setup, fun ws_setup/0, fun ws_cleanup/1, fun(Port) ->
-        {"frame with RSV bit set causes the server to close silently", fun() ->
+        {"frame with RSV bit set closes with a 1002 protocol-error frame", fun() ->
             Sock = ws_handshake(Port),
             %% byte1 = 0xc1: FIN=1, RSV1=1, opcode=text — RSV1 forbidden.
             ok = gen_tcp:send(Sock, <<16#c1, 16#80, 1, 2, 3, 4>>),
+            %% RFC 6455 §5.5.1: a 1002 Close frame, then the TCP close.
+            ?assertEqual({ok, <<16#88, 2, 1002:16>>}, gen_tcp:recv(Sock, 0, 1000)),
             ?assertEqual({error, closed}, gen_tcp:recv(Sock, 0, 1000)),
             ok = gen_tcp:close(Sock)
         end}
@@ -870,11 +872,12 @@ conn_websocket_bad_frame_closes_test_() ->
 
 conn_websocket_unmasked_frame_closes_test_() ->
     {setup, fun ws_setup/0, fun ws_cleanup/1, fun(Port) ->
-        {"RFC 6455 §5.1: client MUST mask frames; server closes on unmasked", fun() ->
+        {"RFC 6455 §5.1: client MUST mask frames; server closes with 1002 on unmasked", fun() ->
             Sock = ws_handshake(Port),
             %% byte1 = 0x81 (FIN+text), byte2 = 0x05 (mask=0, len=5), then
-            %% raw payload. Server must reject and close.
+            %% raw payload. Server rejects with a 1002 Close, then closes.
             ok = gen_tcp:send(Sock, <<16#81, 16#05, "hello">>),
+            ?assertEqual({ok, <<16#88, 2, 1002:16>>}, gen_tcp:recv(Sock, 0, 1000)),
             ?assertEqual({error, closed}, gen_tcp:recv(Sock, 0, 1000)),
             ok = gen_tcp:close(Sock)
         end}

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -1225,6 +1225,64 @@ continuation_outside_message_closes_with_protocol_error_test() ->
     ?assertEqual(<<16#88, 2, 1002:16>>, Sent),
     Sink ! stop.
 
+unmasked_client_frame_closes_with_protocol_error_test() ->
+    %% RFC 6455 §5.1: a client frame without the MASK bit is a protocol
+    %% error. The session must send a 1002 Close, not drop TCP silently.
+    Self = self(),
+    Tag = make_ref(),
+    Unmasked = <<16#81, 5, "hello">>,
+    Sink = spawn_active_sink(Self, Tag, [{recv, Unmasked}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            <<>>,
+            ws_proto_opts()
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    ?assertEqual(<<16#88, 2, 1002:16>>, iolist_to_binary(collect_sends(Tag, 100))),
+    Sink ! stop.
+
+high_bit_64bit_length_closes_with_protocol_error_test() ->
+    %% RFC 6455 §5.2: a 64-bit extended length with the most significant
+    %% bit set is a protocol error (1002), not an oversize (1009).
+    Self = self(),
+    Tag = make_ref(),
+    BadLen = <<16#82, 16#FF, (1 bsl 63):64, 1, 2, 3, 4>>,
+    Sink = spawn_active_sink(Self, Tag, [{recv, BadLen}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            <<>>,
+            ws_proto_opts()
+        },
+        []
+    ),
+    Ref = monitor(process, Pid),
+    Pid ! socket_ready,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> error(no_close)
+    end,
+    ?assertEqual(<<16#88, 2, 1002:16>>, iolist_to_binary(collect_sends(Tag, 100))),
+    Sink ! stop.
+
 oversized_single_frame_closes_with_1009_test() ->
     %% A single frame whose declared payload exceeds `ws_max_frame_size`
     %% is rejected with RFC 6455 §7.4 code 1009. Cap set to 10 bytes;


### PR DESCRIPTION
# Description

Two RFC 6455 close-code fixes for WebSocket framing errors. A 64-bit frame length with the most significant bit set is a protocol error (§5.2), so it now closes `1002` instead of being treated as oversize (`1009`). And any framing violation (bad opcode/RSV, unmasked client frame, fragmented or oversize control frame, high-bit length) now sends a `1002` Close frame before closing, per §5.5.1 / §7.4.1, instead of dropping the TCP connection silently.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)