### PR TITLE
Collapse the h2 END_HEADERS tuple-case into a nested match

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -841,20 +841,20 @@ on_continuation(
                         end_headers := EndHeaders
                     },
                     Streams1 = Streams#{StreamId := Stream1},
-                    %% Set streams + awaiting_continuation in one record update on
-                    %% the END_HEADERS path — two sequential `#loop{}` updates
-                    %% would copy the record twice.
-                    State2 =
-                        case EndHeaders of
-                            true ->
-                                State#loop{streams = Streams1, awaiting_continuation = undefined};
-                            false ->
-                                State#loop{streams = Streams1}
-                        end,
-                    case {EndHeaders, PriorHeaders =:= undefined} of
-                        {true, true} -> finalize_headers(StreamId, State2);
-                        {true, false} -> finalize_trailers(StreamId, State2);
-                        {false, _} -> frame_loop(State2)
+                    case EndHeaders of
+                        false ->
+                            frame_loop(State#loop{streams = Streams1});
+                        true ->
+                            %% Reset awaiting_continuation in the same record
+                            %% update on the END_HEADERS path; two sequential
+                            %% `#loop{}` updates would copy the record twice.
+                            State1 = State#loop{
+                                streams = Streams1, awaiting_continuation = undefined
+                            },
+                            case PriorHeaders of
+                                undefined -> finalize_headers(StreamId, State1);
+                                _ -> finalize_trailers(StreamId, State1)
+                            end
                     end
             end;
         _ ->


### PR DESCRIPTION
# Description

`on_continuation/4` built `{EndHeaders, PriorHeaders =:= undefined}` only to drive a branch, and dispatched on `EndHeaders` twice (once to build the state, once in the tuple-case). This collapses it into a nested `case EndHeaders of` with a direct `case PriorHeaders of undefined`, so there is no constructed tuple, `undefined` is matched directly, `EndHeaders` is dispatched once, and the `awaiting_continuation` reset happens only on the END_HEADERS branch that uses it. Behaviour is identical.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
