### PR TITLE
Stop stress.escript crashing when --profile-min-ms is an integer

### DIFF
--- a/scripts/stress.escript
+++ b/scripts/stress.escript
@@ -91,7 +91,7 @@ with_optional_profile(#{profile := true}, Fun) ->
 maybe_print_profile(#{profile := false}) ->
     ok;
 maybe_print_profile(#{profile := true, profile_min_ms := MinMs}) ->
-    io:format("profile (eprof, total time, rows >= ~.2f ms)~n", [MinMs]),
+    io:format("profile (eprof, total time, rows >= ~.2f ms)~n", [float(MinMs)]),
     %% eprof's analyze prints to whatever was set via log/1; pipe to a
     %% temp file so we can trim out the chatty per-process headers and
     %% keep only the totals table.


### PR DESCRIPTION
# Description

The eprof hotspot-table header formats the threshold with `~.2f`, which rejects a non-float, and getopt hands back a bare integer for `--profile-min-ms 8`. Coerce with `float/1` at the format call so an integer argument works.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
