### PR TITLE
Thread the unsafe-bytes pattern through h2 header validation

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1320,7 +1320,7 @@ encode_and_send_headers(
     %% §8.1.2 (see `roadrunner_handler:response/0`). Bytes outside the
     %% RFC 9110 §5.5 field-value charset (CR/LF/NUL) crash here so the
     %% h2 path matches h1's `encode_headers/1` discipline.
-    ok = validate_headers(Headers),
+    ok = roadrunner_http1:check_headers_safe(Headers),
     AllHeaders =
         [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
@@ -1358,7 +1358,7 @@ encode_and_send_response_atomic(
     %% Names already lowercase per `roadrunner_handler:response/0` contract;
     %% reject CR/LF/NUL anywhere in the pair so they cannot reach the peer
     %% or split at an h2->h1 reverse proxy.
-    ok = validate_headers(Headers),
+    ok = roadrunner_http1:check_headers_safe(Headers),
     AllHeaders =
         [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
@@ -1374,7 +1374,7 @@ encode_and_send_response_atomic(
 encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
     %% Trailer names already lowercase per `roadrunner_handler:response/0`;
     %% h1 trailers run the same check in `roadrunner_stream_response`.
-    ok = validate_headers(Trailers),
+    ok = roadrunner_http1:check_headers_safe(Trailers),
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(Trailers, Enc),
     Frame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04 bor 16#01, undefined, HpackBlock}
@@ -1382,20 +1382,6 @@ encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
     _ = send(State, Frame),
     State1 = State#loop{hpack_enc = Enc1},
     close_stream_send_side(State1, StreamId).
-
-%% RFC 9110 §5.5 / RFC 9113 §8.2.1: field values are VCHAR / SP /
-%% HTAB only; no CTLs. HPACK is length-framed so CR/LF cannot smuggle
-%% a new h2 frame, but malformed bytes still reach the peer (and any
-%% downstream h2->h1 reverse proxy where they would split). Crash
-%% hard so a handler echoing user input into a header turns into a
-%% 500, matching `roadrunner_http1:encode_headers/1`.
--spec validate_headers([{binary(), binary()}]) -> ok.
-validate_headers([]) ->
-    ok;
-validate_headers([{Name, Value} | Rest]) ->
-    ok = roadrunner_http1:check_header_safe(Name, name),
-    ok = roadrunner_http1:check_header_safe(Value, value),
-    validate_headers(Rest).
 
 %% Mark the send side closed. Future worker writes on this stream
 %% get `{h2_stream_reset, _}` so they unwind cleanly.

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -19,6 +19,7 @@
     parse_chunk/2,
     parse_chunk/3,
     check_header_safe/2,
+    check_headers_safe/1,
     response/3,
     compute_cached_decisions/1
 ]).
@@ -939,6 +940,28 @@ check_header_safe(Bin, Kind, UnsafeCp) when is_binary(Bin) ->
         nomatch -> ok;
         _ -> error({header_injection, Kind, Bin})
     end.
+
+-doc """
+Run the header-injection check over every name and value in a header
+list, fetching the compiled unsafe-bytes pattern once and threading it
+through (vs `check_header_safe/2`, which fetches per call). Crashes with
+`{header_injection, Kind, Bin}` on the first unsafe byte.
+
+Public so the HTTP/2 response path, which emits headers via HPACK
+rather than `encode_headers/1`, runs the same single-fetch check.
+""".
+-spec check_headers_safe(headers()) -> ok.
+check_headers_safe(Headers) ->
+    check_headers_safe(Headers, persistent_term:get(?UNSAFE_BYTES_KEY)).
+
+%% Loop with the pre-fetched pattern.
+-spec check_headers_safe(headers(), binary:cp()) -> ok.
+check_headers_safe([], _UnsafeCp) ->
+    ok;
+check_headers_safe([{Name, Value} | Rest], UnsafeCp) ->
+    ok = check_header_safe(Name, name, UnsafeCp),
+    ok = check_header_safe(Value, value, UnsafeCp),
+    check_headers_safe(Rest, UnsafeCp).
 
 %% `-on_load` callback. Returns `ok` so module load succeeds; if the
 %% compile fails (it shouldn't — the pattern is a literal), the module


### PR DESCRIPTION
# Description

h2 response-header validation called the two-arg `roadrunner_http1:check_header_safe/2` once per name and per value, each doing a `persistent_term:get` of the compiled unsafe-bytes pattern (2N lookups per response). This adds `roadrunner_http1:check_headers_safe/1`, which fetches the pattern once and threads it through the list (reusing the existing internal three-arg `check_header_safe/3`), and points the three h2 send paths at it, mirroring what `encode_headers/1` already does on h1. Behaviour is identical: same `{header_injection, _, _}` crash on CR/LF/NUL, same empty-list `ok`.

Microbench (validation step alone, 6-header response, stable across runs): ~695 ns to ~487 ns, about 30% faster on that step. A constant per-response saving, not a throughput claim.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
