### PR TITLE
Add a Why Roadrunner section and tidy the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   all rate-points per server).
 - [`docs/resource_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/resource_results.md): memory + CPU
   shape per scenario.
+- [`docs/resource_limits.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/resource_limits.md): the
+  per-connection and per-peer memory / CPU limits, with defaults and
+  over-limit behavior (operator reference).
 - [`docs/conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md):
   the connection-process model trade-offs and the one h2 case
   cowboy still wins.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ handful of opt-in helpers (cookies, qs, multipart, SSE, WebSocket).
 Modern OTP idioms throughout, with predictable per-connection
 lifecycle observability.
 
+## Why Roadrunner?
+
+A small, fast HTTP core you can trust on the hot path.
+
+- **Fast where it counts.** Tuned for low p50 and p99 under sustained load. See
+  [Performance at a glance](#performance-at-a-glance).
+- **Correct and hostile-input-safe.** Strict RFC 9110 / 9112 / 9113 parsing,
+  100% h2spec and 100% Autobahn (no exclusions), and stress-tested against
+  request-smuggling corpora. See [Conformance](#conformance).
+- **Every HTTP version, one server.** HTTP/1.1, HTTP/2, HTTP/3 (experimental),
+  and WebSocket served from one listener; browsers upgrade to h3 over the same
+  port via `Alt-Svc`.
+- **Pure Erlang, almost no dependencies.** One runtime dep (`telemetry`), no C
+  NIFs, and roadrunner owns its own h1/h2/h3 codecs: easy to read, easy to audit,
+  nothing to sprawl.
+- **Pleasant to build on.** Plain-Erlang request and response values, composable
+  middleware, and opt-in helpers for cookies, query strings, multipart, SSE, and
+  WebSocket.
+- **Production lifecycle in the box.** Graceful drain with a deadline, telemetry
+  events, per-request `request_id` log correlation, and configurable DoS bounds.
+
+Built to give you a fast, correct HTTP core you can build on with confidence.
+
 ## Requirements
 
 Requires **OTP 27+**.

--- a/README.md
+++ b/README.md
@@ -399,24 +399,6 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
 - [`docs/roadmap.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/roadmap.md): deferred items, with rough
   effort estimates for each.
 
-## Design philosophy
-
-- **RFC-correct, hostile-input-safe**: Parsers are pure incremental
-  binary matchers; only programmer errors raise, wire input always
-  becomes `{error, _}`. Malformed bytes are bounded by length and
-  rejected before reaching application code.
-- **Modern OTP idioms**: Sigils for binary literals, body recursion (cons
-  on the way out), binary keys for wire-derived data, `-doc` /
-  `-moduledoc` markdown, dialyzer-clean specs. No `binary_to_atom` on
-  parsed names.
-- **Telemetry over custom callbacks**: `telemetry` is the de facto
-  standard (Phoenix, Ecto, gleam_otp); no dispatch overhead when nothing is
-  subscribed, and integrates with Prometheus / OpenTelemetry / Datadog through
-  the telemetry ecosystem.
-- **No external deps unless stdlib genuinely can't**: Runtime deps are
-  `telemetry` (tiny, no transitive deps) and `quic` (the pure-Erlang HTTP/3
-  transport, started on demand); the only dev-time dep is the `erlfmt` plugin.
-
 ## Sponsors
 
 Roadrunner is open source and maintained on personal time. If you or your company find it useful,

--- a/README.md
+++ b/README.md
@@ -20,22 +20,22 @@ multipart, SSE, WebSocket).
 
 A small, fast HTTP core you can trust on the hot path.
 
-- **Fast where it counts.** Tuned for low p50 and p99 under sustained load. See
+- **Fast where it counts**: Tuned for low p50 and p99 under sustained load. See
   [Performance at a glance](#performance-at-a-glance).
-- **Correct and hostile-input-safe.** Strict RFC 9110 / 9112 / 9113 parsing,
+- **Correct and hostile-input-safe**: Strict RFC 9110 / 9112 / 9113 parsing,
   100% h2spec and 100% Autobahn (no exclusions), and stress-tested against
   request-smuggling corpora. See [Conformance](#conformance).
-- **Every HTTP version, one server.** HTTP/1.1, HTTP/2, HTTP/3 (experimental),
+- **Every HTTP version, one server**: HTTP/1.1, HTTP/2, HTTP/3 (experimental),
   and WebSocket served from one listener; browsers upgrade to h3 over the same
   port via `Alt-Svc`.
-- **Pure Erlang, almost no dependencies.** Two runtime deps (`telemetry` and
+- **Pure Erlang, almost no dependencies**: Two runtime deps (`telemetry` and
   `quic`, the HTTP/3 transport), no C NIFs, and Roadrunner owns its own
   h1/h2/h3 codecs: easy to read and audit. `quic` only starts for HTTP/3, so
   h1/h2 deployments never load it.
-- **Pleasant to build on.** Plain-Erlang request and response values, composable
+- **Pleasant to build on**: Plain-Erlang request and response values, composable
   middleware, and opt-in helpers for cookies, query strings, multipart, SSE, and
   WebSocket.
-- **Production lifecycle in the box.** Graceful drain with a deadline, telemetry
+- **Production lifecycle in the box**: Graceful drain with a deadline, telemetry
   events, per-request `request_id` log correlation, and configurable DoS bounds.
 
 ## Requirements
@@ -58,27 +58,27 @@ request-smuggling vectors.
 
 Standards conformance:
 
-- **HTTP/1.1.** RFC 9110 (semantics) + RFC 9112 (syntax).
-- **HTTP/2.** RFC 9113 (frames + multiplexing) + RFC 7541 (HPACK).
+- **HTTP/1.1**: RFC 9110 (semantics) + RFC 9112 (syntax).
+- **HTTP/2**: RFC 9113 (frames + multiplexing) + RFC 7541 (HPACK).
   Opt-in per listener via `protocols => [http1, http2]` (or
   `[http2]` for h2c prior-knowledge on plain TCP). Conformance
   harness: [`scripts/h2spec.sh`](https://github.com/arizona-framework/roadrunner/blob/main/scripts/h2spec.sh) (drives
   [h2spec](https://github.com/summerwind/h2spec)).
-- **HTTP/3 (experimental).** RFC 9114 over QUIC with QPACK (RFC 9204)
+- **HTTP/3 (experimental)**: RFC 9114 over QUIC with QPACK (RFC 9204)
   static-table compression. Enable per listener via
   `protocols => [http3]` (requires `tls`; QUIC mandates TLS 1.3); it
   co-serves with h1/h2 on the same port number (TCP for h1/h2, UDP for
   h3) and advertises `Alt-Svc` so browsers upgrade. Built on the
   pure-Erlang [`quic`](https://github.com/benoitc/erlang_quic) transport
   (still 1.x), so treat HTTP/3 as experimental.
-- **Content-Encoding (RFC 9110 §8.4.1).** gzip + deflate with
+- **Content-Encoding (RFC 9110 §8.4.1)**: gzip + deflate with
   qvalue-aware `Accept-Encoding` negotiation (RFC 9110 §12.5.3),
   works unchanged over HTTP/2.
-- **WebSocket.** RFC 6455. Conformance harness:
+- **WebSocket**: RFC 6455. Conformance harness:
   [`scripts/autobahn.escript`](https://github.com/arizona-framework/roadrunner/blob/main/scripts/autobahn.escript) (drives the
   [Autobahn|Testsuite](https://github.com/crossbario/autobahn-testsuite)
   fuzzingclient).
-- **WebSocket compression.** RFC 7692 `permessage-deflate`,
+- **WebSocket compression**: RFC 7692 `permessage-deflate`,
   including `*_max_window_bits` and `*_no_context_takeover`.
 
 ## Performance at a glance
@@ -282,98 +282,98 @@ All listener options live in the
 type, with per-key defaults and tuning rationale. Beyond `port`,
 `protocols`, `tls`, and `routes` from the Quickstart, the type covers:
 
-- **DoS bounds.** `max_clients`, `max_concurrent_requests`,
+- **DoS bounds**: `max_clients`, `max_concurrent_requests`,
   `socket_backlog`, `max_content_length`, `request_timeout`,
   `keep_alive_timeout`, `min_bytes_per_second`, `max_keep_alive_requests`
-- **Middleware.** `middlewares`
-- **Body buffering.** `body_buffering`
-- **Graceful drain.** `graceful_drain`, `slot_reconciliation`
-- **Per-conn hibernation.** `hibernate_after`
-- **Handler spawn opts.** `handler_spawn`
-- **HTTP/1 tunables.** Under the `{http1, Opts}` entry in `protocols`:
+- **Middleware**: `middlewares`
+- **Body buffering**: `body_buffering`
+- **Graceful drain**: `graceful_drain`, `slot_reconciliation`
+- **Per-conn hibernation**: `hibernate_after`
+- **Handler spawn opts**: `handler_spawn`
+- **HTTP/1 tunables**: Under the `{http1, Opts}` entry in `protocols`:
   `max_request_line`, `max_header_line`, `max_header_block`,
   `max_header_count`
-- **HTTP/2 tunables.** Under the `{http2, Opts}` entry in `protocols`:
+- **HTTP/2 tunables**: Under the `{http2, Opts}` entry in `protocols`:
   `conn_window`, `stream_window`, `window_refill_threshold`,
   `max_concurrent_streams`, `max_header_block`
-- **HTTP/3 tunables.** Under the `{http3, Opts}` entry in `protocols`:
+- **HTTP/3 tunables**: Under the `{http3, Opts}` entry in `protocols`:
   `listeners` (reuseport pool size), `max_header_block`
 
 ## Features
 
 ### Handlers
 
-- **Buffered responses.** `{Status, Headers, Body}` via `roadrunner_resp:text/2`,
+- **Buffered responses**: `{Status, Headers, Body}` via `roadrunner_resp:text/2`,
   `:html/2`, `:json/2`, `:redirect/2`, plus empty-status shortcuts.
-- **Streaming.** `{stream, Status, Headers, Fun}`, chunked transfer with a
+- **Streaming**: `{stream, Status, Headers, Fun}`, chunked transfer with a
   `Send/2` callback; supports trailer headers per RFC 9112 §7.1.2.
-- **Loop / SSE.** `{loop, Status, Headers, State}` plus an optional
+- **Loop / SSE**: `{loop, Status, Headers, State}` plus an optional
   `handle_info/3` callback for message-driven push.
-- **WebSocket.** `{websocket, Module, State}` upgrade with a
+- **WebSocket**: `{websocket, Module, State}` upgrade with a
   `roadrunner_ws_handler` callback.
-- **Sendfile.** `{sendfile, Status, Headers, {Filename, Offset, Length}}`,
+- **Sendfile**: `{sendfile, Status, Headers, {Filename, Offset, Length}}`,
   zero-copy file body via `file:sendfile/5` (TCP) or chunked `ssl:send`
   fallback (TLS).
 
 ### Routing
 
-- **Router.** `roadrunner_router` with literal / `:param` / `*wildcard` segments.
-- **Hot reload.** Routes published to `persistent_term` for O(1) lookup;
+- **Router**: `roadrunner_router` with literal / `:param` / `*wildcard` segments.
+- **Hot reload**: Routes published to `persistent_term` for O(1) lookup;
   `roadrunner_listener:reload_routes/2` swaps the table without restart.
 
 ### Middleware
 
-- **Continuation-style.** Each entry is a `Callable` or a
+- **Continuation-style**: Each entry is a `Callable` or a
   `{Callable, State}` pair, where `Callable` is a module (`call/3`) or a
   `fun((Req, Next, State) -> {Response, Req2})`. Listener-level + per-route,
   first-in-list = outermost.
 
 ### Built-in handlers
 
-- **`roadrunner_static`.** File serving with ETag, `If-None-Match`, `Range`,
+- **`roadrunner_static`**: File serving with ETag, `If-None-Match`, `Range`,
   `Last-Modified`, `If-Modified-Since`, and configurable symlink policy
   (`refuse_escapes` default).
 
 ### Hardening
 
-- **Strict parsing.** RFC 9110 / 9112, with defenses grouped by subsystem:
-    - **Request smuggling / framing.** CL+TE conflict, multiple-CL,
+- **Strict parsing**: RFC 9110 / 9112, with defenses grouped by subsystem:
+    - **Request smuggling / framing**: CL+TE conflict, multiple-CL,
       chunk-size leading-whitespace rejection.
-    - **Header / control-frame injection.** Header CRLF / NUL rejection,
+    - **Header / control-frame injection**: Header CRLF / NUL rejection,
       SSE event-line CRLF rejection, trailer-header CRLF rejection,
       RFC 6455 §5.5 control-frame limits, RFC 6265 cookie OWS handling.
-    - **Sendfile path safety.** Path traversal + symlink escape defenses.
-- **TLS defaults.** TLS 1.2 / 1.3 only, AEAD-only cipher filter,
+    - **Sendfile path safety**: Path traversal + symlink escape defenses.
+- **TLS defaults**: TLS 1.2 / 1.3 only, AEAD-only cipher filter,
   client renegotiation off, post-quantum hybrid `x25519mlkem768` first
   when the OpenSSL build supports it. Full settings list in the
   `roadrunner_listener` module docs.
-- **DoS bounds.** `max_clients`, `max_concurrent_requests`,
+- **DoS bounds**: `max_clients`, `max_concurrent_requests`,
   `socket_backlog`, `max_content_length`, `min_bytes_per_second`,
   `request_timeout`, `keep_alive_timeout`, `max_keep_alive_requests`.
 
 ### Observability
 
-- **Telemetry.** `telemetry` events covering request, response, listener
+- **Telemetry**: `telemetry` events covering request, response, listener
   accept / close, slot reconciliation, ws upgrade and frames, and
   drain ack (opt-in via `roadrunner:acknowledge_drain/1`). Full event
   list with measurements / metadata in the `roadrunner_telemetry`
   module docs.
-- **Log correlation.** Per-request `request_id` attached to
+- **Log correlation**: Per-request `request_id` attached to
   `logger:set_process_metadata/1` so any `?LOG_*` from
   middleware/handlers is auto-correlated.
-- **Pull metrics.** `roadrunner_listener:info/1` for `active_clients` /
+- **Pull metrics**: `roadrunner_listener:info/1` for `active_clients` /
   `requests_served`.
-- **Process labels.** `proc_lib:set_label/1` per-listener / per-acceptor /
+- **Process labels**: `proc_lib:set_label/1` per-listener / per-acceptor /
   per-conn for legible `observer` process trees.
 
 ### Lifecycle
 
-- **Drain.** `roadrunner_listener:drain/2` does graceful shutdown with a
+- **Drain**: `roadrunner_listener:drain/2` does graceful shutdown with a
   timeout: closes the listen socket, broadcasts `{roadrunner_drain, Deadline}`
   to in-flight conns via `pg`, polls until idle or deadline, then
   `exit(Pid, shutdown)` for stragglers.
-- **Status.** `roadrunner_listener:status/1` returns `accepting | draining`.
-- **Slot reconciliation.** Optional `slot_reconciliation => #{interval => N}`
+- **Status**: `roadrunner_listener:status/1` returns `accepting | draining`.
+- **Slot reconciliation**: Optional `slot_reconciliation => #{interval => N}`
   listener opt: a periodic reaper that compares `client_counter` against the
   conn `pg` group and releases slots orphaned by `kill`-style exits. Off by
   default; enable in production where you can't trust every exit path to run
@@ -381,39 +381,39 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
 
 ## Documentation
 
-- [`docs/comparison.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/comparison.md) — full side-by-side
+- [`docs/comparison.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/comparison.md): full side-by-side
   benchmarks vs cowboy and elli (throughput, latency, architectural
   trade-offs, reproduction commands).
-- [`docs/bench_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/bench_results.md) — full per-protocol
+- [`docs/bench_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/bench_results.md): full per-protocol
   matrix with p50 / p99 across every scenario.
-- [`docs/bench_internals.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/bench_internals.md) — loadgen worker
+- [`docs/bench_internals.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/bench_internals.md): loadgen worker
   model, latency aggregation, when the loader becomes the bottleneck.
-- [`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md) — open-loop,
+- [`docs/wrk2_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/wrk2_results.md): open-loop,
   Coordinated-Omission-corrected tail-latency tables (full per-scenario,
   all rate-points per server).
-- [`docs/resource_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/resource_results.md) — memory + CPU
+- [`docs/resource_results.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/resource_results.md): memory + CPU
   shape per scenario.
-- [`docs/conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md)
-  — the connection-process model trade-offs and the one h2 case
+- [`docs/conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md):
+  the connection-process model trade-offs and the one h2 case
   cowboy still wins.
-- [`docs/roadmap.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/roadmap.md) — deferred items, with rough
+- [`docs/roadmap.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/roadmap.md): deferred items, with rough
   effort estimates for each.
 
 ## Design philosophy
 
-- **RFC-correct, hostile-input-safe.** Parsers are pure incremental
+- **RFC-correct, hostile-input-safe**: Parsers are pure incremental
   binary matchers; only programmer errors raise, wire input always
   becomes `{error, _}`. Malformed bytes are bounded by length and
   rejected before reaching application code.
-- **Modern OTP idioms.** Sigils for binary literals, body recursion (cons
+- **Modern OTP idioms**: Sigils for binary literals, body recursion (cons
   on the way out), binary keys for wire-derived data, `-doc` /
   `-moduledoc` markdown, dialyzer-clean specs. No `binary_to_atom` on
   parsed names.
-- **Telemetry over custom callbacks.** `telemetry` is the de facto
+- **Telemetry over custom callbacks**: `telemetry` is the de facto
   standard (Phoenix, Ecto, gleam_otp); no dispatch overhead when nothing is
   subscribed, and integrates with Prometheus / OpenTelemetry / Datadog through
   the telemetry ecosystem.
-- **No external deps unless stdlib genuinely can't.** Runtime deps are
+- **No external deps unless stdlib genuinely can't**: Runtime deps are
   `telemetry` (tiny, no transitive deps) and `quic` (the pure-Erlang HTTP/3
   transport, started on demand); the only dev-time dep is the `erlfmt` plugin.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Pure-Erlang HTTP/1.1 + HTTP/2 + HTTP/3 + WebSocket server for Erlang/OTP.
 Roadrunner is the HTTP backbone of the
 [arizona-framework](https://github.com/arizona-framework/arizona), and works
 standalone too. The API is small: a handler behaviour, request and response
-accessors, listener controls, and opt-in helpers (cookies, qs, multipart, SSE,
-WebSocket).
+accessors, listener controls, and opt-in helpers (cookies, query strings,
+multipart, SSE, WebSocket).
 
 ## Why Roadrunner?
 
@@ -28,16 +28,15 @@ A small, fast HTTP core you can trust on the hot path.
 - **Every HTTP version, one server.** HTTP/1.1, HTTP/2, HTTP/3 (experimental),
   and WebSocket served from one listener; browsers upgrade to h3 over the same
   port via `Alt-Svc`.
-- **Pure Erlang, almost no dependencies.** One runtime dep (`telemetry`), no C
-  NIFs, and roadrunner owns its own h1/h2/h3 codecs: easy to read, easy to audit,
-  nothing to sprawl.
+- **Pure Erlang, almost no dependencies.** Two runtime deps (`telemetry` and
+  `quic`, the HTTP/3 transport), no C NIFs, and Roadrunner owns its own
+  h1/h2/h3 codecs: easy to read and audit. `quic` only starts for HTTP/3, so
+  h1/h2 deployments never load it.
 - **Pleasant to build on.** Plain-Erlang request and response values, composable
   middleware, and opt-in helpers for cookies, query strings, multipart, SSE, and
   WebSocket.
 - **Production lifecycle in the box.** Graceful drain with a deadline, telemetry
   events, per-request `request_id` log correlation, and configurable DoS bounds.
-
-Built to give you a fast, correct HTTP core you can build on with confidence.
 
 ## Requirements
 
@@ -51,7 +50,7 @@ in your deps if you need stability across upgrades.
 
 ## Conformance
 
-Strict 100 % h2spec (HTTP/2) and Autobahn fuzzingclient across the full
+Strict 100% h2spec (HTTP/2) and Autobahn fuzzingclient across the full
 WebSocket matrix (no exclusions). HTTP/1.1 parsers stress-tested against
 the [llhttp](https://github.com/nodejs/llhttp) test corpus and the
 canonical [PortSwigger](https://portswigger.net/web-security/request-smuggling)
@@ -105,11 +104,10 @@ and [`docs/comparison.md`](https://github.com/arizona-framework/roadrunner/blob/
 | `websocket_msg_throughput`|   **232 k**   |       179 k   |          —    |
 | `gzip_response`           |   **138 k**   |       111 k   |          —    |
 
-Bold = fastest in row. `—` means the elli fixture doesn't expose
-that workload (no router, no gzip middleware, no WebSocket, no
-streaming-POST endpoint). On simple GETs and small POSTs
-Roadrunner and elli are within the bench's ~15 % variance band on
-those rows; the comparison doc has the full honest framing.
+Bold = fastest in row. `—` means that workload has no elli fixture. On
+simple GETs and small POSTs Roadrunner and elli sit within the bench's
+~15% variance band on those rows; the comparison doc has the full
+methodology.
 
 ### Tail latency at sustained load
 
@@ -189,6 +187,56 @@ content-length: 18
 hello, roadrunner!
 ```
 
+A handler is a module with `handle/1`. To read path parameters from a `:param`
+route (`roadrunner_req:bindings/1`), read the body (`read_body/1` returns
+`iodata` and threads `Req2` back), and reply with JSON
+(`roadrunner_resp:json/2` encodes the term):
+
+```erlang
+-module(users_handler).
+-behaviour(roadrunner_handler).
+-export([handle/1]).
+
+handle(Req) ->
+    #{~"id" := Id} = roadrunner_req:bindings(Req),
+    {ok, Body, Req2} = roadrunner_req:read_body(Req),
+    Reply = #{id => Id, received => byte_size(iolist_to_binary(Body))},
+    {roadrunner_resp:json(200, Reply), Req2}.
+```
+
+Mix literal and `:param` routes:
+
+```erlang
+routes => [
+    {~"/", hello_handler, #{greeting => ~"hi"}},
+    {~"/users/:id", users_handler, undefined}
+]
+```
+
+The request accessors (`method/1`, `path/1`, `header/2`, `parse_qs/1`,
+`bindings/1`, `peer/1`, `read_body/1`) all live in `roadrunner_req`.
+
+To wrap every response, register a middleware. An entry is a `Callable` or a
+`{Callable, State}` pair, and the first in the list runs outermost:
+
+```erlang
+-module(server_header_mw).
+-behaviour(roadrunner_middleware).
+-export([call/3]).
+
+call(Req, Next, _State) ->
+    {{Status, Headers, Body}, Req2} = Next(Req),
+    {{Status, [{~"server", ~"roadrunner"} | Headers], Body}, Req2}.
+```
+
+```erlang
+roadrunner:start_listener(api, #{
+    port => 8080,
+    middlewares => [server_header_mw],
+    routes => [{~"/", hello_handler, #{greeting => ~"hi"}}]
+}).
+```
+
 For HTTP/2 over TLS, add a cert and list both protocols. ALPN is
 derived from `protocols` automatically:
 
@@ -260,7 +308,7 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
 - **Buffered responses:** `{Status, Headers, Body}` — `roadrunner_resp:text/2`,
   `:html/2`, `:json/2`, `:redirect/2`, plus empty-status shortcuts.
 - **Streaming:** `{stream, Status, Headers, Fun}` — chunked transfer with a
-  `Send/2` callback; supports trailer headers per RFC 7230 §4.1.2.
+  `Send/2` callback; supports trailer headers per RFC 9112 §7.1.2.
 - **Loop / SSE:** `{loop, Status, Headers, State}` + optional
   `handle_info/3` callback for message-driven push.
 - **WebSocket:** `{websocket, Module, State}` upgrade with
@@ -366,12 +414,12 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   `{Callable, State}`, invoked as `call(Req, Next, State)`; composable at
   listener and per-route level, outermost first.
 - **Telemetry over custom callbacks.** `telemetry` is the de facto
-  standard (Phoenix, Ecto, gleam_otp); zero-overhead when no subscribers,
-  and integrates with Prometheus / OpenTelemetry / Datadog through the
-  telemetry ecosystem.
-- **No external deps unless stdlib genuinely can't.** Only runtime dep
-  is `telemetry` (tiny, no transitive deps); only dev-time dep is the
-  `erlfmt` plugin.
+  standard (Phoenix, Ecto, gleam_otp); no dispatch overhead when nothing is
+  subscribed, and integrates with Prometheus / OpenTelemetry / Datadog through
+  the telemetry ecosystem.
+- **No external deps unless stdlib genuinely can't.** Runtime deps are
+  `telemetry` (tiny, no transitive deps) and `quic` (the pure-Erlang HTTP/3
+  transport, started on demand); the only dev-time dep is the `erlfmt` plugin.
 
 ## Sponsors
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,10 @@ Pure-Erlang HTTP/1.1 + HTTP/2 + HTTP/3 + WebSocket server for Erlang/OTP.
 **Built for low tail latency at sustained load.** Beep beep.
 
 Roadrunner is the HTTP backbone of the
-[arizona-framework](https://github.com/arizona-framework/arizona).
-Strict RFC 9110 / 9112 / 9113 parsing, with **strict 100 %
-[h2spec](https://github.com/summerwind/h2spec)** (HTTP/2 conformance)
-and **strict 100 %
-[Autobahn fuzzingclient](https://github.com/crossbario/autobahn-testsuite)**
-(WebSocket, no exclusions). The user-facing API is a handler
-behaviour, request/response accessors, listener controls, and a
-handful of opt-in helpers (cookies, qs, multipart, SSE, WebSocket).
-Modern OTP idioms throughout, with predictable per-connection
-lifecycle observability.
+[arizona-framework](https://github.com/arizona-framework/arizona), and works
+standalone too. The API is small: a handler behaviour, request and response
+accessors, listener controls, and opt-in helpers (cookies, qs, multipart, SSE,
+WebSocket).
 
 ## Why Roadrunner?
 
@@ -283,8 +277,10 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
 
 ### Middleware
 
-- Continuation-style `(Req, Next) -> {Response, Req2}` — listener-level +
-  per-route, first-in-list = outermost.
+- Continuation-style middleware. Each entry is a `Callable` or a
+  `{Callable, State}` pair, where `Callable` is a module (`call/3`) or a
+  `fun((Req, Next, State) -> {Response, Req2})`. Listener-level + per-route,
+  first-in-list = outermost.
 
 ### Built-in handlers
 
@@ -366,11 +362,13 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   on the way out), binary keys for wire-derived data, `-doc` /
   `-moduledoc` markdown, dialyzer-clean specs. No `binary_to_atom` on
   parsed names.
-- **Continuation-style middleware.** `(Req, Next) -> {Response, Req2}`,
-  composable at listener and per-route level. Outermost first.
+- **Continuation-style middleware.** Entries are `Callable` or
+  `{Callable, State}`, invoked as `call(Req, Next, State)`; composable at
+  listener and per-route level, outermost first.
 - **Telemetry over custom callbacks.** `telemetry` is the de facto
   standard (Phoenix, Ecto, gleam_otp); zero-overhead when no subscribers,
-  integrates with prometheus / opentelemetry / datadog out of the box.
+  and integrates with Prometheus / OpenTelemetry / Datadog through the
+  telemetry ecosystem.
 - **No external deps unless stdlib genuinely can't.** Only runtime dep
   is `telemetry` (tiny, no transitive deps); only dev-time dep is the
   `erlfmt` plugin.

--- a/README.md
+++ b/README.md
@@ -58,27 +58,27 @@ request-smuggling vectors.
 
 Standards conformance:
 
-- **HTTP/1.1**: RFC 9110 (semantics) + RFC 9112 (syntax).
-- **HTTP/2**: RFC 9113 (frames + multiplexing) + RFC 7541 (HPACK).
+- **HTTP/1.1.** RFC 9110 (semantics) + RFC 9112 (syntax).
+- **HTTP/2.** RFC 9113 (frames + multiplexing) + RFC 7541 (HPACK).
   Opt-in per listener via `protocols => [http1, http2]` (or
   `[http2]` for h2c prior-knowledge on plain TCP). Conformance
   harness: [`scripts/h2spec.sh`](https://github.com/arizona-framework/roadrunner/blob/main/scripts/h2spec.sh) (drives
   [h2spec](https://github.com/summerwind/h2spec)).
-- **HTTP/3** (experimental): RFC 9114 over QUIC with QPACK (RFC 9204)
+- **HTTP/3 (experimental).** RFC 9114 over QUIC with QPACK (RFC 9204)
   static-table compression. Enable per listener via
   `protocols => [http3]` (requires `tls`; QUIC mandates TLS 1.3); it
   co-serves with h1/h2 on the same port number (TCP for h1/h2, UDP for
   h3) and advertises `Alt-Svc` so browsers upgrade. Built on the
   pure-Erlang [`quic`](https://github.com/benoitc/erlang_quic) transport
   (still 1.x), so treat HTTP/3 as experimental.
-- **Content-Encoding** (RFC 9110 §8.4.1): gzip + deflate with
+- **Content-Encoding (RFC 9110 §8.4.1).** gzip + deflate with
   qvalue-aware `Accept-Encoding` negotiation (RFC 9110 §12.5.3),
   works unchanged over HTTP/2.
-- **WebSocket**: RFC 6455. Conformance harness:
+- **WebSocket.** RFC 6455. Conformance harness:
   [`scripts/autobahn.escript`](https://github.com/arizona-framework/roadrunner/blob/main/scripts/autobahn.escript) (drives the
   [Autobahn|Testsuite](https://github.com/crossbario/autobahn-testsuite)
   fuzzingclient).
-- **WebSocket compression**: RFC 7692 `permessage-deflate`,
+- **WebSocket compression.** RFC 7692 `permessage-deflate`,
   including `*_max_window_bits` and `*_no_context_takeover`.
 
 ## Performance at a glance
@@ -282,102 +282,101 @@ All listener options live in the
 type, with per-key defaults and tuning rationale. Beyond `port`,
 `protocols`, `tls`, and `routes` from the Quickstart, the type covers:
 
-- **DoS bounds** — `max_clients`, `max_concurrent_requests`,
+- **DoS bounds.** `max_clients`, `max_concurrent_requests`,
   `socket_backlog`, `max_content_length`, `request_timeout`,
   `keep_alive_timeout`, `min_bytes_per_second`, `max_keep_alive_requests`
-- **Middleware** — `middlewares`
-- **Body buffering** — `body_buffering`
-- **Graceful drain** — `graceful_drain`, `slot_reconciliation`
-- **Per-conn hibernation** — `hibernate_after`
-- **Handler spawn opts** — `handler_spawn`
-- **HTTP/1 tunables** (under the `{http1, Opts}` entry in
-  `protocols`) — `max_request_line`, `max_header_line`,
-  `max_header_block`, `max_header_count`
-- **HTTP/2 tunables** (under the `{http2, Opts}` entry in
-  `protocols`) — `conn_window`, `stream_window`,
-  `window_refill_threshold`, `max_concurrent_streams`,
-  `max_header_block`
-- **HTTP/3 tunables** (under the `{http3, Opts}` entry in
-  `protocols`) — `listeners` (reuseport pool size),
-  `max_header_block`
+- **Middleware.** `middlewares`
+- **Body buffering.** `body_buffering`
+- **Graceful drain.** `graceful_drain`, `slot_reconciliation`
+- **Per-conn hibernation.** `hibernate_after`
+- **Handler spawn opts.** `handler_spawn`
+- **HTTP/1 tunables.** Under the `{http1, Opts}` entry in `protocols`:
+  `max_request_line`, `max_header_line`, `max_header_block`,
+  `max_header_count`
+- **HTTP/2 tunables.** Under the `{http2, Opts}` entry in `protocols`:
+  `conn_window`, `stream_window`, `window_refill_threshold`,
+  `max_concurrent_streams`, `max_header_block`
+- **HTTP/3 tunables.** Under the `{http3, Opts}` entry in `protocols`:
+  `listeners` (reuseport pool size), `max_header_block`
 
 ## Features
 
 ### Handlers
 
-- **Buffered responses:** `{Status, Headers, Body}` — `roadrunner_resp:text/2`,
+- **Buffered responses.** `{Status, Headers, Body}` via `roadrunner_resp:text/2`,
   `:html/2`, `:json/2`, `:redirect/2`, plus empty-status shortcuts.
-- **Streaming:** `{stream, Status, Headers, Fun}` — chunked transfer with a
+- **Streaming.** `{stream, Status, Headers, Fun}`, chunked transfer with a
   `Send/2` callback; supports trailer headers per RFC 9112 §7.1.2.
-- **Loop / SSE:** `{loop, Status, Headers, State}` + optional
+- **Loop / SSE.** `{loop, Status, Headers, State}` plus an optional
   `handle_info/3` callback for message-driven push.
-- **WebSocket:** `{websocket, Module, State}` upgrade with
+- **WebSocket.** `{websocket, Module, State}` upgrade with a
   `roadrunner_ws_handler` callback.
-- **Sendfile:** `{sendfile, Status, Headers, {Filename, Offset, Length}}` —
+- **Sendfile.** `{sendfile, Status, Headers, {Filename, Offset, Length}}`,
   zero-copy file body via `file:sendfile/5` (TCP) or chunked `ssl:send`
   fallback (TLS).
 
 ### Routing
 
-- `roadrunner_router` with literal / `:param` / `*wildcard` segments.
-- Routes published to `persistent_term` for O(1) lookup;
+- **Router.** `roadrunner_router` with literal / `:param` / `*wildcard` segments.
+- **Hot reload.** Routes published to `persistent_term` for O(1) lookup;
   `roadrunner_listener:reload_routes/2` swaps the table without restart.
 
 ### Middleware
 
-- Continuation-style middleware. Each entry is a `Callable` or a
+- **Continuation-style.** Each entry is a `Callable` or a
   `{Callable, State}` pair, where `Callable` is a module (`call/3`) or a
   `fun((Req, Next, State) -> {Response, Req2})`. Listener-level + per-route,
   first-in-list = outermost.
 
 ### Built-in handlers
 
-- `roadrunner_static` for file serving with ETag, `If-None-Match`, `Range`,
+- **`roadrunner_static`.** File serving with ETag, `If-None-Match`, `Range`,
   `Last-Modified`, `If-Modified-Since`, and configurable symlink policy
   (`refuse_escapes` default).
 
 ### Hardening
 
-- Strict RFC 9110 / 9112 parsing, with defenses grouped by subsystem:
-    - **Request smuggling / framing:** CL+TE conflict, multiple-CL,
+- **Strict parsing.** RFC 9110 / 9112, with defenses grouped by subsystem:
+    - **Request smuggling / framing.** CL+TE conflict, multiple-CL,
       chunk-size leading-whitespace rejection.
-    - **Header / control-frame injection:** header CRLF / NUL rejection,
+    - **Header / control-frame injection.** Header CRLF / NUL rejection,
       SSE event-line CRLF rejection, trailer-header CRLF rejection,
       RFC 6455 §5.5 control-frame limits, RFC 6265 cookie OWS handling.
-    - **Sendfile path safety:** path traversal + symlink escape defenses.
-- TLS hardened defaults — TLS 1.2 / 1.3 only, AEAD-only cipher filter,
+    - **Sendfile path safety.** Path traversal + symlink escape defenses.
+- **TLS defaults.** TLS 1.2 / 1.3 only, AEAD-only cipher filter,
   client renegotiation off, post-quantum hybrid `x25519mlkem768` first
   when the OpenSSL build supports it. Full settings list in the
   `roadrunner_listener` module docs.
-- DoS bounds — `max_clients`, `max_concurrent_requests`,
+- **DoS bounds.** `max_clients`, `max_concurrent_requests`,
   `socket_backlog`, `max_content_length`, `min_bytes_per_second`,
   `request_timeout`, `keep_alive_timeout`, `max_keep_alive_requests`.
 
 ### Observability
 
-- `telemetry` events covering request, response, listener
+- **Telemetry.** `telemetry` events covering request, response, listener
   accept / close, slot reconciliation, ws upgrade and frames, and
   drain ack (opt-in via `roadrunner:acknowledge_drain/1`). Full event
   list with measurements / metadata in the `roadrunner_telemetry`
   module docs.
-- Per-request `request_id` attached to `logger:set_process_metadata/1`
-  so any `?LOG_*` from middleware/handlers is auto-correlated.
-- `roadrunner_listener:info/1` for pull-side `active_clients` /
-  `requests_served` metrics.
-- `proc_lib:set_label/1` per-listener / per-acceptor / per-conn for
-  legible `observer` process trees.
+- **Log correlation.** Per-request `request_id` attached to
+  `logger:set_process_metadata/1` so any `?LOG_*` from
+  middleware/handlers is auto-correlated.
+- **Pull metrics.** `roadrunner_listener:info/1` for `active_clients` /
+  `requests_served`.
+- **Process labels.** `proc_lib:set_label/1` per-listener / per-acceptor /
+  per-conn for legible `observer` process trees.
 
 ### Lifecycle
 
-- `roadrunner_listener:drain/2` — graceful shutdown with timeout. Closes
-  the listen socket, broadcasts `{roadrunner_drain, Deadline}` to in-flight
-  conns via `pg`, polls until idle or deadline, then `exit(Pid, shutdown)`
-  for stragglers.
-- `roadrunner_listener:status/1` — `accepting | draining`.
-- Optional `slot_reconciliation => #{interval => N}` listener opt — a
-  periodic reaper that compares `client_counter` against the conn `pg`
-  group and releases slots orphaned by `kill`-style exits. Off by default;
-  enable in production where you can't trust every exit path to run
+- **Drain.** `roadrunner_listener:drain/2` does graceful shutdown with a
+  timeout: closes the listen socket, broadcasts `{roadrunner_drain, Deadline}`
+  to in-flight conns via `pg`, polls until idle or deadline, then
+  `exit(Pid, shutdown)` for stragglers.
+- **Status.** `roadrunner_listener:status/1` returns `accepting | draining`.
+- **Slot reconciliation.** Optional `slot_reconciliation => #{interval => N}`
+  listener opt: a periodic reaper that compares `client_counter` against the
+  conn `pg` group and releases slots orphaned by `kill`-style exits. Off by
+  default; enable in production where you can't trust every exit path to run
   `terminate/3` (`kill` signals, OOM kills, supervisor brutal-kill).
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Add to `rebar.config` (latest version on
 ]}.
 ```
 
-Write a handler — the third route element is per-route state, threaded
+Write a handler. The third route element is per-route state, threaded
 to the handler via `roadrunner_req:state/1`:
 
 ```erlang
@@ -171,11 +171,11 @@ handle(Req) ->
 Boot a listener:
 
 ```erlang
-1> application:ensure_all_started(roadrunner).
-2> roadrunner:start_listener(my_listener, #{
-       port => 8080,
-       routes => [{~"/", hello_handler, #{greeting => ~"hello"}}]
-   }).
+application:ensure_all_started(roadrunner).
+roadrunner:start_listener(my_listener, #{
+    port => 8080,
+    routes => [{~"/", hello_handler, #{greeting => ~"hello"}}]
+}).
 ```
 
 ```
@@ -208,7 +208,7 @@ Mix literal and `:param` routes:
 
 ```erlang
 routes => [
-    {~"/", hello_handler, #{greeting => ~"hi"}},
+    {~"/", hello_handler, #{greeting => ~"hello"}},
     {~"/users/:id", users_handler, undefined}
 ]
 ```
@@ -233,7 +233,7 @@ call(Req, Next, _State) ->
 roadrunner:start_listener(api, #{
     port => 8080,
     middlewares => [server_header_mw],
-    routes => [{~"/", hello_handler, #{greeting => ~"hi"}}]
+    routes => [{~"/", hello_handler, #{greeting => ~"hello"}}]
 }).
 ```
 
@@ -241,15 +241,15 @@ For HTTP/2 over TLS, add a cert and list both protocols. ALPN is
 derived from `protocols` automatically:
 
 ```erlang
-3> roadrunner:start_listener(my_tls_listener, #{
-       port => 8443,
-       protocols => [http1, http2],
-       tls => [
-           {certfile, "cert.pem"},
-           {keyfile, "key.pem"}
-       ],
-       routes => [{~"/", hello_handler, #{greeting => ~"hello"}}]
-   }).
+roadrunner:start_listener(my_tls_listener, #{
+    port => 8443,
+    protocols => [http1, http2],
+    tls => [
+        {certfile, "cert.pem"},
+        {keyfile, "key.pem"}
+    ],
+    routes => [{~"/", hello_handler, #{greeting => ~"hello"}}]
+}).
 ```
 
 ALPN routes `h2` clients to the HTTP/2 path and `http/1.1` clients (or
@@ -261,7 +261,7 @@ the `tls` opt.
 For HTTP/3 (experimental), add `http3` to a TLS listener's `protocols`
 (e.g. `protocols => [http1, http2, http3]`). It serves h3 over UDP on the
 same port number and advertises `Alt-Svc` so browsers upgrade from TCP;
-the `quic` transport starts on demand, so h1/h2-only listeners never boot
+the `quic` transport starts on demand, so h1/h2-only listeners never load
 it.
 
 For listeners that don't need routing, `routes => Mod` (or
@@ -409,9 +409,6 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   on the way out), binary keys for wire-derived data, `-doc` /
   `-moduledoc` markdown, dialyzer-clean specs. No `binary_to_atom` on
   parsed names.
-- **Continuation-style middleware.** Entries are `Callable` or
-  `{Callable, State}`, invoked as `call(Req, Next, State)`; composable at
-  listener and per-route level, outermost first.
 - **Telemetry over custom callbacks.** `telemetry` is the de facto
   standard (Phoenix, Ecto, gleam_otp); no dispatch overhead when nothing is
   subscribed, and integrates with Prometheus / OpenTelemetry / Datadog through


### PR DESCRIPTION
# Description

A README pass. Adds a scannable "Why Roadrunner?" highlights section near the top, corrects a few stale or inaccurate claims (the runtime deps are `telemetry` and `quic`, not just `telemetry`; the streaming trailer reference is RFC 9112 §7.1.2, not RFC 7230; the telemetry "zero-overhead" wording), and the middleware docs now match the `{Callable, State}` / `call/3` contract. Expands the Quickstart with request-body + JSON, `:param` routes with bindings, and a middleware example, all checked against the real API. Finally, normalizes every bullet list to one `**Label**: description` colon style (doc links included) and the code blocks to plain Erlang. Docs only, no code changes.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
