### PR TITLE
Pattern-match map and record field access

### DIFF
--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -175,6 +175,17 @@ awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
                         Socket, ProtoOpts, ListenerName, Peer, StartMono
                     );
                 false ->
+                    #{
+                        requests_counter := RequestsCounter,
+                        dispatch := Dispatch,
+                        middlewares := Middlewares,
+                        max_content_length := MaxContentLength,
+                        max_keep_alive_requests := MaxKeepAliveRequests,
+                        min_bytes_per_second := MinRate,
+                        request_timeout := RequestTimeout,
+                        keep_alive_timeout := KeepAliveTimeout,
+                        body_buffering := BodyBuffering
+                    } = ProtoOpts,
                     S = #loop_state{
                         socket = Socket,
                         proto_opts = ProtoOpts,
@@ -182,15 +193,15 @@ awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
                         start_mono = StartMono,
                         peer = Peer,
                         scheme = Scheme,
-                        requests_counter = maps:get(requests_counter, ProtoOpts),
-                        dispatch = maps:get(dispatch, ProtoOpts),
-                        middlewares = maps:get(middlewares, ProtoOpts),
-                        max_content_length = maps:get(max_content_length, ProtoOpts),
-                        max_keep_alive_requests = maps:get(max_keep_alive_requests, ProtoOpts),
-                        min_rate = maps:get(min_bytes_per_second, ProtoOpts),
-                        request_timeout = maps:get(request_timeout, ProtoOpts),
-                        keep_alive_timeout = maps:get(keep_alive_timeout, ProtoOpts),
-                        body_buffering = maps:get(body_buffering, ProtoOpts),
+                        requests_counter = RequestsCounter,
+                        dispatch = Dispatch,
+                        middlewares = Middlewares,
+                        max_content_length = MaxContentLength,
+                        max_keep_alive_requests = MaxKeepAliveRequests,
+                        min_rate = MinRate,
+                        request_timeout = RequestTimeout,
+                        keep_alive_timeout = KeepAliveTimeout,
+                        body_buffering = BodyBuffering,
                         hibernate_after = maps:get(hibernate_after, ProtoOpts, 0),
                         alt_svc = maps:get(alt_svc, ProtoOpts, undefined),
                         http1_limits = {

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -130,13 +130,14 @@
 
 -spec start(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) ->
     {ok, pid()}.
-start(Socket, ProtoOpts) when is_map(ProtoOpts) ->
+start(
+    Socket, #{handler_spawn_opts := SpawnOpts, handler_start_timeout := StartTimeout} = ProtoOpts
+) ->
     %% Unlinked from the acceptor — a single-conn crash never propagates
     %% to the acceptor pool. Mirrors `gen_statem:start/3` (NOT start_link)
     %% so existing acceptor handoff (`controlling_process` then `! shoot`)
     %% works without modification.
     Parent = self(),
-    #{handler_spawn_opts := SpawnOpts, handler_start_timeout := StartTimeout} = ProtoOpts,
     proc_lib:start(?MODULE, init_loop, [Parent, Socket, ProtoOpts], StartTimeout, SpawnOpts).
 
 -doc false.

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -960,8 +960,9 @@ on_data(
             %% §6.9.1: pad-length byte + padding count). Past the window
             %% gates, the body cap and buffering use the stripped `Payload`
             %% the handler will see, so its length is only needed there.
+            ConnWindow = State#loop.conn_recv_window,
             if
-                FlowLen > State#loop.conn_recv_window ->
+                FlowLen > ConnWindow ->
                     %% RFC 9113 §6.9.1: more DATA than the connection-level
                     %% receive window permits is a connection-level
                     %% FLOW_CONTROL_ERROR.
@@ -1003,7 +1004,7 @@ on_data(
                             },
                             State1 = State#loop{
                                 streams = Streams#{StreamId := Stream1},
-                                conn_recv_window = State#loop.conn_recv_window - FlowLen
+                                conn_recv_window = ConnWindow - FlowLen
                             },
                             State2 = maybe_refill_recv_windows(State1, StreamId),
                             case EndStream of

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -171,7 +171,10 @@ start(ConnPid, ProtoOpts) ->
 -doc false.
 -spec init(pid(), roadrunner_conn:proto_opts()) -> ok.
 init(Conn, ProtoOpts) ->
-    ListenerName = maps:get(listener_name, ProtoOpts),
+    #{
+        listener_name := ListenerName,
+        max_content_length := MaxContentLength
+    } = ProtoOpts,
     proc_lib:set_label({roadrunner_conn_loop_http3, ListenerName, Conn}),
     %% The `max_clients` slot was acquired by `start/2` (in the listener
     %% process); it is released in `terminate/1`.
@@ -196,7 +199,7 @@ init(Conn, ProtoOpts) ->
         listener_name = ListenerName,
         peer = Peer,
         start_mono = StartMono,
-        max_content_length = maps:get(max_content_length, ProtoOpts),
+        max_content_length = MaxContentLength,
         max_header_block = MaxHeaderBlock,
         %% Decoded-section cap defaults to 2x the (possibly overridden) encoded
         %% cap, so raising `max_header_block` lifts both gates together.
@@ -332,8 +335,8 @@ handle_request_stream(State0, StreamId, Data, Fin) ->
     #h3{streams = Streams, max_content_length = MaxLen, max_header_block = MaxHdrBlock} =
         State = note_request_id(State0, StreamId),
     Stream0 = maps:get(StreamId, Streams, new_request_stream()),
-    case maps:get(frame_state, Stream0) of
-        discarding ->
+    case Stream0 of
+        #{frame_state := discarding} ->
             %% The stream was already answered (413). Residual in-flight
             %% body must be ignored — it is continued body on an answered
             %% request, NOT a new header-less request, so it must not trip
@@ -344,8 +347,7 @@ handle_request_stream(State0, StreamId, Data, Fin) ->
                 true -> drop_stream(State, StreamId);
                 false -> State
             end;
-        _ ->
-            #{buf := Buf0} = Stream0,
+        #{buf := Buf0} ->
             case
                 decode_request_frames(<<Buf0/binary, Data/binary>>, Stream0, MaxLen, MaxHdrBlock)
             of

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -170,11 +170,7 @@ start(ConnPid, ProtoOpts) ->
 
 -doc false.
 -spec init(pid(), roadrunner_conn:proto_opts()) -> ok.
-init(Conn, ProtoOpts) ->
-    #{
-        listener_name := ListenerName,
-        max_content_length := MaxContentLength
-    } = ProtoOpts,
+init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLength} = ProtoOpts) ->
     proc_lib:set_label({roadrunner_conn_loop_http3, ListenerName, Conn}),
     %% The `max_clients` slot was acquired by `start/2` (in the listener
     %% process); it is released in `terminate/1`.

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -58,13 +58,12 @@ stream's id, leaving the other 99 streams intact.
 """.
 -spec start(pid(), pos_integer(), roadrunner_req:request(), map()) ->
     {pid(), reference()}.
-start(ConnPid, StreamId, Req, ProtoOpts) ->
-    #{handler_spawn_opts := SpawnOpts} = ProtoOpts,
-    spawn_opt(?MODULE, init, [ConnPid, StreamId, Req, ProtoOpts], [monitor | SpawnOpts]).
+start(ConnPid, StreamId, Req, #{handler_spawn_opts := SpawnOpts, dispatch := Dispatch}) ->
+    spawn_opt(?MODULE, init, [ConnPid, StreamId, Req, Dispatch], [monitor | SpawnOpts]).
 
 -doc false.
--spec init(pid(), pos_integer(), roadrunner_req:request(), map()) -> ok.
-init(ConnPid, StreamId, Req, ProtoOpts) ->
+-spec init(pid(), pos_integer(), roadrunner_req:request(), roadrunner_conn:dispatch()) -> ok.
+init(ConnPid, StreamId, Req, Dispatch) ->
     proc_lib:set_label({roadrunner_http2_stream_worker, StreamId}),
     %% Mirror the h1 path: attach request-scoped metadata so any
     %% `?LOG_*` from middleware/handlers is auto-correlated by
@@ -76,20 +75,19 @@ init(ConnPid, StreamId, Req, ProtoOpts) ->
     %% dies, instead of blocking on an ack that never comes until TCP
     %% teardown reaps the worker.
     _ = roadrunner_http2_worker_sync:monitor_conn(ConnPid),
-    run_handler(ConnPid, StreamId, Req, ProtoOpts),
+    run_handler(ConnPid, StreamId, Req, Dispatch),
     %% No explicit completion message: the worker is spawn_monitored by
     %% the conn, which finalises the stream on the worker's `DOWN`
     %% (`normal` -> clean removal, anything else -> RST_STREAM).
     ok.
 
-run_handler(ConnPid, StreamId, Req, ProtoOpts) ->
+run_handler(ConnPid, StreamId, Req, Dispatch) ->
     %% `dispatch` is set by listener init and always present. The
     %% matched route's `Pipeline` is a pre-composed `next()` fun
     %% (listener mws ++ per-route mws, with `state` injected up front
     %% if attached, ending in `fun Handler:handle/1`), built once at
     %% compile / `reload_routes/2` time — we just call it with the
     %% request, no per-request closure allocation.
-    #{dispatch := Dispatch} = ProtoOpts,
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     case roadrunner_conn:resolve_handler(Dispatch, Req) of

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -57,28 +57,26 @@ at the connection / stream level, not by crashing this worker).
 """.
 -spec start(pid(), non_neg_integer(), roadrunner_req:request(), roadrunner_conn:proto_opts()) ->
     {pid(), reference()}.
-start(Conn, StreamId, Req, ProtoOpts) ->
-    #{handler_spawn_opts := SpawnOpts} = ProtoOpts,
-    spawn_opt(?MODULE, init, [Conn, StreamId, Req, ProtoOpts], [monitor | SpawnOpts]).
+start(Conn, StreamId, Req, #{handler_spawn_opts := SpawnOpts, dispatch := Dispatch}) ->
+    spawn_opt(?MODULE, init, [Conn, StreamId, Req, Dispatch], [monitor | SpawnOpts]).
 
 -doc false.
--spec init(pid(), non_neg_integer(), roadrunner_req:request(), roadrunner_conn:proto_opts()) -> ok.
-init(Conn, StreamId, Req, ProtoOpts) ->
+-spec init(pid(), non_neg_integer(), roadrunner_req:request(), roadrunner_conn:dispatch()) -> ok.
+init(Conn, StreamId, Req, Dispatch) ->
     proc_lib:set_label({roadrunner_http3_stream_worker, StreamId}),
     %% Attach request-scoped logger metadata so any `?LOG_*` from
     %% middleware/handlers is auto-correlated by `request_id` — the
     %% handler runs in this worker, not on the conn loop.
     ok = roadrunner_conn:set_request_logger_metadata(Req),
-    run_handler(Conn, StreamId, Req, ProtoOpts),
+    run_handler(Conn, StreamId, Req, Dispatch),
     ok.
 
--spec run_handler(pid(), non_neg_integer(), roadrunner_req:request(), roadrunner_conn:proto_opts()) ->
+-spec run_handler(pid(), non_neg_integer(), roadrunner_req:request(), roadrunner_conn:dispatch()) ->
     ok.
-run_handler(Conn, StreamId, Req, ProtoOpts) ->
+run_handler(Conn, StreamId, Req, Dispatch) ->
     %% `dispatch` is set by listener init and always present; the
     %% matched route's `Pipeline` is the pre-composed `next()` fun
     %% built once at compile / `reload_routes/2` time.
-    #{dispatch := Dispatch} = ProtoOpts,
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     case roadrunner_conn:resolve_handler(Dispatch, Req) of

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -612,7 +612,7 @@ init(#{port := Port} = Opts) ->
     publish_routes(ListenerName, Opts),
     ProtoOpts = build_proto_opts(Opts, ListenerName),
     proc_lib:set_label({roadrunner_listener, ListenerName, Port}),
-    Protocols = maps:get(protocols, ProtoOpts),
+    #{protocols := Protocols} = ProtoOpts,
     %% TCP (`http1`/`http2`) and QUIC (`http3`) are independent
     %% transports that co-listen on the same port number. Bring up
     %% whichever the `protocols` list selects; an `http3`-only listener
@@ -1515,7 +1515,7 @@ do_drain(
     Deadline = erlang:monotonic_time(millisecond) + Timeout,
     Group = drain_group(ProtoOpts),
     notify_conns(Group, Deadline),
-    Counter = maps:get(client_counter, ProtoOpts),
+    #{client_counter := Counter} = ProtoOpts,
     Reply = wait_for_drain(Counter, Deadline, Group),
     %% Stop the QUIC listener LAST: `quic_listener:stop/1` kills the
     %% connections it `start_link`ed (and the h3 conn loops linked to

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -118,7 +118,7 @@ handle(Req) ->
                     #{cache_ttl_ms := T} -> T;
                     _ -> ?DEFAULT_CACHE_TTL_MS
                 end,
-            Dir = maps:get(dir, State),
+            #{dir := Dir} = State,
             FilePath = filename:join([Dir | Segments]),
             {serve_file(FilePath, TtlMs, Req), Req};
         traversal ->

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -448,9 +448,9 @@ process_buffer(#data{buffer = Buf, pmd_params = Pmd} = Data, HibernateAcc) ->
 process_parsed_frame(#data{socket = Socket} = Data1, Buf, Opts, MaybeTotalLen, HibernateAcc) ->
     ParseOpts = parse_opts_with_pre_unmasked(Opts, Data1, MaybeTotalLen),
     case roadrunner_ws:parse_frame(Buf, ParseOpts) of
-        {ok, Frame, NewBuffer} ->
+        {ok, #{opcode := Opcode} = Frame, NewBuffer} ->
             ok = roadrunner_telemetry:ws_frame_in(
-                (Data1#data.ctx)#{opcode => maps:get(opcode, Frame)},
+                (Data1#data.ctx)#{opcode => Opcode},
                 payload_size(Frame)
             ),
             %% Frame parsed. Carry `frame_validated` into handle_frame
@@ -929,9 +929,9 @@ finalize_message(
     Compressed = iolist_to_binary([Iolist, ?PMD_TAIL]),
     try bounded_inflate(Z, Compressed, MaxMsg) of
         {ok, Inflated} ->
-            case maps:get(client_no_context_takeover, Params, false) of
-                true -> ok = zlib:inflateReset(Z);
-                false -> ok
+            case Params of
+                #{client_no_context_takeover := true} -> ok = zlib:inflateReset(Z);
+                #{} -> ok
             end,
             {ok, Inflated, Data};
         {error, _} = Err ->
@@ -1220,9 +1220,9 @@ encode_outbound(Data, Opcode, Payload) ->
 -spec deflate_message(#data{}, iodata()) -> binary().
 deflate_message(#data{deflate_z = Z, pmd_params = Params}, Payload) ->
     Iolist = zlib:deflate(Z, Payload, sync),
-    case maps:get(server_no_context_takeover, Params, false) of
-        true -> ok = zlib:deflateReset(Z);
-        false -> ok
+    case Params of
+        #{server_no_context_takeover := true} -> ok = zlib:deflateReset(Z);
+        #{} -> ok
     end,
     Bin = iolist_to_binary(Iolist),
     %% Strip the per-message tail (last 4 bytes of `0x00 0x00 0xff 0xff`).

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -207,7 +207,16 @@ run(Socket, Req, Mod, State, Buffered, ProtoOpts) ->
     binary(),
     roadrunner_conn:proto_opts()
 ) -> ok.
-run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated, Buffered, ProtoOpts) ->
+run_session(
+    Socket,
+    Req,
+    Mod,
+    State,
+    UpgradeResp,
+    Negotiated,
+    Buffered,
+    #{handler_spawn_opts := SpawnOpts, handler_start_timeout := StartTimeout} = ProtoOpts
+) ->
     Ctx = ws_context(Req, Mod),
     %% Start the gen_statem **before** writing the 101 to the wire so a
     %% start failure never leaves the upgrade response sent with no
@@ -215,7 +224,6 @@ run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated, Buffered, ProtoOpt
     %% conn is intentionally unlinked from its children so a session
     %% crash never propagates to the conn process. We synchronise via
     %% a monitor instead.
-    #{handler_spawn_opts := SpawnOpts, handler_start_timeout := StartTimeout} = ProtoOpts,
     StartOpts = [{spawn_opt, SpawnOpts}, {timeout, StartTimeout}],
     case
         gen_statem:start(


### PR DESCRIPTION
# Description

Read required map and record fields via pattern matching instead of `maps:get` and repeated record accessors, and destructure map parameters in the function head. Pure refactor, no behaviour change.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
