### PR TITLE
Move the static-file metadata cache from persistent_term to ETS

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -274,28 +274,6 @@ grammar enforcement is callers-write-bugs ergonomics, not security.
 
 **Scope:** small per attribute. Add when a real caller hits the gap.
 
-### Static-file metadata cache in persistent_term — small
-
-**What:** `roadrunner_static` caches each file's `{Size, Mtime, Expiry}` in
-`persistent_term` keyed by path (opt-in via `cache_ttl_ms`). Move it to a
-named `read_concurrency` ETS table owned by a small supervised process.
-
-**Why deferred:** off by default and bounded by the docroot in practice, so
-it is hygiene, not a hot-path fix. But `persistent_term` is the wrong store
-for runtime-mutated, per-key-unbounded data: each `cache_put` is a global
-heap scan (only a problem with a short TTL over many hot files), entries
-never evict (one key per file served, until `cache_clear/0` or restart), and
-`cache_clear/0` walks every term on the node. ETS gives cheap writes, native
-eviction, and an O(1) clear. (The `Date` header cache moved to a per-process
-dictionary for the same "wrong store for mutable data" reason; static-meta is
-read across requests so it needs a shared store, hence ETS rather than the
-dictionary.)
-
-**Scope:** small. Add the table owner under `roadrunner_sup`, swap the
-`persistent_term` calls in `cache_get/1` / `cache_put/4` / `cache_clear/0`,
-and start the owner in the eunit setup so the cache tests still drive the
-table directly.
-
 ## Per-route framework knobs the map shape unlocks
 
 The map-shape route entry (`#{path => ..., handler => ..., state =>

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -593,6 +593,11 @@ time, but every subsequent dispatch sees the new table.
 Returns `ok` on success or `{error, no_routes}` if the listener was
 started in single-handler mode (`routes => Module` or no `routes`
 opt) — there's no router table to reload.
+
+Each call performs one global `persistent_term` swap, which scans every
+process heap to reclaim the old table. That cost is acceptable for a
+whole-table swap at deploy time, but callers should batch route changes
+into a single `reload_routes/2` rather than calling it per route.
 """.
 -spec reload_routes(Name :: atom(), roadrunner_router:routes()) ->
     ok | {error, no_routes}.

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -86,15 +86,12 @@ under an `infinity` (or long) TTL.
 
 -define(COMMA_CP_KEY, {?MODULE, comma_cp}).
 -define(DASH_CP_KEY, {?MODULE, dash_cp}).
-%% Node-global ETS table owned by `roadrunner_static_cache`.
--define(CACHE_TABLE, roadrunner_static_meta).
 
 %% Caching is opt-in: default is `0` (disabled). See `## Metadata cache`
 %% in the moduledoc above for when to enable and the trade-offs.
 -define(DEFAULT_CACHE_TTL_MS, 0).
 
 -export([handle/1, cache_clear/0]).
--export([cache_get/1, cache_put/4]).
 
 -define(MIME_TYPES, #{
     ~".html" => ~"text/html; charset=utf-8",
@@ -133,13 +130,10 @@ Drop every cached static-file metadata entry. Pair with
 `cache_ttl_ms => infinity` (or any TTL longer than your deploy
 cycle) to flush stale metadata after replacing files in the
 docroot, without restarting the listener.
-
-Clears the static-meta ETS table in one call (`ets:delete_all_objects/1`).
 """.
 -spec cache_clear() -> ok.
 cache_clear() ->
-    true = ets:delete_all_objects(?CACHE_TABLE),
-    ok.
+    roadrunner_static_cache:clear().
 
 -spec serve_file(
     file:filename_all(), non_neg_integer() | infinity, roadrunner_req:request()
@@ -154,15 +148,15 @@ serve_file(FilePath, TtlMs, Req) ->
 
 %% Cache-aware regular-file metadata lookup. Returns `miss` when the
 %% TTL is non-positive (caching disabled) or when no fresh entry is in
-%% the cache. `infinity` falls through to `cache_get/1` and stays a hit
-%% until the listener restarts. Symlinks always bypass the cache
-%% because the policy gate needs the un-followed `read_link_info` result.
+%% the cache. `infinity` entries stay a hit until cleared. Symlinks
+%% always bypass the cache because the policy gate needs the un-followed
+%% `read_link_info` result.
 -spec cached_lookup(file:filename_all(), non_neg_integer() | infinity) ->
     {ok, non_neg_integer(), integer()} | miss.
 cached_lookup(_FilePath, TtlMs) when is_integer(TtlMs), TtlMs =< 0 ->
     miss;
 cached_lookup(FilePath, _TtlMs) ->
-    cache_get(FilePath).
+    roadrunner_static_cache:lookup(FilePath).
 
 %% Stat the file, populate the cache when applicable, and dispatch on
 %% the file type. Mirrors the original `serve_file/2` body. Used on
@@ -187,56 +181,13 @@ fresh_lookup(FilePath, TtlMs, Req) ->
             roadrunner_resp:not_found()
     end.
 
-%% Read a cached `{Size, Mtime}` for `FilePath` if the entry is still
-%% within its TTL. Returns `miss` if absent or expired. The `infinity`
-%% sentinel in `ExpiresAt` is for entries that never expire (set via
-%% `cache_ttl_ms => infinity`); for those, every read is a hit until
-%% `cache_clear/0` or a node restart. Exported so the eunit suite can
-%% drive the cache directly.
--doc false.
--spec cache_get(file:filename_all()) ->
-    {ok, non_neg_integer(), integer()} | miss.
-cache_get(FilePath) ->
-    case ets:lookup(?CACHE_TABLE, FilePath) of
-        [] ->
-            miss;
-        [{_, {Size, Mtime, infinity}}] ->
-            {ok, Size, Mtime};
-        [{_, {Size, Mtime, ExpiresAt}}] ->
-            case erlang:monotonic_time(millisecond) of
-                Now when Now =< ExpiresAt ->
-                    {ok, Size, Mtime};
-                _ ->
-                    %% Drop the expired row so stale entries don't pile
-                    %% up — cheap in ETS, unlike a persistent_term erase.
-                    true = ets:delete(?CACHE_TABLE, FilePath),
-                    miss
-            end
-    end.
-
-%% Store `{Size, Mtime}` for `FilePath` with a TTL of `TtlMs` ms from
-%% now, or forever when `TtlMs` is `infinity`. The entry is keyed by
-%% absolute path; concurrent inserts for the same path are last-writer-
-%% wins (each `ets:insert` is atomic per key). Exported for direct
-%% eunit coverage.
--doc false.
--spec cache_put(file:filename_all(), non_neg_integer(), integer(), pos_integer() | infinity) ->
-    ok.
-cache_put(FilePath, Size, Mtime, infinity) ->
-    true = ets:insert(?CACHE_TABLE, {FilePath, {Size, Mtime, infinity}}),
-    ok;
-cache_put(FilePath, Size, Mtime, TtlMs) when is_integer(TtlMs), TtlMs > 0 ->
-    ExpiresAt = erlang:monotonic_time(millisecond) + TtlMs,
-    true = ets:insert(?CACHE_TABLE, {FilePath, {Size, Mtime, ExpiresAt}}),
-    ok.
-
 -spec maybe_cache_put(
     file:filename_all(), non_neg_integer(), integer(), non_neg_integer() | infinity
 ) -> ok.
 maybe_cache_put(_FilePath, _Size, _Mtime, TtlMs) when is_integer(TtlMs), TtlMs =< 0 ->
     ok;
 maybe_cache_put(FilePath, Size, Mtime, TtlMs) ->
-    cache_put(FilePath, Size, Mtime, TtlMs).
+    roadrunner_static_cache:store(FilePath, Size, Mtime, TtlMs).
 
 %% Read leaf-stat after the symlink-policy gate has approved follow.
 -spec serve_followed_file(file:filename_all(), roadrunner_req:request()) ->

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -55,7 +55,7 @@ directories are still followed by the kernel.
 ## Metadata cache
 
 `#{cache_ttl_ms => N}` caches the `stat` result (size, mtime) for
-each regular file in `persistent_term` for `N` milliseconds. Hot
+each regular file in a node-global ETS table for `N` milliseconds. Hot
 paths skip the per-request `read_link_info` syscall after the
 first hit. Symlinks always bypass the cache because the policy
 gate needs the un-followed lookup.
@@ -86,7 +86,8 @@ under an `infinity` (or long) TTL.
 
 -define(COMMA_CP_KEY, {?MODULE, comma_cp}).
 -define(DASH_CP_KEY, {?MODULE, dash_cp}).
--define(META_CACHE_KEY(FilePath), {roadrunner_static_meta, FilePath}).
+%% Node-global ETS table owned by `roadrunner_static_cache`.
+-define(CACHE_TABLE, roadrunner_static_meta).
 
 %% Caching is opt-in: default is `0` (disabled). See `## Metadata cache`
 %% in the moduledoc above for when to enable and the trade-offs.
@@ -133,23 +134,11 @@ Drop every cached static-file metadata entry. Pair with
 cycle) to flush stale metadata after replacing files in the
 docroot, without restarting the listener.
 
-Walks `persistent_term:get/0` once to find the static-meta keys —
-cheap on small caches, O(N) over **all** persistent_term entries
-on a busy node. Intended for occasional, deploy-time use, not a
-per-request hot path.
+Clears the static-meta ETS table in one call (`ets:delete_all_objects/1`).
 """.
 -spec cache_clear() -> ok.
 cache_clear() ->
-    lists:foreach(
-        fun
-            ({{roadrunner_static_meta, _Path} = K, _V}) ->
-                _ = persistent_term:erase(K),
-                ok;
-            (_) ->
-                ok
-        end,
-        persistent_term:get()
-    ),
+    true = ets:delete_all_objects(?CACHE_TABLE),
     ok.
 
 -spec serve_file(
@@ -202,40 +191,43 @@ fresh_lookup(FilePath, TtlMs, Req) ->
 %% within its TTL. Returns `miss` if absent or expired. The `infinity`
 %% sentinel in `ExpiresAt` is for entries that never expire (set via
 %% `cache_ttl_ms => infinity`); for those, every read is a hit until
-%% the listener restarts. Exported so the eunit suite can drive the
-%% cache directly.
+%% `cache_clear/0` or a node restart. Exported so the eunit suite can
+%% drive the cache directly.
 -doc false.
 -spec cache_get(file:filename_all()) ->
     {ok, non_neg_integer(), integer()} | miss.
 cache_get(FilePath) ->
-    case persistent_term:get(?META_CACHE_KEY(FilePath), undefined) of
-        undefined ->
+    case ets:lookup(?CACHE_TABLE, FilePath) of
+        [] ->
             miss;
-        {Size, Mtime, infinity} ->
+        [{_, {Size, Mtime, infinity}}] ->
             {ok, Size, Mtime};
-        {Size, Mtime, ExpiresAt} ->
+        [{_, {Size, Mtime, ExpiresAt}}] ->
             case erlang:monotonic_time(millisecond) of
                 Now when Now =< ExpiresAt ->
                     {ok, Size, Mtime};
                 _ ->
+                    %% Drop the expired row so stale entries don't pile
+                    %% up — cheap in ETS, unlike a persistent_term erase.
+                    true = ets:delete(?CACHE_TABLE, FilePath),
                     miss
             end
     end.
 
 %% Store `{Size, Mtime}` for `FilePath` with a TTL of `TtlMs` ms from
 %% now, or forever when `TtlMs` is `infinity`. The entry is keyed by
-%% absolute path; concurrent puts for the same path are idempotent
-%% under the eventual-consistency semantics of `persistent_term`.
-%% Exported for direct eunit coverage.
+%% absolute path; concurrent inserts for the same path are last-writer-
+%% wins (each `ets:insert` is atomic per key). Exported for direct
+%% eunit coverage.
 -doc false.
 -spec cache_put(file:filename_all(), non_neg_integer(), integer(), pos_integer() | infinity) ->
     ok.
 cache_put(FilePath, Size, Mtime, infinity) ->
-    persistent_term:put(?META_CACHE_KEY(FilePath), {Size, Mtime, infinity}),
+    true = ets:insert(?CACHE_TABLE, {FilePath, {Size, Mtime, infinity}}),
     ok;
 cache_put(FilePath, Size, Mtime, TtlMs) when is_integer(TtlMs), TtlMs > 0 ->
     ExpiresAt = erlang:monotonic_time(millisecond) + TtlMs,
-    persistent_term:put(?META_CACHE_KEY(FilePath), {Size, Mtime, ExpiresAt}),
+    true = ets:insert(?CACHE_TABLE, {FilePath, {Size, Mtime, ExpiresAt}}),
     ok.
 
 -spec maybe_cache_put(

--- a/src/roadrunner_static_cache.erl
+++ b/src/roadrunner_static_cache.erl
@@ -1,19 +1,24 @@
 -module(roadrunner_static_cache).
 -moduledoc false.
 
-%% Owner process for the node-global static-file metadata cache table.
+%% Owner and API for the node-global static-file metadata cache.
 %%
 %% `roadrunner_static` caches each served file's `{Size, Mtime, Expiry}`
-%% (opt-in via the `cache_ttl_ms` route option). The table is a public
-%% named ETS table so any connection/worker process can read and write
-%% it directly off the request path: reads copy a tiny 3-tuple, writes
-%% are process-local and cheap, and expiry can delete the row. This
-%% process exists only to create and own the table; it dies cleanly on
+%% (opt-in via the `cache_ttl_ms` route option) so hot paths skip the
+%% per-request `read_link_info` syscall. This module owns the backing
+%% store and exposes `lookup/1` / `store/4` / `clear/0`; callers never
+%% see the representation.
+%%
+%% The store is a public named ETS table, so `lookup`/`store`/`clear`
+%% run in the CALLER process (no message round-trip): reads and writes
+%% stay cheap and concurrent off the request path, which a single owner
+%% process serializing every write could not provide. This process
+%% exists only to create and own the table; it dies cleanly on
 %% shutdown, taking the table with it.
 
 -behaviour(gen_server).
 
--export([start_link/0]).
+-export([start_link/0, lookup/1, store/4, clear/0]).
 -export([init/1, handle_call/3, handle_cast/2]).
 
 -define(TABLE, roadrunner_static_meta).
@@ -21,6 +26,44 @@
 -spec start_link() -> gen_server:start_ret().
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% Read the cached size and mtime for FilePath if it is still within its
+%% TTL. An infinity entry is always a hit; an expired entry is dropped
+%% (cheap in ETS) and reported as a miss.
+-spec lookup(file:filename_all()) -> {ok, non_neg_integer(), integer()} | miss.
+lookup(FilePath) ->
+    case ets:lookup(?TABLE, FilePath) of
+        [] ->
+            miss;
+        [{_, {Size, Mtime, infinity}}] ->
+            {ok, Size, Mtime};
+        [{_, {Size, Mtime, ExpiresAt}}] ->
+            case erlang:monotonic_time(millisecond) of
+                Now when Now =< ExpiresAt ->
+                    {ok, Size, Mtime};
+                _ ->
+                    true = ets:delete(?TABLE, FilePath),
+                    miss
+            end
+    end.
+
+%% Store the size and mtime for FilePath with a TTL of TtlMs ms from now,
+%% or forever when TtlMs is infinity. Concurrent stores for the same path
+%% are last-writer-wins (each insert is atomic per key).
+-spec store(file:filename_all(), non_neg_integer(), integer(), pos_integer() | infinity) -> ok.
+store(FilePath, Size, Mtime, infinity) ->
+    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, infinity}}),
+    ok;
+store(FilePath, Size, Mtime, TtlMs) when is_integer(TtlMs), TtlMs > 0 ->
+    ExpiresAt = erlang:monotonic_time(millisecond) + TtlMs,
+    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ExpiresAt}}),
+    ok.
+
+%% Drop every cached entry in one call.
+-spec clear() -> ok.
+clear() ->
+    true = ets:delete_all_objects(?TABLE),
+    ok.
 
 -spec init([]) -> {ok, undefined}.
 init([]) ->

--- a/src/roadrunner_static_cache.erl
+++ b/src/roadrunner_static_cache.erl
@@ -1,0 +1,38 @@
+-module(roadrunner_static_cache).
+-moduledoc false.
+
+%% Owner process for the node-global static-file metadata cache table.
+%%
+%% `roadrunner_static` caches each served file's `{Size, Mtime, Expiry}`
+%% (opt-in via the `cache_ttl_ms` route option). The table is a public
+%% named ETS table so any connection/worker process can read and write
+%% it directly off the request path: reads copy a tiny 3-tuple, writes
+%% are process-local and cheap, and expiry can delete the row. This
+%% process exists only to create and own the table; it dies cleanly on
+%% shutdown, taking the table with it.
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2]).
+
+-define(TABLE, roadrunner_static_meta).
+
+-spec start_link() -> gen_server:start_ret().
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec init([]) -> {ok, undefined}.
+init([]) ->
+    _ = ets:new(?TABLE, [
+        named_table, public, set, {read_concurrency, true}, {write_concurrency, true}
+    ]),
+    {ok, undefined}.
+
+-spec handle_call(term(), gen_server:from(), State) -> {reply, ok, State}.
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+-spec handle_cast(term(), State) -> {noreply, State}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.

--- a/src/roadrunner_sup.erl
+++ b/src/roadrunner_sup.erl
@@ -17,11 +17,11 @@ start_link() ->
 
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
-    %% Listeners are added dynamically via roadrunner:start_listener/2 — the
-    %% only static child is `pg`'s default scope, which `roadrunner_conn`
-    %% joins so `roadrunner_listener:drain/2` can find conns to notify.
-    %% one_for_one isolates per-listener crashes; pg only restarts on
-    %% its own crash, which is a true protocol break.
+    %% Listeners are added dynamically via roadrunner:start_listener/2. The
+    %% static children are `pg`'s default scope (which `roadrunner_conn` joins
+    %% so `roadrunner_listener:drain/2` can find conns to notify) and the
+    %% static-file metadata cache table owner. one_for_one isolates per-listener
+    %% crashes; the static children only restart on their own crash.
     SupFlags = #{
         strategy => one_for_one,
         intensity => 5,
@@ -35,6 +35,14 @@ init([]) ->
         shutdown => 5000,
         modules => [pg]
     },
-    {ok, {SupFlags, [PgScope]}}.
+    StaticCache = #{
+        id => roadrunner_static_cache,
+        start => {roadrunner_static_cache, start_link, []},
+        type => worker,
+        restart => permanent,
+        shutdown => 5000,
+        modules => [roadrunner_static_cache]
+    },
+    {ok, {SupFlags, [PgScope, StaticCache]}}.
 
 %% internal functions

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -487,22 +487,14 @@ cache_helpers_test_() ->
                     roadrunner_static:cache_get(FilePath)
                 )
             end},
-            {"cache_clear/0 drops every static-meta entry", fun() ->
+            {"cache_clear/0 drops every cached entry", fun() ->
                 F1 = filename:join(Dir, "clear_a.txt"),
                 F2 = filename:join(Dir, "clear_b.txt"),
-                Sentinel = {?MODULE, cache_clear_sentinel},
                 ok = roadrunner_static:cache_put(F1, 10, 1700000000, infinity),
                 ok = roadrunner_static:cache_put(F2, 20, 1700000000, 60000),
-                %% A non-static persistent_term entry must NOT be erased.
-                ok = persistent_term:put(Sentinel, kept),
-                try
-                    ok = roadrunner_static:cache_clear(),
-                    ?assertEqual(miss, roadrunner_static:cache_get(F1)),
-                    ?assertEqual(miss, roadrunner_static:cache_get(F2)),
-                    ?assertEqual(kept, persistent_term:get(Sentinel))
-                after
-                    _ = persistent_term:erase(Sentinel)
-                end
+                ok = roadrunner_static:cache_clear(),
+                ?assertEqual(miss, roadrunner_static:cache_get(F1)),
+                ?assertEqual(miss, roadrunner_static:cache_get(F2))
             end}
         ]
     end}.
@@ -516,7 +508,7 @@ cache_populated_after_request_test_() ->
                 %% The handler builds FilePath from `Dir` + binary segments
                 %% so the resulting cache key is a binary; match that here.
                 FilePath = filename:join([Dir, ~"cached.txt"]),
-                _ = persistent_term:erase({roadrunner_static_meta, FilePath}),
+                ok = roadrunner_static:cache_clear(),
                 ?assertEqual(miss, roadrunner_static:cache_get(FilePath)),
                 _Reply = http_get(Port, ~"/static/cached.txt"),
                 ?assertMatch({ok, _Size, _Mtime}, roadrunner_static:cache_get(FilePath))
@@ -538,16 +530,41 @@ cache_populated_after_request_test_() ->
     end}.
 
 cache_default_off_test_() ->
-    {setup, fun setup/0, fun cleanup/1, fun({Dir, Port}) ->
-        {"default cache_ttl_ms is 0; nothing is cached", fun() ->
-            FilePath = filename:join([Dir, ~"hello.html"]),
-            _ = persistent_term:erase({roadrunner_static_meta, FilePath}),
-            _Reply = http_get(Port, ~"/static/hello.html"),
-            ?assertEqual(miss, roadrunner_static:cache_get(FilePath))
+    {setup,
+        fun() ->
+            ok = start_static_cache(),
+            setup()
+        end,
+        fun(X) ->
+            cleanup(X),
+            ok = stop_static_cache()
+        end,
+        fun({Dir, Port}) ->
+            {"default cache_ttl_ms is 0; nothing is cached", fun() ->
+                FilePath = filename:join([Dir, ~"hello.html"]),
+                ok = roadrunner_static:cache_clear(),
+                _Reply = http_get(Port, ~"/static/hello.html"),
+                ?assertEqual(miss, roadrunner_static:cache_get(FilePath))
+            end}
+        end}.
+
+%% Cover the static-cache owner's gen_server callbacks (init is covered by
+%% the start in the cache setups; the call/cast clauses are not otherwise
+%% exercised). The sync call after the cast guarantees the cast was
+%% processed (so handle_cast actually ran) before the assertion.
+static_cache_owner_test_() ->
+    {setup, fun() -> ok = start_static_cache() end, fun(_) -> ok = stop_static_cache() end, [
+        {"handle_call replies ok", fun() ->
+            ?assertEqual(ok, gen_server:call(roadrunner_static_cache, ping))
+        end},
+        {"handle_cast is accepted", fun() ->
+            ok = gen_server:cast(roadrunner_static_cache, noop),
+            ?assertEqual(ok, gen_server:call(roadrunner_static_cache, sync))
         end}
-    end}.
+    ]}.
 
 cache_helpers_setup() ->
+    ok = start_static_cache(),
     Dir = filename:join(
         "/tmp", "rr_cache_helpers_" ++ integer_to_list(rand:uniform(1000000))
     ),
@@ -555,20 +572,28 @@ cache_helpers_setup() ->
     {Dir}.
 
 cache_helpers_cleanup({Dir}) ->
-    lists:foreach(
-        fun
-            ({{roadrunner_static_meta, _Path} = K, _V}) ->
-                _ = persistent_term:erase(K),
-                ok;
-            (_) ->
-                ok
-        end,
-        persistent_term:get()
-    ),
+    ok = roadrunner_static:cache_clear(),
+    ok = stop_static_cache(),
     _ = file:del_dir_r(Dir),
     ok.
 
+%% The static-meta cache lives in a node-global ETS table owned by
+%% `roadrunner_static_cache`. eunit bypasses the app supervisor, so the
+%% tests that drive the cache start the owner themselves.
+start_static_cache() ->
+    case roadrunner_static_cache:start_link() of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end.
+
+stop_static_cache() ->
+    case whereis(roadrunner_static_cache) of
+        undefined -> ok;
+        Pid -> ok = gen_server:stop(Pid)
+    end.
+
 cache_enabled_setup() ->
+    ok = start_static_cache(),
     Name = static_test_cache_on,
     Dir = filename:join(
         "/tmp", "rr_cache_on_" ++ integer_to_list(rand:uniform(1000000))
@@ -587,6 +612,7 @@ cache_enabled_setup() ->
 
 cache_enabled_cleanup({Name, Dir, _Port}) ->
     ok = roadrunner_listener:stop(Name),
+    ok = stop_static_cache(),
     _ = file:del_dir_r(Dir),
     ok.
 

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -456,45 +456,45 @@ cache_helpers_test_() ->
         [
             {"cache_get returns miss when no entry exists", fun() ->
                 FilePath = filename:join(Dir, "no_cache_yet.txt"),
-                ?assertEqual(miss, roadrunner_static:cache_get(FilePath))
+                ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath))
             end},
             {"cache_put then cache_get within TTL returns the entry", fun() ->
                 FilePath = filename:join(Dir, "fresh.txt"),
-                ok = roadrunner_static:cache_put(FilePath, 100, 1700000000, 60000),
+                ok = roadrunner_static_cache:store(FilePath, 100, 1700000000, 60000),
                 ?assertEqual(
                     {ok, 100, 1700000000},
-                    roadrunner_static:cache_get(FilePath)
+                    roadrunner_static_cache:lookup(FilePath)
                 )
             end},
             {"cache_get returns miss after TTL expires", fun() ->
                 FilePath = filename:join(Dir, "expiring.txt"),
-                ok = roadrunner_static:cache_put(FilePath, 50, 1700000000, 1),
+                ok = roadrunner_static_cache:store(FilePath, 50, 1700000000, 1),
                 timer:sleep(20),
-                ?assertEqual(miss, roadrunner_static:cache_get(FilePath))
+                ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath))
             end},
             {"cache_ttl_ms => infinity entries never expire", fun() ->
                 %% No `monotonic_time + infinity` arithmetic; sleeping
                 %% past any finite TTL must still return the entry.
                 FilePath = filename:join(Dir, "forever.txt"),
-                ok = roadrunner_static:cache_put(FilePath, 42, 1700000000, infinity),
+                ok = roadrunner_static_cache:store(FilePath, 42, 1700000000, infinity),
                 ?assertEqual(
                     {ok, 42, 1700000000},
-                    roadrunner_static:cache_get(FilePath)
+                    roadrunner_static_cache:lookup(FilePath)
                 ),
                 timer:sleep(10),
                 ?assertEqual(
                     {ok, 42, 1700000000},
-                    roadrunner_static:cache_get(FilePath)
+                    roadrunner_static_cache:lookup(FilePath)
                 )
             end},
             {"cache_clear/0 drops every cached entry", fun() ->
                 F1 = filename:join(Dir, "clear_a.txt"),
                 F2 = filename:join(Dir, "clear_b.txt"),
-                ok = roadrunner_static:cache_put(F1, 10, 1700000000, infinity),
-                ok = roadrunner_static:cache_put(F2, 20, 1700000000, 60000),
+                ok = roadrunner_static_cache:store(F1, 10, 1700000000, infinity),
+                ok = roadrunner_static_cache:store(F2, 20, 1700000000, 60000),
                 ok = roadrunner_static:cache_clear(),
-                ?assertEqual(miss, roadrunner_static:cache_get(F1)),
-                ?assertEqual(miss, roadrunner_static:cache_get(F2))
+                ?assertEqual(miss, roadrunner_static_cache:lookup(F1)),
+                ?assertEqual(miss, roadrunner_static_cache:lookup(F2))
             end}
         ]
     end}.
@@ -509,9 +509,9 @@ cache_populated_after_request_test_() ->
                 %% so the resulting cache key is a binary; match that here.
                 FilePath = filename:join([Dir, ~"cached.txt"]),
                 ok = roadrunner_static:cache_clear(),
-                ?assertEqual(miss, roadrunner_static:cache_get(FilePath)),
+                ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath)),
                 _Reply = http_get(Port, ~"/static/cached.txt"),
-                ?assertMatch({ok, _Size, _Mtime}, roadrunner_static:cache_get(FilePath))
+                ?assertMatch({ok, _Size, _Mtime}, roadrunner_static_cache:lookup(FilePath))
             end},
             {"second request hits the cache and serves the same body", fun() ->
                 %% Drive `serve_file` through its cache-hit branch by
@@ -544,7 +544,7 @@ cache_default_off_test_() ->
                 FilePath = filename:join([Dir, ~"hello.html"]),
                 ok = roadrunner_static:cache_clear(),
                 _Reply = http_get(Port, ~"/static/hello.html"),
-                ?assertEqual(miss, roadrunner_static:cache_get(FilePath))
+                ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath))
             end}
         end}.
 


### PR DESCRIPTION
# Description

The static-file metadata cache (opt-in via `cache_ttl_ms`) lived in `persistent_term`, where every write is a global heap scan. Under a positive TTL each hot file re-`put`s on every refill, so those scans land on the request hot path; entries never evict (one key per path, unbounded); and `cache_clear/0` walks every term on the node. This moves it to a node-global public ETS table owned by a small supervised process (`roadrunner_static_cache`): cheap process-local writes, expired rows deleted on read, and an O(1) `cache_clear/0`. Off by default, so no behavior change unless caching is enabled.

Also documents (no code change) that `reload_routes/2` performs one global `persistent_term` swap per call, so route changes should be batched into a single call.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
