### PR TITLE
Cache the HTTP Date header per process, not in persistent_term

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -274,6 +274,28 @@ grammar enforcement is callers-write-bugs ergonomics, not security.
 
 **Scope:** small per attribute. Add when a real caller hits the gap.
 
+### Static-file metadata cache in persistent_term — small
+
+**What:** `roadrunner_static` caches each file's `{Size, Mtime, Expiry}` in
+`persistent_term` keyed by path (opt-in via `cache_ttl_ms`). Move it to a
+named `read_concurrency` ETS table owned by a small supervised process.
+
+**Why deferred:** off by default and bounded by the docroot in practice, so
+it is hygiene, not a hot-path fix. But `persistent_term` is the wrong store
+for runtime-mutated, per-key-unbounded data: each `cache_put` is a global
+heap scan (only a problem with a short TTL over many hot files), entries
+never evict (one key per file served, until `cache_clear/0` or restart), and
+`cache_clear/0` walks every term on the node. ETS gives cheap writes, native
+eviction, and an O(1) clear. (The `Date` header cache moved to a per-process
+dictionary for the same "wrong store for mutable data" reason; static-meta is
+read across requests so it needs a shared store, hence ETS rather than the
+dictionary.)
+
+**Scope:** small. Add the table owner under `roadrunner_sup`, swap the
+`persistent_term` calls in `cache_get/1` / `cache_put/4` / `cache_clear/0`,
+and start the owner in the eunit setup so the cache tests still drive the
+table directly.
+
 ## Per-route framework knobs the map shape unlocks
 
 The map-shape route entry (`#{path => ..., handler => ..., state =>

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -26,8 +26,6 @@ The request map shape lives in `roadrunner_req` alongside the
 accessors that operate on it.
 """.
 
--on_load(init_cache/0).
-
 -export([http_date_now/0, format_http_date/1, with_date/1, auto_headers/2]).
 -export([header_list_size/1]).
 
@@ -56,22 +54,26 @@ Built via direct bit-syntax binary construction rather than
 exact widths and the day/month abbreviations) and this function
 runs on the response hot path.
 
-Cached via `persistent_term` keyed by the current Posix second:
-the formatted binary is identical for every request that lands in
-the same second, so we recompute it only when the second ticks
-over. Updates are racy on the second boundary (multiple processes
-may put the same value), but each put writes the same binary so
-the race is benign.
+Cached per process in the process dictionary, keyed by the current
+Posix second: the formatted binary is identical for every response
+a process emits within the same second, so we recompute it only when
+the second ticks over. Per-process rather than via `persistent_term`
+because the value changes every second, and a `persistent_term:put`
+that frequent forces a global scan of every process heap on the
+response hot path; the per-process cache pays a cheap dictionary read
+instead, and reformats at most once per second per process: once per
+connection on h1/h2, once per request on h3 (its stream workers are
+per-request).
 """.
 -spec http_date_now() -> binary().
 http_date_now() ->
     Now = erlang:system_time(second),
-    case persistent_term:get(?DATE_CACHE_KEY, undefined) of
+    case get(?DATE_CACHE_KEY) of
         {Now, Bin} ->
             Bin;
         _ ->
             Bin = format_http_date(Now),
-            persistent_term:put(?DATE_CACHE_KEY, {Now, Bin}),
+            _ = put(?DATE_CACHE_KEY, {Now, Bin}),
             Bin
     end.
 
@@ -146,11 +148,3 @@ format_http_date(Posix) ->
 -spec pad2(0..99) -> binary().
 pad2(N) when N < 10 -> <<$0, ($0 + N)>>;
 pad2(N) -> integer_to_binary(N).
-
-%% `-on_load` callback. Pre-populate the date cache so the very first
-%% `http_date_now/0` call after module load is a hit, not a miss.
--spec init_cache() -> ok.
-init_cache() ->
-    Now = erlang:system_time(second),
-    persistent_term:put(?DATE_CACHE_KEY, {Now, format_http_date(Now)}),
-    ok.

--- a/test/roadrunner_http_tests.erl
+++ b/test/roadrunner_http_tests.erl
@@ -34,6 +34,28 @@ http_date_now_format_matches_imf_fixdate_test() ->
         ])
     ).
 
+http_date_now_caches_per_process_test_() ->
+    %% Run in a fresh process so the dictionary starts empty: the first
+    %% read takes the reformat (miss) branch, and a same-second second
+    %% read takes the cached (hit) branch. `same_second_pair/0` retries
+    %% across a second boundary so the hit assertion is deterministic.
+    {spawn, fun() ->
+        %% Cold dictionary => miss branch.
+        First = roadrunner_http:http_date_now(),
+        ?assertEqual(29, byte_size(First)),
+        {A, B} = same_second_pair(),
+        ?assertEqual(A, B)
+    end}.
+
+same_second_pair() ->
+    S0 = erlang:system_time(second),
+    A = roadrunner_http:http_date_now(),
+    B = roadrunner_http:http_date_now(),
+    case erlang:system_time(second) of
+        S0 -> {A, B};
+        _ -> same_second_pair()
+    end.
+
 format_http_date_pads_single_digits_test() ->
     %% Pick a timestamp whose calendar fields all need two-digit padding
     %% (1970-01-01 00:00:00 UTC = Posix 0) so the `pad2/1` single-digit


### PR DESCRIPTION
# Description

The once-per-second `Date` refresh lived in `persistent_term`, whose `put` runs a global scan of every process heap, so that scan landed on the response hot path. The formatted value is constant within a second, so this caches it per process (process dictionary) keyed by the current second: a cheap local read, reformatting at most once per second. Not a throughput change; it removes the periodic global scan and the h1/h2 read drops from ~17ns to ~6ns (h3 workers are per-request, so they reformat per request, ~220ns, fine on h3's heavier path).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
