### PR TITLE
Defer docroot state lookup to the branch that uses it

### DIFF
--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -538,7 +538,6 @@ target_inside_docroot(FilePath, Req) ->
     %% we let a TOCTOU race (symlink removed between the two stats)
     %% crash and bubble up as a 500 instead of silently 404'ing.
     {ok, Target} = file:read_link(FilePath),
-    #{dir := Dir} = roadrunner_req:state(Req),
     case filename:pathtype(Target) of
         relative ->
             %% A relative target without any `..` segments must land
@@ -555,6 +554,7 @@ target_inside_docroot(FilePath, Req) ->
             %% to make `string:prefix/2` an exact directory check
             %% rather than a sibling-prefix false positive. `string:prefix/2`
             %% accepts chardata, so neither argument needs flattening.
+            #{dir := Dir} = roadrunner_req:state(Req),
             string:prefix(Target, [filename:absname(Dir), $/]) =/= nomatch
     end.
 


### PR DESCRIPTION
# Description

Move the `#{dir := Dir} = roadrunner_req:state(Req)` lookup in `target_inside_docroot/2` into the `_ ->` branch that actually uses it. The `relative ->` symlink check needs neither the `state/1` call nor `dir`, and unlike a record field read the compiler does not sink a function call or a map match, so both ran for nothing on that path. Behaviour-neutral.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
