### PR TITLE
Move the header-injection check to roadrunner_http

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1320,7 +1320,7 @@ encode_and_send_headers(
     %% §8.1.2 (see `roadrunner_handler:response/0`). Bytes outside the
     %% RFC 9110 §5.5 field-value charset (CR/LF/NUL) crash here so the
     %% h2 path matches h1's `encode_headers/1` discipline.
-    ok = roadrunner_http1:check_headers_safe(Headers),
+    ok = roadrunner_http:check_headers_safe(Headers),
     AllHeaders =
         [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
@@ -1358,7 +1358,7 @@ encode_and_send_response_atomic(
     %% Names already lowercase per `roadrunner_handler:response/0` contract;
     %% reject CR/LF/NUL anywhere in the pair so they cannot reach the peer
     %% or split at an h2->h1 reverse proxy.
-    ok = roadrunner_http1:check_headers_safe(Headers),
+    ok = roadrunner_http:check_headers_safe(Headers),
     AllHeaders =
         [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
@@ -1374,7 +1374,7 @@ encode_and_send_response_atomic(
 encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
     %% Trailer names already lowercase per `roadrunner_handler:response/0`;
     %% h1 trailers run the same check in `roadrunner_stream_response`.
-    ok = roadrunner_http1:check_headers_safe(Trailers),
+    ok = roadrunner_http:check_headers_safe(Trailers),
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(Trailers, Enc),
     Frame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04 bor 16#01, undefined, HpackBlock}

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -19,6 +19,10 @@ Items here:
   time, `format_http_date/1` for an arbitrary posix timestamp)
   for the `Date` response header per RFC 9110 §5.6.7 and the
   `Last-Modified` response header used by the static handler.
+- Header field-value safety (RFC 9110 §5.5): reject CR/LF/NUL in a
+  header name or value before it reaches the wire
+  (`check_header_safe/2`, `check_headers_safe/1`), shared by every
+  version's response path.
 
 `roadrunner_http1` and `roadrunner_req` re-export the primitive
 types as aliases so existing callers keep compiling unchanged.
@@ -28,10 +32,15 @@ accessors that operate on it.
 
 -export([http_date_now/0, format_http_date/1, with_date/1, auto_headers/2]).
 -export([header_list_size/1]).
+-export([check_header_safe/2, check_header_safe/3, check_headers_safe/1]).
+-export([unsafe_bytes_pattern/0]).
 
 -export_type([headers/0, status/0, redirect_status/0, version/0]).
 
+-on_load(init_patterns/0).
+
 -define(DATE_CACHE_KEY, {?MODULE, date_cache}).
+-define(UNSAFE_BYTES_KEY, {?MODULE, unsafe_bytes_cp}).
 
 -type headers() :: [{Name :: binary(), Value :: binary()}].
 -type status() :: 100..599.
@@ -148,3 +157,74 @@ format_http_date(Posix) ->
 -spec pad2(0..99) -> binary().
 pad2(N) when N < 10 -> <<$0, ($0 + N)>>;
 pad2(N) -> integer_to_binary(N).
+
+-doc """
+Validate that a header name or value contains no CR, LF, or NUL —
+the bytes that would let an attacker who controls the value inject
+new headers (or terminate the header block early). Crashes with
+`{header_injection, Kind, Bin}` when an unsafe byte is present.
+
+Public so any response path emitting a single header (e.g.
+`roadrunner_stream_response` for chunked-response trailers) can run
+the check before writing to the wire.
+""".
+-spec check_header_safe(binary(), name | value) -> ok.
+check_header_safe(Bin, Kind) when is_binary(Bin) ->
+    check_header_safe(Bin, Kind, persistent_term:get(?UNSAFE_BYTES_KEY)).
+
+%% Accepts a pre-fetched pattern so a caller iterating a header list
+%% (`check_headers_safe/2`, or h1's fused `encode_headers/1`) pays one
+%% `persistent_term:get/1` instead of one per field. Exported for the
+%% h1 encode path; most callers want `check_header_safe/2`.
+-doc false.
+-spec check_header_safe(binary(), name | value, binary:cp()) -> ok.
+check_header_safe(Bin, Kind, UnsafeCp) when is_binary(Bin) ->
+    case binary:match(Bin, UnsafeCp) of
+        nomatch -> ok;
+        _ -> error({header_injection, Kind, Bin})
+    end.
+
+-doc """
+Run the header-injection check over every name and value in a header
+list, fetching the compiled unsafe-bytes pattern once and threading it
+through (vs `check_header_safe/2`, which fetches per call). Crashes with
+`{header_injection, Kind, Bin}` on the first unsafe byte.
+
+Public so each version's response path runs the same single-fetch
+check: h1 `roadrunner_http1:encode_headers/1` and the HTTP/2 conn loop.
+""".
+-spec check_headers_safe(headers()) -> ok.
+check_headers_safe(Headers) ->
+    check_headers_safe(Headers, persistent_term:get(?UNSAFE_BYTES_KEY)).
+
+%% Loop with the pre-fetched pattern.
+-spec check_headers_safe(headers(), binary:cp()) -> ok.
+check_headers_safe([], _UnsafeCp) ->
+    ok;
+check_headers_safe([{Name, Value} | Rest], UnsafeCp) ->
+    ok = check_header_safe(Name, name, UnsafeCp),
+    ok = check_header_safe(Value, value, UnsafeCp),
+    check_headers_safe(Rest, UnsafeCp).
+
+%% The compiled CR/LF/NUL pattern, for a caller that runs the check in
+%% a loop and wants a single `persistent_term:get/1` for the whole list
+%% (h1's fused `encode_headers/1`), passing it to `check_header_safe/3`.
+%% Callers not already iterating want `check_header_safe/2` or
+%% `check_headers_safe/1` instead.
+-doc false.
+-spec unsafe_bytes_pattern() -> binary:cp().
+unsafe_bytes_pattern() ->
+    persistent_term:get(?UNSAFE_BYTES_KEY).
+
+%% `-on_load` callback. Stashes the compiled unsafe-bytes pattern in
+%% `persistent_term` so `check_header_safe/3` reads a constant on the
+%% response hot path. Returns `ok` so module load succeeds; if the
+%% compile fails (it shouldn't, the pattern is a literal), the module
+%% won't load and we'll see it loudly.
+-spec init_patterns() -> ok.
+init_patterns() ->
+    persistent_term:put(
+        ?UNSAFE_BYTES_KEY,
+        binary:compile_pattern([~"\r", ~"\n", ~"\0"])
+    ),
+    ok.

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -190,8 +190,10 @@ list, fetching the compiled unsafe-bytes pattern once and threading it
 through (vs `check_header_safe/2`, which fetches per call). Crashes with
 `{header_injection, Kind, Bin}` on the first unsafe byte.
 
-Public so each version's response path runs the same single-fetch
-check: h1 `roadrunner_http1:encode_headers/1` and the HTTP/2 conn loop.
+The list-validating entry for response paths that emit headers via a
+binary codec rather than the CRLF encoder: the HTTP/2 conn loop, and
+HTTP/3 once its check is wired. h1's CRLF encoder fuses the per-field
+check into its build pass instead, so it does not use this entry.
 """.
 -spec check_headers_safe(headers()) -> ok.
 check_headers_safe(Headers) ->

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -18,8 +18,6 @@
     parse_chunk/1,
     parse_chunk/2,
     parse_chunk/3,
-    check_header_safe/2,
-    check_headers_safe/1,
     response/3,
     compute_cached_decisions/1
 ]).
@@ -41,7 +39,6 @@
 %% We compile the patterns the parser uses repeatedly and stash them in
 %% `persistent_term` so each call reads a constant — `persistent_term:get/1`
 %% measured at the same speed as a bound variable.
--define(UNSAFE_BYTES_KEY, {?MODULE, unsafe_bytes_cp}).
 -define(LF_KEY, {?MODULE, lf_cp}).
 -define(CRLF_KEY, {?MODULE, crlf_cp}).
 -define(COLON_KEY, {?MODULE, colon_cp}).
@@ -897,81 +894,29 @@ status_line(Status) -> [~"HTTP/1.1 ", integer_to_binary(Status), ~" \r\n"].
 
 -spec encode_headers(headers()) -> iodata().
 encode_headers(Headers) ->
-    %% Fetch the unsafe-bytes pattern ONCE here and thread it through
-    %% the per-header injection check. Saves a `persistent_term:get/1`
-    %% per header (was 2 per header for name + value).
-    UnsafeCp = persistent_term:get(?UNSAFE_BYTES_KEY),
+    %% Fetch the shared unsafe-bytes pattern ONCE and thread it through
+    %% the fused injection-check + encode pass, so the whole header list
+    %% costs a single `persistent_term:get/1`.
+    UnsafeCp = roadrunner_http:unsafe_bytes_pattern(),
     encode_headers_loop(Headers, UnsafeCp).
 
 -spec encode_headers_loop(headers(), binary:cp()) -> iodata().
 encode_headers_loop([], _UnsafeCp) ->
     [];
 encode_headers_loop([{Name, Value} | Rest], UnsafeCp) ->
-    %% Defend against HTTP response splitting / header injection: any
-    %% CR, LF, or NUL in a header name or value would let an attacker
-    %% who controls part of either inject an entirely new header (or
-    %% terminate the header block early). Crash hard so a programmer
-    %% bug — usually echoing user input into a header without
-    %% validation — turns into a 500, not a wire-level vulnerability.
-    ok = check_header_safe(Name, name, UnsafeCp),
-    ok = check_header_safe(Value, value, UnsafeCp),
+    %% Reject CR/LF/NUL in a name or value: either would let an attacker
+    %% who controls part of it inject a new header or terminate the block
+    %% early. Crash hard so a handler echoing unvalidated user input into
+    %% a header turns into a 500, not a wire-level vulnerability.
+    ok = roadrunner_http:check_header_safe(Name, name, UnsafeCp),
+    ok = roadrunner_http:check_header_safe(Value, value, UnsafeCp),
     [Name, ~": ", Value, ~"\r\n" | encode_headers_loop(Rest, UnsafeCp)].
-
--doc """
-Validate that a header name or value contains no CR, LF, or NUL —
-the bytes that would let an attacker who controls the value inject
-new headers (or terminate the header block early). Crashes with
-`{header_injection, Kind, Bin}` when an unsafe byte is present.
-
-Public so other modules emitting headers (e.g. `roadrunner_conn` for
-chunked-response trailers) can run the same check before writing
-to the wire.
-""".
--spec check_header_safe(binary(), name | value) -> ok.
-check_header_safe(Bin, Kind) when is_binary(Bin) ->
-    check_header_safe(Bin, Kind, persistent_term:get(?UNSAFE_BYTES_KEY)).
-
-%% Internal entry that accepts a pre-fetched pattern. Used by
-%% `encode_headers/1` to avoid a `persistent_term:get/1` per
-%% (name, value) pair on the response hot path.
--spec check_header_safe(binary(), name | value, binary:cp()) -> ok.
-check_header_safe(Bin, Kind, UnsafeCp) when is_binary(Bin) ->
-    case binary:match(Bin, UnsafeCp) of
-        nomatch -> ok;
-        _ -> error({header_injection, Kind, Bin})
-    end.
-
--doc """
-Run the header-injection check over every name and value in a header
-list, fetching the compiled unsafe-bytes pattern once and threading it
-through (vs `check_header_safe/2`, which fetches per call). Crashes with
-`{header_injection, Kind, Bin}` on the first unsafe byte.
-
-Public so the HTTP/2 response path, which emits headers via HPACK
-rather than `encode_headers/1`, runs the same single-fetch check.
-""".
--spec check_headers_safe(headers()) -> ok.
-check_headers_safe(Headers) ->
-    check_headers_safe(Headers, persistent_term:get(?UNSAFE_BYTES_KEY)).
-
-%% Loop with the pre-fetched pattern.
--spec check_headers_safe(headers(), binary:cp()) -> ok.
-check_headers_safe([], _UnsafeCp) ->
-    ok;
-check_headers_safe([{Name, Value} | Rest], UnsafeCp) ->
-    ok = check_header_safe(Name, name, UnsafeCp),
-    ok = check_header_safe(Value, value, UnsafeCp),
-    check_headers_safe(Rest, UnsafeCp).
 
 %% `-on_load` callback. Returns `ok` so module load succeeds; if the
 %% compile fails (it shouldn't — the pattern is a literal), the module
 %% won't load and we'll see it loudly.
 -spec init_patterns() -> ok.
 init_patterns() ->
-    persistent_term:put(
-        ?UNSAFE_BYTES_KEY,
-        binary:compile_pattern([~"\r", ~"\n", ~"\0"])
-    ),
     persistent_term:put(?LF_KEY, binary:compile_pattern(~"\n")),
     persistent_term:put(?CRLF_KEY, binary:compile_pattern(~"\r\n")),
     persistent_term:put(?COLON_KEY, binary:compile_pattern(~":")),

--- a/src/roadrunner_stream_response.erl
+++ b/src/roadrunner_stream_response.erl
@@ -82,8 +82,8 @@ encode_trailers(Trailers) ->
     %% phantom trailer header.
     [
         begin
-            ok = roadrunner_http1:check_header_safe(Name, name),
-            ok = roadrunner_http1:check_header_safe(Value, value),
+            ok = roadrunner_http:check_header_safe(Name, name),
+            ok = roadrunner_http:check_header_safe(Value, value),
             [Name, ~": ", Value, ~"\r\n"]
         end
      || {Name, Value} <- Trailers


### PR DESCRIPTION
# Description

The CR/LF/NUL header field-value check (RFC 9110 §5.5) is version-agnostic, so it now lives in the shared `roadrunner_http` layer instead of `roadrunner_http1` — that was h2's only remaining dependency on the h1 module. `roadrunner_http` gains `check_header_safe/2,/3`, `check_headers_safe/1`, the compiled pattern, and its `-on_load`; h2 and `roadrunner_stream_response` repoint to it. h1's `encode_headers/1` keeps its fused single-pass encode by threading the shared pattern, so there is no measurable h1 regression (local-call vs cross-module-call microbenched as noise, unstable sign).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
