### PR TITLE
Answer OTP sys and gen messages in the streaming-response loops

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -245,30 +245,6 @@ variance). Eyeball-from-summary covers the v1 use case.
 **Scope:** medium. The parser, distribution stats, baseline storage, and
 presentation are the bulk; the artifact upload already ships.
 
-### Proper OTP citizenship in loop responses
-
-**What:** The h1 (`roadrunner_loop_response:info_loop/4`), h2
-(`roadrunner_http2_loop_response:info_loop/5`), and h3
-(`roadrunner_http3_stream_worker:info_loop/5`) loops all silently
-drop `{system, _, _}`, `{'$gen_call', _, _}`, and `{'$gen_cast', _}`
-messages. A more polite implementation would call
-`sys:handle_system_msg/6` on the system message, reply to gen-calls
-with `gen:reply(From, {error, not_supported})`, and so on.
-
-**Why deferred:** the conn (h1) and the h2/h3 stream workers are
-plain `proc_lib`-spawned loops, not `gen_*` behaviours, so the only
-path for these shapes to reach them is misuse (`gen_server:call(ConnPid, _)`
-or `sys:get_state(ConnPid)`). The current contract is "those calls
-appear to hang; the caller should expect to time out", documented
-in the `roadrunner_loop_response` moduledoc. Proper handling would
-make these calls observable (e.g. `sys:get_state/1` would return the
-loop state), which has debugging value but no functional fix.
-
-**Scope:** small. New helper `roadrunner_loop_sys` exporting a
-single `handle/3` (sys message, From, ProcessState) used from the
-h1, h2, and h3 info_loops. Tests covering sys/get_state, sys/replace_state,
-gen_call rejection, gen_cast no-op.
-
 ### h2 manual-mode body reading
 
 **What:** Parity with the h1 manual-mode body reader for h2 streams

--- a/rebar.config
+++ b/rebar.config
@@ -88,7 +88,12 @@
         {"test/roadrunner_http3_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_tls_tests.erl", unnecessary_function_arguments},
-        {"test/roadrunner_conn_tests.erl", unnecessary_function_arguments}
+        {"test/roadrunner_conn_tests.erl", unnecessary_function_arguments},
+        %% `sys` callbacks (`system_continue/3`, `system_terminate/4`) have a
+        %% fixed arity mandated by `sys:handle_system_msg/6`; there is no
+        %% `-behaviour(sys)` to tell hank the unused Parent/Debug args are
+        %% contractual, so its `unnecessary_function_arguments` rule flags them.
+        {"src/roadrunner_loop_sys.erl", unnecessary_function_arguments}
     ]}
 ]}.
 

--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -9,9 +9,10 @@
 %% h1: a handler's `self() ! Msg` and `register/2` calls from
 %% `handle/1` work because the worker IS the dispatch process. OTP
 %% shapes (`{system, _, _}`, `{'$gen_call', _, _}`, `{'$gen_cast', _}`)
-%% are silently dropped via dedicated receive clauses; we're a plain
-%% spawn, not a `gen_*`, so `gen_server:call/2,3` against the worker
-%% will time out instead of surfacing in `handle_info/3`.
+%% are answered via `roadrunner_loop_sys` rather than surfacing in
+%% `handle_info/3`: `sys:get_state/1` & friends work, and
+%% `gen_server:call/2,3` against the worker gets `{error, not_supported}`
+%% instead of hanging (see `roadrunner_loop_response` for the full contract).
 %%
 %% On `{stop, _NewState}` the worker emits an empty DATA frame with
 %% END_STREAM and returns; the conn cleans up the stream slot via the
@@ -53,9 +54,11 @@ info_loop(ConnPid, StreamId, Handler, Push, State) ->
             %% it. Stop looping rather than forwarding the reset to the
             %% handler's `handle_info/3` as if it were application data.
             ok;
-        {system, _, _} ->
-            info_loop(ConnPid, StreamId, Handler, Push, State);
-        {'$gen_call', _, _} ->
+        {system, From, Req} ->
+            Resume = fun(S) -> info_loop(ConnPid, StreamId, Handler, Push, S) end,
+            roadrunner_loop_sys:handle_system(Req, From, State, Resume);
+        {'$gen_call', From, _} ->
+            ok = roadrunner_loop_sys:gen_call_unsupported(From),
             info_loop(ConnPid, StreamId, Handler, Push, State);
         {'$gen_cast', _} ->
             info_loop(ConnPid, StreamId, Handler, Push, State);

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -373,18 +373,22 @@ send_loop(Conn, StreamId, Status, Headers, Handler, State) ->
     Push = fun(Data) -> loop_push(Conn, StreamId, Data) end,
     info_loop(Conn, StreamId, Handler, Push, State).
 
-%% OTP message shapes are dropped (we are a plain spawn, not a `gen_*`,
-%% so a `gen_server:call/2,3` against the worker times out rather than
-%% surfacing in `handle_info/3`); any other message is the handler's.
+%% OTP message shapes are answered via `roadrunner_loop_sys` rather than
+%% surfacing in `handle_info/3`: `sys:get_state/1` & friends work and a
+%% `gen_server:call/2,3` against the worker gets `{error, not_supported}`
+%% instead of hanging (see `roadrunner_loop_response` for the full
+%% contract); any other message is the handler's.
 -spec info_loop(pid(), non_neg_integer(), module(), roadrunner_handler:push_fun(), term()) -> ok.
 info_loop(Conn, StreamId, Handler, Push, State) ->
     receive
         {'DOWN', _MonRef, process, Conn, _Reason} ->
             %% Connection gone — stop looping.
             ok;
-        {system, _, _} ->
-            info_loop(Conn, StreamId, Handler, Push, State);
-        {'$gen_call', _, _} ->
+        {system, From, Req} ->
+            Resume = fun(S) -> info_loop(Conn, StreamId, Handler, Push, S) end,
+            roadrunner_loop_sys:handle_system(Req, From, State, Resume);
+        {'$gen_call', From, _} ->
+            ok = roadrunner_loop_sys:gen_call_unsupported(From),
             info_loop(Conn, StreamId, Handler, Push, State);
         {'$gen_cast', _} ->
             info_loop(Conn, StreamId, Handler, Push, State);

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -19,15 +19,16 @@
 %% ## Mailbox contract
 %%
 %% The conn is a plain `proc_lib`-spawned loop, not a `gen_*` behaviour,
-%% so it doesn't speak the OTP `sys` / `gen_call` / `gen_cast` protocols.
-%% The receive selectively skips those shapes (`{system, _, _}`,
-%% `{'$gen_call', _, _}`, `{'$gen_cast', _}`) so a misuse like
-%% `gen_server:call(ConnPid, _)` doesn't accidentally surface as an
-%% `handle_info/3` event to the user handler. Concretely:
+%% but it still answers the OTP message shapes (via `roadrunner_loop_sys`)
+%% so they don't leak to the user handler:
 %%
-%% - `sys:get_state/1`, `sys:trace/2`, `gen_server:call/2,3` and
-%%   friends against the conn process will appear to hang — the
-%%   caller should expect to time out.
+%% - `{system, _, _}` — `sys:get_state/1`, `sys:replace_state/2`,
+%%   `sys:get_status/1` and `sys:terminate/2` work (`get_state` returns the
+%%   handler state). Live tracing (`sys:trace`/`sys:log`) installs but emits
+%%   no events: the loop does not thread `sys:handle_debug/4` per message.
+%% - `{'$gen_call', _, _}` — replied `{error, not_supported}`, so
+%%   `gen_server:call(ConnPid, _)` fails fast instead of hanging.
+%% - `{'$gen_cast', _}` — a no-op (casts expect no reply).
 %% - Any other Erlang message reaches the handler's `handle_info/3`
 %%   verbatim. Handlers should pattern-match defensively (with a
 %%   catch-all clause) rather than crash on unexpected messages.
@@ -55,15 +56,12 @@ run(Socket, Status, UserHeaders, Handler, State) ->
     info_loop(Socket, Handler, Push, State).
 
 %% Selective receive on every Erlang message → handler:handle_info/3,
-%% **except** OTP-internal shapes (`{system, _, _}` for the `sys`
-%% protocol, `{'$gen_call', _, _}` and `{'$gen_cast', _}` for
-%% gen_server/gen_statem requests). Those would only reach the conn
-%% via misuse (the conn is a plain proc_lib loop, not a gen_*) and
-%% delivering them to the user handler would surface a confusing
-%% shape it has no reason to pattern-match on. Each OTP shape gets
-%% its own no-op clause that re-enters the loop; non-OTP messages
-%% fall through to the catch-all `Info` clause. On `{stop, _}` we
-%% emit the size-0 chunked terminator and return.
+%% **except** the OTP-internal shapes, which are answered via
+%% `roadrunner_loop_sys` rather than delivered to the user handler:
+%% `{system, _, _}` goes to the `sys` protocol handler, `{'$gen_call', _, _}`
+%% is replied `{error, not_supported}`, and `{'$gen_cast', _}` is a no-op.
+%% Non-OTP messages fall through to the catch-all `Info` clause. On
+%% `{stop, _}` we emit the size-0 chunked terminator and return.
 %%
 %% **No `after` clause:** the loop blocks indefinitely until the
 %% handler returns `{stop, _}` from `handle_info/3`. A handler that
@@ -74,9 +72,11 @@ run(Socket, Status, UserHeaders, Handler, State) ->
     ok.
 info_loop(Socket, Handler, Push, State) ->
     receive
-        {system, _, _} ->
-            info_loop(Socket, Handler, Push, State);
-        {'$gen_call', _, _} ->
+        {system, From, Req} ->
+            Resume = fun(S) -> info_loop(Socket, Handler, Push, S) end,
+            roadrunner_loop_sys:handle_system(Req, From, State, Resume);
+        {'$gen_call', From, _} ->
+            ok = roadrunner_loop_sys:gen_call_unsupported(From),
             info_loop(Socket, Handler, Push, State);
         {'$gen_cast', _} ->
             info_loop(Socket, Handler, Push, State);

--- a/src/roadrunner_loop_sys.erl
+++ b/src/roadrunner_loop_sys.erl
@@ -1,0 +1,73 @@
+-module(roadrunner_loop_sys).
+-moduledoc false.
+
+%% Shared OTP `sys` / `gen` message handling for the hand-written
+%% `{loop, ...}` streaming-response loops: h1 `roadrunner_loop_response`,
+%% h2 `roadrunner_http2_loop_response`, h3 `roadrunner_http3_stream_worker`.
+%% Those are plain `receive` loops, not `gen_*` behaviours, so they do not
+%% speak the OTP system protocol on their own. Each routes the OTP message
+%% shapes here so `sys:get_state/1`, `sys:replace_state/2`,
+%% `sys:get_status/1` and `sys:terminate/2` work, and a stray
+%% `gen_server:call/2,3` fails fast instead of hanging.
+%%
+%% The state ops (get_state, replace_state, get_status, terminate) work.
+%% `self()` is passed as the sys Parent: these loops are top-level processes
+%% with no OTP supervisor driving them over the sys protocol, and no
+%% supported op calls or links the Parent. Live tracing (`sys:trace` /
+%% `sys:log`) installs but emits no events, because the loops do not thread
+%% `sys:handle_debug/4` per message.
+
+-export([handle_system/4, gen_call_unsupported/1]).
+%% `sys` callbacks — invoked by `sys:handle_system_msg/6`, not called directly.
+-export([system_continue/3, system_terminate/4, system_get_state/1, system_replace_state/2]).
+
+%% Closure that re-enters the calling loop with a (possibly replaced)
+%% handler state. The loops return ok when the handler stops.
+-type resume() :: fun((State :: term()) -> ok).
+%% sys Misc payload: the loop resume closure paired with the handler state
+%% exposed via system_get_state/1.
+-type misc() :: {resume(), State :: term()}.
+
+%% Hand a received `{system, From, Req}` to the OTP system-message handler.
+%% This runs inline in the loop `receive`, so `self()` is the loop process
+%% and is used as the sys Parent (sound: no supported op calls or links it).
+%% On a state op `sys` calls `system_continue/3` (which resumes the loop via
+%% `Resume`); on terminate it calls `system_terminate/4`. The spec is
+%% `no_return()` to match `sys:handle_system_msg/6`; at runtime it returns
+%% `ok` once the resumed loop stops.
+-doc false.
+-spec handle_system(Req :: term(), From :: {pid(), term()}, State :: term(), resume()) ->
+    no_return().
+handle_system(Req, From, State, Resume) ->
+    sys:handle_system_msg(Req, From, self(), ?MODULE, [], {Resume, State}).
+
+%% Reply to a gen-call request so the caller fails fast rather than timing
+%% out: these loops implement no gen call protocol.
+-doc false.
+-spec gen_call_unsupported(From :: {pid(), term()}) -> ok.
+gen_call_unsupported(From) ->
+    gen:reply(From, {error, not_supported}).
+
+%% Resume the loop. Spec is `ok` (the loop returns when the handler stops),
+%% though the sys behaviour declares `no_return()` for gen_* loops that never
+%% return normally; we are not a `-behaviour(sys)`, so the narrower type holds.
+-doc false.
+-spec system_continue(pid(), [sys:dbg_opt()], misc()) -> ok.
+system_continue(_Parent, _Debug, {Resume, State}) ->
+    Resume(State).
+
+-doc false.
+-spec system_terminate(term(), pid(), [sys:dbg_opt()], misc()) -> no_return().
+system_terminate(Reason, _Parent, _Debug, _Misc) ->
+    exit(Reason).
+
+-doc false.
+-spec system_get_state(misc()) -> {ok, State :: term()}.
+system_get_state({_Resume, State}) ->
+    {ok, State}.
+
+-doc false.
+-spec system_replace_state(fun((term()) -> term()), misc()) -> {ok, term(), misc()}.
+system_replace_state(StateFun, {Resume, State}) ->
+    NState = StateFun(State),
+    {ok, NState, {Resume, NState}}.

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -942,15 +942,15 @@ loop_response_emits_data_then_closes_on_stop() ->
     cleanup(Pid, Ref).
 
 loop_response_filters_otp_messages() ->
-    %% sys / gen_call / gen_cast shapes must NOT reach `handle_info/3`.
-    %% The handler increments `N` only on `{push, _}`; if any OTP
-    %% message slipped through to handle_info the `bye(N)` chunk
-    %% would show a larger counter.
+    %% sys / gen_call / gen_cast shapes are answered (not delivered to
+    %% `handle_info/3`). The handler increments `N` only on `{push, _}`, so
+    %% the OTP shapes must not advance it: `sys:get_state/1` returns the
+    %% counter, a gen-call gets `{error, not_supported}`, a gen-cast no-ops.
     {Pid, Ref} = run_stream_request(~"/loop"),
     wait_for_register(roadrunner_h2_loop_test, 1000),
-    roadrunner_h2_loop_test ! {system, make_ref(), get_state},
-    roadrunner_h2_loop_test ! {'$gen_call', {self(), make_ref()}, ping},
-    roadrunner_h2_loop_test ! {'$gen_cast', whatever},
+    ?assertEqual(0, sys:get_state(roadrunner_h2_loop_test)),
+    ?assertEqual({error, not_supported}, gen_server:call(roadrunner_h2_loop_test, ping)),
+    ok = gen_server:cast(roadrunner_h2_loop_test, whatever),
     roadrunner_h2_loop_test ! {push, ~"real"},
     roadrunner_h2_loop_test ! stop,
     Frames = collect_response_frames(),

--- a/test/roadrunner_http2_loop_response_tests.erl
+++ b/test/roadrunner_http2_loop_response_tests.erl
@@ -61,6 +61,22 @@ sync_exits_on_stream_reset_test() ->
     end,
     FakeConn ! stop.
 
+%% --- OTP messages are answered, not delivered to the handler ---
+
+loop_answers_otp_messages_test() ->
+    %% `gen_server:call` gets `{error, not_supported}` (not a hang),
+    %% `sys:get_state/1` returns the loop state, and `gen_server:cast` is
+    %% a no-op that leaves the loop running.
+    {FakeConn, Worker} = spawn_loop([stop]),
+    ?assertEqual({error, not_supported}, gen_server:call(Worker, ping)),
+    ?assertEqual([stop], sys:get_state(Worker)),
+    ok = gen_server:cast(Worker, noop),
+    ?assertEqual([stop], sys:get_state(Worker)),
+    %% Drive the loop to stop so the worker exits cleanly.
+    Worker ! go,
+    ok = wait_for_exit(Worker, 1000),
+    FakeConn ! stop.
+
 %% --- helpers ---
 
 spawn_loop(Directives) ->

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -313,14 +313,16 @@ loop_response(Config) ->
     close(Conn).
 
 loop_filters_otp(Config) ->
-    %% OTP message shapes are dropped (never reach `handle_info/3`), so
-    %% only the real push advances the counter.
+    %% OTP message shapes are answered by `roadrunner_loop_sys` (not
+    %% delivered to `handle_info/3`), so only the real push advances the
+    %% counter: `sys:get_state/1` returns the loop counter, a gen-call
+    %% gets `{error, not_supported}`, and a gen-cast is a no-op.
     Conn = connect(?config(port, Config)),
     {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/loop")),
     Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
-    Worker ! {system, self(), get_state},
-    Worker ! {'$gen_call', {self(), make_ref()}, ping},
-    Worker ! {'$gen_cast', noop},
+    ?assertEqual(0, sys:get_state(Worker)),
+    ?assertEqual({error, not_supported}, gen_server:call(Worker, ping)),
+    ok = gen_server:cast(Worker, noop),
     Worker ! {push, ~"x"},
     Worker ! stop,
     {200, _Headers, Body} = collect(Conn, StreamId),

--- a/test/roadrunner_loop_response_tests.erl
+++ b/test/roadrunner_loop_response_tests.erl
@@ -18,11 +18,9 @@ handle_info(Msg, _Push, ProbePid) ->
 
 %% `info_loop/4` must NOT deliver `{system, _, _}`,
 %% `{'$gen_call', _, _}`, or `{'$gen_cast', _}` to the handler.
-%% Those shapes only reach the conn via misuse (the conn doesn't
-%% speak the OTP gen_* protocols) and surfacing them at
-%% `handle_info/3` would force handlers to defensively match on
-%% bytes they have no reason to handle. Skipped messages remain
-%% queued and are dropped when the conn exits.
+%% Those shapes are answered by `roadrunner_loop_sys` (the dedicated
+%% behaviour tests below cover the answers); the handler only ever sees
+%% the user-bound messages.
 loop_skips_otp_internal_messages_test() ->
     Tag = make_ref(),
     Self = self(),
@@ -51,6 +49,49 @@ loop_skips_otp_internal_messages_test() ->
     %% The handler must see the two user messages in order, and
     %% nothing else.
     ?assertEqual([user_msg_1, user_msg_2], Got).
+
+%% A `gen_server:call/2,3` against the loop replies `{error, not_supported}`
+%% instead of hanging.
+loop_gen_call_replies_not_supported_test() ->
+    {Worker, Ref} = start_loop_worker(some_state),
+    ?assertEqual({error, not_supported}, gen_server:call(Worker, ping)),
+    stop_loop_worker(Worker, Ref).
+
+%% `sys:get_state/1` returns the handler's loop state.
+loop_sys_get_state_returns_state_test() ->
+    {Worker, Ref} = start_loop_worker({loop_state, 42}),
+    ?assertEqual({loop_state, 42}, sys:get_state(Worker)),
+    stop_loop_worker(Worker, Ref).
+
+%% `sys:replace_state/2` swaps the loop state in place.
+loop_sys_replace_state_test() ->
+    {Worker, Ref} = start_loop_worker(0),
+    ?assertEqual(1, sys:replace_state(Worker, fun(N) -> N + 1 end)),
+    ?assertEqual(1, sys:get_state(Worker)),
+    stop_loop_worker(Worker, Ref).
+
+%% `sys:terminate/2` stops the loop with the given reason.
+loop_sys_terminate_stops_worker_test() ->
+    {Worker, Ref} = start_loop_worker(some_state),
+    ok = sys:terminate(Worker, shutdown),
+    receive
+        {'DOWN', Ref, process, Worker, shutdown} -> ok
+    after 1000 -> error(worker_not_terminated)
+    end.
+
+%% Spawn the loop in a monitored worker over a fake socket. No user
+%% messages are sent in the sys/gen tests, so the handler's forward
+%% logic is never exercised and the loop state can be any term.
+stop_loop_worker(Worker, Ref) ->
+    ok = sys:terminate(Worker, normal),
+    _ = erlang:demonitor(Ref, [flush]),
+    ok.
+
+start_loop_worker(State) ->
+    Sink = spawn_send_log_sink(self(), make_ref()),
+    spawn_monitor(fun() ->
+        roadrunner_loop_response:run({fake, Sink}, 200, [], ?MODULE, State)
+    end).
 
 collect_handler_msgs(Acc, Timeout) ->
     receive


### PR DESCRIPTION
# Description

The h1/h2/h3 `{loop, ...}` streaming-response loops dropped `{system,_,_}`, `{'$gen_call',_,_}` and `{'$gen_cast',_}`, so `sys:get_state/1` was blind and a stray `gen_server:call` hung. A shared `roadrunner_loop_sys` now routes them: `sys` get_state/replace_state/get_status/terminate work, gen-calls reply `{error, not_supported}`, gen-casts no-op. Observability/politeness only, no functional change for real requests.

`self()` is the sys Parent (these loops are top-level, with no OTP supervisor driving them over the sys protocol), so no conn-loop threading is needed. Live tracing installs but emits no events (the loops do not thread `sys:handle_debug/4` per message).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)