### PR TITLE
Cache connection config in the HTTP/1, HTTP/2 and HTTP/3 loop records

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -938,7 +938,7 @@ response_kind({_, _, _}) -> buffered.
 %% shapes (stream / loop) are left to the handler, matching h1 (which
 %% strips only buffered + sendfile). Used by the h2 / h3 workers, which
 %% otherwise have no method-aware response step — h1 handles HEAD
-%% directly in `dispatch_response/5`.
+%% directly in `dispatch_response/4`.
 -doc false.
 -spec head_response(roadrunner_handler:response(), binary()) -> roadrunner_handler:response().
 head_response({sendfile, Status, Headers, _Spec}, ~"HEAD") ->

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -34,9 +34,9 @@
     peer/1,
     try_acquire_slot/1,
     release_slot/1,
-    try_acquire_request_slot/1,
-    release_request_slot/1,
-    release_request_slots/2,
+    try_acquire_request_slot/2,
+    release_request_slot/2,
+    release_request_slots/3,
     consume_body_reader/2,
     join_drain_group/2,
     join_drain_group_for/2
@@ -278,29 +278,33 @@ unconfigured listener pays nothing on the hot path.
 Same eventually-consistent overshoot contract as `try_acquire_slot/1`: the
 `counters` ref uses `write_concurrency`, so a brief read slightly above the
 cap is possible before rollbacks reconcile, bounded by in-flight admissions.
-Paired with `release_request_slot/1`, which must run exactly once per
+Paired with `release_request_slot/2`, which must run exactly once per
 successfully-acquired worker (tie it to the worker monitor-ref removal so a
 worker is released by its `DOWN` or by the conn's clean exit, never both).
+
+The `Max` and `Counter` are cached on the connection loop record at setup so
+the per-stream path passes them directly instead of re-reading `proto_opts`.
 """.
--spec try_acquire_request_slot(proto_opts()) -> boolean().
-try_acquire_request_slot(#{max_concurrent_requests := infinity}) ->
+-spec try_acquire_request_slot(infinity | pos_integer(), counters:counters_ref() | undefined) ->
+    boolean().
+try_acquire_request_slot(infinity, _Counter) ->
     true;
-try_acquire_request_slot(#{inflight_counter := Ref, max_concurrent_requests := Max}) ->
-    ok = counters:add(Ref, 1, 1),
-    case counters:get(Ref, 1) of
+try_acquire_request_slot(Max, Counter) ->
+    ok = counters:add(Counter, 1, 1),
+    case counters:get(Counter, 1) of
         N when N =< Max ->
             true;
         _ ->
-            ok = counters:sub(Ref, 1, 1),
+            ok = counters:sub(Counter, 1, 1),
             false
     end.
 
--doc "Decrement the in-flight-request counter, paired with `try_acquire_request_slot/1`.".
--spec release_request_slot(proto_opts()) -> ok.
-release_request_slot(#{max_concurrent_requests := infinity}) ->
+-doc "Decrement the in-flight-request counter, paired with `try_acquire_request_slot/2`.".
+-spec release_request_slot(infinity | pos_integer(), counters:counters_ref() | undefined) -> ok.
+release_request_slot(infinity, _Counter) ->
     ok;
-release_request_slot(#{inflight_counter := Ref}) ->
-    ok = counters:sub(Ref, 1, 1),
+release_request_slot(_Max, Counter) ->
+    ok = counters:sub(Counter, 1, 1),
     ok.
 
 -doc """
@@ -309,13 +313,15 @@ account for stream workers still live at teardown (each held one slot), so
 their slots are not leaked until the listener restarts. `N = 0` and
 `infinity` are no-ops.
 """.
--spec release_request_slots(proto_opts(), non_neg_integer()) -> ok.
-release_request_slots(_ProtoOpts, 0) ->
+-spec release_request_slots(
+    infinity | pos_integer(), counters:counters_ref() | undefined, non_neg_integer()
+) -> ok.
+release_request_slots(_Max, _Counter, 0) ->
     ok;
-release_request_slots(#{max_concurrent_requests := infinity}, _N) ->
+release_request_slots(infinity, _Counter, _N) ->
     ok;
-release_request_slots(#{inflight_counter := Ref}, N) ->
-    ok = counters:sub(Ref, 1, N),
+release_request_slots(_Max, Counter, N) ->
+    ok = counters:sub(Counter, 1, N),
     ok.
 
 -doc false.

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -89,12 +89,23 @@
     req_id_buffer = <<>> :: binary(),
     %% Conn-stable values pulled from `proto_opts` once at `shoot`
     %% time so the per-request hot path doesn't re-`maps:get` them.
-    %% Saves ~5 hash lookups per request.
+    %% Saves ~8 hash lookups per request.
     requests_counter :: atomics:atomics_ref() | undefined,
     dispatch :: roadrunner_conn:dispatch() | undefined,
     middlewares = [] :: roadrunner_middleware:middleware_list(),
     max_content_length = 0 :: non_neg_integer(),
     max_keep_alive_requests = 1 :: pos_integer(),
+    %% Read-phase deadlines: `request_timeout` for the first request on a
+    %% fresh conn, `keep_alive_timeout` for keep-alive loop-backs. Picked
+    %% by `phase_timeout/1` per `phase`.
+    request_timeout = 0 :: non_neg_integer(),
+    keep_alive_timeout = 0 :: non_neg_integer(),
+    %% `auto` reads the full body synchronously; `manual` builds a
+    %% body_reader the handler pulls from. Drives `read_body_phase/3`.
+    body_buffering = auto :: auto | manual,
+    %% `proto_opts.hibernate_after`, or 0 when unset (the common case).
+    %% When > 0, `recv_request_bytes/2` takes the active+hibernate path.
+    hibernate_after = 0 :: non_neg_integer(),
     %% HTTP/1 inbound size limits as the
     %% `{max_request_line, max_header_line, max_header_block, max_header_count}`
     %% tuple `roadrunner_http1:parse_request/2` takes. Cached from the
@@ -174,6 +185,10 @@ awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
                         max_content_length = maps:get(max_content_length, ProtoOpts),
                         max_keep_alive_requests = maps:get(max_keep_alive_requests, ProtoOpts),
                         min_rate = maps:get(min_bytes_per_second, ProtoOpts),
+                        request_timeout = maps:get(request_timeout, ProtoOpts),
+                        keep_alive_timeout = maps:get(keep_alive_timeout, ProtoOpts),
+                        body_buffering = maps:get(body_buffering, ProtoOpts),
+                        hibernate_after = maps:get(hibernate_after, ProtoOpts, 0),
                         http1_limits = {
                             maps:get(http1_max_request_line, ProtoOpts, 8192),
                             maps:get(http1_max_header_line, ProtoOpts, 8192),
@@ -259,10 +274,10 @@ read_request_phase(#loop_state{buffered = Buf} = S) ->
 %% `keep_alive_timeout` (typically shorter — connections that have
 %% nothing to do drop faster).
 -spec phase_timeout(#loop_state{}) -> non_neg_integer().
-phase_timeout(#loop_state{phase = first, proto_opts = ProtoOpts}) ->
-    maps:get(request_timeout, ProtoOpts);
-phase_timeout(#loop_state{phase = keep_alive, proto_opts = ProtoOpts}) ->
-    maps:get(keep_alive_timeout, ProtoOpts).
+phase_timeout(#loop_state{phase = first, request_timeout = T}) ->
+    T;
+phase_timeout(#loop_state{phase = keep_alive, keep_alive_timeout = T}) ->
+    T.
 
 %% Drain-detection cap when in passive recv. Each `gen_tcp:recv` call
 %% is bounded to at most this many ms so the conn re-checks its
@@ -273,14 +288,11 @@ phase_timeout(#loop_state{phase = keep_alive, proto_opts = ProtoOpts}) ->
 -define(DRAIN_CHECK_INTERVAL_MS, 100).
 
 -spec recv_request_bytes(#loop_state{}, integer()) -> no_return().
+recv_request_bytes(#loop_state{hibernate_after = Ms} = S, Deadline) when Ms > 0 ->
+    arm_active_once(S),
+    recv_with_hibernate(S, Deadline, Ms);
 recv_request_bytes(S, Deadline) ->
-    case S#loop_state.proto_opts of
-        #{hibernate_after := Ms} when is_integer(Ms), Ms > 0 ->
-            arm_active_once(S),
-            recv_with_hibernate(S, Deadline, Ms);
-        #{} ->
-            recv_passive(S, Deadline)
-    end.
+    recv_passive(S, Deadline).
 
 %% Passive-mode recv path (default — `hibernate_after` unset or 0).
 %% Bypasses `gen_tcp_socket`'s gen_statem dispatch entirely — direct
@@ -513,20 +525,20 @@ handle_request_bytes(
 read_body_phase(
     #loop_state{
         socket = Socket,
-        proto_opts = ProtoOpts,
+        min_rate = MinRate,
+        body_buffering = BodyMode,
         max_content_length = MaxCL,
         http1_limits = {_ReqLine, MaxHdrLine, MaxHdrBlock, MaxHdrCount}
     } = S,
     Req,
     Deadline
 ) ->
-    MinRate = maps:get(min_bytes_per_second, ProtoOpts),
     Recv = roadrunner_conn:make_recv(Socket, Deadline, MinRate),
     Buffered = S#loop_state.buffered,
     %% Trailer headers (chunked bodies) obey the same caps as request
     %% headers; the request-line cap doesn't apply to a trailer block.
     TrailerLimits = {MaxHdrLine, MaxHdrBlock, MaxHdrCount},
-    case maps:get(body_buffering, ProtoOpts) of
+    case BodyMode of
         auto ->
             case roadrunner_conn:read_body(Req, Buffered, Recv, MaxCL, TrailerLimits) of
                 {ok, Body, Leftover} ->

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -106,6 +106,9 @@
     %% `proto_opts.hibernate_after`, or 0 when unset (the common case).
     %% When > 0, `recv_request_bytes/2` takes the active+hibernate path.
     hibernate_after = 0 :: non_neg_integer(),
+    %% Precomputed `Alt-Svc` value (h3 co-serving), or `undefined`.
+    %% Prepended to every response by `roadrunner_http:auto_headers/2`.
+    alt_svc = undefined :: binary() | undefined,
     %% HTTP/1 inbound size limits as the
     %% `{max_request_line, max_header_line, max_header_block, max_header_count}`
     %% tuple `roadrunner_http1:parse_request/2` takes. Cached from the
@@ -189,6 +192,7 @@ awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
                         keep_alive_timeout = maps:get(keep_alive_timeout, ProtoOpts),
                         body_buffering = maps:get(body_buffering, ProtoOpts),
                         hibernate_after = maps:get(hibernate_after, ProtoOpts, 0),
+                        alt_svc = maps:get(alt_svc, ProtoOpts, undefined),
                         http1_limits = {
                             maps:get(http1_max_request_line, ProtoOpts, 8192),
                             maps:get(http1_max_header_line, ProtoOpts, 8192),
@@ -586,7 +590,7 @@ read_body_phase(
 %% pipeline, run it bracketed by request_start / request_stop |
 %% request_exception telemetry. The 5 response shapes (buffered,
 %% stream, loop, sendfile, websocket) dispatch to their respective
-%% writers via `dispatch_response/5`.
+%% writers via `dispatch_response/4`.
 -spec dispatch_phase(#loop_state{}, roadrunner_req:request()) -> no_return().
 dispatch_phase(
     #loop_state{
@@ -614,9 +618,7 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     try Pipeline(Req) of
         {Response, Req2} when is_map(Req2) ->
-            _ = dispatch_response(
-                Socket, Handler, Req2, Response, S#loop_state.buffered, S#loop_state.proto_opts
-            ),
+            _ = dispatch_response(S, Handler, Req2, Response),
             ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
                 status => roadrunner_conn:response_status(Response),
                 response_kind => roadrunner_conn:response_kind(Response)
@@ -647,45 +649,52 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
 %% sendfile / websocket force connection close (the underlying
 %% writers manage their own keep-alive semantics — generally none).
 -spec dispatch_response(
-    roadrunner_transport:socket(),
+    #loop_state{},
     module(),
     roadrunner_req:request(),
-    roadrunner_handler:response(),
-    binary(),
-    roadrunner_conn:proto_opts()
+    roadrunner_handler:response()
 ) -> ok.
-dispatch_response(Socket, _Handler, Req, {websocket, Mod, State}, Buffered, ProtoOpts) when
+dispatch_response(
+    #loop_state{socket = Socket, buffered = Buffered, proto_opts = ProtoOpts},
+    _Handler,
+    Req,
+    {websocket, Mod, State}
+) when
     is_atom(Mod)
 ->
     ok = roadrunner_ws_session:run(Socket, Req, Mod, State, Buffered, ProtoOpts),
     ok;
 dispatch_response(
-    Socket, _Handler, _Req, {stream, Status, Headers0, Fun}, _Buffered, ProtoOpts
+    #loop_state{socket = Socket, alt_svc = AltSvc},
+    _Handler,
+    _Req,
+    {stream, Status, Headers0, Fun}
 ) when
     is_function(Fun, 1)
 ->
-    Headers = roadrunner_http:auto_headers(Headers0, ProtoOpts),
+    Headers = roadrunner_http:auto_headers(Headers0, AltSvc),
     _ = roadrunner_stream_response:run(Socket, Status, Headers, Fun),
     ok;
 dispatch_response(
-    Socket, Handler, _Req, {loop, Status, Headers0, LoopState}, _Buffered, ProtoOpts
+    #loop_state{socket = Socket, alt_svc = AltSvc},
+    Handler,
+    _Req,
+    {loop, Status, Headers0, LoopState}
 ) when
     is_integer(Status)
 ->
-    Headers = roadrunner_http:auto_headers(Headers0, ProtoOpts),
+    Headers = roadrunner_http:auto_headers(Headers0, AltSvc),
     _ = roadrunner_loop_response:run(Socket, Status, Headers, Handler, LoopState),
     ok;
 dispatch_response(
-    Socket,
+    #loop_state{socket = Socket, alt_svc = AltSvc},
     _Handler,
     Req,
-    {sendfile, Status, Headers0, {Filename, Offset, Length}},
-    _Buffered,
-    ProtoOpts
+    {sendfile, Status, Headers0, {Filename, Offset, Length}}
 ) when
     is_integer(Status)
 ->
-    Headers = roadrunner_http:auto_headers(Headers0, ProtoOpts),
+    Headers = roadrunner_http:auto_headers(Headers0, AltSvc),
     Head = roadrunner_http1:response(Status, Headers, ~""),
     _ = roadrunner_telemetry:response_send(
         roadrunner_transport:send(Socket, Head), sendfile_response_head
@@ -720,20 +729,28 @@ dispatch_response(
 %% function head and emit the response with an empty body. Free
 %% pattern-match dispatch (no `maps:get(method, _)` per response).
 dispatch_response(
-    Socket, _Handler, #{method := ~"HEAD"}, {Status, Headers0, _Body}, _Buffered, ProtoOpts
+    #loop_state{socket = Socket, alt_svc = AltSvc},
+    _Handler,
+    #{method := ~"HEAD"},
+    {Status, Headers0, _Body}
 ) when
     is_integer(Status)
 ->
-    Headers = roadrunner_http:auto_headers(Headers0, ProtoOpts),
+    Headers = roadrunner_http:auto_headers(Headers0, AltSvc),
     Resp = roadrunner_http1:response(Status, Headers, ~""),
     _ = roadrunner_telemetry:response_send(
         roadrunner_transport:send(Socket, Resp), buffered_response
     ),
     ok;
-dispatch_response(Socket, _Handler, _Req, {Status, Headers0, Body}, _Buffered, ProtoOpts) when
+dispatch_response(
+    #loop_state{socket = Socket, alt_svc = AltSvc},
+    _Handler,
+    _Req,
+    {Status, Headers0, Body}
+) when
     is_integer(Status)
 ->
-    Headers = roadrunner_http:auto_headers(Headers0, ProtoOpts),
+    Headers = roadrunner_http:auto_headers(Headers0, AltSvc),
     Resp = roadrunner_http1:response(Status, Headers, Body),
     _ = roadrunner_telemetry:response_send(
         roadrunner_transport:send(Socket, Resp), buffered_response

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -228,6 +228,10 @@
     %% When > 0 and no streams are in flight, the idle-wait path parks
     %% for this window and hibernates. Read from proto_opts at `enter/5`.
     hibernate_after = 0 :: non_neg_integer(),
+    %% Precomputed `Alt-Svc` value (h3 co-serving), or `undefined`.
+    %% Prepended to every response by `roadrunner_http:auto_headers/2`.
+    %% Read from proto_opts at `enter/5`.
+    alt_svc = undefined :: binary() | undefined,
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -283,6 +287,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
     MaxHeaderListSize = maps:get(http2_max_header_list_size, ProtoOpts, 2 * MaxHeaderBlock),
     MaxContentLength = maps:get(max_content_length, ProtoOpts, ?DEFAULT_MAX_CONTENT_LENGTH),
     HibernateAfter = maps:get(hibernate_after, ProtoOpts, 0),
+    AltSvc = maps:get(alt_svc, ProtoOpts, undefined),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -302,7 +307,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         max_header_block = MaxHeaderBlock,
         max_header_list_size = MaxHeaderListSize,
         max_content_length = MaxContentLength,
-        hibernate_after = HibernateAfter
+        hibernate_after = HibernateAfter,
+        alt_svc = AltSvc
     },
     handshake(State).
 
@@ -1292,7 +1298,7 @@ encode_and_send_headers(
     %% h2 path matches h1's `encode_headers/1` discipline.
     ok = validate_headers(Headers),
     AllHeaders =
-        [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.proto_opts)],
+        [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     %% `frame:encode` accepts iodata for the header block — skip
     %% the upfront flatten; ssl:send walks the iolist anyway.
@@ -1330,7 +1336,7 @@ encode_and_send_response_atomic(
     %% or split at an h2->h1 reverse proxy.
     ok = validate_headers(Headers),
     AllHeaders =
-        [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.proto_opts)],
+        [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     HFrame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04, undefined, HpackBlock}

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -224,6 +224,10 @@
     %% advertised in our SETTINGS and enforced after HPACK decode in
     %% `finalize_headers/2`. Read from proto_opts at `enter/5`.
     max_header_list_size = ?DEFAULT_MAX_HEADER_LIST_SIZE :: pos_integer(),
+    %% `proto_opts.hibernate_after`, or 0 when unset (the common case).
+    %% When > 0 and no streams are in flight, the idle-wait path parks
+    %% for this window and hibernates. Read from proto_opts at `enter/5`.
+    hibernate_after = 0 :: non_neg_integer(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -278,6 +282,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
     %% so raising `max_header_block` for big headers lifts both gates together.
     MaxHeaderListSize = maps:get(http2_max_header_list_size, ProtoOpts, 2 * MaxHeaderBlock),
     MaxContentLength = maps:get(max_content_length, ProtoOpts, ?DEFAULT_MAX_CONTENT_LENGTH),
+    HibernateAfter = maps:get(hibernate_after, ProtoOpts, 0),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -296,7 +301,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         max_concurrent_streams = MaxStreams,
         max_header_block = MaxHeaderBlock,
         max_header_list_size = MaxHeaderListSize,
-        max_content_length = MaxContentLength
+        max_content_length = MaxContentLength,
+        hibernate_after = HibernateAfter
     },
     handshake(State).
 
@@ -474,13 +480,10 @@ recv_more(
 %% active, where worker messages are imminent and hibernating would be
 %% pointless.
 -spec recv_timeout(#loop{}) -> non_neg_integer().
-recv_timeout(#loop{streams = Streams, proto_opts = ProtoOpts}) when
-    map_size(Streams) =:= 0
+recv_timeout(#loop{streams = Streams, hibernate_after = Ms}) when
+    map_size(Streams) =:= 0, Ms > 0
 ->
-    case ProtoOpts of
-        #{hibernate_after := Ms} when is_integer(Ms), Ms > 0 -> Ms;
-        _ -> idle_timeout()
-    end;
+    Ms;
 recv_timeout(_State) ->
     idle_timeout().
 
@@ -491,15 +494,10 @@ recv_timeout(_State) ->
 %% frame — or any worker / `'DOWN'` / drain message — wakes us and
 %% `recv_more_hib/1` resumes the loop. Otherwise emit the idle GOAWAY.
 -spec recv_idle_expired(#loop{}) -> no_return().
-recv_idle_expired(#loop{streams = Streams, proto_opts = ProtoOpts} = State) when
-    map_size(Streams) =:= 0
+recv_idle_expired(#loop{streams = Streams, hibernate_after = Ms} = State) when
+    map_size(Streams) =:= 0, Ms > 0
 ->
-    case ProtoOpts of
-        #{hibernate_after := Ms} when is_integer(Ms), Ms > 0 ->
-            erlang:hibernate(?MODULE, recv_more_hib, [State]);
-        _ ->
-            idle_goaway(State)
-    end;
+    erlang:hibernate(?MODULE, recv_more_hib, [State]);
 recv_idle_expired(State) ->
     idle_goaway(State).
 

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -232,6 +232,12 @@
     %% Prepended to every response by `roadrunner_http:auto_headers/2`.
     %% Read from proto_opts at `enter/5`.
     alt_svc = undefined :: binary() | undefined,
+    %% In-flight-request slot accounting (cross-listener cap). `infinity`
+    %% (default) disables it; `inflight_counter` is the shared gauge.
+    %% Read from proto_opts at `enter/5` so the per-stream acquire/release
+    %% passes them to `roadrunner_conn` directly. See `dispatch_stream/2`.
+    max_concurrent_requests = infinity :: infinity | pos_integer(),
+    inflight_counter :: counters:counters_ref() | undefined,
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -288,6 +294,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
     MaxContentLength = maps:get(max_content_length, ProtoOpts, ?DEFAULT_MAX_CONTENT_LENGTH),
     HibernateAfter = maps:get(hibernate_after, ProtoOpts, 0),
     AltSvc = maps:get(alt_svc, ProtoOpts, undefined),
+    MaxConcReq = maps:get(max_concurrent_requests, ProtoOpts, infinity),
+    InflightCounter = maps:get(inflight_counter, ProtoOpts, undefined),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -308,7 +316,9 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         max_header_list_size = MaxHeaderListSize,
         max_content_length = MaxContentLength,
         hibernate_after = HibernateAfter,
-        alt_svc = AltSvc
+        alt_svc = AltSvc,
+        max_concurrent_requests = MaxConcReq,
+        inflight_counter = InflightCounter
     },
     handshake(State).
 
@@ -1078,7 +1088,9 @@ dispatch_stream(
         proto_opts = ProtoOpts,
         peer = Peer,
         scheme = Scheme,
-        listener_name = ListenerName
+        listener_name = ListenerName,
+        max_concurrent_requests = MaxConcReq,
+        inflight_counter = InflightCounter
     } = State
 ) ->
     #{
@@ -1104,7 +1116,7 @@ dispatch_stream(
             },
             case roadrunner_http2_request:from_headers(Headers, BodyIolist, RequestContext) of
                 {ok, Req} ->
-                    case roadrunner_conn:try_acquire_request_slot(ProtoOpts) of
+                    case roadrunner_conn:try_acquire_request_slot(MaxConcReq, InflightCounter) of
                         true ->
                             {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
                                 self(), StreamId, Req, ProtoOpts
@@ -1261,7 +1273,9 @@ handle_worker_down(#loop{worker_refs = Refs} = State, MonRef, Reason) ->
             %% Release the in-flight slot exactly once, tied to removing the
             %% worker ref so a worker is accounted for by its `DOWN` here or
             %% by the conn's clean exit, never both.
-            ok = roadrunner_conn:release_request_slot(State#loop.proto_opts),
+            ok = roadrunner_conn:release_request_slot(
+                State#loop.max_concurrent_requests, State#loop.inflight_counter
+            ),
             State1 = State#loop{worker_refs = maps:remove(MonRef, Refs)},
             case Reason of
                 normal -> remove_stream(State1, StreamId);
@@ -1572,7 +1586,9 @@ reset_stream(#loop{streams = Streams, worker_refs = Refs} = State, StreamId) ->
                 %% `DOWN` fires) and drop its ref here, so this is the only
                 %% place that can release the slot — `handle_worker_down`
                 %% never runs and `exit_clean` no longer sees the ref.
-                ok = roadrunner_conn:release_request_slot(State#loop.proto_opts),
+                ok = roadrunner_conn:release_request_slot(
+                    State#loop.max_concurrent_requests, State#loop.inflight_counter
+                ),
                 maps:remove(MonRef, Refs)
         end,
     State#loop{
@@ -1743,7 +1759,9 @@ exit_clean(#loop{
     listener_name = ListenerName,
     peer = Peer,
     start_mono = StartMono,
-    worker_refs = Refs
+    worker_refs = Refs,
+    max_concurrent_requests = MaxConcReq,
+    inflight_counter = InflightCounter
 }) ->
     roadrunner_telemetry:listener_conn_close(StartMono, #{
         listener_name => ListenerName,
@@ -1753,7 +1771,7 @@ exit_clean(#loop{
     %% Account for any stream workers still live at teardown (each holds one
     %% in-flight slot). Workers whose `DOWN` already fired were removed from
     %% `worker_refs`, so this releases each remaining worker exactly once.
-    ok = roadrunner_conn:release_request_slots(ProtoOpts, map_size(Refs)),
+    ok = roadrunner_conn:release_request_slots(MaxConcReq, InflightCounter, map_size(Refs)),
     ok = roadrunner_conn:release_slot(ProtoOpts),
     ok = roadrunner_transport:close(Socket),
     exit(normal).

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -135,7 +135,13 @@
     %% (so conformant clients self-limit, §4.2.2) and enforced after QPACK
     %% decode in `dispatch_request/2`. Read from proto_opts; defaults to
     %% `2 * max_header_block`.
-    max_field_section_size = ?DEFAULT_MAX_FIELD_SECTION_SIZE :: pos_integer()
+    max_field_section_size = ?DEFAULT_MAX_FIELD_SECTION_SIZE :: pos_integer(),
+    %% In-flight-request slot accounting (cross-listener cap). `infinity`
+    %% (default) disables it; `inflight_counter` is the shared gauge. Read
+    %% from proto_opts at `init/2` so the per-stream acquire/release passes
+    %% them to `roadrunner_conn` directly. See `dispatch_decoded/3`.
+    max_concurrent_requests = infinity :: infinity | pos_integer(),
+    inflight_counter :: counters:counters_ref() | undefined
 }).
 
 -doc """
@@ -196,7 +202,9 @@ init(Conn, ProtoOpts) ->
         %% cap, so raising `max_header_block` lifts both gates together.
         max_field_section_size = maps:get(
             http3_max_field_section_size, ProtoOpts, 2 * MaxHeaderBlock
-        )
+        ),
+        max_concurrent_requests = maps:get(max_concurrent_requests, ProtoOpts, infinity),
+        inflight_counter = maps:get(inflight_counter, ProtoOpts, undefined)
     }).
 
 -spec loop(#h3{}) -> ok.
@@ -748,7 +756,11 @@ dispatch_decoded(#h3{streams = Streams} = State, StreamId, Headers, Body) ->
             %% stream error H3_MESSAGE_ERROR.
             reset_and_drop(State1, StreamId, ?H3_MESSAGE_ERROR);
         {ok, Req} ->
-            case roadrunner_conn:try_acquire_request_slot(State1#h3.proto_opts) of
+            case
+                roadrunner_conn:try_acquire_request_slot(
+                    State1#h3.max_concurrent_requests, State1#h3.inflight_counter
+                )
+            of
                 true ->
                     {_WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
                         State1#h3.conn, StreamId, Req, State1#h3.proto_opts
@@ -781,7 +793,9 @@ handle_worker_down(#h3{worker_refs = WorkerRefs} = State, MonRef, Reason) ->
     %% Release the in-flight slot exactly once, tied to removing the worker
     %% ref so it is accounted for by this `DOWN` or by the conn's clean
     %% exit, never both.
-    ok = roadrunner_conn:release_request_slot(State#h3.proto_opts),
+    ok = roadrunner_conn:release_request_slot(
+        State#h3.max_concurrent_requests, State#h3.inflight_counter
+    ),
     State1 = State#h3{worker_refs = WorkerRefs1},
     case Reason of
         normal ->
@@ -827,7 +841,9 @@ terminate(#h3{
     listener_name = ListenerName,
     peer = Peer,
     start_mono = StartMono,
-    worker_refs = Refs
+    worker_refs = Refs,
+    max_concurrent_requests = MaxConcReq,
+    inflight_counter = InflightCounter
 }) ->
     ok = roadrunner_telemetry:listener_conn_close(StartMono, #{
         listener_name => ListenerName,
@@ -837,5 +853,5 @@ terminate(#h3{
     %% Account for any stream workers still live at teardown (each holds one
     %% in-flight slot); workers whose `DOWN` already fired were removed from
     %% `worker_refs`, so this releases each remaining worker exactly once.
-    ok = roadrunner_conn:release_request_slots(ProtoOpts, map_size(Refs)),
+    ok = roadrunner_conn:release_request_slots(MaxConcReq, InflightCounter, map_size(Refs)),
     ok = roadrunner_conn:release_slot(ProtoOpts).

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -93,23 +93,24 @@ with_date(Headers) ->
 Inject the framework's automatic response headers for an HTTP/1 or
 HTTP/2 (TCP) response: `Date` always (RFC 9110 §6.6.1) plus `Alt-Svc`
 advertising the listener's HTTP/3 endpoint (RFC 7838) when it co-serves
-h3 on a fixed port (`proto_opts` carries the precomputed value only
-then). HTTP/3 responses use `with_date/1` directly — a client already
-on h3 needs no Alt-Svc.
+h3 on a fixed port. The caller passes the precomputed `Alt-Svc` value
+(cached on the connection loop record), or `undefined` when no h3 is
+co-served. HTTP/3 responses use `with_date/1` directly — a client
+already on h3 needs no Alt-Svc.
 """.
--spec auto_headers(headers(), map()) -> headers().
-auto_headers(Headers, ProtoOpts) ->
-    with_alt_svc(with_date(Headers), ProtoOpts).
+-spec auto_headers(headers(), binary() | undefined) -> headers().
+auto_headers(Headers, AltSvc) ->
+    with_alt_svc(with_date(Headers), AltSvc).
 
 %% Prepend the precomputed `Alt-Svc` value when the listener co-serves
-%% h3 — `proto_opts` carries `alt_svc` only then. `Alt-Svc` is
-%% list-valued (RFC 7838 §3 / RFC 9110 §5.3), so it composes with any
-%% handler-set value; no de-dup needed (unlike the singular `Date`).
--spec with_alt_svc(headers(), map()) -> headers().
-with_alt_svc(Headers, #{alt_svc := Value}) ->
-    [{~"alt-svc", Value} | Headers];
-with_alt_svc(Headers, #{}) ->
-    Headers.
+%% h3 — `undefined` otherwise. `Alt-Svc` is list-valued (RFC 7838 §3 /
+%% RFC 9110 §5.3), so it composes with any handler-set value; no de-dup
+%% needed (unlike the singular `Date`).
+-spec with_alt_svc(headers(), binary() | undefined) -> headers().
+with_alt_svc(Headers, undefined) ->
+    Headers;
+with_alt_svc(Headers, AltSvc) ->
+    [{~"alt-svc", AltSvc} | Headers].
 
 %% RFC 7541 §4.1: the uncompressed size of a header list is the sum over
 %% its fields of `byte_size(Name) + byte_size(Value) + 32`. This is the

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -3,7 +3,7 @@
 
 %% Per-connection `{loop, ...}` response — message-driven streaming.
 %%
-%% Called by `roadrunner_conn_loop:dispatch_response/5` after a handler
+%% Called by `roadrunner_conn_loop:dispatch_response/4` after a handler
 %% returns `{loop, Status, Headers, State}`. Writes the status line +
 %% chunked headers, then runs a recursive selective-receive loop that
 %% dispatches every Erlang message through `Module:handle_info/3`. The

--- a/src/roadrunner_stream_response.erl
+++ b/src/roadrunner_stream_response.erl
@@ -3,7 +3,7 @@
 
 %% Per-connection `{stream, ...}` response — chunked Transfer-Encoding.
 %%
-%% Called by `roadrunner_conn_loop:dispatch_response/5` after a handler returns
+%% Called by `roadrunner_conn_loop:dispatch_response/4` after a handler returns
 %% `{stream, Status, Headers, Fun}`. Writes the status line + chunked
 %% headers, then calls the user's `Fun(Send)` with a `Send/2` callback
 %% that frames each emission as one chunk on the wire.

--- a/test/roadrunner_conn_loop_sendfile_handler.erl
+++ b/test/roadrunner_conn_loop_sendfile_handler.erl
@@ -1,7 +1,7 @@
 -module(roadrunner_conn_loop_sendfile_handler).
 -moduledoc """
 Test fixture — emits a `{sendfile, ...}` response covering
-`roadrunner_conn_loop:dispatch_response/5`'s sendfile clause. The
+`roadrunner_conn_loop:dispatch_response/4`'s sendfile clause. The
 file path is read from the request's `state` (set by the
 single-handler dispatch helper that stashes state there) or from
 `persistent_term` under `{?MODULE, file}`.

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1066,7 +1066,7 @@ request_start_and_stop_pair_with_shared_request_id_test() ->
 
 head_method_buffered_response_omits_body_test() ->
     %% RFC 9110 §9.3.2 — HEAD must NOT include a message body even
-    %% when the handler returns one. The dispatch_response/5 fast
+    %% when the handler returns one. The dispatch_response/4 fast
     %% path in conn_loop pattern-matches on `method := ~"HEAD"` and
     %% forces the body to `~""`. Headers (including content-length)
     %% stay as-is so the framing matches what GET would have returned.
@@ -1180,7 +1180,7 @@ sendfile_response_writes_head_then_body_test() ->
 
 sendfile_response_skips_body_for_head_method_test() ->
     %% RFC 9110 §9.3.2 — HEAD must not include a message body.
-    %% Covers the `~"HEAD"` branch of dispatch_response/5's sendfile clause.
+    %% Covers the `~"HEAD"` branch of dispatch_response/4's sendfile clause.
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
@@ -1216,7 +1216,7 @@ sendfile_response_skips_body_for_head_method_test() ->
 sendfile_dispatch_closes_socket_on_error_test() ->
     %% Sendfile responses honor keep-alive (per finishing_phase/3), so a
     %% mid-write failure would otherwise leave the conn idling for a
-    %% truncated request the client will never send. dispatch_response/5
+    %% truncated request the client will never send. dispatch_response/4
     %% must force-close the socket on `roadrunner_transport:sendfile/4`
     %% errors so the keep-alive loop sees `closed` on its next recv and
     %% the conn exits normally.

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -2172,42 +2172,39 @@ parse_error_status_other_is_400_test() ->
     ?assertEqual(400, roadrunner_conn:parse_error_status(missing_host)).
 
 %% =============================================================================
-%% try_acquire_request_slot/1 + release_request_slot[s] — pure unit tests
+%% try_acquire_request_slot/2 + release_request_slot[s] — pure unit tests
 %% =============================================================================
 
 request_slot_infinity_is_noop_test() ->
-    %% `infinity` short-circuits before touching any counter, so the map
-    %% needs no `inflight_counter`. Acquire always succeeds; release is a
+    %% `infinity` short-circuits before touching any counter, so the counter
+    %% ref is irrelevant (`undefined`). Acquire always succeeds; release is a
     %% no-op.
-    Opts = #{max_concurrent_requests => infinity},
-    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
-    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
-    ?assertEqual(ok, roadrunner_conn:release_request_slot(Opts)),
-    ?assertEqual(ok, roadrunner_conn:release_request_slots(Opts, 5)).
+    ?assert(roadrunner_conn:try_acquire_request_slot(infinity, undefined)),
+    ?assert(roadrunner_conn:try_acquire_request_slot(infinity, undefined)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slot(infinity, undefined)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(infinity, undefined, 5)).
 
 request_slot_admits_up_to_cap_then_refuses_test() ->
     Ref = counters:new(1, [write_concurrency]),
-    Opts = #{max_concurrent_requests => 2, inflight_counter => Ref},
     %% Two admits up to the cap, the third is refused and rolls back so the
     %% gauge stays at the cap.
-    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
-    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
-    ?assertNot(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assert(roadrunner_conn:try_acquire_request_slot(2, Ref)),
+    ?assert(roadrunner_conn:try_acquire_request_slot(2, Ref)),
+    ?assertNot(roadrunner_conn:try_acquire_request_slot(2, Ref)),
     ?assertEqual(2, counters:get(Ref, 1)),
     %% Releasing one frees a slot; the next acquire succeeds again.
-    ?assertEqual(ok, roadrunner_conn:release_request_slot(Opts)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slot(2, Ref)),
     ?assertEqual(1, counters:get(Ref, 1)),
-    ?assert(roadrunner_conn:try_acquire_request_slot(Opts)),
+    ?assert(roadrunner_conn:try_acquire_request_slot(2, Ref)),
     ?assertEqual(2, counters:get(Ref, 1)).
 
 request_slot_release_many_test() ->
     Ref = counters:new(1, [write_concurrency]),
-    Opts = #{max_concurrent_requests => 10, inflight_counter => Ref},
-    [?assert(roadrunner_conn:try_acquire_request_slot(Opts)) || _ <- lists:seq(1, 4)],
+    [?assert(roadrunner_conn:try_acquire_request_slot(10, Ref)) || _ <- lists:seq(1, 4)],
     ?assertEqual(4, counters:get(Ref, 1)),
     %% Bulk release (conn teardown with N live workers) drops the gauge by N;
     %% N = 0 is a no-op.
-    ?assertEqual(ok, roadrunner_conn:release_request_slots(Opts, 0)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 0)),
     ?assertEqual(4, counters:get(Ref, 1)),
-    ?assertEqual(ok, roadrunner_conn:release_request_slots(Opts, 4)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 4)),
     ?assertEqual(0, counters:get(Ref, 1)).


### PR DESCRIPTION
# Description

Finishes hoisting connection-stable config out of the per-request and per-stream hot paths into the connection loop records, so the steady state pattern-matches cached fields instead of re-reading `proto_opts` every time. Covers HTTP/1 (request/keep-alive timeouts, body buffering, `hibernate_after`, `alt_svc`), HTTP/2 (`hibernate_after`, `alt_svc`, request-slot counters), and HTTP/3 (request-slot counters); `roadrunner_http:auto_headers/2` and the `roadrunner_conn` request-slot helpers now take the resolved values directly.

This is a consistency change, not a measurable throughput win: the reads it removes are O(1) map probes already in the preferred pattern-match idiom, so any delta sits inside bench variance.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
