### PR TITLE
Cache the h2 idle/handshake timeouts in loop state instead of reading persistent_term per recv loop

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -228,6 +228,12 @@
     %% When > 0 and no streams are in flight, the idle-wait path parks
     %% for this window and hibernates. Read from proto_opts at `enter/5`.
     hibernate_after = 0 :: non_neg_integer(),
+    %% Read-deadline caps, cached once at `enter/5` so the per-iteration
+    %% handshake/idle waits read a record field instead of re-reading
+    %% persistent_term every loop. The persistent_term override (a test
+    %% hook) is captured at `enter/5`, so it must be set before connect.
+    handshake_timeout = ?HANDSHAKE_TIMEOUT_DEFAULT :: non_neg_integer(),
+    idle_timeout = ?IDLE_TIMEOUT_DEFAULT :: non_neg_integer(),
     %% Precomputed `Alt-Svc` value (h3 co-serving), or `undefined`.
     %% Prepended to every response by `roadrunner_http:auto_headers/2`.
     %% Read from proto_opts at `enter/5`.
@@ -296,6 +302,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
     AltSvc = maps:get(alt_svc, ProtoOpts, undefined),
     MaxConcReq = maps:get(max_concurrent_requests, ProtoOpts, infinity),
     InflightCounter = maps:get(inflight_counter, ProtoOpts, undefined),
+    HandshakeTimeout = handshake_timeout(),
+    IdleTimeout = idle_timeout(),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -318,7 +326,9 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         hibernate_after = HibernateAfter,
         alt_svc = AltSvc,
         max_concurrent_requests = MaxConcReq,
-        inflight_counter = InflightCounter
+        inflight_counter = InflightCounter,
+        handshake_timeout = HandshakeTimeout,
+        idle_timeout = IdleTimeout
     },
     handshake(State).
 
@@ -425,7 +435,7 @@ handshake_recv(
             exit_clean(State);
         {MError, _, _} ->
             exit_clean(State)
-    after handshake_timeout() ->
+    after State#loop.handshake_timeout ->
         exit_clean(State)
     end.
 
@@ -500,8 +510,8 @@ recv_timeout(#loop{streams = Streams, hibernate_after = Ms}) when
     map_size(Streams) =:= 0, Ms > 0
 ->
     Ms;
-recv_timeout(_State) ->
-    idle_timeout().
+recv_timeout(#loop{idle_timeout = T}) ->
+    T.
 
 %% Fired when `recv_more/1` sees no traffic for `recv_timeout/1`. With
 %% an empty streams map and `hibernate_after` set, collapse the heap

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -375,17 +375,17 @@ blocked_send_peer_closes_exits_clean(_Config) ->
     wait_down(Pid, Ref).
 
 blocked_send_idle_timeout_emits_goaway(_Config) ->
-    %% Stalled-send waits past the idle deadline. `idle_timeout()`
-    %% is evaluated at receive entry, so we lower the deadline
-    %% AFTER the body drain finishes and then poke the conn with
-    %% an unknown-stream WINDOW_UPDATE — that's silently ignored
-    %% by `handle_frame_during_send/4` and forces a re-entry into
-    %% `recv_more_during_send/3`, which reads the new 100-ms
-    %% timeout and fires shortly after.
-    {Pid, Ref, ConnPid} = setup_blocked_send(),
-    drain_all_sends(),
-    persistent_term:put({roadrunner_conn_loop_http2, idle_timeout}, 100),
+    %% Stalled-send waits past the idle deadline → GOAWAY. The idle
+    %% timeout is cached at connection setup (`enter/5`), so the override
+    %% is set BEFORE the connection starts; 500 ms clears the blocked-send
+    %% setup + `drain_all_sends/0` (which waits ~200 ms) without a
+    %% premature fire, and the unknown-stream WINDOW_UPDATE poke (silently
+    %% ignored) resets the recv timer to a known point so the deadline
+    %% fires shortly after.
+    persistent_term:put({roadrunner_conn_loop_http2, idle_timeout}, 500),
     try
+        {Pid, Ref, ConnPid} = setup_blocked_send(),
+        drain_all_sends(),
         Wu = encode_frame({window_update, 99, 1024}),
         serve_recv(ConnPid, Wu),
         expect_send_type(7),


### PR DESCRIPTION
# Description

`roadrunner_conn_loop_http2:idle_timeout/0` did a `persistent_term:get` on **every** recv-loop iteration (profiling showed 904k calls on the h2 streaming path), and `handshake_timeout/0` the same per handshake-recv iteration — both for a value that is constant per connection. This reads them once at `enter/5` into the `#loop{}` record (the h1 conn loop already caches its timeouts this way) and uses the record fields at the per-iteration call sites. The persistent_term test-override hook is preserved: it is captured at `enter/5`, so an override must be set before the connection starts (the one flow-control test that lowered it mid-connection was updated accordingly). Microbench: the per-iteration cost drops ~12ns → ~6ns and the global persistent_term access leaves the recv loop.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
