### PR TITLE
Strip connection-specific fields from h2/h3 responses

### DIFF
--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1317,12 +1317,13 @@ encode_and_send_headers(
 ) ->
     StatusBin = integer_to_binary(Status),
     %% Handler-supplied header names MUST already be lowercase per RFC 9113
-    %% §8.1.2 (see `roadrunner_handler:response/0`). Bytes outside the
-    %% RFC 9110 §5.5 field-value charset (CR/LF/NUL) crash here so the
-    %% h2 path matches h1's `encode_headers/1` discipline.
-    ok = roadrunner_http:check_headers_safe(Headers),
+    %% §8.1.2 (see `roadrunner_handler:response/0`). In one pass: crash on
+    %% CR/LF/NUL outside the RFC 9110 §5.5 field-value charset (matching h1's
+    %% `encode_headers/1` discipline) and strip the connection-specific fields
+    %% RFC 9113 §8.2.2 forbids h2 from generating.
+    WireHeaders = roadrunner_http:strip_connection_specific_fields_safe(Headers),
     AllHeaders =
-        [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
+        [{~":status", StatusBin} | roadrunner_http:auto_headers(WireHeaders, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     %% `frame:encode` accepts iodata for the header block — skip
     %% the upfront flatten; ssl:send walks the iolist anyway.
@@ -1355,12 +1356,13 @@ encode_and_send_response_atomic(
 ) ->
     #{StreamId := Stream} = Streams,
     StatusBin = integer_to_binary(Status),
-    %% Names already lowercase per `roadrunner_handler:response/0` contract;
-    %% reject CR/LF/NUL anywhere in the pair so they cannot reach the peer
-    %% or split at an h2->h1 reverse proxy.
-    ok = roadrunner_http:check_headers_safe(Headers),
+    %% Names already lowercase per `roadrunner_handler:response/0` contract.
+    %% One pass rejects CR/LF/NUL anywhere in the pair (so they cannot reach
+    %% the peer or split at an h2->h1 reverse proxy) and strips the
+    %% connection-specific fields RFC 9113 §8.2.2 forbids h2 from generating.
+    WireHeaders = roadrunner_http:strip_connection_specific_fields_safe(Headers),
     AllHeaders =
-        [{~":status", StatusBin} | roadrunner_http:auto_headers(Headers, State#loop.alt_svc)],
+        [{~":status", StatusBin} | roadrunner_http:auto_headers(WireHeaders, State#loop.alt_svc)],
     {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(AllHeaders, Enc),
     HFrame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04, undefined, HpackBlock}
@@ -1373,9 +1375,11 @@ encode_and_send_response_atomic(
 
 encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
     %% Trailer names already lowercase per `roadrunner_handler:response/0`;
-    %% h1 trailers run the same check in `roadrunner_stream_response`.
-    ok = roadrunner_http:check_headers_safe(Trailers),
-    {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(Trailers, Enc),
+    %% h1 trailers run the same check in `roadrunner_stream_response`. One
+    %% pass rejects CR/LF/NUL and strips connection-specific fields (RFC 9113
+    %% §8.2.2).
+    WireTrailers = roadrunner_http:strip_connection_specific_fields_safe(Trailers),
+    {HpackBlock, Enc1} = roadrunner_http2_hpack:encode(WireTrailers, Enc),
     Frame = roadrunner_http2_frame:encode(
         {headers, StreamId, 16#04 bor 16#01, undefined, HpackBlock}
     ),

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -21,8 +21,14 @@ Items here:
   `Last-Modified` response header used by the static handler.
 - Header field-value safety (RFC 9110 §5.5): reject CR/LF/NUL in a
   header name or value before it reaches the wire
-  (`check_header_safe/2`, `check_headers_safe/1`), shared by every
-  version's response path.
+  (`check_header_safe/2`), shared by every version's response path.
+- Connection-specific field stripping (RFC 9113 §8.2.2 / RFC 9114
+  §4.2): drop the hop-by-hop fields HTTP/2 and HTTP/3 MUST NOT
+  generate from a response field section
+  (`strip_connection_specific_fields/1`), or do it fused with the
+  field-value check in a single pass
+  (`strip_connection_specific_fields_safe/1`); HTTP/1.1 honours these
+  fields, so it does not strip.
 
 `roadrunner_http1` and `roadrunner_req` re-export the primitive
 types as aliases so existing callers keep compiling unchanged.
@@ -32,8 +38,9 @@ accessors that operate on it.
 
 -export([http_date_now/0, format_http_date/1, with_date/1, auto_headers/2]).
 -export([header_list_size/1]).
--export([check_header_safe/2, check_header_safe/3, check_headers_safe/1]).
+-export([check_header_safe/2, check_header_safe/3]).
 -export([unsafe_bytes_pattern/0]).
+-export([strip_connection_specific_fields/1, strip_connection_specific_fields_safe/1]).
 
 -export_type([headers/0, status/0, redirect_status/0, version/0]).
 
@@ -173,9 +180,9 @@ check_header_safe(Bin, Kind) when is_binary(Bin) ->
     check_header_safe(Bin, Kind, persistent_term:get(?UNSAFE_BYTES_KEY)).
 
 %% Accepts a pre-fetched pattern so a caller iterating a header list
-%% (`check_headers_safe/2`, or h1's fused `encode_headers/1`) pays one
-%% `persistent_term:get/1` instead of one per field. Exported for the
-%% h1 encode path; most callers want `check_header_safe/2`.
+%% (`strip_connection_specific_fields_safe/1`, or h1's fused
+%% `encode_headers/1`) pays one `persistent_term:get/1` instead of one
+%% per field. Exported for those; most callers want `check_header_safe/2`.
 -doc false.
 -spec check_header_safe(binary(), name | value, binary:cp()) -> ok.
 check_header_safe(Bin, Kind, UnsafeCp) when is_binary(Bin) ->
@@ -184,39 +191,73 @@ check_header_safe(Bin, Kind, UnsafeCp) when is_binary(Bin) ->
         _ -> error({header_injection, Kind, Bin})
     end.
 
--doc """
-Run the header-injection check over every name and value in a header
-list, fetching the compiled unsafe-bytes pattern once and threading it
-through (vs `check_header_safe/2`, which fetches per call). Crashes with
-`{header_injection, Kind, Bin}` on the first unsafe byte.
-
-The list-validating entry for response paths that emit headers via a
-binary codec rather than the CRLF encoder: the HTTP/2 conn loop, and
-HTTP/3 once its check is wired. h1's CRLF encoder fuses the per-field
-check into its build pass instead, so it does not use this entry.
-""".
--spec check_headers_safe(headers()) -> ok.
-check_headers_safe(Headers) ->
-    check_headers_safe(Headers, persistent_term:get(?UNSAFE_BYTES_KEY)).
-
-%% Loop with the pre-fetched pattern.
--spec check_headers_safe(headers(), binary:cp()) -> ok.
-check_headers_safe([], _UnsafeCp) ->
-    ok;
-check_headers_safe([{Name, Value} | Rest], UnsafeCp) ->
-    ok = check_header_safe(Name, name, UnsafeCp),
-    ok = check_header_safe(Value, value, UnsafeCp),
-    check_headers_safe(Rest, UnsafeCp).
-
 %% The compiled CR/LF/NUL pattern, for a caller that runs the check in a
 %% loop and wants a single `persistent_term:get/1` for the whole list:
-%% h1's fused `encode_headers/1` (via `check_header_safe/3`) and the
-%% HTTP/3 emit gate (inline `binary:match`). Callers not already iterating
-%% want `check_header_safe/2` or `check_headers_safe/1` instead.
+%% h1's fused `encode_headers/1`, the fused
+%% `strip_connection_specific_fields_safe/1`, and the HTTP/3 emit gate
+%% (all via `check_header_safe/3` or inline `binary:match`). Callers not
+%% already iterating want `check_header_safe/2`.
 -doc false.
 -spec unsafe_bytes_pattern() -> binary:cp().
 unsafe_bytes_pattern() ->
     persistent_term:get(?UNSAFE_BYTES_KEY).
+
+-doc """
+Drop connection-specific header fields from an HTTP/2 or HTTP/3
+response field section. RFC 9113 §8.2.2 and RFC 9114 §4.2 forbid
+*generating* `connection`, `keep-alive`, `proxy-connection`,
+`transfer-encoding`, or `upgrade` over those protocols — they are
+hop-by-hop fields (RFC 9110 §7.6.1) meaningful only on an HTTP/1.1
+connection. A handler shared across protocols may set one (e.g.
+`connection: close`, idiomatic on h1); stripping it on h2/h3 keeps that
+handler working while staying conformant, since the framework never
+puts the field on the wire. HTTP/1.1 honours these fields, so its
+response path does not strip.
+""".
+-spec strip_connection_specific_fields(headers()) -> headers().
+strip_connection_specific_fields(Headers) ->
+    [Field || {Name, _} = Field <- Headers, not connection_specific_field(Name)].
+
+-doc """
+Single-pass combination of `check_header_safe/2` and
+`strip_connection_specific_fields/1` for the response paths that crash
+on injection (the HTTP/2 conn loop and the HTTP/3 trailer path): in one
+traversal it rejects CR/LF/NUL in any name or value (crashing with
+`{header_injection, Kind, Bin}`, like `check_header_safe/2`) and drops
+the connection-specific fields h2/h3 MUST NOT generate. HTTP/3 response
+headers answer 500 on injection instead of crashing, so they run the
+non-crashing check and `strip_connection_specific_fields/1` separately.
+""".
+-spec strip_connection_specific_fields_safe(headers()) -> headers().
+strip_connection_specific_fields_safe(Headers) ->
+    strip_connection_specific_fields_safe(Headers, persistent_term:get(?UNSAFE_BYTES_KEY)).
+
+%% One pass with the pre-fetched pattern: check CR/LF/NUL on every field
+%% (including ones about to be dropped, matching the prior two-pass
+%% behaviour) and cons the field only when it is not connection-specific.
+%% Mirrors h1's fused `encode_headers_loop/2`.
+-spec strip_connection_specific_fields_safe(headers(), binary:cp()) -> headers().
+strip_connection_specific_fields_safe([], _UnsafeCp) ->
+    [];
+strip_connection_specific_fields_safe([{Name, Value} = Field | Rest], UnsafeCp) ->
+    ok = check_header_safe(Name, name, UnsafeCp),
+    ok = check_header_safe(Value, value, UnsafeCp),
+    case connection_specific_field(Name) of
+        true -> strip_connection_specific_fields_safe(Rest, UnsafeCp);
+        false -> [Field | strip_connection_specific_fields_safe(Rest, UnsafeCp)]
+    end.
+
+%% The RFC 9110 §7.6.1 connection-specific (hop-by-hop) field names that
+%% RFC 9113 §8.2.2 / RFC 9114 §4.2 forbid an h2/h3 endpoint from
+%% generating. Function-clause dispatch mirrors the request-side
+%% `check_banned/1` in `roadrunner_http2_request` / `roadrunner_http3_request`.
+-spec connection_specific_field(binary()) -> boolean().
+connection_specific_field(~"connection") -> true;
+connection_specific_field(~"keep-alive") -> true;
+connection_specific_field(~"proxy-connection") -> true;
+connection_specific_field(~"transfer-encoding") -> true;
+connection_specific_field(~"upgrade") -> true;
+connection_specific_field(_) -> false.
 
 %% `-on_load` callback. Stashes the compiled unsafe-bytes pattern in
 %% `persistent_term` so `check_header_safe/3` reads a constant on the

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -177,74 +177,44 @@ emit_handler_response(Conn, StreamId, Handler, {loop, Status, Headers, State}) -
 emit_handler_response(Conn, StreamId, _Handler, {websocket, _, _}) ->
     emit_501(Conn, StreamId).
 
-%% Emit a response unless it carries a connection-specific header
-%% (RFC 9114 §4.2), in which case answer 500. `Emit` performs the send
-%% and returns the status sent; shared by the buffered / stream /
-%% sendfile paths.
+%% Emit a response unless it carries a header with CR/LF/NUL (RFC 9110
+%% §5.5), in which case answer 500. Connection-specific fields (RFC 9114
+%% §4.2) are not rejected here — `header_frame/2` strips them. `Emit`
+%% performs the send and returns the status sent; shared by the buffered
+%% / stream / sendfile paths.
 -spec emit_checked(
     pid(), non_neg_integer(), roadrunner_http:headers(), fun(() -> roadrunner_http:status())
 ) -> roadrunner_http:status().
 emit_checked(Conn, StreamId, Headers, Emit) ->
     case validate_response_headers(Headers) of
         ok -> Emit();
-        {unsafe, Kind} -> reject_unsafe(Conn, StreamId, Kind);
-        {forbidden, Name} -> reject_forbidden(Conn, StreamId, Name)
+        {unsafe, Kind} -> reject_unsafe(Conn, StreamId, Kind)
     end.
 
-%% One pass over the response headers, applying both gates per field: the
-%% RFC 9114 §4.2 connection-specific name set, and the RFC 9110 §5.5
-%% CR/LF/NUL field-byte check (the shared compiled pattern, fetched once).
-%% `is_forbidden_header/1` is function-clause dispatch (mirrors
-%% `roadrunner_http3_request:check_banned/1`); a forbidden name returns it
-%% for the log, an unsafe field returns only the kind (never raw bytes).
+%% One pass over the response headers running the RFC 9110 §5.5 CR/LF/NUL
+%% field-byte check (the shared compiled pattern, fetched once), returning
+%% the offending kind (never the raw bytes) on the first unsafe field.
+%% Non-crashing because `emit_checked/4` runs in the `try ... of` body,
+%% whose exceptions the `try` does NOT catch.
 -spec validate_response_headers(roadrunner_http:headers()) ->
-    ok | {unsafe, name | value} | {forbidden, binary()}.
+    ok | {unsafe, name | value}.
 validate_response_headers(Headers) ->
     validate_response_headers(Headers, roadrunner_http:unsafe_bytes_pattern()).
 
 -spec validate_response_headers(roadrunner_http:headers(), binary:cp()) ->
-    ok | {unsafe, name | value} | {forbidden, binary()}.
+    ok | {unsafe, name | value}.
 validate_response_headers([], _UnsafeCp) ->
     ok;
 validate_response_headers([{Name, Value} | Rest], UnsafeCp) ->
-    case is_forbidden_header(Name) of
-        true ->
-            {forbidden, Name};
-        false ->
-            case binary:match(Name, UnsafeCp) of
-                nomatch ->
-                    case binary:match(Value, UnsafeCp) of
-                        nomatch -> validate_response_headers(Rest, UnsafeCp);
-                        _ -> {unsafe, value}
-                    end;
-                _ ->
-                    {unsafe, name}
-            end
+    case binary:match(Name, UnsafeCp) of
+        nomatch ->
+            case binary:match(Value, UnsafeCp) of
+                nomatch -> validate_response_headers(Rest, UnsafeCp);
+                _ -> {unsafe, value}
+            end;
+        _ ->
+            {unsafe, name}
     end.
-
--spec is_forbidden_header(binary()) -> boolean().
-is_forbidden_header(~"connection") -> true;
-is_forbidden_header(~"keep-alive") -> true;
-is_forbidden_header(~"proxy-connection") -> true;
-is_forbidden_header(~"transfer-encoding") -> true;
-is_forbidden_header(~"upgrade") -> true;
-is_forbidden_header(_) -> false.
-
-%% RFC 9114 §4.2: connection-specific header fields MUST NOT be
-%% generated. A handler emitting one (e.g. a shared h1/h2 handler with
-%% `connection: close`) is a server bug, not a received malformed
-%% message — answer 500 rather than write a response the client rejects.
-%% Shared by the buffered and streaming response paths.
--spec reject_forbidden(pid(), non_neg_integer(), binary()) -> 500.
-reject_forbidden(Conn, StreamId, Name) ->
-    logger:error(#{
-        msg => "roadrunner h3 handler returned a connection-specific header",
-        header => Name
-    }),
-    send_buffered(
-        Conn, StreamId, 500, [{~"content-type", ~"text/plain"}], ~"Internal Server Error"
-    ),
-    500.
 
 %% RFC 9110 §5.5: a response header name or value containing CR, LF, or
 %% NUL is a handler bug (usually unvalidated user input echoed into a
@@ -339,12 +309,14 @@ stream_send(Conn, StreamId, Data, fin) ->
     quic:send_data(Conn, StreamId, data_frame(Data, iolist_size(Data)), true);
 stream_send(Conn, StreamId, Data, {fin, Trailers}) ->
     %% Trailers go out after the status + body, so an injected one cannot
-    %% become a 500; crash on the RFC 9110 §5.5 check before writing the
-    %% frame so the conn loop resets the stream and the malformed bytes
-    %% never reach the client, the same cut-off h1 does for chunked trailers.
-    ok = roadrunner_http:check_headers_safe(Trailers),
+    %% become a 500. One pass crashes on the RFC 9110 §5.5 check (so the conn
+    %% loop resets the stream and the malformed bytes never reach the client,
+    %% the same cut-off h1 does for chunked trailers) and strips the
+    %% connection-specific fields RFC 9114 §4.2 forbids, matching the header
+    %% path. The crash must happen before `?FIN_KEY` is set, so run it first.
+    Stripped = roadrunner_http:strip_connection_specific_fields_safe(Trailers),
     put(?FIN_KEY, true),
-    TrailersFrame = quic_h3_frame:encode_headers(quic_qpack:encode(Trailers)),
+    TrailersFrame = quic_h3_frame:encode_headers(quic_qpack:encode(Stripped)),
     quic:send_data(Conn, StreamId, [data_frame(Data, iolist_size(Data)), TrailersFrame], true).
 
 %% `{sendfile, ...}` response. There is no kernel sendfile over QUIC
@@ -451,11 +423,13 @@ loop_push(Conn, StreamId, Data) ->
         Len -> quic:send_data(Conn, StreamId, data_frame(Data, Len), false)
     end.
 
-%% HEADERS frame: QPACK-encoded `:status` + the handler's headers, plus
-%% the auto-injected `Date` (RFC 9110 §6.6.1).
+%% HEADERS frame: QPACK-encoded `:status` + the handler's headers, with
+%% connection-specific fields stripped (RFC 9114 §4.2 — h3 MUST NOT
+%% generate them) and the auto-injected `Date` (RFC 9110 §6.6.1) added.
 -spec header_frame(roadrunner_http:status(), roadrunner_http:headers()) -> binary().
 header_frame(Status, Headers) ->
-    HeaderList = [{~":status", integer_to_binary(Status)} | roadrunner_http:with_date(Headers)],
+    Stripped = roadrunner_http:strip_connection_specific_fields(Headers),
+    HeaderList = [{~":status", integer_to_binary(Status)} | roadrunner_http:with_date(Stripped)],
     quic_h3_frame:encode_headers(quic_qpack:encode(HeaderList)).
 
 %% DATA frame as iodata (type + length varints, then the body by

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -22,6 +22,8 @@ all_test_() ->
         fun bad_preface_closes_connection/0,
         fun non_settings_first_frame_triggers_goaway/0,
         fun full_get_request_returns_response/0,
+        fun buffered_response_strips_connection_specific_fields/0,
+        fun streaming_response_strips_connection_specific_fields/0,
         fun head_request_omits_body/0,
         fun all_frame_types_handled/0,
         fun goaway_received_closes_connection/0,
@@ -258,6 +260,68 @@ full_get_request_returns_response() ->
     {ok, {data, 1, DataFlags, _Body, _}, _} =
         roadrunner_http2_frame:parse(AfterHeaders, 16384),
     ?assertNotEqual(0, DataFlags band 16#01),
+    cleanup(Pid, Ref).
+
+buffered_response_strips_connection_specific_fields() ->
+    %% RFC 9113 §8.2.2: h2 MUST NOT generate connection-specific fields.
+    %% The hello handler sets `connection: close` (idiomatic on h1); it is
+    %% stripped from the buffered (HEADERS + DATA atomic) response.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(),
+    _InitialSettings = expect_send(),
+    serve_recv(ConnPid, ?PREFACE),
+    serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+    _ServerAck = expect_send(),
+    Enc = roadrunner_http2_hpack:new_encoder(4096),
+    {HpackBlock, _} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"https"},
+            {~":authority", ~"localhost"},
+            {~":path", ~"/"}
+        ],
+        Enc
+    ),
+    HpackBin = iolist_to_binary(HpackBlock),
+    HeadersFrame = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 16#04 bor 16#01, undefined, HpackBin})
+    ),
+    serve_recv(ConnPid, HeadersFrame),
+    Response1 = expect_send(),
+    Response2 = drain_send(50),
+    AllResponse =
+        case Response2 of
+            undefined -> Response1;
+            _ -> <<Response1/binary, Response2/binary>>
+        end,
+    Dec0 = roadrunner_http2_hpack:new_decoder(4096),
+    {ok, {headers, 1, _, _, RespHpack}, _} =
+        roadrunner_http2_frame:parse(AllResponse, 16384),
+    {ok, RespHeaders, _} = roadrunner_http2_hpack:decode(RespHpack, Dec0),
+    ?assertEqual(~"200", proplists:get_value(~":status", RespHeaders)),
+    ?assertEqual(undefined, proplists:get_value(~"connection", RespHeaders)),
+    cleanup(Pid, Ref).
+
+streaming_response_strips_connection_specific_fields() ->
+    %% RFC 9113 §8.2.2: connection-specific fields are stripped from both
+    %% the streaming response's HEADERS and its trailers; the legit
+    %% `x-checksum` trailer rides through.
+    {Pid, Ref} = run_stream_request(~"/stream/strip"),
+    Bin = collect_send_bytes(<<>>),
+    Dec0 = roadrunner_http2_hpack:new_decoder(4096),
+    {ok, {headers, 1, _, _, StatusHpack}, Rest1} =
+        roadrunner_http2_frame:parse(Bin, 16384),
+    {ok, StatusHeaders, Dec1} = roadrunner_http2_hpack:decode(StatusHpack, Dec0),
+    ?assertEqual(~"200", proplists:get_value(~":status", StatusHeaders)),
+    ?assertEqual(undefined, proplists:get_value(~"connection", StatusHeaders)),
+    {ok, {data, 1, _, _Body, _}, Rest2} =
+        roadrunner_http2_frame:parse(Rest1, 16384),
+    {ok, {headers, 1, _, _, TrailerHpack}, _} =
+        roadrunner_http2_frame:parse(Rest2, 16384),
+    {ok, TrailerHeaders, _} = roadrunner_http2_hpack:decode(TrailerHpack, Dec1),
+    ?assertEqual(undefined, proplists:get_value(~"connection", TrailerHeaders)),
+    ?assertEqual(~"deadbeef", proplists:get_value(~"x-checksum", TrailerHeaders)),
     cleanup(Pid, Ref).
 
 head_request_omits_body() ->

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -62,6 +62,16 @@ handle(#{target := ~"/stream/trailers"} = Req) ->
         end},
         Req
     };
+handle(#{target := ~"/stream/strip"} = Req) ->
+    %% Connection-specific fields in BOTH the streaming HEADERS and the
+    %% trailers. RFC 9113 §8.2.2 forbids generating them over h2, so the
+    %% server strips both; the legit `x-checksum` trailer rides through.
+    {
+        {stream, 200, [{~"connection", ~"close"}, {~"trailer", ~"x-checksum"}], fun(Send) ->
+            Send(~"hi", {fin, [{~"connection", ~"close"}, {~"x-checksum", ~"deadbeef"}]})
+        end},
+        Req
+    };
 handle(#{target := ~"/stream/trailers-only"} = Req) ->
     {
         {stream, 200, [{~"trailer", ~"x-checksum"}], fun(Send) ->

--- a/test/roadrunner_h3_test_handler.erl
+++ b/test/roadrunner_h3_test_handler.erl
@@ -28,7 +28,7 @@ handle(#{target := ~"/slow"} = Req) ->
     {{200, [], ~"slow"}, Req};
 handle(#{target := <<"/forbidden/", Name/binary>>} = Req) ->
     %% Emits a connection-specific response header (named by the path),
-    %% which RFC 9114 §4.2 forbids over h3.
+    %% which RFC 9114 §4.2 forbids over h3 — the server strips it.
     {{200, [{Name, ~"x"}], ~"x"}, Req};
 handle(#{target := ~"/inject-value"} = Req) ->
     %% A response header VALUE with CR/LF (RFC 9110 §5.5 bans CTLs) → 500.
@@ -69,8 +69,17 @@ handle(#{target := ~"/stream-noend"} = Req) ->
     %% Returns without a `fin` — the framework auto-closes the stream.
     {{stream, 200, [], fun(Send) -> ok = Send(~"data", nofin) end}, Req};
 handle(#{target := ~"/stream-forbidden"} = Req) ->
-    %% A connection-specific header on a stream response → 500.
+    %% A connection-specific header on a stream response → stripped.
     {{stream, 200, [{~"connection", ~"close"}], fun(Send) -> ok = Send(~"x", fin) end}, Req};
+handle(#{target := ~"/stream-forbidden-trailers"} = Req) ->
+    %% A connection-specific field in a trailer → stripped; the legit
+    %% trailer rides through (RFC 9114 §4.2).
+    {
+        {stream, 200, [], fun(Send) ->
+            ok = Send(~"body", {fin, [{~"connection", ~"close"}, {~"x-trailer", ~"v"}]})
+        end},
+        Req
+    };
 handle(#{target := ~"/loop"} = Req) ->
     %% Register the worker so the test can drive it from outside.
     %% Unregister first in case a prior test's worker leaked the name.

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -24,7 +24,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     large_post/1,
     not_found/1,
     crash_500/1,
-    forbidden_response_header_500/1,
+    forbidden_response_header_stripped/1,
     unsafe_response_header_500/1,
     unsupported_shapes_501/1,
     loop_response/1,
@@ -33,7 +33,8 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     stream_response/1,
     stream_trailers/1,
     stream_autoclose/1,
-    stream_forbidden_header_500/1,
+    stream_forbidden_header_stripped/1,
+    stream_forbidden_trailer_stripped/1,
     stream_unsafe_header_500/1,
     stream_trailer_injection_aborts/1,
     sendfile_empty/1,
@@ -89,7 +90,7 @@ all() ->
         large_post,
         not_found,
         crash_500,
-        forbidden_response_header_500,
+        forbidden_response_header_stripped,
         unsafe_response_header_500,
         unsupported_shapes_501,
         loop_response,
@@ -98,7 +99,8 @@ all() ->
         stream_response,
         stream_trailers,
         stream_autoclose,
-        stream_forbidden_header_500,
+        stream_forbidden_header_stripped,
+        stream_forbidden_trailer_stripped,
         stream_unsafe_header_500,
         stream_trailer_injection_aborts,
         sendfile_empty,
@@ -283,13 +285,14 @@ crash_500(Config) ->
     ?assertMatch({500, _}, status_body(get(Conn, ~"/crash"))),
     close(Conn).
 
-forbidden_response_header_500(Config) ->
-    %% A handler returning any connection-specific header is rejected
-    %% (RFC 9114 §4.2): the client sees 500 and the connection survives.
+forbidden_response_header_stripped(Config) ->
+    %% A handler returning any connection-specific header has it stripped
+    %% (RFC 9114 §4.2): the client sees a clean 200 without the field.
     Conn = connect(?config(port, Config)),
     lists:foreach(
         fun(Name) ->
-            ?assertMatch({500, _}, status_body(get(Conn, <<"/forbidden/", Name/binary>>)))
+            {200, Headers, ~"x"} = get(Conn, <<"/forbidden/", Name/binary>>),
+            ?assertEqual(false, lists:keymember(Name, 1, Headers))
         end,
         [~"connection", ~"keep-alive", ~"proxy-connection", ~"transfer-encoding", ~"upgrade"]
     ),
@@ -407,11 +410,19 @@ stream_autoclose(Config) ->
     ?assertEqual({200, ~"data"}, status_body(get(Conn, ~"/stream-noend"))),
     close(Conn).
 
-stream_forbidden_header_500(Config) ->
-    %% A streaming response carrying a connection-specific header is
-    %% rejected with 500 (RFC 9114 §4.2), same as the buffered path.
+stream_forbidden_header_stripped(Config) ->
+    %% A streaming response carrying a connection-specific header has it
+    %% stripped (RFC 9114 §4.2), same as the buffered path.
     Conn = connect(?config(port, Config)),
-    ?assertMatch({500, _}, status_body(get(Conn, ~"/stream-forbidden"))),
+    {200, Headers, ~"x"} = get(Conn, ~"/stream-forbidden"),
+    ?assertEqual(false, lists:keymember(~"connection", 1, Headers)),
+    close(Conn).
+
+stream_forbidden_trailer_stripped(Config) ->
+    %% A connection-specific field in a response trailer is stripped
+    %% (RFC 9114 §4.2); a legitimate trailer rides through.
+    Conn = connect(?config(port, Config)),
+    {200, _Headers, ~"body"} = get(Conn, ~"/stream-forbidden-trailers"),
     close(Conn).
 
 stream_unsafe_header_500(Config) ->


### PR DESCRIPTION
# Description

HTTP/2 and HTTP/3 MUST NOT generate connection-specific header fields (RFC 9113 §8.2.2 / RFC 9114 §4.2: `connection`, `keep-alive`, `proxy-connection`, `transfer-encoding`, `upgrade`). Strip them from every h2/h3 response header and trailer in a single pass, so a handler shared with h1 (which sets `connection: close`) works everywhere. h1 still honors them; CR/LF/NUL injection stays a hard reject.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)