### PR TITLE
Fix stress.escript h2 listener ALPN by setting protocols instead of a bogus key

### DIFF
--- a/scripts/stress.escript
+++ b/scripts/stress.escript
@@ -339,7 +339,7 @@ listener_opts(#{protocol := h2, cert_dir := CertDir}) ->
             {certfile, CertDir ++ "/cert.pem"},
             {keyfile, CertDir ++ "/key.pem"}
         ],
-        http2_enabled => true,
+        protocols => [http2],
         routes => roadrunner_keepalive_handler,
         keep_alive_timeout => 60000,
         max_clients => 100000,


### PR DESCRIPTION
# Description

The h2 stress listener was configured with `http2_enabled => true`, which is not a roadrunner listener option, so it was silently ignored: the listener stayed `protocols => [http1]`, advertised only `http/1.1` in ALPN, and h2 clients got a fatal "no application protocol" alert. Setting `protocols => [http2]` lets ALPN negotiate h2, so `--protocol h2` now serves (140k req/s locally) instead of failing every handshake.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
