### PR TITLE
Cache the gzip-sibling stat result on the static cache path

### DIFF
--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -140,8 +140,8 @@ cache_clear() ->
 ) -> roadrunner_handler:response().
 serve_file(FilePath, TtlMs, Req) ->
     case cached_lookup(FilePath, TtlMs) of
-        {ok, Size, Mtime, ETag, LastMod} ->
-            serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Req);
+        {ok, Size, Mtime, ETag, LastMod, GzInfo} ->
+            serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, GzInfo, Req);
         miss ->
             fresh_lookup(FilePath, TtlMs, Req)
     end.
@@ -152,7 +152,7 @@ serve_file(FilePath, TtlMs, Req) ->
 %% always bypass the cache because the policy gate needs the un-followed
 %% `read_link_info` result.
 -spec cached_lookup(file:filename_all(), non_neg_integer() | infinity) ->
-    {ok, non_neg_integer(), integer(), binary(), binary()} | miss.
+    {ok, non_neg_integer(), integer(), binary(), binary(), {gz, non_neg_integer()} | nogz} | miss.
 cached_lookup(_FilePath, TtlMs) when is_integer(TtlMs), TtlMs =< 0 ->
     miss;
 cached_lookup(FilePath, _TtlMs) ->
@@ -177,26 +177,34 @@ fresh_lookup(FilePath, TtlMs, Req) ->
         {ok, #file_info{type = regular, size = Size, mtime = Mtime}} ->
             ETag = etag(Size, Mtime),
             LastMod = roadrunner_http:format_http_date(Mtime),
-            ok = maybe_cache_put(FilePath, Size, Mtime, ETag, LastMod, TtlMs),
-            serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Req);
+            serve_and_maybe_cache(FilePath, Size, Mtime, ETag, LastMod, TtlMs, Req);
         _ ->
             roadrunner_resp:not_found()
     end.
 
--spec maybe_cache_put(
+%% Caching off (non-positive TTL): serve `lazy` — the gzip sibling is
+%% stat'd per request only when the client accepts gzip, the default-path
+%% behaviour, and nothing is cached. Caching on (positive TTL or
+%% infinity): stat the gzip sibling once now and cache the full metadata,
+%% so every later hit skips both that stat and the ETag/Last-Modified
+%% recompute.
+-spec serve_and_maybe_cache(
     file:filename_all(),
     non_neg_integer(),
     integer(),
     binary(),
     binary(),
-    non_neg_integer() | infinity
-) -> ok.
-maybe_cache_put(_FilePath, _Size, _Mtime, _ETag, _LastMod, TtlMs) when
+    non_neg_integer() | infinity,
+    roadrunner_req:request()
+) -> roadrunner_handler:response().
+serve_and_maybe_cache(FilePath, Size, Mtime, ETag, LastMod, TtlMs, Req) when
     is_integer(TtlMs), TtlMs =< 0
 ->
-    ok;
-maybe_cache_put(FilePath, Size, Mtime, ETag, LastMod, TtlMs) ->
-    roadrunner_static_cache:store(FilePath, Size, Mtime, ETag, LastMod, TtlMs).
+    serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, lazy, Req);
+serve_and_maybe_cache(FilePath, Size, Mtime, ETag, LastMod, TtlMs, Req) ->
+    GzInfo = stat_gz(FilePath),
+    ok = roadrunner_static_cache:store(FilePath, Size, Mtime, ETag, LastMod, GzInfo, TtlMs),
+    serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, GzInfo, Req).
 
 %% Read leaf-stat after the symlink-policy gate has approved follow.
 -spec serve_followed_file(file:filename_all(), roadrunner_req:request()) ->
@@ -206,7 +214,9 @@ serve_followed_file(FilePath, Req) ->
         {ok, #file_info{type = regular, size = Size, mtime = Mtime}} ->
             ETag = etag(Size, Mtime),
             LastMod = roadrunner_http:format_http_date(Mtime),
-            serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Req);
+            %% Symlink leaves never cache, so the gzip sibling is resolved
+            %% lazily (stat'd per request, only when gzip is accepted).
+            serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, lazy, Req);
         _ ->
             roadrunner_resp:not_found()
     end.
@@ -217,9 +227,10 @@ serve_followed_file(FilePath, Req) ->
     integer(),
     binary(),
     binary(),
+    lazy | {gz, non_neg_integer()} | nogz,
     roadrunner_req:request()
 ) -> roadrunner_handler:response().
-serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Req) ->
+serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, GzMeta, Req) ->
     case is_cached(Req, ETag, Mtime) of
         true ->
             {304,
@@ -230,7 +241,7 @@ serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Req) ->
                 ],
                 ~""};
         false ->
-            case maybe_serve_gzip(FilePath, ETag, LastMod, Req) of
+            case maybe_serve_gzip(FilePath, ETag, LastMod, GzMeta, Req) of
                 {ok, Resp} -> Resp;
                 none -> serve_with_range(FilePath, Size, ETag, LastMod, Req)
             end
@@ -241,24 +252,48 @@ serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Req) ->
 %% requests skip this path — byte offsets over a compressed
 %% representation have subtle semantics, so we let Range win and
 %% serve the raw file.
--spec maybe_serve_gzip(file:filename_all(), binary(), binary(), roadrunner_req:request()) ->
-    {ok, roadrunner_handler:response()} | none.
-maybe_serve_gzip(FilePath, ETag, LastMod, Req) ->
+-spec maybe_serve_gzip(
+    file:filename_all(),
+    binary(),
+    binary(),
+    lazy | {gz, non_neg_integer()} | nogz,
+    roadrunner_req:request()
+) -> {ok, roadrunner_handler:response()} | none.
+maybe_serve_gzip(FilePath, ETag, LastMod, GzMeta, Req) ->
     case
         (roadrunner_req:header(~"range", Req) =:= undefined) andalso
             accepts_gzip(Req)
     of
         true ->
-            GzPath = iolist_to_binary([FilePath, ~".gz"]),
-            case file:read_file_info(GzPath, [raw, {time, posix}]) of
-                {ok, #file_info{type = regular, size = GzSize}} ->
-                    {ok, gzip_response(FilePath, GzPath, GzSize, ETag, LastMod)};
-                _ ->
+            case resolve_gz(FilePath, GzMeta) of
+                {gz, GzSize} ->
+                    {ok, gzip_response(FilePath, gz_path(FilePath), GzSize, ETag, LastMod)};
+                nogz ->
                     none
             end;
         false ->
             none
     end.
+
+%% Resolve the gzip-sibling result: use the cached value, or stat the
+%% sibling now (`lazy` — the no-cache / symlink path).
+-spec resolve_gz(file:filename_all(), lazy | {gz, non_neg_integer()} | nogz) ->
+    {gz, non_neg_integer()} | nogz.
+resolve_gz(FilePath, lazy) -> stat_gz(FilePath);
+resolve_gz(_FilePath, GzInfo) -> GzInfo.
+
+%% Stat the `<file>.gz` sibling: `{gz, GzSize}` when it is a regular file,
+%% `nogz` otherwise.
+-spec stat_gz(file:filename_all()) -> {gz, non_neg_integer()} | nogz.
+stat_gz(FilePath) ->
+    case file:read_file_info(gz_path(FilePath), [raw, {time, posix}]) of
+        {ok, #file_info{type = regular, size = GzSize}} -> {gz, GzSize};
+        _ -> nogz
+    end.
+
+-spec gz_path(file:filename_all()) -> binary().
+gz_path(FilePath) ->
+    iolist_to_binary([FilePath, ~".gz"]).
 
 -spec accepts_gzip(roadrunner_req:request()) -> boolean().
 accepts_gzip(Req) ->

--- a/src/roadrunner_static_cache.erl
+++ b/src/roadrunner_static_cache.erl
@@ -18,7 +18,7 @@
 
 -behaviour(gen_server).
 
--export([start_link/0, lookup/1, store/6, clear/0]).
+-export([start_link/0, lookup/1, store/7, clear/0]).
 -export([init/1, handle_call/3, handle_cast/2]).
 
 -define(TABLE, roadrunner_static_meta).
@@ -27,41 +27,49 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-%% Read the cached size and mtime for FilePath if it is still within its
-%% TTL. An infinity entry is always a hit; an expired entry is dropped
-%% (cheap in ETS) and reported as a miss. The cached value carries the
-%% derived ETag + Last-Modified strings so a hit skips recomputing them.
+%% Read the cached metadata for FilePath if it is still within its TTL.
+%% An infinity entry is always a hit; an expired entry is dropped (cheap
+%% in ETS) and reported as a miss. The cached value carries the derived
+%% ETag + Last-Modified strings and the gzip-sibling result, so a hit
+%% skips recomputing them and skips the per-request `<file>.gz` stat.
 -spec lookup(file:filename_all()) ->
-    {ok, non_neg_integer(), integer(), binary(), binary()} | miss.
+    {ok, non_neg_integer(), integer(), binary(), binary(), {gz, non_neg_integer()} | nogz} | miss.
 lookup(FilePath) ->
     case ets:lookup(?TABLE, FilePath) of
         [] ->
             miss;
-        [{_, {Size, Mtime, ETag, LastMod, infinity}}] ->
-            {ok, Size, Mtime, ETag, LastMod};
-        [{_, {Size, Mtime, ETag, LastMod, ExpiresAt}}] ->
+        [{_, {Size, Mtime, ETag, LastMod, GzInfo, infinity}}] ->
+            {ok, Size, Mtime, ETag, LastMod, GzInfo};
+        [{_, {Size, Mtime, ETag, LastMod, GzInfo, ExpiresAt}}] ->
             case erlang:monotonic_time(millisecond) of
                 Now when Now =< ExpiresAt ->
-                    {ok, Size, Mtime, ETag, LastMod};
+                    {ok, Size, Mtime, ETag, LastMod, GzInfo};
                 _ ->
                     true = ets:delete(?TABLE, FilePath),
                     miss
             end
     end.
 
-%% Store the size, mtime, and derived ETag + Last-Modified strings for
-%% FilePath with a TTL of TtlMs ms from now, or forever when TtlMs is
-%% infinity. Concurrent stores for the same path are last-writer-wins
-%% (each insert is atomic per key).
+%% Store the size, mtime, derived ETag + Last-Modified strings, and the
+%% gzip-sibling result (`{gz, GzSize}` when a `<file>.gz` is on disk,
+%% `nogz` otherwise) for FilePath with a TTL of TtlMs ms from now, or
+%% forever when TtlMs is infinity. Concurrent stores for the same path
+%% are last-writer-wins (each insert is atomic per key).
 -spec store(
-    file:filename_all(), non_neg_integer(), integer(), binary(), binary(), pos_integer() | infinity
+    file:filename_all(),
+    non_neg_integer(),
+    integer(),
+    binary(),
+    binary(),
+    {gz, non_neg_integer()} | nogz,
+    pos_integer() | infinity
 ) -> ok.
-store(FilePath, Size, Mtime, ETag, LastMod, infinity) ->
-    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, infinity}}),
+store(FilePath, Size, Mtime, ETag, LastMod, GzInfo, infinity) ->
+    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, GzInfo, infinity}}),
     ok;
-store(FilePath, Size, Mtime, ETag, LastMod, TtlMs) when is_integer(TtlMs), TtlMs > 0 ->
+store(FilePath, Size, Mtime, ETag, LastMod, GzInfo, TtlMs) when is_integer(TtlMs), TtlMs > 0 ->
     ExpiresAt = erlang:monotonic_time(millisecond) + TtlMs,
-    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, ExpiresAt}}),
+    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, GzInfo, ExpiresAt}}),
     ok.
 
 %% Drop every cached entry in one call.

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -461,16 +461,16 @@ cache_helpers_test_() ->
             {"cache_put then cache_get within TTL returns the entry", fun() ->
                 FilePath = filename:join(Dir, "fresh.txt"),
                 ok = roadrunner_static_cache:store(
-                    FilePath, 100, 1700000000, ~"etag-fresh", ~"lm-fresh", 60000
+                    FilePath, 100, 1700000000, ~"etag-fresh", ~"lm-fresh", nogz, 60000
                 ),
                 ?assertEqual(
-                    {ok, 100, 1700000000, ~"etag-fresh", ~"lm-fresh"},
+                    {ok, 100, 1700000000, ~"etag-fresh", ~"lm-fresh", nogz},
                     roadrunner_static_cache:lookup(FilePath)
                 )
             end},
             {"cache_get returns miss after TTL expires", fun() ->
                 FilePath = filename:join(Dir, "expiring.txt"),
-                ok = roadrunner_static_cache:store(FilePath, 50, 1700000000, ~"e", ~"lm", 1),
+                ok = roadrunner_static_cache:store(FilePath, 50, 1700000000, ~"e", ~"lm", nogz, 1),
                 timer:sleep(20),
                 ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath))
             end},
@@ -479,23 +479,25 @@ cache_helpers_test_() ->
                 %% past any finite TTL must still return the entry.
                 FilePath = filename:join(Dir, "forever.txt"),
                 ok = roadrunner_static_cache:store(
-                    FilePath, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", infinity
+                    FilePath, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", {gz, 17}, infinity
                 ),
                 ?assertEqual(
-                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr"},
+                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", {gz, 17}},
                     roadrunner_static_cache:lookup(FilePath)
                 ),
                 timer:sleep(10),
                 ?assertEqual(
-                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr"},
+                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", {gz, 17}},
                     roadrunner_static_cache:lookup(FilePath)
                 )
             end},
             {"cache_clear/0 drops every cached entry", fun() ->
                 F1 = filename:join(Dir, "clear_a.txt"),
                 F2 = filename:join(Dir, "clear_b.txt"),
-                ok = roadrunner_static_cache:store(F1, 10, 1700000000, ~"e1", ~"lm1", infinity),
-                ok = roadrunner_static_cache:store(F2, 20, 1700000000, ~"e2", ~"lm2", 60000),
+                ok = roadrunner_static_cache:store(
+                    F1, 10, 1700000000, ~"e1", ~"lm1", nogz, infinity
+                ),
+                ok = roadrunner_static_cache:store(F2, 20, 1700000000, ~"e2", ~"lm2", nogz, 60000),
                 ok = roadrunner_static:cache_clear(),
                 ?assertEqual(miss, roadrunner_static_cache:lookup(F1)),
                 ?assertEqual(miss, roadrunner_static_cache:lookup(F2))
@@ -516,7 +518,7 @@ cache_populated_after_request_test_() ->
                 ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath)),
                 _Reply = http_get(Port, ~"/static/cached.txt"),
                 ?assertMatch(
-                    {ok, _Size, _Mtime, _ETag, _LastMod},
+                    {ok, _Size, _Mtime, _ETag, _LastMod, _GzInfo},
                     roadrunner_static_cache:lookup(FilePath)
                 )
             end},
@@ -532,6 +534,19 @@ cache_populated_after_request_test_() ->
                 [_, Body2] = binary:split(Reply2, ~"\r\n\r\n"),
                 ?assertEqual(Body1, Body2),
                 ?assertEqual(~"cached", Body1)
+            end},
+            {"cache hit serves the gzip sibling from the cached result", fun() ->
+                %% Two gzip requests to a cached, .gz-backed file: the cold
+                %% one caches the gzip-sibling result, the hit serves from it
+                %% (no per-request `.gz` stat). Both carry gzip encoding.
+                R1 = http_get_with(
+                    Port, ~"/static/gz_cached.css", [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                R2 = http_get_with(
+                    Port, ~"/static/gz_cached.css", [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                {match, _} = re:run(R1, ~"content-encoding: gzip", [caseless]),
+                {match, _} = re:run(R2, ~"content-encoding: gzip", [caseless])
             end}
         ]
     end}.
@@ -607,6 +622,8 @@ cache_enabled_setup() ->
     ),
     ok = filelib:ensure_dir(filename:join(Dir, "x")),
     ok = file:write_file(filename:join(Dir, "cached.txt"), ~"cached"),
+    ok = file:write_file(filename:join(Dir, "gz_cached.css"), ~"body{}"),
+    ok = file:write_file(filename:join(Dir, "gz_cached.css.gz"), zlib:gzip(~"body{}")),
     {ok, _} = roadrunner_listener:start_link(Name, #{
         port => 0,
         routes => [


### PR DESCRIPTION
# Description

On the opt-in `cache_ttl_ms` static path, a cache hit still ran `file:read_file_info(<file>.gz)` on every request (the gzip-sibling check in `maybe_serve_gzip/4`) even though that result is file-derived and cacheable. The metadata cache now stores the gzip-sibling result (`{gz, GzSize} | nogz`) alongside the size/mtime/ETag/Last-Modified it already held, populated on the cold lookup that stats the main file, so a hit serves gzip with no extra syscall until the TTL expires.

The default (no-cache) path is unchanged: it resolves the sibling `lazy`, stat-ing it per request only when the client accepts gzip, so there is no regression there. Symlink leaves also stay `lazy` (never cached).

Microbench: the `.gz` `file:read_file_info` costs ~1.8 µs, eliminated per cache hit. A constant per-hit syscall saving on the opt-in path, not a throughput claim.

Companion to the roadmap cleanup in #99 (which removes the now-resolved hot-path items, including this one).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
