### PR TITLE
Return the conn-level window for DATA discarded on a closed h2 stream

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -199,6 +199,22 @@ only parse the peer's value and bound inbound via the encoded
 `max_header_block` cap. The ~50 handshake fixtures that drain the server
 SETTINGS need to tolerate the extra entry.
 
+### h2 padded-DATA flow-control accounting
+
+**What:** A padded DATA frame undercounts its flow-control debit by the
+padding bytes — the codec strips padding before `on_data` sees the
+length, so the stream / connection recv windows (and the conn-window
+replenish on a reset stream) are charged the unpadded length.
+
+**Why deferred:** DATA padding is essentially never used by real
+clients, the undercount is at most 256 bytes per frame, and
+`max_content_length` already bounds the buffered body — so it's a
+codec-shape change for near-zero practical benefit. A correct fix
+threads the frame's declared Length through the codec (the decoded DATA
+tuple is matched in several places).
+
+**Scope:** small-to-medium.
+
 ### Refresh resource_results.md against the current headline scenarios
 
 **What:** `docs/resource_results.md` still carries its own scenario
@@ -274,24 +290,6 @@ loop state), which has debugging value but no functional fix.
 single `handle/3` (sys message, From, ProcessState) used from the
 h1, h2, and h3 info_loops. Tests covering sys/get_state, sys/replace_state,
 gen_call rejection, gen_cast no-op.
-
-### Wake an h2 worker blocked in `sync/1` when the conn dies
-
-**What:** An h2 stream worker blocked in
-`roadrunner_http2_stream_worker:sync/1` (waiting on `h2_send_ack`)
-does not wake when the conn dies: its selective receive matches only
-the ack and `h2_stream_reset`, so it blocks until the conn's TCP
-teardown reaps it. The idle `info_loop` case already stops on the
-conn's `DOWN`, so this is the narrow remaining window for the
-`stream` and `loop` response modes.
-
-**Why deferred:** h3 does not share the gap (its worker sends frames
-directly via `quic:send_data` and its `info_loop/5` already handles
-the conn `DOWN`), and the window is narrow. Fix: the conn loop kills
-in-flight workers on teardown, or `sync/1` adds the conn monitor to
-its receive.
-
-**Scope:** small.
 
 ### h2 manual-mode body reading
 

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -867,15 +867,15 @@ on_data(StreamId, _Flags, _Payload, State) when StreamId > State#loop.last_strea
     %% RFC 9113 §5.1: DATA on an idle stream is PROTOCOL_ERROR.
     _ = send_goaway(State, protocol_error),
     exit_clean(State);
-on_data(StreamId, _Flags, _Payload, #loop{streams = Streams} = State) when
+on_data(StreamId, _Flags, Payload, #loop{streams = Streams} = State) when
     not is_map_key(StreamId, Streams)
 ->
-    %% RFC 9113 §6.1: DATA on a closed stream is STREAM_CLOSED.
-    %% In our setup the conn-level recv window has already been
-    %% partially consumed by the peer's send so we still emit a
-    %% RST_STREAM rather than ignoring.
+    %% RFC 9113 §6.1: DATA on a closed stream is STREAM_CLOSED. The bytes
+    %% still consumed the peer's connection-level send window (§6.9.1);
+    %% return it since we're discarding them, so the conn window doesn't
+    %% drift down across stream resets.
     _ = send_rst_stream(State, StreamId, stream_closed),
-    frame_loop(State);
+    frame_loop(replenish_conn_window(State, byte_size(Payload)));
 on_data(StreamId, Flags, Payload, #loop{streams = Streams, max_content_length = MaxCL} = State) ->
     case Streams of
         #{
@@ -939,8 +939,21 @@ on_data(StreamId, Flags, Payload, #loop{streams = Streams, max_content_length = 
             %% delivered (which would also re-dispatch on a second
             %% END_STREAM).
             _ = send_rst_stream(State, StreamId, stream_closed),
-            frame_loop(reset_stream(State, StreamId))
+            frame_loop(replenish_conn_window(reset_stream(State, StreamId), byte_size(Payload)))
     end.
+
+%% Return `N` bytes of connection-level receive window to the peer after
+%% discarding a DATA payload on a closed / reset stream (RFC 9113
+%% §6.9.1: flow-controlled bytes count against the conn window
+%% regardless of stream state). A zero-length payload consumed no
+%% window, and a WINDOW_UPDATE with a 0 increment is itself a protocol
+%% error, so skip it.
+-spec replenish_conn_window(#loop{}, non_neg_integer()) -> #loop{}.
+replenish_conn_window(State, 0) ->
+    State;
+replenish_conn_window(State, N) ->
+    _ = send(State, roadrunner_http2_frame:encode({window_update, 0, N})),
+    State.
 
 %% Refill the conn-level + stream-level recv windows whenever they
 %% drop below the configured threshold. Both refills can fire on

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -103,6 +103,7 @@ all_test_() ->
         fun data_on_stream_zero_protocol_error/0,
         fun data_on_idle_stream_protocol_error/0,
         fun data_on_closed_stream_rst/0,
+        fun data_empty_payload_on_closed_stream_no_window_update/0,
         fun data_after_end_stream_on_half_closed_remote_rst/0,
         fun headers_self_dependency_rst_stream/0,
         fun priority_self_dependency_rst_stream/0,
@@ -2573,10 +2574,33 @@ data_on_closed_stream_rst() ->
     %% RST stream 1 — removes from map.
     Rst = iolist_to_binary(roadrunner_http2_frame:encode({rst_stream, 1, cancel})),
     serve_recv(ConnPid, Rst),
-    %% Now send DATA on closed stream 1.
+    %% Now send DATA (1-byte payload) on closed stream 1.
     serve_recv(ConnPid, <<1:24, 0, 0, 0:1, 1:31, 0>>),
     Out = expect_send(),
     ?assertMatch(<<_:24, 3, _/binary>>, Out),
+    %% The discarded byte's conn-level window is returned so the window
+    %% doesn't drift down across the reset (RFC 9113 §6.9.1).
+    ?assertMatch(
+        {ok, {window_update, 0, 1}, _},
+        roadrunner_http2_frame:parse(expect_send(), 16384)
+    ),
+    cleanup(Pid, Ref).
+
+data_empty_payload_on_closed_stream_no_window_update() ->
+    %% An empty DATA frame on a closed stream consumed no flow-control
+    %% window, so it resets but emits no WINDOW_UPDATE (a 0-increment
+    %% WINDOW_UPDATE is itself a protocol error).
+    {Pid, Ref, ConnPid} = post_handshake_conn(),
+    HpackBin = encode_post_root_headers(),
+    H = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 16#04, undefined, HpackBin})
+    ),
+    serve_recv(ConnPid, H),
+    serve_recv(ConnPid, iolist_to_binary(roadrunner_http2_frame:encode({rst_stream, 1, cancel}))),
+    %% Empty DATA (length 0) on closed stream 1.
+    serve_recv(ConnPid, <<0:24, 0, 0, 0:1, 1:31>>),
+    ?assertMatch(<<_:24, 3, _/binary>>, expect_send()),
+    ?assertEqual(undefined, drain_send(50)),
     cleanup(Pid, Ref).
 
 data_after_end_stream_on_half_closed_remote_rst() ->
@@ -2623,6 +2647,11 @@ data_after_end_stream_on_half_closed_remote_rst() ->
     serve_recv(ConnPid, DataF),
     ?assertMatch(
         {ok, {rst_stream, 1, stream_closed}, _},
+        roadrunner_http2_frame:parse(expect_send(), 16384)
+    ),
+    %% The discarded byte's conn-level window is returned (RFC 9113 §6.9.1).
+    ?assertMatch(
+        {ok, {window_update, 0, 1}, _},
         roadrunner_http2_frame:parse(expect_send(), 16384)
     ),
     %% The worker is parked in `handle/1`; `reset_stream/2` already


### PR DESCRIPTION
# Description

DATA on a closed or half-closed-remote h2 stream is discarded, but its bytes still count against the peer's connection-level send window (RFC 9113 §6.9.1: flow-controlled bytes count against the conn window regardless of stream state). roadrunner wasn't returning them, so the conn window drifted down across stream resets. It now sends a conn-level `WINDOW_UPDATE` for the discarded payload (skipping a zero-length one).

Also folds in the roadmap update agreed for this batch: drops the shipped `sync/1` item and adds the (rare) padded-DATA accounting nit as the one remaining deferred item.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)