### PR TITLE
Explain the compiled-pattern convention inline instead of naming a memory file

### DIFF
--- a/src/roadrunner_cookie.erl
+++ b/src/roadrunner_cookie.erl
@@ -248,9 +248,9 @@ valid_attr_expires(<<C, R/binary>>, Orig) when
 valid_attr_expires(<<_, _/binary>>, Orig) ->
     error({invalid_cookie_attr, expires, Orig}).
 
-%% `-on_load` callback. See `feedback_compile_pattern_convention` —
-%% binary:match/split patterns belong in `persistent_term` so the
-%% per-cookie hot path doesn't recompile on every call.
+%% `-on_load` callback. binary:match/split patterns belong in
+%% `persistent_term` so the per-cookie hot path doesn't recompile on
+%% every call.
 -spec init_patterns() -> ok.
 init_patterns() ->
     persistent_term:put(?SEMI_CP_KEY, binary:compile_pattern(~";")),

--- a/src/roadrunner_multipart.erl
+++ b/src/roadrunner_multipart.erl
@@ -251,7 +251,8 @@ parse_header_lines_loop([Line | Rest], ColonCp) ->
         Other -> Other
     end.
 
-%% `-on_load` callback. See `feedback_compile_pattern_convention`.
+%% `-on_load` callback. Compiles the binary patterns once into
+%% `persistent_term` so the hot path reads a constant, not a recompile.
 -spec init_patterns() -> ok.
 init_patterns() ->
     persistent_term:put(?SEMI_CP_KEY, binary:compile_pattern(~";")),

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -598,7 +598,8 @@ listener name).
 listener_name(#{listener_name := Name}) -> Name;
 listener_name(_) -> undefined.
 
-%% `-on_load` callback. See `feedback_compile_pattern_convention`.
+%% `-on_load` callback. Compiles the binary patterns once into
+%% `persistent_term` so the hot path reads a constant, not a recompile.
 -spec init_patterns() -> ok.
 init_patterns() ->
     persistent_term:put(?QMARK_CP_KEY, binary:compile_pattern(~"?")),

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -201,8 +201,7 @@ path_segments(Path) ->
     binary:split(Path, persistent_term:get(?SLASH_CP_KEY), [global, trim_all]).
 
 %% `-on_load` callback. Compiles the path-segment separator once at
-%% module load — see the `feedback_compile_pattern_convention`
-%% project rule.
+%% module load into `persistent_term` so the hot path reads a constant.
 -spec init_patterns() -> ok.
 init_patterns() ->
     persistent_term:put(?SLASH_CP_KEY, binary:compile_pattern(~"/")),

--- a/src/roadrunner_sse.erl
+++ b/src/roadrunner_sse.erl
@@ -122,7 +122,8 @@ data_lines(Data) ->
      || Line <- binary:split(Data, persistent_term:get(?DATA_SPLIT_CP_KEY), [global])
     ].
 
-%% `-on_load` callback. See `feedback_compile_pattern_convention`.
+%% `-on_load` callback. Compiles the binary patterns once into
+%% `persistent_term` so the hot path reads a constant, not a recompile.
 -spec init_patterns() -> ok.
 init_patterns() ->
     persistent_term:put(?DATA_SPLIT_CP_KEY, binary:compile_pattern([~"\r\n", ~"\r", ~"\n"])),

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -571,7 +571,8 @@ month_number(Mon) ->
         ~"Dec" => 12
     }).
 
-%% `-on_load` callback. See `feedback_compile_pattern_convention`.
+%% `-on_load` callback. Compiles the binary patterns once into
+%% `persistent_term` so the hot path reads a constant, not a recompile.
 -spec init_patterns() -> ok.
 init_patterns() ->
     persistent_term:put(?COMMA_CP_KEY, binary:compile_pattern(~",")),


### PR DESCRIPTION
# Description

Six `-on_load` pattern comments referenced an internal project-memory artifact name; this rewords them to explain the `persistent_term` compiled-pattern convention inline instead. Comment-only, no code change.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
