### PR TITLE
Reject CR/LF/NUL in HTTP/3 response headers with a 500

### DIFF
--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -32,7 +32,7 @@ accessors that operate on it.
 
 -export([http_date_now/0, format_http_date/1, with_date/1, auto_headers/2]).
 -export([header_list_size/1]).
--export([check_header_safe/2, check_header_safe/3, check_headers_safe/1]).
+-export([check_header_safe/2, check_header_safe/3, check_headers_safe/1, first_unsafe_field/1]).
 -export([unsafe_bytes_pattern/0]).
 
 -export_type([headers/0, status/0, redirect_status/0, version/0]).
@@ -207,6 +207,37 @@ check_headers_safe([{Name, Value} | Rest], UnsafeCp) ->
     ok = check_header_safe(Name, name, UnsafeCp),
     ok = check_header_safe(Value, value, UnsafeCp),
     check_headers_safe(Rest, UnsafeCp).
+
+-doc """
+Non-crashing form of the header-injection check: scan a header list and
+return `{unsafe, name | value}` for the first field whose name or value
+contains CR, LF, or NUL, or `ok` when all are clean. The kind (not the
+offending bytes) is returned so a caller logging the result cannot echo
+control bytes onto a log line.
+
+For response paths that must answer a clean error rather than crash, e.g.
+the HTTP/3 emit gate, whose `try ... of` body does not catch a raise.
+`check_headers_safe/1` is the crashing form, used where a crash is caught
+upstream (h1/h2).
+""".
+-spec first_unsafe_field(headers()) -> {unsafe, name | value} | ok.
+first_unsafe_field(Headers) ->
+    first_unsafe_field(Headers, persistent_term:get(?UNSAFE_BYTES_KEY)).
+
+%% Loop with the pre-fetched pattern.
+-spec first_unsafe_field(headers(), binary:cp()) -> {unsafe, name | value} | ok.
+first_unsafe_field([], _UnsafeCp) ->
+    ok;
+first_unsafe_field([{Name, Value} | Rest], UnsafeCp) ->
+    case binary:match(Name, UnsafeCp) of
+        nomatch ->
+            case binary:match(Value, UnsafeCp) of
+                nomatch -> first_unsafe_field(Rest, UnsafeCp);
+                _ -> {unsafe, value}
+            end;
+        _ ->
+            {unsafe, name}
+    end.
 
 %% The compiled CR/LF/NUL pattern, for a caller that runs the check in
 %% a loop and wants a single `persistent_term:get/1` for the whole list

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -32,7 +32,7 @@ accessors that operate on it.
 
 -export([http_date_now/0, format_http_date/1, with_date/1, auto_headers/2]).
 -export([header_list_size/1]).
--export([check_header_safe/2, check_header_safe/3, check_headers_safe/1, first_unsafe_field/1]).
+-export([check_header_safe/2, check_header_safe/3, check_headers_safe/1]).
 -export([unsafe_bytes_pattern/0]).
 
 -export_type([headers/0, status/0, redirect_status/0, version/0]).
@@ -208,42 +208,11 @@ check_headers_safe([{Name, Value} | Rest], UnsafeCp) ->
     ok = check_header_safe(Value, value, UnsafeCp),
     check_headers_safe(Rest, UnsafeCp).
 
--doc """
-Non-crashing form of the header-injection check: scan a header list and
-return `{unsafe, name | value}` for the first field whose name or value
-contains CR, LF, or NUL, or `ok` when all are clean. The kind (not the
-offending bytes) is returned so a caller logging the result cannot echo
-control bytes onto a log line.
-
-For response paths that must answer a clean error rather than crash, e.g.
-the HTTP/3 emit gate, whose `try ... of` body does not catch a raise.
-`check_headers_safe/1` is the crashing form, used where a crash is caught
-upstream (h1/h2).
-""".
--spec first_unsafe_field(headers()) -> {unsafe, name | value} | ok.
-first_unsafe_field(Headers) ->
-    first_unsafe_field(Headers, persistent_term:get(?UNSAFE_BYTES_KEY)).
-
-%% Loop with the pre-fetched pattern.
--spec first_unsafe_field(headers(), binary:cp()) -> {unsafe, name | value} | ok.
-first_unsafe_field([], _UnsafeCp) ->
-    ok;
-first_unsafe_field([{Name, Value} | Rest], UnsafeCp) ->
-    case binary:match(Name, UnsafeCp) of
-        nomatch ->
-            case binary:match(Value, UnsafeCp) of
-                nomatch -> first_unsafe_field(Rest, UnsafeCp);
-                _ -> {unsafe, value}
-            end;
-        _ ->
-            {unsafe, name}
-    end.
-
-%% The compiled CR/LF/NUL pattern, for a caller that runs the check in
-%% a loop and wants a single `persistent_term:get/1` for the whole list
-%% (h1's fused `encode_headers/1`), passing it to `check_header_safe/3`.
-%% Callers not already iterating want `check_header_safe/2` or
-%% `check_headers_safe/1` instead.
+%% The compiled CR/LF/NUL pattern, for a caller that runs the check in a
+%% loop and wants a single `persistent_term:get/1` for the whole list:
+%% h1's fused `encode_headers/1` (via `check_header_safe/3`) and the
+%% HTTP/3 emit gate (inline `binary:match`). Callers not already iterating
+%% want `check_header_safe/2` or `check_headers_safe/1` instead.
 -doc false.
 -spec unsafe_bytes_pattern() -> binary:cp().
 unsafe_bytes_pattern() ->

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -185,26 +185,41 @@ emit_handler_response(Conn, StreamId, _Handler, {websocket, _, _}) ->
     pid(), non_neg_integer(), roadrunner_http:headers(), fun(() -> roadrunner_http:status())
 ) -> roadrunner_http:status().
 emit_checked(Conn, StreamId, Headers, Emit) ->
-    case roadrunner_http:first_unsafe_field(Headers) of
-        {unsafe, Kind} ->
-            reject_unsafe(Conn, StreamId, Kind);
-        ok ->
-            case forbidden_header(Headers) of
-                {true, Name} -> reject_forbidden(Conn, StreamId, Name);
-                false -> Emit()
-            end
+    case validate_response_headers(Headers) of
+        ok -> Emit();
+        {unsafe, Kind} -> reject_unsafe(Conn, StreamId, Kind);
+        {forbidden, Name} -> reject_forbidden(Conn, StreamId, Name)
     end.
 
-%% RFC 9114 §4.2 connection-specific header set. Function-clause
-%% dispatch (mirrors `roadrunner_http3_request:check_banned/1`) keeps it
-%% branch-friendly; returns the offending name for the log.
--spec forbidden_header(roadrunner_http:headers()) -> {true, binary()} | false.
-forbidden_header([]) ->
-    false;
-forbidden_header([{Name, _} | Rest]) ->
+%% One pass over the response headers, applying both gates per field: the
+%% RFC 9114 §4.2 connection-specific name set, and the RFC 9110 §5.5
+%% CR/LF/NUL field-byte check (the shared compiled pattern, fetched once).
+%% `is_forbidden_header/1` is function-clause dispatch (mirrors
+%% `roadrunner_http3_request:check_banned/1`); a forbidden name returns it
+%% for the log, an unsafe field returns only the kind (never raw bytes).
+-spec validate_response_headers(roadrunner_http:headers()) ->
+    ok | {unsafe, name | value} | {forbidden, binary()}.
+validate_response_headers(Headers) ->
+    validate_response_headers(Headers, roadrunner_http:unsafe_bytes_pattern()).
+
+-spec validate_response_headers(roadrunner_http:headers(), binary:cp()) ->
+    ok | {unsafe, name | value} | {forbidden, binary()}.
+validate_response_headers([], _UnsafeCp) ->
+    ok;
+validate_response_headers([{Name, Value} | Rest], UnsafeCp) ->
     case is_forbidden_header(Name) of
-        true -> {true, Name};
-        false -> forbidden_header(Rest)
+        true ->
+            {forbidden, Name};
+        false ->
+            case binary:match(Name, UnsafeCp) of
+                nomatch ->
+                    case binary:match(Value, UnsafeCp) of
+                        nomatch -> validate_response_headers(Rest, UnsafeCp);
+                        _ -> {unsafe, value}
+                    end;
+                _ ->
+                    {unsafe, name}
+            end
     end.
 
 -spec is_forbidden_header(binary()) -> boolean().

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -185,9 +185,14 @@ emit_handler_response(Conn, StreamId, _Handler, {websocket, _, _}) ->
     pid(), non_neg_integer(), roadrunner_http:headers(), fun(() -> roadrunner_http:status())
 ) -> roadrunner_http:status().
 emit_checked(Conn, StreamId, Headers, Emit) ->
-    case forbidden_header(Headers) of
-        {true, Name} -> reject_forbidden(Conn, StreamId, Name);
-        false -> Emit()
+    case roadrunner_http:first_unsafe_field(Headers) of
+        {unsafe, Kind} ->
+            reject_unsafe(Conn, StreamId, Kind);
+        ok ->
+            case forbidden_header(Headers) of
+                {true, Name} -> reject_forbidden(Conn, StreamId, Name);
+                false -> Emit()
+            end
     end.
 
 %% RFC 9114 §4.2 connection-specific header set. Function-clause
@@ -220,6 +225,23 @@ reject_forbidden(Conn, StreamId, Name) ->
     logger:error(#{
         msg => "roadrunner h3 handler returned a connection-specific header",
         header => Name
+    }),
+    send_buffered(
+        Conn, StreamId, 500, [{~"content-type", ~"text/plain"}], ~"Internal Server Error"
+    ),
+    500.
+
+%% RFC 9110 §5.5: a response header name or value containing CR, LF, or
+%% NUL is a handler bug (usually unvalidated user input echoed into a
+%% header) that would put malformed bytes on the wire, or split at a
+%% downstream h3->h1 reverse proxy. Answer 500 rather than emit it; only
+%% the kind is logged, never the raw bytes. Shared by every response
+%% shape via `emit_checked/4`.
+-spec reject_unsafe(pid(), non_neg_integer(), name | value) -> 500.
+reject_unsafe(Conn, StreamId, Kind) ->
+    logger:error(#{
+        msg => "roadrunner h3 handler returned a header with CR/LF/NUL",
+        kind => Kind
     }),
     send_buffered(
         Conn, StreamId, 500, [{~"content-type", ~"text/plain"}], ~"Internal Server Error"

--- a/test/roadrunner_h3_test_handler.erl
+++ b/test/roadrunner_h3_test_handler.erl
@@ -30,6 +30,15 @@ handle(#{target := <<"/forbidden/", Name/binary>>} = Req) ->
     %% Emits a connection-specific response header (named by the path),
     %% which RFC 9114 §4.2 forbids over h3.
     {{200, [{Name, ~"x"}], ~"x"}, Req};
+handle(#{target := ~"/inject-value"} = Req) ->
+    %% A response header VALUE with CR/LF (RFC 9110 §5.5 bans CTLs) → 500.
+    {{200, [{~"x-evil", ~"a\r\nb"}], ~"x"}, Req};
+handle(#{target := ~"/inject-name"} = Req) ->
+    %% A response header NAME with CR/LF → 500.
+    {{200, [{~"x-ev\r\nil", ~"v"}], ~"x"}, Req};
+handle(#{target := ~"/stream-inject"} = Req) ->
+    %% Same defect on a streaming response's headers → 500.
+    {{stream, 200, [{~"x-evil", ~"a\r\nb"}], fun(Send) -> ok = Send(~"x", fin) end}, Req};
 handle(#{target := ~"/crash"} = _Req) ->
     error(boom);
 handle(#{target := ~"/badheaders"} = Req) ->

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -25,6 +25,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     not_found/1,
     crash_500/1,
     forbidden_response_header_500/1,
+    unsafe_response_header_500/1,
     unsupported_shapes_501/1,
     loop_response/1,
     loop_filters_otp/1,
@@ -33,6 +34,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     stream_trailers/1,
     stream_autoclose/1,
     stream_forbidden_header_500/1,
+    stream_unsafe_header_500/1,
     sendfile_empty/1,
     sendfile_small/1,
     sendfile_large/1,
@@ -87,6 +89,7 @@ all() ->
         not_found,
         crash_500,
         forbidden_response_header_500,
+        unsafe_response_header_500,
         unsupported_shapes_501,
         loop_response,
         loop_filters_otp,
@@ -95,6 +98,7 @@ all() ->
         stream_trailers,
         stream_autoclose,
         stream_forbidden_header_500,
+        stream_unsafe_header_500,
         sendfile_empty,
         sendfile_small,
         sendfile_large,
@@ -289,6 +293,14 @@ forbidden_response_header_500(Config) ->
     ),
     close(Conn).
 
+unsafe_response_header_500(Config) ->
+    %% A handler returning a response header with CR/LF/NUL in the name or
+    %% value is rejected (RFC 9110 §5.5): 500, and the connection survives.
+    Conn = connect(?config(port, Config)),
+    ?assertMatch({500, _}, status_body(get(Conn, ~"/inject-value"))),
+    ?assertMatch({500, _}, status_body(get(Conn, ~"/inject-name"))),
+    close(Conn).
+
 unsupported_shapes_501(Config) ->
     Conn = connect(?config(port, Config)),
     lists:foreach(
@@ -398,6 +410,13 @@ stream_forbidden_header_500(Config) ->
     %% rejected with 500 (RFC 9114 §4.2), same as the buffered path.
     Conn = connect(?config(port, Config)),
     ?assertMatch({500, _}, status_body(get(Conn, ~"/stream-forbidden"))),
+    close(Conn).
+
+stream_unsafe_header_500(Config) ->
+    %% A streaming response carrying a header with CR/LF/NUL is rejected
+    %% with 500 (RFC 9110 §5.5), same as the buffered path.
+    Conn = connect(?config(port, Config)),
+    ?assertMatch({500, _}, status_body(get(Conn, ~"/stream-inject"))),
     close(Conn).
 
 oversized_413(_Config) ->


### PR DESCRIPTION
# Description

h1 and h2 run the CR/LF/NUL field-value check (RFC 9110 §5.5) on every response header; h3 did not, so a handler echoing unvalidated input into a header could put malformed bytes on the wire (or split at a downstream h3→h1 reverse proxy). This wires the check into `roadrunner_http3_stream_worker:emit_checked/4` (the gate all response shapes pass through). It uses a new non-crashing `roadrunner_http:first_unsafe_field/1` rather than the crashing `check_headers_safe/1`, because h3's emit runs in a `try ... of` body that does not catch raises — so a hit returns a clean 500 (matching h1/h2's caught-crash→500 and h3's own forbidden-header 500), logging only the kind, never the raw bytes.

```erlang
%% handler returns {200, [{~"x-evil", ~"a\r\nb"}], Body} over h3  ->  500, connection survives
```

Trailers (sent mid-stream, where a 500 isn't possible) are left for a separate follow-up.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
