### PR TITLE
Advertise and enforce SETTINGS_MAX_HEADER_LIST_SIZE on HTTP/2

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -82,6 +82,13 @@
 %% to 16384).
 -define(MAX_HEADER_BLOCK, 16_384).
 
+%% Default SETTINGS_MAX_HEADER_LIST_SIZE: 2x the encoded-block cap. The
+%% decoded list is always larger than the compressed block (the +32/field
+%% overhead alone pushes it up), so giving it headroom over `max_header_block`
+%% means the decoded gate only fires on genuinely huge header sets. When the
+%% encoded cap is overridden, the default tracks it (`2 * max_header_block`).
+-define(DEFAULT_MAX_HEADER_LIST_SIZE, (2 * ?MAX_HEADER_BLOCK)).
+
 %% RFC 7541 §4.2 default HPACK dynamic-table size: what we tell the peer
 %% its encoder may use (our decoder), and the ceiling we hold our own
 %% encoder to even when the peer advertises a larger table.
@@ -213,6 +220,10 @@
     %% body answers 413 + RST_STREAM(NO_ERROR). Read from proto_opts at
     %% `enter/5`.
     max_content_length = ?DEFAULT_MAX_CONTENT_LENGTH :: non_neg_integer(),
+    %% Decoded header-list cap (RFC 9113 §6.5.2 SETTINGS_MAX_HEADER_LIST_SIZE):
+    %% advertised in our SETTINGS and enforced after HPACK decode in
+    %% `finalize_headers/2`. Read from proto_opts at `enter/5`.
+    max_header_list_size = ?DEFAULT_MAX_HEADER_LIST_SIZE :: pos_integer(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -263,6 +274,9 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
     ),
     MaxStreams = maps:get(http2_max_concurrent_streams, ProtoOpts, ?MAX_CONCURRENT_STREAMS),
     MaxHeaderBlock = maps:get(http2_max_header_block, ProtoOpts, ?MAX_HEADER_BLOCK),
+    %% Decoded-list cap defaults to 2x the (possibly overridden) encoded cap,
+    %% so raising `max_header_block` for big headers lifts both gates together.
+    MaxHeaderListSize = maps:get(http2_max_header_list_size, ProtoOpts, 2 * MaxHeaderBlock),
     MaxContentLength = maps:get(max_content_length, ProtoOpts, ?DEFAULT_MAX_CONTENT_LENGTH),
     State = #loop{
         socket = Socket,
@@ -281,6 +295,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         recv_window_threshold = Threshold,
         max_concurrent_streams = MaxStreams,
         max_header_block = MaxHeaderBlock,
+        max_header_list_size = MaxHeaderListSize,
         max_content_length = MaxContentLength
     },
     handshake(State).
@@ -294,10 +309,11 @@ handshake(
     #loop{
         recv_window_peak = ConnPeak,
         stream_recv_window_peak = StreamPeak,
-        max_concurrent_streams = MaxStreams
+        max_concurrent_streams = MaxStreams,
+        max_header_list_size = MaxHeaderListSize
     } = State
 ) ->
-    _ = send(State, server_settings_frame(StreamPeak, MaxStreams)),
+    _ = send(State, server_settings_frame(StreamPeak, MaxStreams, MaxHeaderListSize)),
     %% RFC 9113 §6.9.2: SETTINGS_INITIAL_WINDOW_SIZE only affects
     %% stream-level recv windows. The conn-level recv window stays
     %% at the 65535 default until an explicit `WINDOW_UPDATE(0, _)`,
@@ -313,15 +329,16 @@ handshake(
         end,
     handshake_phase_preface(State1).
 
--spec server_settings_frame(pos_integer(), pos_integer()) -> iodata().
-server_settings_frame(StreamPeak, MaxStreams) ->
-    %% Advertise MAX_CONCURRENT_STREAMS and MAX_FRAME_SIZE.
-    %% IDs from RFC 9113 §6.5.2: 3 = MAX_CONCURRENT_STREAMS,
-    %% 5 = MAX_FRAME_SIZE.  When the stream-level recv peak is bigger
+-spec server_settings_frame(pos_integer(), pos_integer(), pos_integer()) -> iodata().
+server_settings_frame(StreamPeak, MaxStreams, MaxHeaderListSize) ->
+    %% Advertise MAX_CONCURRENT_STREAMS, MAX_FRAME_SIZE and
+    %% MAX_HEADER_LIST_SIZE. IDs from RFC 9113 §6.5.2: 3 =
+    %% MAX_CONCURRENT_STREAMS, 5 = MAX_FRAME_SIZE, 6 =
+    %% MAX_HEADER_LIST_SIZE. When the stream-level recv peak is bigger
     %% than the RFC 65535 default, also advertise
     %% SETTINGS_INITIAL_WINDOW_SIZE (id 4) so streams the peer opens
     %% start with the larger receive allowance.
-    Base = [{3, MaxStreams}, {5, ?MAX_FRAME_SIZE}],
+    Base = [{3, MaxStreams}, {5, ?MAX_FRAME_SIZE}, {6, MaxHeaderListSize}],
     Settings =
         case StreamPeak > ?INITIAL_WINDOW of
             true -> [{4, StreamPeak} | Base];
@@ -844,7 +861,9 @@ finalize_trailers(StreamId, #loop{streams = Streams, hpack_dec = Dec} = State) -
 %% Decode the accumulated HPACK fragment, store decoded headers on
 %% the stream entry. If END_STREAM was set on the HEADERS frame,
 %% dispatch the worker now (no body); otherwise wait for DATA.
-finalize_headers(StreamId, #loop{streams = Streams, hpack_dec = Dec} = State) ->
+finalize_headers(
+    StreamId, #loop{streams = Streams, hpack_dec = Dec, max_header_list_size = MaxHLS} = State
+) ->
     #{
         StreamId := #{
             header_fragment := Fragment,
@@ -854,13 +873,36 @@ finalize_headers(StreamId, #loop{streams = Streams, hpack_dec = Dec} = State) ->
     case roadrunner_http2_hpack:decode(iolist_to_binary(Fragment), Dec) of
         {ok, Headers, Dec1} ->
             Stream1 = Stream#{headers := Headers, header_fragment := <<>>},
+            %% Commit the mutated HPACK context even if we reject below: the
+            %% decode advanced the dynamic table, so dropping it would desync
+            %% our decoder from the peer's encoder for every later block.
             State1 = State#loop{
                 hpack_dec = Dec1,
                 streams = Streams#{StreamId := Stream1}
             },
-            case EndStreamSeen of
-                true -> dispatch_stream(StreamId, State1);
-                false -> frame_loop(State1)
+            case roadrunner_http:header_list_size(Headers) > MaxHLS of
+                true ->
+                    %% RFC 9113 §6.5.2: the decoded list exceeds the
+                    %% MAX_HEADER_LIST_SIZE we advertised. Answer 431, then
+                    %% RST_STREAM(NO_ERROR) (decode succeeded, so the
+                    %% connection is intact), and drop the stream — no worker
+                    %% is dispatched until END_STREAM.
+                    Resp = ~"Request Header Fields Too Large",
+                    State2 = encode_and_send_response_atomic(
+                        State1,
+                        StreamId,
+                        431,
+                        [{~"content-type", ~"text/plain"}],
+                        Resp,
+                        byte_size(Resp)
+                    ),
+                    _ = send_rst_stream(State2, StreamId, no_error),
+                    frame_loop(remove_stream(State2, StreamId));
+                false ->
+                    case EndStreamSeen of
+                        true -> dispatch_stream(StreamId, State1);
+                        false -> frame_loop(State1)
+                    end
             end;
         {error, _} ->
             _ = send_goaway(State, protocol_error),

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -29,6 +29,7 @@ accessors that operate on it.
 -on_load(init_cache/0).
 
 -export([http_date_now/0, format_http_date/1, with_date/1, auto_headers/2]).
+-export([header_list_size/1]).
 
 -export_type([headers/0, status/0, redirect_status/0, version/0]).
 
@@ -109,6 +110,18 @@ with_alt_svc(Headers, #{alt_svc := Value}) ->
     [{~"alt-svc", Value} | Headers];
 with_alt_svc(Headers, #{}) ->
     Headers.
+
+%% RFC 7541 §4.1: the uncompressed size of a header list is the sum over
+%% its fields of `byte_size(Name) + byte_size(Value) + 32`. This is the
+%% unit bounded by SETTINGS_MAX_HEADER_LIST_SIZE (h2, RFC 9113 §6.5.2)
+%% and SETTINGS_MAX_FIELD_SECTION_SIZE (h3, RFC 9114 §7.2.4.1), distinct
+%% from the compressed on-wire block the `max_header_block` cap bounds.
+-doc false.
+-spec header_list_size(headers()) -> non_neg_integer().
+header_list_size([{Name, Value} | Rest]) ->
+    byte_size(Name) + byte_size(Value) + 32 + header_list_size(Rest);
+header_list_size([]) ->
+    0.
 
 -doc """
 Format a posix timestamp (seconds since epoch) as an IMF-fixdate

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -376,13 +376,21 @@ HTTP/2 listener tunables (under `{http2, ThisMap}` in `protocols`).
   Default `16384`. This is the h2 counterpart to the `{http1, ...}`
   `max_header_block` opt, but the two are independent and default
   differently (h1 `10240`, h2 `16384`).
+- `max_header_list_size` — cap on the *decoded* (uncompressed)
+  header-list size (RFC 7541 §4.1: sum of name + value + 32 per
+  field), advertised via `SETTINGS_MAX_HEADER_LIST_SIZE`; an
+  over-cap request gets `431` + `RST_STREAM(NO_ERROR)`. Bounds a
+  different unit than `max_header_block` (which caps the compressed
+  block). Defaults to `2 * max_header_block`, so raising the encoded
+  cap lifts this one too unless set explicitly.
 """.
 -type http2_opts() :: #{
     conn_window => 1..16#7FFFFFFF,
     stream_window => 1..16#7FFFFFFF,
     window_refill_threshold => 1..16#7FFFFFFF,
     max_concurrent_streams => 1..16#7FFFFFFF,
-    max_header_block => 1..16#7FFFFFFF
+    max_header_block => 1..16#7FFFFFFF,
+    max_header_list_size => 1..16#7FFFFFFF
 }.
 
 -doc """
@@ -1224,13 +1232,16 @@ http2_defaults() ->
         stream_window => 65535,
         window_refill_threshold => 32768,
         max_concurrent_streams => 100,
-        max_header_block => 16384
+        max_header_block => 16384,
+        %% Placeholder: resolved to `2 * max_header_block` when not set
+        %% explicitly (see `resolve_max_header_list_size/2`).
+        max_header_list_size => 32768
     }.
 
 -spec validate_http2_opts(map(), term()) -> http2_opts().
 validate_http2_opts(Opts, Raw) ->
     Defaults = http2_defaults(),
-    maps:fold(
+    Merged = maps:fold(
         fun(K, V, Acc) ->
             case is_map_key(K, Defaults) of
                 false -> error({invalid_listener_opt, protocols, Raw});
@@ -1240,7 +1251,17 @@ validate_http2_opts(Opts, Raw) ->
         end,
         Defaults,
         Opts
-    ).
+    ),
+    resolve_max_header_list_size(Merged, Opts).
+
+%% MAX_HEADER_LIST_SIZE defaults to 2x the resolved encoded-block cap so
+%% raising `max_header_block` lifts both gates together; an explicit value
+%% (already range-checked above) is kept as-is.
+-spec resolve_max_header_list_size(http2_opts(), map()) -> http2_opts().
+resolve_max_header_list_size(Merged, Opts) when is_map_key(max_header_list_size, Opts) ->
+    Merged;
+resolve_max_header_list_size(#{max_header_block := MaxHeaderBlock} = Merged, _Opts) ->
+    Merged#{max_header_list_size => 2 * MaxHeaderBlock}.
 
 %% Flatten the http2 sub-opts onto proto_opts top-level with an
 %% `http2_` prefix so the hot path reads each knob with a single
@@ -1255,14 +1276,16 @@ flatten_http2_opts(Entries) ->
             stream_window := Stream,
             window_refill_threshold := Threshold,
             max_concurrent_streams := MaxStreams,
-            max_header_block := MaxHeaderBlock
+            max_header_block := MaxHeaderBlock,
+            max_header_list_size := MaxHeaderListSize
         }} ->
             #{
                 http2_conn_window => Conn,
                 http2_stream_window => Stream,
                 http2_window_refill_threshold => Threshold,
                 http2_max_concurrent_streams => MaxStreams,
-                http2_max_header_block => MaxHeaderBlock
+                http2_max_header_block => MaxHeaderBlock,
+                http2_max_header_list_size => MaxHeaderListSize
             }
     end.
 

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -132,6 +132,8 @@ all_test_() ->
         fun preface_settings_initial_window_applied/0,
         fun settings_header_table_size_shrinks_encoder/0,
         fun settings_header_table_size_above_default_emits_no_update/0,
+        fun settings_advertises_max_header_list_size/0,
+        fun header_list_too_large_returns_431_and_keeps_hpack_in_sync/0,
         fun content_length_multi_valued_rst_stream/0,
         fun trailers_after_first_end_stream_protocol_error/0
     ],
@@ -3217,6 +3219,67 @@ settings_header_table_size_above_default_emits_no_update() ->
     ?assertNotEqual(16#20, First band 16#E0),
     cleanup(Pid, Ref).
 
+settings_advertises_max_header_list_size() ->
+    %% RFC 9113 §6.5.2: the server's initial SETTINGS advertises
+    %% SETTINGS_MAX_HEADER_LIST_SIZE (id 6) with the configured value.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    {Pid, Ref, _ConnPid} = start_http2_conn(#{http2_max_header_list_size => 12345}),
+    InitialSettings = expect_send(),
+    {ok, {settings, 0, Params}, _} = roadrunner_http2_frame:parse(InitialSettings, 16384),
+    ?assertEqual(12345, proplists:get_value(6, Params)),
+    cleanup(Pid, Ref).
+
+header_list_too_large_returns_431_and_keeps_hpack_in_sync() ->
+    %% RFC 9113 §6.5.2: a request whose DECODED header list exceeds the
+    %% advertised MAX_HEADER_LIST_SIZE gets 431 + RST_STREAM(NO_ERROR). The
+    %% connection and its HPACK decoder survive: a follow-up request that
+    %% references a dynamic-table entry the rejected block inserted still
+    %% decodes, proving the decoder context was committed before the reject.
+    {Pid, Ref, ConnPid} = post_handshake_conn(#{http2_max_header_list_size => 200}),
+    Enc0 = roadrunner_http2_hpack:new_encoder(4096),
+    Big = binary:copy(<<"v">>, 100),
+    {Block1, Enc1} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"https"},
+            {~":authority", ~"example"},
+            {~":path", ~"/"},
+            {~"x-pad", Big}
+        ],
+        Enc0
+    ),
+    serve_recv(ConnPid, headers_frame_complete(1, Block1)),
+    Resp1 = collect_send_bytes(<<>>),
+    Dec0 = roadrunner_http2_hpack:new_decoder(4096),
+    {ok, {headers, 1, _, _, Hpack431}, _} = roadrunner_http2_frame:parse(Resp1, 16384),
+    {ok, Headers431, Dec1} = roadrunner_http2_hpack:decode(Hpack431, Dec0),
+    ?assertEqual(~"431", proplists:get_value(~":status", Headers431)),
+    %% Stream 3 references {:authority, example} (inserted by the rejected
+    %% block) via a dynamic index — only decodable if the server kept Dec1.
+    {Block2, _} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"https"},
+            {~":authority", ~"example"},
+            {~":path", ~"/"}
+        ],
+        Enc1
+    ),
+    serve_recv(ConnPid, headers_frame_complete(3, Block2)),
+    Resp2 = collect_send_bytes(<<>>),
+    {ok, {headers, 3, _, _, Hpack200}, _} = roadrunner_http2_frame:parse(Resp2, 16384),
+    {ok, Headers200, _} = roadrunner_http2_hpack:decode(Hpack200, Dec1),
+    ?assertEqual(~"200", proplists:get_value(~":status", Headers200)),
+    cleanup(Pid, Ref).
+
+headers_frame_complete(StreamId, Block) ->
+    iolist_to_binary(
+        roadrunner_http2_frame:encode(
+            {headers, StreamId, 16#04 bor 16#01, undefined, iolist_to_binary(Block)}
+        )
+    ).
+
 settings_initial_window_size_shifts_stream_window() ->
     %% Open a stream, then SETTINGS with a new INITIAL_WINDOW_SIZE
     %% mixed with an unrelated setting id (3, MAX_CONCURRENT_STREAMS)
@@ -3360,9 +3423,12 @@ drain_until_goaway() ->
 %% return the handles so the test can drive whatever frame it
 %% wants next.
 post_handshake_conn() ->
+    post_handshake_conn(#{}).
+
+post_handshake_conn(Extra) ->
     {ok, _} = application:ensure_all_started(telemetry),
     drain_mailbox(),
-    {Pid, Ref, ConnPid} = start_http2_conn(),
+    {Pid, Ref, ConnPid} = start_http2_conn(Extra),
     _ = expect_send(),
     serve_recv(ConnPid, ?PREFACE),
     serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),

--- a/test/roadrunner_http_tests.erl
+++ b/test/roadrunner_http_tests.erl
@@ -40,3 +40,12 @@ format_http_date_pads_single_digits_test() ->
     %% clause is exercised regardless of wall-clock at test run time.
     Date = roadrunner_http:format_http_date(0),
     ?assertEqual(~"Thu, 01 Jan 1970 00:00:00 GMT", Date).
+
+header_list_size_sums_fields_with_overhead_test() ->
+    %% RFC 7541 §4.1: each field contributes name + value + 32 bytes.
+    ?assertEqual(0, roadrunner_http:header_list_size([])),
+    %% "a"(1) + "bb"(2) + 32 = 35; plus "ccc"(3) + ""(0) + 32 = 35 → 70.
+    ?assertEqual(
+        70,
+        roadrunner_http:header_list_size([{~"a", ~"bb"}, {~"ccc", ~""}])
+    ).

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -375,6 +375,30 @@ listener_threads_http1_limits_into_proto_opts_test() ->
     ?assertEqual(250, maps:get(http1_max_header_count, ProtoOpts)),
     ok = roadrunner_listener:stop(Name).
 
+listener_http2_max_header_list_size_threads_into_proto_opts_test() ->
+    %% An explicit `max_header_list_size` flattens through verbatim;
+    %% omitting it derives `2 * max_header_block` so raising the encoded
+    %% cap lifts the decoded gate too.
+    Explicit = listener_test_h2_hls_explicit,
+    {ok, P1} = roadrunner_listener:start_link(Explicit, #{
+        port => 0,
+        protocols => [{http2, #{max_header_list_size => 50000}}],
+        routes => roadrunner_hello_handler
+    }),
+    PO1 = element(4, sys:get_state(P1)),
+    ?assertEqual(50000, maps:get(http2_max_header_list_size, PO1)),
+    ok = roadrunner_listener:stop(Explicit),
+    Derived = listener_test_h2_hls_derived,
+    {ok, P2} = roadrunner_listener:start_link(Derived, #{
+        port => 0,
+        protocols => [{http2, #{max_header_block => 65536}}],
+        routes => roadrunner_hello_handler
+    }),
+    PO2 = element(4, sys:get_state(P2)),
+    ?assertEqual(65536, maps:get(http2_max_header_block, PO2)),
+    ?assertEqual(131072, maps:get(http2_max_header_list_size, PO2)),
+    ok = roadrunner_listener:stop(Derived).
+
 listener_http1_defaults_thread_into_proto_opts_test() ->
     %% Bare `http1` (no tuple) fills the default limits into proto_opts.
     Name = listener_test_http1_defaults,


### PR DESCRIPTION
# Description

Advertise `SETTINGS_MAX_HEADER_LIST_SIZE` (RFC 9113 §6.5.2, id 6) and enforce it honestly: after HPACK decode, a request whose decoded header-list size (RFC 7541 §4.1: sum of name + value + 32 per field) exceeds the limit gets `431` + `RST_STREAM(NO_ERROR)`. The mutated HPACK context is committed before the reject, so the connection's decoder stays in sync with the peer's encoder. New `http2_max_header_list_size` opt defaults to `2 * max_header_block` (so raising the encoded cap lifts the decoded gate too).

> The value is based on the uncompressed size of header fields, including the length of the name and value in octets plus an overhead of 32 octets for each header field. (RFC 9113 §6.5.2)

Proof: a follow-up request that references a dynamic-table entry inserted by a rejected block still decodes to 200 — dropping the HPACK context on the reject path breaks it.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)