### PR TITLE
Sync rebar.lock on Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,9 +6,6 @@
     ":pinDevDependencies",
     ":pinDigestsDisabled"
   ],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "matchFileNames": [".github/**/*.yml", ".tool-versions"],

--- a/.github/workflows/rebar-lock.yml
+++ b/.github/workflows/rebar-lock.yml
@@ -1,0 +1,93 @@
+---
+name: Update rebar.lock
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch: {}
+  merge_group:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  branch:
+    outputs:
+      head_ref: ${{steps.branch.outputs.head_ref}}
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - id: branch
+        run: |
+          head_ref=${GITHUB_HEAD_REF}
+          echo "head_ref is ${head_ref}"
+          echo "head_ref=${head_ref}" > "${GITHUB_OUTPUT}"
+
+  update:
+    name: Update rebar.lock
+
+    needs: [branch]
+
+    if: endsWith(needs.branch.outputs.head_ref, 'rebar.config-deps')
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{vars.ARIZONA_BOT_APP_ID}}
+          private-key: ${{secrets.ARIZONA_BOT_PRIVATE_KEY}}
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{steps.app-token.outputs.token}}
+          ref: ${{needs.branch.outputs.head_ref}}
+
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24
+        id: setup-beam
+        with:
+          version-type: strict
+          version-file: .tool-versions
+
+      - name: Restore _build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: _build
+          key: "_build-cache-for\
+            -os-${{runner.os}}\
+            -otp-${{steps.setup-beam.outputs.otp-version}}\
+            -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
+            -hash-${{hashFiles('rebar.lock')}}-${{hashFiles('rebar.config')}}"
+
+      - name: Restore rebar3's cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/rebar3
+          key: "rebar3-cache-for\
+            -os-${{runner.os}}\
+            -otp-${{steps.setup-beam.outputs.otp-version}}\
+            -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
+            -hash-${{hashFiles('rebar.lock')}}-${{hashFiles('rebar.config')}}"
+
+      - run: |
+          rebar3 upgrade --all
+          if ! git diff --exit-code >/dev/null; then
+              # there's stuff to push
+              git config user.name "arizona[bot]"
+              git config user.email "arizona_bot_@user.noreply.github.com"
+              git add rebar.lock
+              git commit -m "[automation] update \`rebar.lock\` after Renovate"
+              git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# Description

Renovate's regex manager bumps `rebar.config` but can't regenerate `rebar.lock`. This adds the Arizona `rebar-lock.yml` job that runs `rebar3 upgrade --all` on Renovate PR branches and pushes the synced lock, and drops the now-dead `lockFileMaintenance` setting.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
