### PR TITLE
Reject CR/LF/NUL in HTTP/3 response trailers

### DIFF
--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -338,6 +338,11 @@ stream_send(Conn, StreamId, Data, fin) ->
     put(?FIN_KEY, true),
     quic:send_data(Conn, StreamId, data_frame(Data, iolist_size(Data)), true);
 stream_send(Conn, StreamId, Data, {fin, Trailers}) ->
+    %% Trailers go out after the status + body, so an injected one cannot
+    %% become a 500; crash on the RFC 9110 §5.5 check before writing the
+    %% frame so the conn loop resets the stream and the malformed bytes
+    %% never reach the client, the same cut-off h1 does for chunked trailers.
+    ok = roadrunner_http:check_headers_safe(Trailers),
     put(?FIN_KEY, true),
     TrailersFrame = quic_h3_frame:encode_headers(quic_qpack:encode(Trailers)),
     quic:send_data(Conn, StreamId, [data_frame(Data, iolist_size(Data)), TrailersFrame], true).

--- a/test/roadrunner_h3_test_handler.erl
+++ b/test/roadrunner_h3_test_handler.erl
@@ -58,6 +58,13 @@ handle(#{target := ~"/stream"} = Req) ->
     };
 handle(#{target := ~"/stream-trailers"} = Req) ->
     {{stream, 200, [], fun(Send) -> ok = Send(~"body", {fin, [{~"x-trailer", ~"v"}]}) end}, Req};
+handle(#{target := ~"/stream-bad-trailers"} = Req) ->
+    %% CR/LF in a trailer value → the injection check crashes mid-stream
+    %% (status already sent), so the conn loop resets the stream.
+    {
+        {stream, 200, [], fun(Send) -> ok = Send(~"body", {fin, [{~"x-trailer", ~"a\r\nb"}]}) end},
+        Req
+    };
 handle(#{target := ~"/stream-noend"} = Req) ->
     %% Returns without a `fin` — the framework auto-closes the stream.
     {{stream, 200, [], fun(Send) -> ok = Send(~"data", nofin) end}, Req};

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -35,6 +35,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     stream_autoclose/1,
     stream_forbidden_header_500/1,
     stream_unsafe_header_500/1,
+    stream_trailer_injection_aborts/1,
     sendfile_empty/1,
     sendfile_small/1,
     sendfile_large/1,
@@ -99,6 +100,7 @@ all() ->
         stream_autoclose,
         stream_forbidden_header_500,
         stream_unsafe_header_500,
+        stream_trailer_injection_aborts,
         sendfile_empty,
         sendfile_small,
         sendfile_large,
@@ -418,6 +420,29 @@ stream_unsafe_header_500(Config) ->
     Conn = connect(?config(port, Config)),
     ?assertMatch({500, _}, status_body(get(Conn, ~"/stream-inject"))),
     close(Conn).
+
+stream_trailer_injection_aborts(Config) ->
+    %% Wire-level proof that a CR/LF in a response trailer never reaches the
+    %% wire. A raw client reads the server's actual stream bytes: with the
+    %% check the server sends the 200 HEADERS then RESETS the stream, so the
+    %% malformed value ("a\r\nb" = <<97,13,10,98>>) is never emitted; without
+    %% it, QPACK encodes those bytes into a trailer frame and the stream
+    %% finishes cleanly. The conformant `quic_h3` client cannot show this --
+    %% it rejects the bad field either way -- so this drives a raw client.
+    Conn = ll_connect(?config(port, Config)),
+    try
+        {ok, StreamId} = quic:open_stream(Conn),
+        Block = quic_qpack:encode(headers(~"GET", ~"/stream-bad-trailers")),
+        ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_headers(Block), true),
+        Result = ll_collect_until_end(Conn, StreamId, <<>>),
+        %% The server aborts the stream rather than completing it normally,
+        ?assertMatch({reset, _, _}, Result),
+        {reset, _ErrorCode, Bytes} = Result,
+        %% and the malformed trailer value never appears on the wire.
+        ?assertEqual(nomatch, binary:match(Bytes, <<$a, $\r, $\n, $b>>))
+    after
+        ll_close(Conn)
+    end.
 
 oversized_413(_Config) ->
     Name = listener_name(oversized_413),
@@ -1135,6 +1160,21 @@ ll_await_reset(Conn, StreamId) ->
         {quic, Conn, {stream_reset, StreamId, ErrorCode}} -> ErrorCode
     after 5000 ->
         ct:fail(no_stream_reset)
+    end.
+
+%% Read every byte the server writes on `StreamId` until it finishes the
+%% stream (`{fin, Bytes}`) or resets it (`{reset, ErrorCode, Bytes}`), so a
+%% test can inspect exactly what reached the wire.
+ll_collect_until_end(Conn, StreamId, Acc) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Bin, true}} ->
+            {fin, <<Acc/binary, Bin/binary>>};
+        {quic, Conn, {stream_data, StreamId, Bin, false}} ->
+            ll_collect_until_end(Conn, StreamId, <<Acc/binary, Bin/binary>>);
+        {quic, Conn, {stream_reset, StreamId, ErrorCode}} ->
+            {reset, ErrorCode, Acc}
+    after 5000 ->
+        ct:fail(no_stream_end)
     end.
 
 %% Spin until a `{loop, _}` handler registers `Name` (it does so from


### PR DESCRIPTION
# Description

h1 and h2 reject CR/LF/NUL in response trailers; h3 didn't. On the h3 streaming path `stream_send/4`'s `{fin, Trailers}` clause QPACK-encoded and sent trailers with no check, so a handler echoing unvalidated input into a trailer shipped those bytes to the peer (and they would split at a downstream h3→h1 reverse proxy that translates trailers to chunked). This adds the same `roadrunner_http:check_headers_safe/1` gate the h1/h2 paths use, at the top of that clause. Because the status + body are already in flight, a 500 is impossible: the check crashes before the trailer frame is written, the conn loop resets the stream, and the malformed bytes never reach the wire — the same cut-off h1 does for chunked trailers.

Proven by a wire-level test (raw QUIC client) that reads the server's actual stream bytes: with the check the server sends the HEADERS then RESETS, and `"a\r\nb"` never appears; the test fails without the check (the stream completes and the trailer bytes are emitted). A conformant `quic_h3` client rejects the bad field either way, so only the raw client can show the difference.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
