### PR TITLE
Accept the {end_of_headers, _} tuple in the http1 parser robustness property

### DIFF
--- a/test/property_test/roadrunner_http1_props.erl
+++ b/test/property_test/roadrunner_http1_props.erl
@@ -42,7 +42,7 @@ is_documented_shape({ok, _, _, _}) -> true;
 is_documented_shape({ok, _, _, _, _}) -> true;
 is_documented_shape({more, _}) -> true;
 is_documented_shape({error, _}) -> true;
-is_documented_shape(end_of_headers) -> true;
+is_documented_shape({end_of_headers, _}) -> true;
 is_documented_shape(_) -> false.
 
 %% =============================================================================


### PR DESCRIPTION
# Description

The property `http1_parse_header_never_crashes` failed intermittently because its own predicate was wrong, not the parser: `parse_header/1` returns `{end_of_headers, Rest}` on a blank line, but `is_documented_shape/1` only matched the dead bare atom `end_of_headers`, so it tripped on the rare PropEr run that generated a CRLF-leading binary. This accepts the tuple shape.

```erlang
parse_header(<<"\r\n">>) = {end_of_headers, <<>>}   %% predicate: false -> true
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
