### PR TITLE
Count DATA frame padding against the HTTP/2 flow-control windows

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -199,22 +199,6 @@ only parse the peer's value and bound inbound via the encoded
 `max_header_block` cap. The ~50 handshake fixtures that drain the server
 SETTINGS need to tolerate the extra entry.
 
-### h2 padded-DATA flow-control accounting
-
-**What:** A padded DATA frame undercounts its flow-control debit by the
-padding bytes — the codec strips padding before `on_data` sees the
-length, so the stream / connection recv windows (and the conn-window
-replenish on a reset stream) are charged the unpadded length.
-
-**Why deferred:** DATA padding is essentially never used by real
-clients, the undercount is at most 256 bytes per frame, and
-`max_content_length` already bounds the buffered body — so it's a
-codec-shape change for near-zero practical benefit. A correct fix
-threads the frame's declared Length through the codec (the decoded DATA
-tuple is matched in several places).
-
-**Scope:** small-to-medium.
-
 ### Refresh resource_results.md against the current headline scenarios
 
 **What:** `docs/resource_results.md` still carries its own scenario

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -636,8 +636,8 @@ handle_frame({headers, StreamId, Flags, Priority, Fragment}, State) ->
     on_headers(StreamId, Flags, Priority, Fragment, State);
 handle_frame({continuation, StreamId, Flags, Fragment}, State) ->
     on_continuation(StreamId, Flags, Fragment, State);
-handle_frame({data, StreamId, Flags, Payload}, State) ->
-    on_data(StreamId, Flags, Payload, State);
+handle_frame({data, StreamId, Flags, Payload, FlowLen}, State) ->
+    on_data(StreamId, Flags, Payload, FlowLen, State);
 handle_frame({push_promise, _, _, _, _}, State) ->
     %% Servers MUST NOT receive PUSH_PROMISE — RFC 9113 §6.6.
     _ = send_goaway(State, protocol_error),
@@ -869,71 +869,81 @@ finalize_headers(StreamId, #loop{streams = Streams, hpack_dec = Dec} = State) ->
 
 %% --- DATA ---
 
-on_data(StreamId, _Flags, _Payload, State) when StreamId > State#loop.last_stream_id ->
+on_data(StreamId, _Flags, _Payload, _FlowLen, State) when StreamId > State#loop.last_stream_id ->
     %% RFC 9113 §5.1: DATA on an idle stream is PROTOCOL_ERROR.
     _ = send_goaway(State, protocol_error),
     exit_clean(State);
-on_data(StreamId, _Flags, Payload, #loop{streams = Streams} = State) when
+on_data(StreamId, _Flags, _Payload, FlowLen, #loop{streams = Streams} = State) when
     not is_map_key(StreamId, Streams)
 ->
     %% RFC 9113 §6.1: DATA on a closed stream is STREAM_CLOSED. The bytes
     %% still consumed the peer's connection-level send window (§6.9.1);
-    %% return it since we're discarding them, so the conn window doesn't
-    %% drift down across stream resets.
+    %% return the full on-wire `FlowLen` (padding included) since we're
+    %% discarding them, so the conn window doesn't drift down across resets.
     _ = send_rst_stream(State, StreamId, stream_closed),
-    frame_loop(replenish_conn_window(State, byte_size(Payload)));
-on_data(StreamId, Flags, Payload, #loop{streams = Streams, max_content_length = MaxCL} = State) ->
+    frame_loop(replenish_conn_window(State, FlowLen));
+on_data(
+    StreamId, Flags, Payload, FlowLen, #loop{streams = Streams, max_content_length = MaxCL} = State
+) ->
     case Streams of
         #{
             StreamId :=
                 #{state := open, body := Body, body_len := Len, recv_window := RW} = Stream
         } ->
-            PayloadLen = byte_size(Payload),
+            %% Flow control charges the full on-wire `FlowLen` (RFC 9113
+            %% §6.9.1: pad-length byte + padding count). Past the window
+            %% gates, the body cap and buffering use the stripped `Payload`
+            %% the handler will see, so its length is only needed there.
             if
-                PayloadLen > State#loop.conn_recv_window ->
+                FlowLen > State#loop.conn_recv_window ->
                     %% RFC 9113 §6.9.1: more DATA than the connection-level
                     %% receive window permits is a connection-level
                     %% FLOW_CONTROL_ERROR.
                     _ = send_goaway(State, flow_control_error),
                     exit_clean(State);
-                PayloadLen > RW ->
+                FlowLen > RW ->
                     %% More DATA than the stream-level window permits is a
                     %% stream-level FLOW_CONTROL_ERROR.
                     _ = send_rst_stream(State, StreamId, flow_control_error),
                     frame_loop(reset_stream(State, StreamId));
-                Len + PayloadLen > MaxCL ->
-                    %% RFC 9113 §8.1: the request body exceeds
-                    %% `max_content_length`. Answer 413 before the full
-                    %% request, then RST_STREAM(NO_ERROR) to ask the client to
-                    %% stop sending the rest, and drop the stream (no worker
-                    %% was dispatched — dispatch is at END_STREAM).
-                    Resp = ~"Payload Too Large",
-                    State1 = encode_and_send_response_atomic(
-                        State,
-                        StreamId,
-                        413,
-                        [{~"content-type", ~"text/plain"}],
-                        Resp,
-                        byte_size(Resp)
-                    ),
-                    _ = send_rst_stream(State1, StreamId, no_error),
-                    frame_loop(remove_stream(State1, StreamId));
                 true ->
-                    EndStream = (Flags band 16#01) =/= 0,
-                    Stream1 = Stream#{
-                        body := [Body, Payload],
-                        body_len := Len + PayloadLen,
-                        end_stream_seen := EndStream,
-                        recv_window := RW - PayloadLen
-                    },
-                    State1 = State#loop{
-                        streams = Streams#{StreamId := Stream1},
-                        conn_recv_window = State#loop.conn_recv_window - PayloadLen
-                    },
-                    State2 = maybe_refill_recv_windows(State1, StreamId),
-                    case EndStream of
-                        true -> dispatch_stream(StreamId, State2);
-                        false -> frame_loop(State2)
+                    PayloadLen = byte_size(Payload),
+                    if
+                        Len + PayloadLen > MaxCL ->
+                            %% RFC 9113 §8.1: the request body exceeds
+                            %% `max_content_length`. Answer 413 before the
+                            %% full request, then RST_STREAM(NO_ERROR) to ask
+                            %% the client to stop sending the rest, and drop
+                            %% the stream (no worker was dispatched — dispatch
+                            %% is at END_STREAM).
+                            Resp = ~"Payload Too Large",
+                            State1 = encode_and_send_response_atomic(
+                                State,
+                                StreamId,
+                                413,
+                                [{~"content-type", ~"text/plain"}],
+                                Resp,
+                                byte_size(Resp)
+                            ),
+                            _ = send_rst_stream(State1, StreamId, no_error),
+                            frame_loop(remove_stream(State1, StreamId));
+                        true ->
+                            EndStream = (Flags band 16#01) =/= 0,
+                            Stream1 = Stream#{
+                                body := [Body, Payload],
+                                body_len := Len + PayloadLen,
+                                end_stream_seen := EndStream,
+                                recv_window := RW - FlowLen
+                            },
+                            State1 = State#loop{
+                                streams = Streams#{StreamId := Stream1},
+                                conn_recv_window = State#loop.conn_recv_window - FlowLen
+                            },
+                            State2 = maybe_refill_recv_windows(State1, StreamId),
+                            case EndStream of
+                                true -> dispatch_stream(StreamId, State2);
+                                false -> frame_loop(State2)
+                            end
                     end
             end;
         #{StreamId := _} ->
@@ -945,7 +955,7 @@ on_data(StreamId, Flags, Payload, #loop{streams = Streams, max_content_length = 
             %% delivered (which would also re-dispatch on a second
             %% END_STREAM).
             _ = send_rst_stream(State, StreamId, stream_closed),
-            frame_loop(replenish_conn_window(reset_stream(State, StreamId), byte_size(Payload)))
+            frame_loop(replenish_conn_window(reset_stream(State, StreamId), FlowLen))
     end.
 
 %% Return `N` bytes of connection-level receive window to the peer after

--- a/src/roadrunner_http2_frame.erl
+++ b/src/roadrunner_http2_frame.erl
@@ -118,7 +118,12 @@
 -type settings_param() :: {ParamId :: non_neg_integer(), Value :: non_neg_integer()}.
 
 -type frame() ::
+    %% `encode/1` builds the 4-tuple DATA frame; `parse/2` yields the
+    %% 5-tuple form, where `FlowLen` is the on-wire payload size (the
+    %% pad-length byte + padding included) that RFC 9113 §6.9.1 counts
+    %% against the flow-control windows, distinct from the stripped body.
     {data, stream_id(), flags(), Payload :: iodata()}
+    | {data, stream_id(), flags(), Body :: binary(), FlowLen :: non_neg_integer()}
     | {headers, stream_id(), flags(), Priority :: priority() | undefined, HeaderBlock :: iodata()}
     | {priority, stream_id(), priority()}
     | {rst_stream, stream_id(), error_code()}
@@ -215,7 +220,10 @@ decode(?TYPE_DATA, _Flags, 0, _Payload) ->
     {error, stream_id_violation};
 decode(?TYPE_DATA, Flags, StreamId, Payload) ->
     case strip_padding(Flags, Payload) of
-        {ok, Body} -> {ok, {data, StreamId, Flags, Body}};
+        %% `byte_size(Payload)` is the full on-wire payload (pad-length
+        %% byte + padding included): the flow-controlled length per
+        %% RFC 9113 §6.9.1, kept distinct from the stripped `Body`.
+        {ok, Body} -> {ok, {data, StreamId, Flags, Body, byte_size(Payload)}};
         {error, _} = E -> E
     end;
 decode(?TYPE_HEADERS, _Flags, 0, _Payload) ->

--- a/test/roadrunner_bench_client.erl
+++ b/test/roadrunner_bench_client.erl
@@ -354,7 +354,7 @@ recv_h2_streams(Sock, Buf, Pending, Dec) ->
                 false ->
                     {error, no_status}
             end;
-        {ok, {data, Sid, F, _Payload}, Rest} ->
+        {ok, {data, Sid, F, _Payload, _FlowLen}, Rest} ->
             Pending1 =
                 case (F band 16#01) =/= 0 of
                     true -> maps:remove(Sid, Pending);
@@ -524,7 +524,7 @@ recv_h2_loop(Sock, Buf, Sid, Dec, Status, Headers, Body) ->
                 true -> {ok, NewStatus, NewHeaders, Body, Rest, Dec1};
                 false -> recv_h2_loop(Sock, Rest, Sid, Dec1, NewStatus, NewHeaders, Body)
             end;
-        {ok, {data, Sid, F, Payload}, Rest} ->
+        {ok, {data, Sid, F, Payload, _FlowLen}, Rest} ->
             Body1 = <<Body/binary, Payload/binary>>,
             case (F band 16#01) =/= 0 of
                 true -> {ok, Status, Headers, Body1, Rest, Dec};

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -253,7 +253,7 @@ full_get_request_returns_response() ->
     %% RFC 9110 §6.6.1: the response carries an auto-injected `date`.
     ?assert(is_binary(proplists:get_value(~"date", RespHeaders))),
     %% Followed by a DATA frame on stream 1.
-    {ok, {data, 1, DataFlags, _Body}, _} =
+    {ok, {data, 1, DataFlags, _Body, _}, _} =
         roadrunner_http2_frame:parse(AfterHeaders, 16384),
     ?assertNotEqual(0, DataFlags band 16#01),
     cleanup(Pid, Ref).
@@ -2853,7 +2853,7 @@ oversized_body_413_then_rst() ->
         roadrunner_http2_frame:parse(AllResponse, 16384),
     {ok, RespHeaders, _} = roadrunner_http2_hpack:decode(RespHpack, Dec0),
     ?assertEqual(~"413", proplists:get_value(~":status", RespHeaders)),
-    {ok, {data, 1, DataFlags, _Body}, AfterData} =
+    {ok, {data, 1, DataFlags, _Body, _}, AfterData} =
         roadrunner_http2_frame:parse(AfterHeaders, 16384),
     ?assertNotEqual(0, DataFlags band 16#01),
     ?assertMatch(

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -24,6 +24,7 @@ reuse / scheduling races.
     stream_window_update_overflow_triggers_rst_stream/1,
     inbound_data_over_stream_window_triggers_rst_stream/1,
     inbound_data_over_conn_window_triggers_goaway/1,
+    inbound_padded_data_counts_padding_against_window/1,
     window_update_for_unknown_stream_ignored/1,
     stream_window_update_grows_send_window/1,
     large_response_chunks_through_send_window/1,
@@ -54,6 +55,7 @@ all() ->
         stream_window_update_overflow_triggers_rst_stream,
         inbound_data_over_stream_window_triggers_rst_stream,
         inbound_data_over_conn_window_triggers_goaway,
+        inbound_padded_data_counts_padding_against_window,
         window_update_for_unknown_stream_ignored,
         stream_window_update_grows_send_window,
         large_response_chunks_through_send_window,
@@ -140,6 +142,27 @@ inbound_data_over_conn_window_triggers_goaway(_Config) ->
     expect_send_type(7),
     expect_close(),
     wait_down(Pid, Ref).
+
+inbound_padded_data_counts_padding_against_window(_Config) ->
+    %% RFC 9113 §6.9.1: the whole DATA payload (pad-length byte + padding)
+    %% is flow-controlled, not just the stripped body. A 5-byte body fits
+    %% the 10-byte stream window, but the padded frame is 14 bytes on the
+    %% wire (1 pad-length + 5 body + 8 padding), so it overruns the stream
+    %% window. Without counting the padding this frame would be accepted.
+    {Pid, Ref, ConnPid} = start_conn(roadrunner_hello_handler, #{http2_stream_window => 10}),
+    handshake(ConnPid),
+    HpackBin = encode_request_headers(~"POST", ~"/"),
+    serve_recv(ConnPid, encode_frame({headers, 1, 16#04, undefined, HpackBin})),
+    Body = binary:copy(<<"x">>, 5),
+    PadLen = 8,
+    Payload = <<PadLen:8, Body/binary, 0:(PadLen * 8)>>,
+    PaddedData = <<(byte_size(Payload)):24, 0, 16#08, 0:1, 1:31, Payload/binary>>,
+    serve_recv(ConnPid, PaddedData),
+    Rst = expect_send_type(3),
+    {ok, {rst_stream, 1, flow_control_error}, <<>>} =
+        roadrunner_http2_frame:parse(Rst, 16384),
+    true = is_process_alive(Pid),
+    cleanup(Pid, Ref).
 
 window_update_for_unknown_stream_ignored(_Config) ->
     %% WINDOW_UPDATE for a stream that's not currently open is

--- a/test/roadrunner_http2_frame_tests.erl
+++ b/test/roadrunner_http2_frame_tests.erl
@@ -41,12 +41,16 @@ parse_returns_remainder_after_frame_test() ->
 %% =============================================================================
 
 data_frame_round_trip_test() ->
-    Frame = {data, 1, 0, ~"hello"},
-    ?assertEqual({ok, Frame, <<>>}, parse(Frame)).
+    %% `encode/1` takes the 4-tuple; `parse/2` yields the 5-tuple with the
+    %% on-wire flow-control length (= the body size when unpadded).
+    ?assertEqual(
+        {ok, {data, 1, 0, ~"hello", 5}, <<>>}, parse({data, 1, 0, ~"hello"})
+    ).
 
 data_frame_with_end_stream_round_trip_test() ->
-    Frame = {data, 3, 16#01, ~"bye"},
-    ?assertEqual({ok, Frame, <<>>}, parse(Frame)).
+    ?assertEqual(
+        {ok, {data, 3, 16#01, ~"bye", 3}, <<>>}, parse({data, 3, 16#01, ~"bye"})
+    ).
 
 data_frame_with_padding_strips_pad_bytes_test() ->
     %% Manually encode a padded DATA frame: <<PadLen, Body, Pad>>.
@@ -56,7 +60,12 @@ data_frame_with_padding_strips_pad_bytes_test() ->
     Payload = <<PadLen:8, Body/binary, Padding/binary>>,
     Header = <<(byte_size(Payload)):24, 0, 16#08, 0:1, 1:31>>,
     Bin = <<Header/binary, Payload/binary>>,
-    ?assertEqual({ok, {data, 1, 16#08, Body}, <<>>}, roadrunner_http2_frame:parse(Bin, ?MAX)).
+    %% Parse strips padding to `Body` but reports the full on-wire payload
+    %% (1 pad-length byte + 5 body + 5 padding = 11) as the flow length.
+    ?assertEqual(
+        {ok, {data, 1, 16#08, Body, byte_size(Payload)}, <<>>},
+        roadrunner_http2_frame:parse(Bin, ?MAX)
+    ).
 
 data_frame_pad_too_long_returns_bad_padding_test() ->
     %% PadLen=10 but only 5 bytes available after the length byte —


### PR DESCRIPTION
# Description

A padded HTTP/2 DATA frame undercounted its flow-control debit: the codec strips padding before the conn loop sees the frame, so the receive windows were charged the unpadded body length. The decoded DATA tuple now carries the on-wire payload length, used for every window check, debit, and the closed/reset-stream replenish; the stripped body still drives buffering and the `max_content_length` cap.

> The entire DATA frame payload is included in flow control, including the Pad Length and Padding fields if present. (RFC 9113 §6.9.1)

Proof: a 5-byte body in a 14-byte padded frame now overruns a 10-byte stream window (RST_STREAM(FLOW_CONTROL_ERROR)); before, the stripped 5 bytes slipped through.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)