### PR TITLE
Destructure h1 telemetry metadata in one match instead of per-key maps:get

### DIFF
--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -839,13 +839,24 @@ drain_body_if_manual(_Req) ->
     {ok, <<>>}.
 
 -spec telemetry_metadata(roadrunner_req:request()) -> roadrunner_telemetry:metadata().
-telemetry_metadata(Req) ->
+telemetry_metadata(
     #{
-        request_id => maps:get(request_id, Req),
-        peer => maps:get(peer, Req),
-        method => maps:get(method, Req),
-        path => maps:get(target, Req),
-        scheme => maps:get(scheme, Req),
+        request_id := RequestId,
+        peer := Peer,
+        method := Method,
+        target := Target,
+        scheme := Scheme
+    } = Req
+) ->
+    %% Destructure the five always-present keys in one match instead of
+    %% a `maps:get/2` each (matching the h2/h3 builders); `listener_name`
+    %% keeps its defaulted lookup since it is optional in the request map.
+    #{
+        request_id => RequestId,
+        peer => Peer,
+        method => Method,
+        path => Target,
+        scheme => Scheme,
         listener_name => maps:get(listener_name, Req, undefined)
     }.
 


### PR DESCRIPTION
# Description

The h1 `telemetry_metadata/1` builder was the lone straggler still doing one `maps:get` per key, while the h2 and h3 builders already destructure the request map in a single match; this brings h1 in line. Microbench (same input/output, interleaved): ~30ns/op down to ~14ns/op, a stable ~2.2x per-call drop. `listener_name` keeps its defaulted lookup since it is optional in the request map.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
