### PR TITLE
Build request_stop telemetry metadata with a map-update instead of maps:merge

### DIFF
--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -619,10 +619,12 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
     try Pipeline(Req) of
         {Response, Req2} when is_map(Req2) ->
             _ = dispatch_response(S, Handler, Req2, Response),
-            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
-                status => roadrunner_conn:response_status(Response),
-                response_kind => roadrunner_conn:response_kind(Response)
-            }),
+            ok = roadrunner_telemetry:request_stop(
+                ReqStart,
+                Metadata,
+                roadrunner_conn:response_status(Response),
+                roadrunner_conn:response_kind(Response)
+            ),
             finishing_phase(
                 S#loop_state{requests_served = S#loop_state.requests_served + 1},
                 Req2,

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -107,9 +107,7 @@ run_handler(ConnPid, StreamId, Req, ProtoOpts) ->
             send_buffered(
                 ConnPid, StreamId, 404, [{~"content-type", ~"text/plain"}], ~"Not Found"
             ),
-            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
-                status => 404, response_kind => buffered
-            })
+            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, 404, buffered)
     end.
 
 invoke(ConnPid, StreamId, Handler, Pipeline, #{method := Method} = Req, Metadata, ReqStart) ->
@@ -121,10 +119,12 @@ invoke(ConnPid, StreamId, Handler, Pipeline, #{method := Method} = Req, Metadata
             emit_handler_response(
                 ConnPid, StreamId, Handler, roadrunner_conn:head_response(Response, Method)
             ),
-            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
-                status => roadrunner_conn:response_status(Response),
-                response_kind => roadrunner_conn:response_kind(Response)
-            })
+            ok = roadrunner_telemetry:request_stop(
+                ReqStart,
+                Metadata,
+                roadrunner_conn:response_status(Response),
+                roadrunner_conn:response_kind(Response)
+            )
     catch
         Class:Reason:Stack ->
             ok = roadrunner_telemetry:request_exception(

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -88,9 +88,7 @@ run_handler(Conn, StreamId, Req, ProtoOpts) ->
             );
         not_found ->
             send_buffered(Conn, StreamId, 404, [{~"content-type", ~"text/plain"}], ~"Not Found"),
-            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
-                status => 404, response_kind => buffered
-            })
+            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, 404, buffered)
     end.
 
 -spec invoke(
@@ -116,10 +114,9 @@ invoke(Conn, StreamId, Handler, Pipeline, #{method := Method} = Req, Metadata, R
             Status = emit_handler_response(
                 Conn, StreamId, Handler, roadrunner_conn:head_response(Response, Method)
             ),
-            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, #{
-                status => Status,
-                response_kind => roadrunner_conn:response_kind(Response)
-            })
+            ok = roadrunner_telemetry:request_stop(
+                ReqStart, Metadata, Status, roadrunner_conn:response_kind(Response)
+            )
     catch
         Class:Reason:Stack ->
             ok = roadrunner_telemetry:request_exception(ReqStart, Metadata, Class, Reason),

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -124,7 +124,7 @@
 %%     `reason` (`max_frame_size | max_message_size`).
 %%
 %% The `start_time` value returned by `request_start/1` must be passed
-%% back into `request_stop/3` / `request_exception/4` to compute
+%% back into `request_stop/4` / `request_exception/4` to compute
 %% `duration`. Subscribers can wire up via `telemetry:attach/4` in
 %% production or `telemetry_test:attach_event_handlers/2` in tests.
 %%
@@ -158,7 +158,7 @@
 
 -export([
     request_start/1,
-    request_stop/3,
+    request_stop/4,
     request_exception/4,
     response_send/2,
     listener_accept/1,
@@ -198,14 +198,19 @@ request_start(Metadata) ->
 
 -doc """
 Emit `[roadrunner, request, stop]` with `duration = now - StartMono` and
-the start metadata merged with `Extra` (status + response_kind).
+the start metadata extended with `status` and `response_kind`.
 """.
--spec request_stop(integer(), metadata(), map()) -> ok.
-request_stop(StartMono, Metadata, Extra) ->
+-spec request_stop(
+    integer(),
+    metadata(),
+    roadrunner_http:status(),
+    buffered | stream | loop | sendfile | websocket
+) -> ok.
+request_stop(StartMono, Metadata, Status, Kind) ->
     telemetry:execute(
         [roadrunner, request, stop],
         #{duration => erlang:monotonic_time() - StartMono},
-        maps:merge(Metadata, Extra)
+        Metadata#{status => Status, response_kind => Kind}
     ),
     ok.
 


### PR DESCRIPTION
# Description

`request_stop` emitted its telemetry metadata with `maps:merge(Metadata, Extra)` on every request, allocating the `Extra` map at each call site and running the merge BIF, while its sibling `request_exception` already used the cheaper `Metadata#{...}` map-update. This switches `request_stop` to the same map-update (passing `status` + `response_kind` directly), removing a per-request allocation and making the two consistent. An interleaved microbench shows the map-update wins every round; it's an allocation/consistency change, not a throughput claim.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
