### PR TITLE
Apply the peer's SETTINGS_HEADER_TABLE_SIZE to the HPACK encoder

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -82,6 +82,11 @@
 %% to 16384).
 -define(MAX_HEADER_BLOCK, 16_384).
 
+%% RFC 7541 §4.2 default HPACK dynamic-table size: what we tell the peer
+%% its encoder may use (our decoder), and the ceiling we hold our own
+%% encoder to even when the peer advertises a larger table.
+-define(HPACK_TABLE_SIZE, 4096).
+
 %% RFC 9113 §6.9.2 initial window size for both the connection and
 %% each stream.
 -define(INITIAL_WINDOW, 65535).
@@ -269,8 +274,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         msg_data = Data,
         msg_closed = Closed,
         msg_error = Error,
-        hpack_dec = roadrunner_http2_hpack:new_decoder(4096),
-        hpack_enc = roadrunner_http2_hpack:new_encoder(4096),
+        hpack_dec = roadrunner_http2_hpack:new_decoder(?HPACK_TABLE_SIZE),
+        hpack_enc = roadrunner_http2_hpack:new_encoder(?HPACK_TABLE_SIZE),
         recv_window_peak = ConnPeak,
         stream_recv_window_peak = StreamPeak,
         recv_window_threshold = Threshold,
@@ -545,8 +550,9 @@ handle_frame({settings, 0, Params}, State) ->
                     %% Raising INITIAL_WINDOW_SIZE grows open streams' send
                     %% windows (RFC 9113 §6.9.2): ACK, then drain any sends
                     %% blocked at the old window, like the WINDOW_UPDATE path.
-                    _ = send(State1, roadrunner_http2_frame:encode({settings, 1, []})),
-                    frame_loop(flush_all_pending_data(State1));
+                    State2 = apply_header_table_size(Params, State1),
+                    _ = send(State2, roadrunner_http2_frame:encode({settings, 1, []})),
+                    frame_loop(flush_all_pending_data(State2));
                 {error, flow_control_error} ->
                     _ = send_goaway(State, flow_control_error),
                     exit_clean(State)
@@ -1582,6 +1588,32 @@ apply_initial_window_size(Params, #loop{peer_initial_window = Old} = State) ->
                     }};
                 {error, _} = E ->
                     E
+            end
+    end.
+
+%% RFC 9113 §6.5.2 / RFC 7541 §6.3: the peer's SETTINGS_HEADER_TABLE_SIZE
+%% (id 1) caps OUR encoder's dynamic table. Apply the last value (§6.5.3),
+%% clamped at our own ?HPACK_TABLE_SIZE ceiling so a generous peer can't
+%% grow our table, and a smaller one shrinks it (evicting entries the
+%% peer's decoder dropped, avoiding a desync). set_max_table_size flags
+%% the encoder to emit the matching dynamic-table-size update on its next
+%% encode.
+-spec apply_header_table_size(
+    [{non_neg_integer(), non_neg_integer()}], #loop{}
+) -> #loop{}.
+apply_header_table_size(Params, #loop{hpack_enc = Enc} = State) ->
+    case last_setting(Params, 1, undefined) of
+        undefined ->
+            State;
+        Limit ->
+            Size = min(?HPACK_TABLE_SIZE, Limit),
+            case roadrunner_http2_hpack:max_table_size(Enc) of
+                Size ->
+                    %% Already at this cap (e.g. the peer advertised our
+                    %% default or larger): don't flag a redundant Size Update.
+                    State;
+                _ ->
+                    State#loop{hpack_enc = roadrunner_http2_hpack:set_max_table_size(Size, Enc)}
             end
     end.
 

--- a/src/roadrunner_http2_hpack.erl
+++ b/src/roadrunner_http2_hpack.erl
@@ -45,7 +45,8 @@
     new_encoder/1,
     decode/2,
     encode/2,
-    set_max_table_size/2
+    set_max_table_size/2,
+    max_table_size/1
 ]).
 
 -export_type([context/0, decode_error/0]).
@@ -141,6 +142,16 @@ set_max_table_size(NewLimit, #hpack_ctx{} = Ctx) ->
                 Ctx
         end,
     Ctx1#hpack_ctx{limit = NewLimit, pending_update = true}.
+
+-doc """
+The current maximum dynamic-table size cap (the value last set by
+`set_max_table_size/2`, or the initial size). Lets a caller skip a
+redundant `set_max_table_size/2` (and its Size Update) when the cap
+is unchanged.
+""".
+-spec max_table_size(context()) -> non_neg_integer().
+max_table_size(#hpack_ctx{limit = Limit}) ->
+    Limit.
 
 %% =============================================================================
 %% decode/2 — parse a header block fragment

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -130,6 +130,8 @@ all_test_() ->
         fun settings_initial_window_size_shifts_stream_window/0,
         fun settings_initial_window_size_flushes_pending_data/0,
         fun preface_settings_initial_window_applied/0,
+        fun settings_header_table_size_shrinks_encoder/0,
+        fun settings_header_table_size_above_default_emits_no_update/0,
         fun content_length_multi_valued_rst_stream/0,
         fun trailers_after_first_end_stream_protocol_error/0
     ],
@@ -3174,6 +3176,45 @@ preface_settings_initial_window_applied() ->
     DataBytes = lists:sum([byte_size(P) || {data, _, _, P} <- Frames]),
     ?assertEqual(20000, DataBytes),
     ?assertEqual([], [F || {data, _, true, _} = F <- Frames]),
+    cleanup(Pid, Ref).
+
+settings_header_table_size_shrinks_encoder() ->
+    %% RFC 9113 §6.5.2 / RFC 7541 §6.3: SETTINGS_HEADER_TABLE_SIZE below our
+    %% 4096 default caps our encoder. Advertising 0 makes the next response
+    %% HEADERS block lead with a Dynamic Table Size Update to 0 (the byte
+    %% 0x20), and the block still decodes to a valid 200.
+    {Pid, Ref, ConnPid} = post_handshake_conn(),
+    Settings = iolist_to_binary(
+        roadrunner_http2_frame:encode({settings, 0, [{1, 0}]})
+    ),
+    serve_recv(ConnPid, Settings),
+    _SettingsAck = expect_send(),
+    serve_recv(ConnPid, complete_get_headers(1, ~"/")),
+    Response = collect_send_bytes(<<>>),
+    {ok, {headers, 1, _, _, RespHpack}, _} =
+        roadrunner_http2_frame:parse(Response, 16384),
+    ?assertMatch(<<16#20, _/binary>>, RespHpack),
+    {ok, RespHeaders, _} =
+        roadrunner_http2_hpack:decode(RespHpack, roadrunner_http2_hpack:new_decoder(4096)),
+    ?assertEqual(~"200", proplists:get_value(~":status", RespHeaders)),
+    cleanup(Pid, Ref).
+
+settings_header_table_size_above_default_emits_no_update() ->
+    %% A peer advertising >= our 4096 default must not trigger a redundant
+    %% Size Update: we clamp at 4096 (already our size), so the next HEADERS
+    %% block opens at a header representation, not a 001xxxxx Size Update.
+    {Pid, Ref, ConnPid} = post_handshake_conn(),
+    Settings = iolist_to_binary(
+        roadrunner_http2_frame:encode({settings, 0, [{1, 8192}]})
+    ),
+    serve_recv(ConnPid, Settings),
+    _SettingsAck = expect_send(),
+    serve_recv(ConnPid, complete_get_headers(1, ~"/")),
+    Response = collect_send_bytes(<<>>),
+    {ok, {headers, 1, _, _, RespHpack}, _} =
+        roadrunner_http2_frame:parse(Response, 16384),
+    <<First, _/binary>> = RespHpack,
+    ?assertNotEqual(16#20, First band 16#E0),
     cleanup(Pid, Ref).
 
 settings_initial_window_size_shifts_stream_window() ->

--- a/test/roadrunner_http2_hpack_tests.erl
+++ b/test/roadrunner_http2_hpack_tests.erl
@@ -483,6 +483,14 @@ encoder_emits_size_update_after_cap_change_test() ->
     BlockBin = iolist_to_binary(Block),
     ?assertMatch(<<16#3F, 16#E1, 16#0F, _:8>>, BlockBin).
 
+max_table_size_reflects_cap_test() ->
+    %% The getter returns the cap last set (or the initial size), so the
+    %% conn loop can skip a redundant set_max_table_size + Size Update.
+    Enc0 = roadrunner_http2_hpack:new_encoder(4096),
+    ?assertEqual(4096, roadrunner_http2_hpack:max_table_size(Enc0)),
+    Enc1 = roadrunner_http2_hpack:set_max_table_size(2048, Enc0),
+    ?assertEqual(2048, roadrunner_http2_hpack:max_table_size(Enc1)).
+
 %% =============================================================================
 %% RFC 7541 §C.4 — Huffman-encoded string fields.
 %% =============================================================================


### PR DESCRIPTION
# Description

Apply the peer's `SETTINGS_HEADER_TABLE_SIZE` (id 1) to our HPACK encoder, clamped at our 4096 default: a smaller advertised table shrinks our encoder (evicting entries the peer's decoder already dropped, so the two stay in sync per RFC 7541 §6.3); a larger one is capped so it can't grow our table. A new `roadrunner_http2_hpack:max_table_size/1` getter skips a redundant Dynamic Table Size Update when the peer advertises our default or larger (the common case).

> This dynamic table size is the largest size the encoder can use for the dynamic table. (RFC 7541 §6.3)

Proof: a peer advertising `SETTINGS_HEADER_TABLE_SIZE=0` now makes the next response HEADERS block lead with a Size Update to 0 (`0x20`); before, it kept indexing into a table the peer had already evicted.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)