### PR TITLE
Advertise and enforce SETTINGS_MAX_FIELD_SECTION_SIZE on HTTP/3

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -48,12 +48,6 @@ only). Remaining work:
 - h3 manual-mode body reading (parity with the deferred h2 item) —
   needs the same conn-loop→worker inbound routing WebSocket would, so
   do it alongside that work, not standalone
-- Advertise `SETTINGS_MAX_FIELD_SECTION_SIZE` (RFC 9114 §7.2.4.1). The
-  encoded request header block is now capped (16384-byte default, 431 on
-  overflow, as the h1 and h2 `max_header_block` caps do); advertising the
-  decoded-size limit would let conformant clients avoid sending an
-  oversized field section in the first place rather than learning via the
-  431
 - WebSocket over h3 (`websocket` shape, still `501`) — RFC 9220
   Extended CONNECT; do WebSocket over h2 (RFC 8441) first, since it's
   the more common transport and h2 has no WebSocket either

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -78,6 +78,13 @@
 %% configurable; h1 defaults to 10240, h2 to 16384).
 -define(MAX_HEADER_BLOCK, 16384).
 
+%% Default SETTINGS_MAX_FIELD_SECTION_SIZE (RFC 9114 §7.2.4.1): 2x the
+%% encoded-block cap, mirroring the h2 MAX_HEADER_LIST_SIZE default. The
+%% decoded field section is always larger than the compressed block (the
+%% +32/field overhead alone), so the headroom means the decoded gate only
+%% fires on genuinely huge header sets; tracks `max_header_block` when set.
+-define(DEFAULT_MAX_FIELD_SECTION_SIZE, (2 * ?MAX_HEADER_BLOCK)).
+
 %% A critical stream role can be claimed at most once per connection.
 -type critical_role() :: control | qpack_encoder | qpack_decoder.
 -type critical_set() :: #{critical_role() => true}.
@@ -122,7 +129,13 @@
     max_content_length :: non_neg_integer(),
     %% Cap on the encoded request field section (HEADERS block). Read from
     %% proto_opts at conn start; defaults to `?MAX_HEADER_BLOCK`.
-    max_header_block = ?MAX_HEADER_BLOCK :: pos_integer()
+    max_header_block = ?MAX_HEADER_BLOCK :: pos_integer(),
+    %% Cap on the DECODED field-section size (RFC 9114 §7.2.4.1
+    %% SETTINGS_MAX_FIELD_SECTION_SIZE): advertised on the control stream
+    %% (so conformant clients self-limit, §4.2.2) and enforced after QPACK
+    %% decode in `dispatch_request/2`. Read from proto_opts; defaults to
+    %% `2 * max_header_block`.
+    max_field_section_size = ?DEFAULT_MAX_FIELD_SECTION_SIZE :: pos_integer()
 }).
 
 -doc """
@@ -170,6 +183,7 @@ init(Conn, ProtoOpts) ->
     StartMono = roadrunner_telemetry:listener_accept(#{
         listener_name => ListenerName, peer => Peer
     }),
+    MaxHeaderBlock = maps:get(http3_max_header_block, ProtoOpts, ?MAX_HEADER_BLOCK),
     loop(#h3{
         conn = Conn,
         proto_opts = ProtoOpts,
@@ -177,7 +191,12 @@ init(Conn, ProtoOpts) ->
         peer = Peer,
         start_mono = StartMono,
         max_content_length = maps:get(max_content_length, ProtoOpts),
-        max_header_block = maps:get(http3_max_header_block, ProtoOpts, ?MAX_HEADER_BLOCK)
+        max_header_block = MaxHeaderBlock,
+        %% Decoded-section cap defaults to 2x the (possibly overridden) encoded
+        %% cap, so raising `max_header_block` lifts both gates together.
+        max_field_section_size = maps:get(
+            http3_max_field_section_size, ProtoOpts, 2 * MaxHeaderBlock
+        )
     }).
 
 -spec loop(#h3{}) -> ok.
@@ -237,12 +256,13 @@ recv_loop(#h3{conn = Conn} = State) ->
 %% runs the instant the handshake completes, before any peer close can
 %% arrive, so it stays strictly matched.
 -spec send_control_stream(#h3{}) -> #h3{}.
-send_control_stream(#h3{conn = Conn} = State) ->
+send_control_stream(#h3{conn = Conn, max_field_section_size = MaxFieldSection} = State) ->
     {ok, CtrlStreamId} = quic:open_unidirectional_stream(Conn),
     Prefix = quic_h3_frame:encode_stream_type(control),
     Settings = quic_h3_frame:encode_settings(#{
         qpack_max_table_capacity => 0,
-        qpack_blocked_streams => 0
+        qpack_blocked_streams => 0,
+        max_field_section_size => MaxFieldSection
     }),
     _ = quic:send_data(Conn, CtrlStreamId, [Prefix, Settings], false),
     State#h3{control_stream_id = CtrlStreamId}.
@@ -669,7 +689,7 @@ dispatch_request(#h3{streams = Streams} = State, StreamId) ->
             %% Stream ended with no HEADERS frame — a malformed message
             %% (RFC 9114 §4.1): stream error H3_MESSAGE_ERROR.
             reset_and_drop(State, StreamId, ?H3_MESSAGE_ERROR);
-        #{header_block := Block, body := Body} ->
+        #{header_block := Block} = Stream ->
             %% QPACK decode happens here (not in the worker) because a
             %% decompression failure is a CONNECTION error per RFC 9204
             %% §2.2 — the dynamic-table state is unrecoverable — whereas
@@ -678,9 +698,37 @@ dispatch_request(#h3{streams = Streams} = State, StreamId) ->
                 {error, _} ->
                     {conn_error, ?H3_QPACK_DECOMPRESSION_FAILED, ~"QPACK decompression failed"};
                 {ok, Headers} ->
-                    dispatch_decoded(State, StreamId, Headers, Body)
+                    case
+                        roadrunner_http:header_list_size(Headers) >
+                            State#h3.max_field_section_size
+                    of
+                        true ->
+                            %% RFC 9114 §4.2.2: the decoded field section
+                            %% exceeds the MAX_FIELD_SECTION_SIZE we advertised.
+                            %% QPACK is static-only here, so there's no decoder
+                            %% state to desync — answer 431 and drop the stream.
+                            respond_field_section_too_large(State, StreamId);
+                        false ->
+                            #{body := Body} = Stream,
+                            dispatch_decoded(State, StreamId, Headers, Body)
+                    end
             end
     end.
+
+%% RFC 9114 §4.2.2: a request whose decoded field section exceeds the
+%% advertised MAX_FIELD_SECTION_SIZE gets 431. The request stream has
+%% already ended (we dispatch at stream close), so no `stop_sending` is
+%% needed — just answer and drop the stream.
+-spec respond_field_section_too_large(#h3{}, non_neg_integer()) -> #h3{}.
+respond_field_section_too_large(#h3{conn = Conn} = State, StreamId) ->
+    ok = roadrunner_http3_stream_worker:send_buffered(
+        Conn,
+        StreamId,
+        431,
+        [{~"content-type", ~"text/plain"}],
+        ~"Request Header Fields Too Large"
+    ),
+    drop_stream(State, StreamId).
 
 -spec dispatch_decoded(#h3{}, non_neg_integer(), roadrunner_http:headers(), iodata()) ->
     handle_result().

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -410,11 +410,21 @@ HTTP/3 listener tunables (under `{http3, ThisMap}` in `protocols`).
   (request) streams, advertised to the peer in the QUIC transport
   parameters. Default `100`. The h3 counterpart to the `{http2, ...}`
   `max_concurrent_streams` opt.
+- `max_field_section_size` — cap on the *decoded* (uncompressed)
+  field-section size (RFC 7541 §4.1: sum of name + value + 32 per field),
+  advertised via `SETTINGS_MAX_FIELD_SECTION_SIZE` (so conformant clients
+  self-limit, RFC 9114 §4.2.2) and enforced after QPACK decode: an
+  over-cap request gets `431`. Bounds a different unit than
+  `max_header_block` (which caps the compressed block). Defaults to
+  `2 * max_header_block`, so raising the encoded cap lifts this one too
+  unless set explicitly. The h3 counterpart to the `{http2, ...}`
+  `max_header_list_size` opt.
 """.
 -type http3_opts() :: #{
     listeners => 1..?MAX_H3_LISTENERS,
     max_header_block => 1..16#7FFFFFFF,
-    max_streams_bidi => 1..16#7FFFFFFF
+    max_streams_bidi => 1..16#7FFFFFFF,
+    max_field_section_size => 1..16#7FFFFFFF
 }.
 
 -doc """
@@ -1294,22 +1304,26 @@ http3_defaults() ->
     #{
         listeners => ?DEFAULT_H3_LISTENERS,
         max_header_block => 16384,
-        max_streams_bidi => ?H3_MAX_STREAMS_BIDI
+        max_streams_bidi => ?H3_MAX_STREAMS_BIDI,
+        %% Placeholder: resolved to `2 * max_header_block` when not set
+        %% explicitly (see `resolve_max_field_section_size/2`).
+        max_field_section_size => 32768
     }.
 
 -spec validate_http3_opts(map(), term()) -> http3_opts().
 validate_http3_opts(Opts, Raw) ->
     Defaults = http3_defaults(),
-    maps:fold(
+    Merged = maps:fold(
         fun(K, V, Acc) ->
             %% `listeners` caps at the reuseport-pool limit; `max_header_block`
-            %% (a byte size) and `max_streams_bidi` (a stream count) go up to
-            %% the 31-bit ceiling.
+            %% (a byte size), `max_streams_bidi` (a stream count) and
+            %% `max_field_section_size` (a byte size) go up to the 31-bit ceiling.
             Max =
                 case K of
                     listeners -> ?MAX_H3_LISTENERS;
                     max_header_block -> 16#7FFFFFFF;
                     max_streams_bidi -> 16#7FFFFFFF;
+                    max_field_section_size -> 16#7FFFFFFF;
                     _ -> 0
                 end,
             case is_map_key(K, Defaults) of
@@ -1320,7 +1334,17 @@ validate_http3_opts(Opts, Raw) ->
         end,
         Defaults,
         Opts
-    ).
+    ),
+    resolve_max_field_section_size(Merged, Opts).
+
+%% MAX_FIELD_SECTION_SIZE defaults to 2x the resolved encoded-block cap so
+%% raising `max_header_block` lifts both gates together; an explicit value
+%% (already range-checked above) is kept as-is.
+-spec resolve_max_field_section_size(http3_opts(), map()) -> http3_opts().
+resolve_max_field_section_size(Merged, Opts) when is_map_key(max_field_section_size, Opts) ->
+    Merged;
+resolve_max_field_section_size(#{max_header_block := MaxHeaderBlock} = Merged, _Opts) ->
+    Merged#{max_field_section_size => 2 * MaxHeaderBlock}.
 
 %% Flatten the http3 sub-opts onto proto_opts top-level (`http3_*`) so
 %% the conn loop reads each knob with a single `maps:get/2`. Returns an
@@ -1333,12 +1357,14 @@ flatten_http3_opts(Entries) ->
         {http3, #{
             listeners := Listeners,
             max_header_block := MaxHeaderBlock,
-            max_streams_bidi := MaxStreamsBidi
+            max_streams_bidi := MaxStreamsBidi,
+            max_field_section_size := MaxFieldSection
         }} ->
             #{
                 http3_listeners => Listeners,
                 http3_max_header_block => MaxHeaderBlock,
-                http3_max_streams_bidi => MaxStreamsBidi
+                http3_max_streams_bidi => MaxStreamsBidi,
+                http3_max_field_section_size => MaxFieldSection
             }
     end.
 

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -39,6 +39,8 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     head_sendfile/1,
     oversized_413/1,
     oversized_headers_431/1,
+    advertises_max_field_section_size/1,
+    field_section_too_large_431/1,
     protocols_tuple_form/1,
     certfile_keyfile/1,
     certs_keys_form/1,
@@ -99,6 +101,8 @@ all() ->
         head_sendfile,
         oversized_413,
         oversized_headers_431,
+        advertises_max_field_section_size,
+        field_section_too_large_431,
         protocols_tuple_form,
         certfile_keyfile,
         certs_keys_form,
@@ -182,7 +186,10 @@ init_per_testcase(Case, Config) when
     Case =:= rejects_http3_without_tls;
     Case =:= max_clients_refuse;
     Case =:= max_concurrent_requests_refuse;
-    Case =:= extra_data_after_413
+    Case =:= extra_data_after_413;
+    Case =:= oversized_headers_431;
+    Case =:= advertises_max_field_section_size;
+    Case =:= field_section_too_large_431
 ->
     Config;
 init_per_testcase(Case, Config) ->
@@ -408,15 +415,88 @@ oversized_413(_Config) ->
         roadrunner_listener:stop(Name)
     end.
 
-oversized_headers_431(Config) ->
+oversized_headers_431(_Config) ->
     %% A request whose encoded field section exceeds MAX_HEADER_BLOCK
     %% (16384) is answered 431, rejected by the conn loop before dispatch
-    %% (parity with the body 413). Uses the shared default listener.
-    Conn = connect(?config(port, Config)),
-    Big = binary:copy(<<"x">>, 50000),
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/") ++ [{~"x-big", Big}]),
-    ?assertMatch({431, _, _}, collect(Conn, StreamId)),
-    close(Conn).
+    %% (parity with the body 413). Advertise a huge MAX_FIELD_SECTION_SIZE
+    %% so the conformant client doesn't self-limit on the decoded size
+    %% before the request reaches the encoded cap.
+    Name = listener_name(oversized_headers_431),
+    {ok, _} = start_h3(Name, #{
+        protocols => [{http3, #{max_field_section_size => 16#7FFFFFFF}}]
+    }),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        Big = binary:copy(<<"x">>, 50000),
+        {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/") ++ [{~"x-big", Big}]),
+        ?assertMatch({431, _, _}, collect(Conn, StreamId))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+advertises_max_field_section_size(_Config) ->
+    %% RFC 9114 §7.2.4.1: the server advertises SETTINGS_MAX_FIELD_SECTION_SIZE
+    %% on its control stream so conformant clients self-limit (§4.2.2). A
+    %% connected client reads it back via get_peer_settings.
+    Name = listener_name(advertises_max_field_section_size),
+    {ok, _} = start_h3(Name, #{
+        protocols => [{http3, #{max_field_section_size => 54321}}]
+    }),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        Settings = quic_h3:get_peer_settings(Conn),
+        ?assertEqual(54321, maps:get(max_field_section_size, Settings))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+field_section_too_large_431(_Config) ->
+    %% RFC 9114 §4.2.2: a request whose DECODED field section exceeds the
+    %% advertised MAX_FIELD_SECTION_SIZE is answered 431. The conformant
+    %% `quic_h3` client self-limits to the advertised value, so this drives
+    %% a raw, non-conformant client (the same codecs roadrunner's server
+    %% uses) over a plain QUIC stream. A 300-byte header stays well under
+    %% the 16384 encoded cap but blows the tiny 200-byte decoded limit.
+    Name = listener_name(field_section_too_large_431),
+    {ok, _} = start_h3(Name, #{
+        protocols => [{http3, #{max_field_section_size => 200}}]
+    }),
+    Conn = ll_connect(roadrunner_listener:port(Name)),
+    try
+        {ok, StreamId} = quic:open_stream(Conn),
+        Headers = headers(~"GET", ~"/") ++ [{~"x-pad", binary:copy(<<"v">>, 300)}],
+        Block = quic_qpack:encode(Headers),
+        %% Stay under the 16384 encoded cap so the ENCODED gate can't fire;
+        %% the decoded size (well over the 200 cap) is what triggers the 431.
+        ?assert(byte_size(Block) < 16384),
+        ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_headers(Block), true),
+        ?assertEqual(431, raw_h3_response_status(Conn, StreamId, <<>>))
+    after
+        ll_close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+%% Accumulate raw QUIC stream data on `StreamId` until the leading h3
+%% HEADERS frame is complete, then QPACK-decode it and return `:status`
+%% as an integer. Ignores frames on the server's control / QPACK streams.
+raw_h3_response_status(Conn, StreamId, Acc) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Bin, _Fin}} ->
+            Buf = <<Acc/binary, Bin/binary>>,
+            case quic_h3_frame:decode(Buf) of
+                {ok, {headers, Block}, _Rest} ->
+                    {ok, Hdrs} = quic_qpack:decode(Block),
+                    binary_to_integer(proplists:get_value(~":status", Hdrs));
+                {more, _} ->
+                    raw_h3_response_status(Conn, StreamId, Buf);
+                {error, Reason} ->
+                    ct:fail({h3_frame_decode_error, Reason})
+            end
+    after 5000 ->
+        ct:fail(no_h3_response)
+    end.
 
 protocols_tuple_form(_Config) ->
     Name = listener_name(protocols_tuple_form),

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -491,7 +491,10 @@ listener_rejects_invalid_http3_opt_test() ->
             #{listeners => 16#80000000},
             #{max_streams_bidi => 0},
             #{max_streams_bidi => 16#80000000},
-            #{max_streams_bidi => not_an_integer}
+            #{max_streams_bidi => not_an_integer},
+            #{max_field_section_size => 0},
+            #{max_field_section_size => 16#80000000},
+            #{max_field_section_size => not_an_integer}
         ]
     ).
 


### PR DESCRIPTION
# Description

Advertise `SETTINGS_MAX_FIELD_SECTION_SIZE` (RFC 9114 §7.2.4.1) on the h3 control stream so conformant clients self-limit, and enforce it: a request whose decoded field-section size (RFC 7541 §4.1) exceeds the cap gets `431` after QPACK decode. Symmetric with the h2 `max_header_list_size` sibling (#75). New `http3_max_field_section_size` opt, default `2 * max_header_block`.

QPACK runs static-table-only here (capacity 0), so there's no decoder state to desync on the reject path. The conformant `quic_h3` client self-limits to exactly the advertised value, so the 431 path is exercised by a raw non-conformant client over a plain QUIC stream (the same `quic_qpack`/`quic_h3_frame` codecs the server uses).

> An implementation that has received this parameter SHOULD NOT send an HTTP message header that exceeds the indicated size. (RFC 9114 §4.2.2)

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)