### PR TITLE
Add native HTTP/3 codecs (varint, frame, QPACK)

### DIFF
--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -265,8 +265,8 @@ recv_loop(#h3{conn = Conn} = State) ->
 -spec send_control_stream(#h3{}) -> #h3{}.
 send_control_stream(#h3{conn = Conn, max_field_section_size = MaxFieldSection} = State) ->
     {ok, CtrlStreamId} = quic:open_unidirectional_stream(Conn),
-    Prefix = quic_h3_frame:encode_stream_type(control),
-    Settings = quic_h3_frame:encode_settings(#{
+    Prefix = roadrunner_quic_h3_frame:encode_stream_type(control),
+    Settings = roadrunner_quic_h3_frame:encode_settings(#{
         qpack_max_table_capacity => 0,
         qpack_blocked_streams => 0,
         max_field_section_size => MaxFieldSection
@@ -288,7 +288,7 @@ start_drain(#h3{conn = Conn, control_stream_id = CtrlId, last_request_id = LastI
     is_integer(CtrlId)
 ->
     GoawayId = LastId + 4,
-    _ = quic:send_data(Conn, CtrlId, quic_h3_frame:encode_goaway(GoawayId), false),
+    _ = quic:send_data(Conn, CtrlId, roadrunner_quic_h3_frame:encode_goaway(GoawayId), false),
     State#h3{goaway_id = GoawayId}.
 
 %% A draining connection is done once no request is in flight — neither
@@ -466,7 +466,7 @@ decode_request_frames(Buf, Stream, MaxLen) ->
 
 -spec decode_request_frames(binary(), map(), non_neg_integer(), pos_integer()) -> decode_result().
 decode_request_frames(Buf, Stream, MaxLen, MaxHdrBlock) ->
-    case quic_h3_frame:decode(Buf) of
+    case roadrunner_quic_h3_frame:decode(Buf) of
         {ok, Frame, Rest} ->
             case apply_frame(Frame, Stream, MaxLen, MaxHdrBlock) of
                 {ok, Stream1} -> decode_request_frames(Rest, Stream1, MaxLen, MaxHdrBlock);
@@ -495,7 +495,7 @@ decode_request_frames(Buf, Stream, MaxLen, MaxHdrBlock) ->
 %% H3_FRAME_UNEXPECTED (§4.1, §7.2.4); unknown/reserved frames are
 %% ignored (§9). Trailers (a HEADERS after the body) are accepted but
 %% not surfaced by the buffered path.
--spec apply_frame(quic_h3_frame:frame(), map(), non_neg_integer(), pos_integer()) ->
+-spec apply_frame(roadrunner_quic_h3_frame:frame(), map(), non_neg_integer(), pos_integer()) ->
     {ok, map()} | too_large | headers_too_large | {conn_error, non_neg_integer(), binary()}.
 apply_frame({headers, Block}, #{frame_state := expecting_headers}, _MaxLen, MaxHdrBlock) when
     byte_size(Block) > MaxHdrBlock
@@ -541,7 +541,7 @@ uni_event({drain, Criticality}, Critical, _Data, Fin) ->
 %% Read the leading stream-type varint and dispatch on it.
 -spec uni_classify(binary(), critical_set(), boolean()) -> uni_result().
 uni_classify(Buf, Critical, Fin) ->
-    case quic_h3_frame:decode_stream_type(Buf) of
+    case roadrunner_quic_h3_frame:decode_stream_type(Buf) of
         {more, _} ->
             uni_more(Buf, Critical, Fin);
         {ok, control, Rest} ->
@@ -638,7 +638,7 @@ claim(Critical, Role) ->
 -spec validate_control_frames(binary(), boolean()) ->
     {ok, binary(), boolean()} | {conn_error, non_neg_integer(), binary()}.
 validate_control_frames(Buf, SettingsReceived) ->
-    case quic_h3_frame:decode(Buf) of
+    case roadrunner_quic_h3_frame:decode(Buf) of
         {ok, Frame, Rest} ->
             case control_frame(Frame, SettingsReceived) of
                 {ok, SettingsReceived1} -> validate_control_frames(Rest, SettingsReceived1);
@@ -655,7 +655,7 @@ validate_control_frames(Buf, SettingsReceived) ->
             {conn_error, frame_error_code(Reason), ~"control frame error"}
     end.
 
--spec control_frame(quic_h3_frame:frame(), boolean()) ->
+-spec control_frame(roadrunner_quic_h3_frame:frame(), boolean()) ->
     {ok, boolean()} | {conn_error, non_neg_integer(), binary()}.
 control_frame({settings, _}, false) ->
     {ok, true};
@@ -675,7 +675,7 @@ control_frame(Frame, true) ->
 %% RFC 9114 §7.2: DATA / HEADERS / PUSH_PROMISE belong on request (or
 %% push) streams, never the control stream; everything else (GOAWAY,
 %% MAX_PUSH_ID, CANCEL_PUSH, reserved/grease) is fine after SETTINGS.
--spec is_control_allowed(quic_h3_frame:frame()) -> boolean().
+-spec is_control_allowed(roadrunner_quic_h3_frame:frame()) -> boolean().
 is_control_allowed({data, _}) -> false;
 is_control_allowed({headers, _}) -> false;
 is_control_allowed({push_promise, _, _}) -> false;
@@ -700,7 +700,7 @@ dispatch_request(#h3{streams = Streams} = State, StreamId) ->
             %% decompression failure is a CONNECTION error per RFC 9204
             %% §2.2 — the dynamic-table state is unrecoverable — whereas
             %% a malformed message is a per-stream error.
-            case quic_qpack:decode(Block) of
+            case roadrunner_qpack:decode(Block) of
                 {error, _} ->
                     {conn_error, ?H3_QPACK_DECOMPRESSION_FAILED, ~"QPACK decompression failed"};
                 {ok, Headers} ->

--- a/src/roadrunner_http2_hpack.erl
+++ b/src/roadrunner_http2_hpack.erl
@@ -49,6 +49,11 @@
     max_table_size/1
 ]).
 
+%% The RFC 7541 §5.1 prefixed-integer codec is byte-identical to QPACK's
+%% RFC 9204 §4.1.1 prefixed integers, so `roadrunner_qpack` reuses these two
+%% rather than duplicating the math. Exported for that cross-module use only.
+-export([encode_integer/3, decode_integer/2]).
+
 -export_type([context/0, decode_error/0]).
 
 %% RFC 7541 Appendix A — 61 static-table entries. Defined up here
@@ -334,6 +339,7 @@ encode_size_update(N) ->
 %% integer plus the rest of the bitstring (which is byte-aligned
 %% afterwards if Rest is byte-aligned at start — the integer
 %% codec only emits/consumes whole bytes after the prefix).
+-doc false.
 -spec decode_integer(pos_integer(), bitstring()) ->
     {ok, non_neg_integer(), bitstring()} | {error, bad_integer}.
 decode_integer(N, Bits) ->
@@ -357,6 +363,7 @@ decode_integer_continuation(_, _, _) ->
 %% Encode an integer with an N-bit prefix and a leading byte that
 %% has the prefix-bit pattern set in its high bits (encoded by
 %% caller via `Marker bor I` for the prefix byte).
+-doc false.
 -spec encode_integer(pos_integer(), 0..255, non_neg_integer()) -> iodata().
 encode_integer(N, Marker, I) ->
     Max = (1 bsl N) - 1,

--- a/src/roadrunner_http3_request.erl
+++ b/src/roadrunner_http3_request.erl
@@ -21,7 +21,7 @@
 %%   malformed request.
 %% - Pseudo-headers other than the four defined are rejected.
 %% - `:path` MUST NOT be empty.
-%% - Header field names are lowercase — `quic_qpack:decode/1` returns
+%% - Header field names are lowercase — `roadrunner_qpack:decode/1` returns
 %%   them as received, and an h3 client MUST send them lowercase.
 %% - Connection-specific headers MUST NOT appear (RFC 9114 §4.2).
 

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -32,7 +32,7 @@
 
 %% RFC 9114 §7.2.1: the DATA frame type is 0x00. We frame the body by
 %% hand (type + length varints, then the body by reference) instead of
-%% `quic_h3_frame:encode_data/1` so a large body is never flattened
+%% `roadrunner_quic_h3_frame:encode_data/1` so a large body is never flattened
 %% into one binary on the response path.
 -define(H3_FRAME_DATA, 16#00).
 
@@ -314,7 +314,7 @@ stream_send(Conn, StreamId, Data, {fin, Trailers}) ->
     %% path. The crash must happen before `?FIN_KEY` is set, so run it first.
     Stripped = roadrunner_http:strip_connection_specific_fields_safe(Trailers),
     put(?FIN_KEY, true),
-    TrailersFrame = quic_h3_frame:encode_headers(quic_qpack:encode(Stripped)),
+    TrailersFrame = roadrunner_quic_h3_frame:encode_headers(roadrunner_qpack:encode(Stripped)),
     quic:send_data(Conn, StreamId, [data_frame(Data, iolist_size(Data)), TrailersFrame], true).
 
 %% `{sendfile, ...}` response. There is no kernel sendfile over QUIC
@@ -424,15 +424,15 @@ loop_push(Conn, StreamId, Data) ->
 %% HEADERS frame: QPACK-encoded `:status` + the handler's headers, with
 %% connection-specific fields stripped (RFC 9114 §4.2 — h3 MUST NOT
 %% generate them) and the auto-injected `Date` (RFC 9110 §6.6.1) added.
--spec header_frame(roadrunner_http:status(), roadrunner_http:headers()) -> binary().
+-spec header_frame(roadrunner_http:status(), roadrunner_http:headers()) -> iolist().
 header_frame(Status, Headers) ->
     Stripped = roadrunner_http:strip_connection_specific_fields(Headers),
     HeaderList = [{~":status", integer_to_binary(Status)} | roadrunner_http:with_date(Stripped)],
-    quic_h3_frame:encode_headers(quic_qpack:encode(HeaderList)).
+    roadrunner_quic_h3_frame:encode_headers(roadrunner_qpack:encode(HeaderList)).
 
-%% DATA frame as iodata (type + length varints, then the body by
+%% DATA frame as an iolist (type + length varints, then the body by
 %% reference) so a large body is never flattened. `Len` is the caller's
 %% already-computed `iolist_size(Body)`.
--spec data_frame(iodata(), non_neg_integer()) -> iodata().
+-spec data_frame(iodata(), non_neg_integer()) -> iolist().
 data_frame(Body, Len) ->
-    [quic_varint:encode(?H3_FRAME_DATA), quic_varint:encode(Len), Body].
+    [roadrunner_quic_varint:encode(?H3_FRAME_DATA), roadrunner_quic_varint:encode(Len), Body].

--- a/src/roadrunner_qpack.erl
+++ b/src/roadrunner_qpack.erl
@@ -1,0 +1,653 @@
+-module(roadrunner_qpack).
+-moduledoc false.
+
+%% QPACK field-section codec for HTTP/3 (RFC 9204), static-table only.
+%%
+%% roadrunner advertises `SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0`, so neither
+%% side uses the dynamic table: every field line is an indexed static entry,
+%% a literal with a static name reference, or a literal with a literal name
+%% (RFC 9204 §4.5). The Encoded Field Section Prefix is therefore always the
+%% two bytes `00 00` (Required Insert Count 0, Base 0, §4.5.1).
+%%
+%% The prefixed-integer codec (RFC 9204 §4.1.1) is byte-identical to HPACK's
+%% (RFC 7541 §5.1) and the string Huffman table is the shared RFC 7541
+%% Appendix B table, so encoding/decoding reuses
+%% `roadrunner_http2_hpack:encode_integer/3`+`decode_integer/2` and
+%% `roadrunner_http2_hpack_huffman:encode/1`+`decode/1` rather than
+%% duplicating them. The 99-entry static table (RFC 9204 Appendix A) is
+%% function-clause dispatch, mirroring `roadrunner_http2_hpack`'s static
+%% table (the BEAM turns it into a jump table, no `persistent_term` read).
+
+-export([encode/1, decode/1]).
+
+-export_type([headers/0]).
+
+-type header() :: {Name :: binary(), Value :: binary()}.
+-type headers() :: [header()].
+
+-type decode_error() ::
+    {qpack, dynamic_table_required}
+    | {qpack, dynamic_field_line, byte()}
+    | {qpack, invalid_static_index, non_neg_integer()}
+    | {qpack, bad_integer}
+    | {qpack, huffman}
+    | {qpack, truncated}.
+
+%% =============================================================================
+%% encode/1
+%% =============================================================================
+
+-doc """
+Encode a header list as a static-only QPACK field section. Returns a
+binary (the encoder builds iodata internally and flattens at the API
+boundary, where the caller wants a binary to frame as HEADERS).
+""".
+-spec encode(headers()) -> binary().
+encode(Headers) ->
+    %% Field Section Prefix `00 00` (RIC 0, Base 0) then one field line each.
+    iolist_to_binary([<<0, 0>> | encode_field_lines(Headers)]).
+
+-spec encode_field_lines(headers()) -> iodata().
+encode_field_lines([]) ->
+    [];
+encode_field_lines([Header | Rest]) ->
+    [encode_field_line(Header) | encode_field_lines(Rest)].
+
+-spec encode_field_line(header()) -> iodata().
+encode_field_line({Name, Value}) ->
+    case static_full_match(Name, Value) of
+        Index when is_integer(Index) ->
+            %% Indexed Field Line, static (RFC 9204 §4.5.2): `1 1` + 6-bit index.
+            roadrunner_http2_hpack:encode_integer(6, 2#11000000, Index);
+        none ->
+            encode_literal(Name, Value)
+    end.
+
+-spec encode_literal(binary(), binary()) -> iodata().
+encode_literal(Name, Value) ->
+    case static_name_match(Name) of
+        Index when is_integer(Index) ->
+            %% Literal Field Line with Name Reference, static (RFC 9204 §4.5.4):
+            %% `0 1 N=0 T=1` + 4-bit name index, then the value string.
+            [
+                roadrunner_http2_hpack:encode_integer(4, 2#01010000, Index),
+                encode_string(Value)
+            ];
+        none ->
+            %% Literal Field Line with Literal Name (RFC 9204 §4.5.6):
+            %% `0 0 1 N=0 H=0` + 3-bit name length, the raw name, then the
+            %% value string. The name stays raw (matching the reference codec).
+            [
+                roadrunner_http2_hpack:encode_integer(3, 2#00100000, byte_size(Name)),
+                Name,
+                encode_string(Value)
+            ]
+    end.
+
+%% A string is `H` (1 bit) + a 7-bit-prefix length + the octets, Huffman
+%% coded when that is shorter (RFC 9204 §4.1.2).
+-spec encode_string(binary()) -> iodata().
+encode_string(Str) ->
+    Huffman = roadrunner_http2_hpack_huffman:encode(Str),
+    HuffmanSize = byte_size(Huffman),
+    StrSize = byte_size(Str),
+    case HuffmanSize < StrSize of
+        true ->
+            [roadrunner_http2_hpack:encode_integer(7, 2#10000000, HuffmanSize), Huffman];
+        false ->
+            [roadrunner_http2_hpack:encode_integer(7, 2#00000000, StrSize), Str]
+    end.
+
+%% =============================================================================
+%% decode/1
+%% =============================================================================
+
+-doc """
+Decode a static-only QPACK field section. Any field line that references
+the dynamic table (which roadrunner never enables) is a decode error,
+surfaced as `{error, {qpack, _}}` for the caller to map to
+H3_QPACK_DECOMPRESSION_FAILED (RFC 9204 §2.2).
+""".
+-spec decode(binary()) -> {ok, headers()} | {error, decode_error()}.
+decode(Data) ->
+    maybe
+        {ok, Rest} ?= decode_prefix(Data),
+        decode_field_lines(Rest)
+    end.
+
+%% Field Section Prefix (RFC 9204 §4.5.1): an 8-bit-prefix Encoded Insert
+%% Count then a Sign bit + 7-bit-prefix Delta Base. Static-only sections
+%% carry Required Insert Count 0, so the first byte is 0; the Base is then
+%% irrelevant (no dynamic entry is referenced) and skipped.
+-spec decode_prefix(binary()) -> {ok, binary()} | {error, decode_error()}.
+decode_prefix(<<0, _S:1, DeltaBaseBits/bitstring>>) ->
+    maybe
+        {ok, _DeltaBase, Rest} ?= integer(7, DeltaBaseBits),
+        {ok, Rest}
+    end;
+decode_prefix(<<Eric, _/binary>>) when Eric =/= 0 ->
+    {error, {qpack, dynamic_table_required}};
+decode_prefix(_) ->
+    {error, {qpack, truncated}}.
+
+-spec decode_field_lines(binary()) -> {ok, headers()} | {error, decode_error()}.
+decode_field_lines(<<>>) ->
+    {ok, []};
+decode_field_lines(Data) ->
+    maybe
+        {ok, Header, Rest} ?= decode_field_line(Data),
+        {ok, Tail} ?= decode_field_lines(Rest),
+        {ok, [Header | Tail]}
+    end.
+
+-spec decode_field_line(binary()) ->
+    {ok, header(), binary()} | {error, decode_error()}.
+decode_field_line(<<2#11:2, IndexBits/bitstring>>) ->
+    %% Indexed Field Line, static.
+    maybe
+        {ok, Index, Rest} ?= integer(6, IndexBits),
+        {ok, Entry} ?= static_indexed(Index),
+        {ok, Entry, Rest}
+    end;
+decode_field_line(<<2#0101:4, IndexBits/bitstring>>) ->
+    %% Literal Field Line with Name Reference, static.
+    maybe
+        {ok, Index, AfterIndex} ?= integer(4, IndexBits),
+        {ok, Name} ?= static_name(Index),
+        {ok, Value, Rest} ?= decode_string(AfterIndex),
+        {ok, {Name, Value}, Rest}
+    end;
+decode_field_line(<<2#001:3, _N:1, H:1, LenBits/bitstring>>) ->
+    %% Literal Field Line with Literal Name.
+    maybe
+        {ok, NameLen, AfterLen} ?= integer(3, LenBits),
+        {ok, Name, AfterName} ?= take_string(H, NameLen, AfterLen),
+        {ok, Value, Rest} ?= decode_string(AfterName),
+        {ok, {Name, Value}, Rest}
+    end;
+decode_field_line(<<Byte, _/binary>>) ->
+    %% `1 0` (dynamic indexed), `0 1 _ 0` (dynamic name ref), `0 0 0 1`
+    %% (post-base index), `0 0 0 0` (post-base name ref): all reference the
+    %% dynamic table, which is never enabled. `decode_field_lines/1` only
+    %% calls this on a non-empty buffer, so a 1-byte match is total.
+    {error, {qpack, dynamic_field_line, Byte}}.
+
+%% A string: `H` bit + 7-bit-prefix length + octets (Huffman if H=1).
+-spec decode_string(bitstring()) -> {ok, binary(), binary()} | {error, decode_error()}.
+decode_string(<<H:1, LenBits/bitstring>>) ->
+    maybe
+        {ok, Len, AfterLen} ?= integer(7, LenBits),
+        take_string(H, Len, AfterLen)
+    end;
+decode_string(<<>>) ->
+    {error, {qpack, truncated}}.
+
+%% Take `Len` octets from a byte-aligned buffer, Huffman-decoding when H=1.
+-spec take_string(0..1, non_neg_integer(), bitstring()) ->
+    {ok, binary(), binary()} | {error, decode_error()}.
+take_string(0, Len, Bits) when bit_size(Bits) >= Len * 8 ->
+    <<Str:Len/binary, Rest/binary>> = Bits,
+    {ok, Str, Rest};
+take_string(1, Len, Bits) when bit_size(Bits) >= Len * 8 ->
+    <<Encoded:Len/binary, Rest/binary>> = Bits,
+    case roadrunner_http2_hpack_huffman:decode(Encoded) of
+        {ok, Decoded} -> {ok, Decoded, Rest};
+        {error, _} -> {error, {qpack, huffman}}
+    end;
+take_string(_H, _Len, _Bits) ->
+    {error, {qpack, truncated}}.
+
+%% Reuse HPACK's prefixed-integer decoder, normalising its `bad_integer`
+%% error into the QPACK error space.
+-spec integer(pos_integer(), bitstring()) ->
+    {ok, non_neg_integer(), bitstring()} | {error, decode_error()}.
+integer(PrefixBits, Bits) ->
+    case roadrunner_http2_hpack:decode_integer(PrefixBits, Bits) of
+        {ok, _, _} = Ok -> Ok;
+        {error, bad_integer} -> {error, {qpack, bad_integer}}
+    end.
+
+-spec static_indexed(non_neg_integer()) -> {ok, header()} | {error, decode_error()}.
+static_indexed(Index) ->
+    case static_entry(Index) of
+        invalid -> {error, {qpack, invalid_static_index, Index}};
+        Entry -> {ok, Entry}
+    end.
+
+-spec static_name(non_neg_integer()) -> {ok, binary()} | {error, decode_error()}.
+static_name(Index) ->
+    case static_entry(Index) of
+        invalid -> {error, {qpack, invalid_static_index, Index}};
+        {Name, _Value} -> {ok, Name}
+    end.
+
+%% =============================================================================
+%% Static table (RFC 9204 Appendix A, indices 0-98)
+%%
+%% `static_entry/1` is the single source of truth (decode index -> entry).
+%% `static_full_match/2` (exact name+value -> index, for entries with a
+%% concrete value) and `static_name_match/1` (name -> lowest index) drive
+%% encoding. Name-only entries (no concrete value) take an empty-binary
+%% value here and never produce an exact match.
+%% =============================================================================
+
+-spec static_entry(non_neg_integer()) -> header() | invalid.
+static_entry(0) ->
+    {~":authority", ~""};
+static_entry(1) ->
+    {~":path", ~"/"};
+static_entry(2) ->
+    {~":age", ~"0"};
+static_entry(3) ->
+    {~"content-disposition", ~""};
+static_entry(4) ->
+    {~"content-length", ~"0"};
+static_entry(5) ->
+    {~"cookie", ~""};
+static_entry(6) ->
+    {~"date", ~""};
+static_entry(7) ->
+    {~"etag", ~""};
+static_entry(8) ->
+    {~"if-modified-since", ~""};
+static_entry(9) ->
+    {~"if-none-match", ~""};
+static_entry(10) ->
+    {~"last-modified", ~""};
+static_entry(11) ->
+    {~"link", ~""};
+static_entry(12) ->
+    {~"location", ~""};
+static_entry(13) ->
+    {~"referer", ~""};
+static_entry(14) ->
+    {~"set-cookie", ~""};
+static_entry(15) ->
+    {~":method", ~"CONNECT"};
+static_entry(16) ->
+    {~":method", ~"DELETE"};
+static_entry(17) ->
+    {~":method", ~"GET"};
+static_entry(18) ->
+    {~":method", ~"HEAD"};
+static_entry(19) ->
+    {~":method", ~"OPTIONS"};
+static_entry(20) ->
+    {~":method", ~"POST"};
+static_entry(21) ->
+    {~":method", ~"PUT"};
+static_entry(22) ->
+    {~":scheme", ~"http"};
+static_entry(23) ->
+    {~":scheme", ~"https"};
+static_entry(24) ->
+    {~":status", ~"103"};
+static_entry(25) ->
+    {~":status", ~"200"};
+static_entry(26) ->
+    {~":status", ~"304"};
+static_entry(27) ->
+    {~":status", ~"404"};
+static_entry(28) ->
+    {~":status", ~"503"};
+static_entry(29) ->
+    {~"accept", ~"*/*"};
+static_entry(30) ->
+    {~"accept", ~"application/dns-message"};
+static_entry(31) ->
+    {~"accept-encoding", ~"gzip, deflate, br"};
+static_entry(32) ->
+    {~"accept-ranges", ~"bytes"};
+static_entry(33) ->
+    {~"access-control-allow-headers", ~"cache-control"};
+static_entry(34) ->
+    {~"access-control-allow-headers", ~"content-type"};
+static_entry(35) ->
+    {~"access-control-allow-origin", ~"*"};
+static_entry(36) ->
+    {~"cache-control", ~"max-age=0"};
+static_entry(37) ->
+    {~"cache-control", ~"max-age=2592000"};
+static_entry(38) ->
+    {~"cache-control", ~"max-age=604800"};
+static_entry(39) ->
+    {~"cache-control", ~"no-cache"};
+static_entry(40) ->
+    {~"cache-control", ~"no-store"};
+static_entry(41) ->
+    {~"cache-control", ~"public, max-age=31536000"};
+static_entry(42) ->
+    {~"content-encoding", ~"br"};
+static_entry(43) ->
+    {~"content-encoding", ~"gzip"};
+static_entry(44) ->
+    {~"content-type", ~"application/dns-message"};
+static_entry(45) ->
+    {~"content-type", ~"application/javascript"};
+static_entry(46) ->
+    {~"content-type", ~"application/json"};
+static_entry(47) ->
+    {~"content-type", ~"application/x-www-form-urlencoded"};
+static_entry(48) ->
+    {~"content-type", ~"image/gif"};
+static_entry(49) ->
+    {~"content-type", ~"image/jpeg"};
+static_entry(50) ->
+    {~"content-type", ~"image/png"};
+static_entry(51) ->
+    {~"content-type", ~"text/css"};
+static_entry(52) ->
+    {~"content-type", ~"text/html; charset=utf-8"};
+static_entry(53) ->
+    {~"content-type", ~"text/plain"};
+static_entry(54) ->
+    {~"content-type", ~"text/plain;charset=utf-8"};
+static_entry(55) ->
+    {~"range", ~"bytes=0-"};
+static_entry(56) ->
+    {~"strict-transport-security", ~"max-age=31536000"};
+static_entry(57) ->
+    {~"strict-transport-security", ~"max-age=31536000; includesubdomains"};
+static_entry(58) ->
+    {~"strict-transport-security", ~"max-age=31536000; includesubdomains; preload"};
+static_entry(59) ->
+    {~"vary", ~"accept-encoding"};
+static_entry(60) ->
+    {~"vary", ~"origin"};
+static_entry(61) ->
+    {~"x-content-type-options", ~"nosniff"};
+static_entry(62) ->
+    {~"x-xss-protection", ~"1; mode=block"};
+static_entry(63) ->
+    {~":status", ~"100"};
+static_entry(64) ->
+    {~":status", ~"204"};
+static_entry(65) ->
+    {~":status", ~"206"};
+static_entry(66) ->
+    {~":status", ~"302"};
+static_entry(67) ->
+    {~":status", ~"400"};
+static_entry(68) ->
+    {~":status", ~"403"};
+static_entry(69) ->
+    {~":status", ~"421"};
+static_entry(70) ->
+    {~":status", ~"425"};
+static_entry(71) ->
+    {~":status", ~"500"};
+static_entry(72) ->
+    {~"accept-language", ~""};
+static_entry(73) ->
+    {~"access-control-allow-credentials", ~"FALSE"};
+static_entry(74) ->
+    {~"access-control-allow-credentials", ~"TRUE"};
+static_entry(75) ->
+    {~"access-control-allow-headers", ~"*"};
+static_entry(76) ->
+    {~"access-control-allow-methods", ~"get"};
+static_entry(77) ->
+    {~"access-control-allow-methods", ~"get, post, options"};
+static_entry(78) ->
+    {~"access-control-allow-methods", ~"options"};
+static_entry(79) ->
+    {~"access-control-expose-headers", ~"content-length"};
+static_entry(80) ->
+    {~"access-control-request-headers", ~"content-type"};
+static_entry(81) ->
+    {~"access-control-request-method", ~"get"};
+static_entry(82) ->
+    {~"access-control-request-method", ~"post"};
+static_entry(83) ->
+    {~"alt-svc", ~"clear"};
+static_entry(84) ->
+    {~"authorization", ~""};
+static_entry(85) ->
+    {~"content-security-policy", ~"script-src 'none'; object-src 'none'; base-uri 'none'"};
+static_entry(86) ->
+    {~"early-data", ~"1"};
+static_entry(87) ->
+    {~"expect-ct", ~""};
+static_entry(88) ->
+    {~"forwarded", ~""};
+static_entry(89) ->
+    {~"if-range", ~""};
+static_entry(90) ->
+    {~"origin", ~""};
+static_entry(91) ->
+    {~"purpose", ~"prefetch"};
+static_entry(92) ->
+    {~"server", ~""};
+static_entry(93) ->
+    {~"timing-allow-origin", ~"*"};
+static_entry(94) ->
+    {~"upgrade-insecure-requests", ~"1"};
+static_entry(95) ->
+    {~"user-agent", ~""};
+static_entry(96) ->
+    {~"x-forwarded-for", ~""};
+static_entry(97) ->
+    {~"x-frame-options", ~"deny"};
+static_entry(98) ->
+    {~"x-frame-options", ~"sameorigin"};
+static_entry(_) ->
+    invalid.
+
+%% Exact name+value match -> index (concrete-value entries only).
+-spec static_full_match(binary(), binary()) -> non_neg_integer() | none.
+static_full_match(~":path", ~"/") ->
+    1;
+static_full_match(~":age", ~"0") ->
+    2;
+static_full_match(~"content-length", ~"0") ->
+    4;
+static_full_match(~":method", ~"CONNECT") ->
+    15;
+static_full_match(~":method", ~"DELETE") ->
+    16;
+static_full_match(~":method", ~"GET") ->
+    17;
+static_full_match(~":method", ~"HEAD") ->
+    18;
+static_full_match(~":method", ~"OPTIONS") ->
+    19;
+static_full_match(~":method", ~"POST") ->
+    20;
+static_full_match(~":method", ~"PUT") ->
+    21;
+static_full_match(~":scheme", ~"http") ->
+    22;
+static_full_match(~":scheme", ~"https") ->
+    23;
+static_full_match(~":status", ~"103") ->
+    24;
+static_full_match(~":status", ~"200") ->
+    25;
+static_full_match(~":status", ~"304") ->
+    26;
+static_full_match(~":status", ~"404") ->
+    27;
+static_full_match(~":status", ~"503") ->
+    28;
+static_full_match(~"accept", ~"*/*") ->
+    29;
+static_full_match(~"accept", ~"application/dns-message") ->
+    30;
+static_full_match(~"accept-encoding", ~"gzip, deflate, br") ->
+    31;
+static_full_match(~"accept-ranges", ~"bytes") ->
+    32;
+static_full_match(~"access-control-allow-headers", ~"cache-control") ->
+    33;
+static_full_match(~"access-control-allow-headers", ~"content-type") ->
+    34;
+static_full_match(~"access-control-allow-origin", ~"*") ->
+    35;
+static_full_match(~"cache-control", ~"max-age=0") ->
+    36;
+static_full_match(~"cache-control", ~"max-age=2592000") ->
+    37;
+static_full_match(~"cache-control", ~"max-age=604800") ->
+    38;
+static_full_match(~"cache-control", ~"no-cache") ->
+    39;
+static_full_match(~"cache-control", ~"no-store") ->
+    40;
+static_full_match(~"cache-control", ~"public, max-age=31536000") ->
+    41;
+static_full_match(~"content-encoding", ~"br") ->
+    42;
+static_full_match(~"content-encoding", ~"gzip") ->
+    43;
+static_full_match(~"content-type", ~"application/dns-message") ->
+    44;
+static_full_match(~"content-type", ~"application/javascript") ->
+    45;
+static_full_match(~"content-type", ~"application/json") ->
+    46;
+static_full_match(~"content-type", ~"application/x-www-form-urlencoded") ->
+    47;
+static_full_match(~"content-type", ~"image/gif") ->
+    48;
+static_full_match(~"content-type", ~"image/jpeg") ->
+    49;
+static_full_match(~"content-type", ~"image/png") ->
+    50;
+static_full_match(~"content-type", ~"text/css") ->
+    51;
+static_full_match(~"content-type", ~"text/html; charset=utf-8") ->
+    52;
+static_full_match(~"content-type", ~"text/plain") ->
+    53;
+static_full_match(~"content-type", ~"text/plain;charset=utf-8") ->
+    54;
+static_full_match(~"range", ~"bytes=0-") ->
+    55;
+static_full_match(~"strict-transport-security", ~"max-age=31536000") ->
+    56;
+static_full_match(~"strict-transport-security", ~"max-age=31536000; includesubdomains") ->
+    57;
+static_full_match(~"strict-transport-security", ~"max-age=31536000; includesubdomains; preload") ->
+    58;
+static_full_match(~"vary", ~"accept-encoding") ->
+    59;
+static_full_match(~"vary", ~"origin") ->
+    60;
+static_full_match(~"x-content-type-options", ~"nosniff") ->
+    61;
+static_full_match(~"x-xss-protection", ~"1; mode=block") ->
+    62;
+static_full_match(~":status", ~"100") ->
+    63;
+static_full_match(~":status", ~"204") ->
+    64;
+static_full_match(~":status", ~"206") ->
+    65;
+static_full_match(~":status", ~"302") ->
+    66;
+static_full_match(~":status", ~"400") ->
+    67;
+static_full_match(~":status", ~"403") ->
+    68;
+static_full_match(~":status", ~"421") ->
+    69;
+static_full_match(~":status", ~"425") ->
+    70;
+static_full_match(~":status", ~"500") ->
+    71;
+static_full_match(~"access-control-allow-credentials", ~"FALSE") ->
+    73;
+static_full_match(~"access-control-allow-credentials", ~"TRUE") ->
+    74;
+static_full_match(~"access-control-allow-headers", ~"*") ->
+    75;
+static_full_match(~"access-control-allow-methods", ~"get") ->
+    76;
+static_full_match(~"access-control-allow-methods", ~"get, post, options") ->
+    77;
+static_full_match(~"access-control-allow-methods", ~"options") ->
+    78;
+static_full_match(~"access-control-expose-headers", ~"content-length") ->
+    79;
+static_full_match(~"access-control-request-headers", ~"content-type") ->
+    80;
+static_full_match(~"access-control-request-method", ~"get") ->
+    81;
+static_full_match(~"access-control-request-method", ~"post") ->
+    82;
+static_full_match(~"alt-svc", ~"clear") ->
+    83;
+static_full_match(
+    ~"content-security-policy", ~"script-src 'none'; object-src 'none'; base-uri 'none'"
+) ->
+    85;
+static_full_match(~"early-data", ~"1") ->
+    86;
+static_full_match(~"purpose", ~"prefetch") ->
+    91;
+static_full_match(~"timing-allow-origin", ~"*") ->
+    93;
+static_full_match(~"upgrade-insecure-requests", ~"1") ->
+    94;
+static_full_match(~"x-frame-options", ~"deny") ->
+    97;
+static_full_match(~"x-frame-options", ~"sameorigin") ->
+    98;
+static_full_match(_, _) ->
+    none.
+
+%% Name -> lowest index carrying that name.
+-spec static_name_match(binary()) -> non_neg_integer() | none.
+static_name_match(~":authority") -> 0;
+static_name_match(~":path") -> 1;
+static_name_match(~":age") -> 2;
+static_name_match(~"content-disposition") -> 3;
+static_name_match(~"content-length") -> 4;
+static_name_match(~"cookie") -> 5;
+static_name_match(~"date") -> 6;
+static_name_match(~"etag") -> 7;
+static_name_match(~"if-modified-since") -> 8;
+static_name_match(~"if-none-match") -> 9;
+static_name_match(~"last-modified") -> 10;
+static_name_match(~"link") -> 11;
+static_name_match(~"location") -> 12;
+static_name_match(~"referer") -> 13;
+static_name_match(~"set-cookie") -> 14;
+static_name_match(~":method") -> 15;
+static_name_match(~":scheme") -> 22;
+static_name_match(~":status") -> 24;
+static_name_match(~"accept") -> 29;
+static_name_match(~"accept-encoding") -> 31;
+static_name_match(~"accept-ranges") -> 32;
+static_name_match(~"access-control-allow-headers") -> 33;
+static_name_match(~"access-control-allow-origin") -> 35;
+static_name_match(~"cache-control") -> 36;
+static_name_match(~"content-encoding") -> 42;
+static_name_match(~"content-type") -> 44;
+static_name_match(~"range") -> 55;
+static_name_match(~"strict-transport-security") -> 56;
+static_name_match(~"vary") -> 59;
+static_name_match(~"x-content-type-options") -> 61;
+static_name_match(~"x-xss-protection") -> 62;
+static_name_match(~"accept-language") -> 72;
+static_name_match(~"access-control-allow-credentials") -> 73;
+static_name_match(~"access-control-allow-methods") -> 76;
+static_name_match(~"access-control-expose-headers") -> 79;
+static_name_match(~"access-control-request-headers") -> 80;
+static_name_match(~"access-control-request-method") -> 81;
+static_name_match(~"alt-svc") -> 83;
+static_name_match(~"authorization") -> 84;
+static_name_match(~"content-security-policy") -> 85;
+static_name_match(~"early-data") -> 86;
+static_name_match(~"expect-ct") -> 87;
+static_name_match(~"forwarded") -> 88;
+static_name_match(~"if-range") -> 89;
+static_name_match(~"origin") -> 90;
+static_name_match(~"purpose") -> 91;
+static_name_match(~"server") -> 92;
+static_name_match(~"timing-allow-origin") -> 93;
+static_name_match(~"upgrade-insecure-requests") -> 94;
+static_name_match(~"user-agent") -> 95;
+static_name_match(~"x-forwarded-for") -> 96;
+static_name_match(~"x-frame-options") -> 97;
+static_name_match(_) -> none.

--- a/src/roadrunner_qpack.erl
+++ b/src/roadrunner_qpack.erl
@@ -38,16 +38,17 @@
 %% =============================================================================
 
 -doc """
-Encode a header list as a static-only QPACK field section. Returns a
-binary (the encoder builds iodata internally and flattens at the API
-boundary, where the caller wants a binary to frame as HEADERS).
+Encode a header list as a static-only QPACK field section, returned as
+an iolist. The caller frames it with
+`roadrunner_quic_h3_frame:encode_headers/1` and sends it as iodata, so the
+field section is never flattened here.
 """.
--spec encode(headers()) -> binary().
+-spec encode(headers()) -> iolist().
 encode(Headers) ->
     %% Field Section Prefix `00 00` (RIC 0, Base 0) then one field line each.
-    iolist_to_binary([<<0, 0>> | encode_field_lines(Headers)]).
+    [<<0, 0>> | encode_field_lines(Headers)].
 
--spec encode_field_lines(headers()) -> iodata().
+-spec encode_field_lines(headers()) -> iolist().
 encode_field_lines([]) ->
     [];
 encode_field_lines([Header | Rest]) ->
@@ -63,7 +64,7 @@ encode_field_line({Name, Value}) ->
             encode_literal(Name, Value)
     end.
 
--spec encode_literal(binary(), binary()) -> iodata().
+-spec encode_literal(binary(), binary()) -> iolist().
 encode_literal(Name, Value) ->
     case static_name_match(Name) of
         Index when is_integer(Index) ->
@@ -86,7 +87,7 @@ encode_literal(Name, Value) ->
 
 %% A string is `H` (1 bit) + a 7-bit-prefix length + the octets, Huffman
 %% coded when that is shorter (RFC 9204 §4.1.2).
--spec encode_string(binary()) -> iodata().
+-spec encode_string(binary()) -> iolist().
 encode_string(Str) ->
     Huffman = roadrunner_http2_hpack_huffman:encode(Str),
     HuffmanSize = byte_size(Huffman),

--- a/src/roadrunner_quic_h3_frame.erl
+++ b/src/roadrunner_quic_h3_frame.erl
@@ -81,13 +81,13 @@
 %% Frame encoding
 %% =============================================================================
 
--doc "Encode a DATA frame (RFC 9114 §7.2.1) as iodata.".
--spec encode_data(binary()) -> iodata().
+-doc "Encode a DATA frame (RFC 9114 §7.2.1) as an iolist.".
+-spec encode_data(iodata()) -> iolist().
 encode_data(Payload) ->
     frame_io(?FRAME_DATA, Payload).
 
 -doc "Encode a HEADERS frame (RFC 9114 §7.2.2) wrapping a QPACK field section.".
--spec encode_headers(binary()) -> iodata().
+-spec encode_headers(iodata()) -> iolist().
 encode_headers(HeaderBlock) ->
     frame_io(?FRAME_HEADERS, HeaderBlock).
 
@@ -96,12 +96,12 @@ Encode a SETTINGS frame (RFC 9114 §7.2.4) from a settings map. Every
 entry in the map is emitted as an id+value varint pair, in
 `maps:to_list/1` order.
 """.
--spec encode_settings(map()) -> iodata().
+-spec encode_settings(map()) -> iolist().
 encode_settings(Settings) ->
     frame_io(?FRAME_SETTINGS, encode_settings_pairs(maps:to_list(Settings))).
 
 -doc "Encode a GOAWAY frame (RFC 9114 §7.2.6) naming the last stream id.".
--spec encode_goaway(non_neg_integer()) -> iodata().
+-spec encode_goaway(non_neg_integer()) -> iolist().
 encode_goaway(StreamId) ->
     frame_io(?FRAME_GOAWAY, roadrunner_quic_varint:encode(StreamId)).
 
@@ -115,8 +115,8 @@ encode_stream_type(push) -> roadrunner_quic_varint:encode(?STREAM_PUSH);
 encode_stream_type(Type) when is_integer(Type) -> roadrunner_quic_varint:encode(Type).
 
 %% A frame is its type varint, its length varint, then the payload. Kept
-%% as iodata so the (possibly large) payload is never recopied.
--spec frame_io(non_neg_integer(), iodata()) -> iodata().
+%% as an iolist so the (possibly large) payload is never recopied.
+-spec frame_io(non_neg_integer(), iodata()) -> iolist().
 frame_io(Type, Payload) ->
     [
         roadrunner_quic_varint:encode(Type),
@@ -126,7 +126,7 @@ frame_io(Type, Payload) ->
 
 %% Encode each {id, value} setting as a varint pair, building the payload
 %% by consing on the way out (no reverse, no quadratic binary append).
--spec encode_settings_pairs([{atom() | non_neg_integer(), non_neg_integer()}]) -> iodata().
+-spec encode_settings_pairs([{atom() | non_neg_integer(), non_neg_integer()}]) -> iolist().
 encode_settings_pairs([]) ->
     [];
 encode_settings_pairs([{Key, Value} | Rest]) ->

--- a/src/roadrunner_quic_h3_frame.erl
+++ b/src/roadrunner_quic_h3_frame.erl
@@ -1,0 +1,294 @@
+-module(roadrunner_quic_h3_frame).
+-moduledoc false.
+
+%% HTTP/3 frame codec (RFC 9114 §7). Frame type and length are QUIC
+%% varints (`roadrunner_quic_varint`); the payload follows.
+%%
+%% Pure wire syntax only: this module parses bytes into typed frame
+%% terms and encodes typed terms back to bytes. It does NOT enforce the
+%% frame-sequence rules (SETTINGS first, DATA-after-HEADERS, control vs
+%% request streams) — `roadrunner_conn_loop_http3` owns those.
+%%
+%% The result shapes match what that loop already consumes so the codec
+%% can be swapped in with no caller change: `decode/1` yields
+%% `{ok, frame(), Rest} | {more, Need} | {error, Reason}`, where a
+%% `{settings, map()}` frame carries a map, an unknown/grease type is
+%% surfaced as `{unknown, Type, Payload}` (RFC 9114 §9), and the two
+%% load-bearing error reasons are `{frame_error, settings, _}` (mapped
+%% to H3_SETTINGS_ERROR upstream) and `{h2_reserved_frame, Type}` (the
+%% HTTP/2-only types reserved by RFC 9114 §7.2.8).
+%%
+%% Encoders return `iodata()` so a large DATA/HEADERS payload is framed
+%% by prepending a header, never copied.
+
+-export([
+    encode_data/1,
+    encode_headers/1,
+    encode_settings/1,
+    encode_goaway/1,
+    encode_stream_type/1,
+    decode/1,
+    decode_stream_type/1
+]).
+
+-export_type([frame/0]).
+
+%% RFC 9114 §7.2 frame types.
+-define(FRAME_DATA, 16#00).
+-define(FRAME_HEADERS, 16#01).
+-define(FRAME_CANCEL_PUSH, 16#03).
+-define(FRAME_SETTINGS, 16#04).
+-define(FRAME_PUSH_PROMISE, 16#05).
+-define(FRAME_GOAWAY, 16#07).
+-define(FRAME_MAX_PUSH_ID, 16#0D).
+
+%% RFC 9114 §6.2 unidirectional stream types.
+-define(STREAM_CONTROL, 16#00).
+-define(STREAM_PUSH, 16#01).
+-define(STREAM_QPACK_ENCODER, 16#02).
+-define(STREAM_QPACK_DECODER, 16#03).
+
+%% RFC 9114 §7.2.4.1 settings identifiers we map to atoms; any other id
+%% (extension / grease) is surfaced under its integer key.
+-define(SETTINGS_QPACK_MAX_TABLE_CAPACITY, 16#01).
+-define(SETTINGS_MAX_FIELD_SECTION_SIZE, 16#06).
+-define(SETTINGS_QPACK_BLOCKED_STREAMS, 16#07).
+-define(SETTINGS_ENABLE_CONNECT_PROTOCOL, 16#08).
+
+%% RFC 9114 §7.1: bound a frame payload before allocating, so a peer
+%% cannot force unbounded buffering with a pathological Length varint.
+-define(MAX_FRAME_SIZE, 16#100000).
+
+-type frame() ::
+    {data, binary()}
+    | {headers, binary()}
+    | {cancel_push, non_neg_integer()}
+    | {settings, map()}
+    | {push_promise, non_neg_integer(), binary()}
+    | {goaway, non_neg_integer()}
+    | {max_push_id, non_neg_integer()}
+    | {unknown, non_neg_integer(), binary()}.
+
+-type stream_type() ::
+    control | qpack_encoder | qpack_decoder | push | {unknown, non_neg_integer()}.
+
+-type decode_result() ::
+    {ok, frame(), Rest :: binary()}
+    | {more, Need :: pos_integer()}
+    | {error, term()}.
+
+%% =============================================================================
+%% Frame encoding
+%% =============================================================================
+
+-doc "Encode a DATA frame (RFC 9114 §7.2.1) as iodata.".
+-spec encode_data(binary()) -> iodata().
+encode_data(Payload) ->
+    frame_io(?FRAME_DATA, Payload).
+
+-doc "Encode a HEADERS frame (RFC 9114 §7.2.2) wrapping a QPACK field section.".
+-spec encode_headers(binary()) -> iodata().
+encode_headers(HeaderBlock) ->
+    frame_io(?FRAME_HEADERS, HeaderBlock).
+
+-doc """
+Encode a SETTINGS frame (RFC 9114 §7.2.4) from a settings map. Every
+entry in the map is emitted as an id+value varint pair, in
+`maps:to_list/1` order.
+""".
+-spec encode_settings(map()) -> iodata().
+encode_settings(Settings) ->
+    frame_io(?FRAME_SETTINGS, encode_settings_pairs(maps:to_list(Settings))).
+
+-doc "Encode a GOAWAY frame (RFC 9114 §7.2.6) naming the last stream id.".
+-spec encode_goaway(non_neg_integer()) -> iodata().
+encode_goaway(StreamId) ->
+    frame_io(?FRAME_GOAWAY, roadrunner_quic_varint:encode(StreamId)).
+
+-doc "Encode the leading stream-type varint for a server unidirectional stream.".
+-spec encode_stream_type(control | qpack_encoder | qpack_decoder | push | non_neg_integer()) ->
+    binary().
+encode_stream_type(control) -> roadrunner_quic_varint:encode(?STREAM_CONTROL);
+encode_stream_type(qpack_encoder) -> roadrunner_quic_varint:encode(?STREAM_QPACK_ENCODER);
+encode_stream_type(qpack_decoder) -> roadrunner_quic_varint:encode(?STREAM_QPACK_DECODER);
+encode_stream_type(push) -> roadrunner_quic_varint:encode(?STREAM_PUSH);
+encode_stream_type(Type) when is_integer(Type) -> roadrunner_quic_varint:encode(Type).
+
+%% A frame is its type varint, its length varint, then the payload. Kept
+%% as iodata so the (possibly large) payload is never recopied.
+-spec frame_io(non_neg_integer(), iodata()) -> iodata().
+frame_io(Type, Payload) ->
+    [
+        roadrunner_quic_varint:encode(Type),
+        roadrunner_quic_varint:encode(iolist_size(Payload)),
+        Payload
+    ].
+
+%% Encode each {id, value} setting as a varint pair, building the payload
+%% by consing on the way out (no reverse, no quadratic binary append).
+-spec encode_settings_pairs([{atom() | non_neg_integer(), non_neg_integer()}]) -> iodata().
+encode_settings_pairs([]) ->
+    [];
+encode_settings_pairs([{Key, Value} | Rest]) ->
+    [
+        roadrunner_quic_varint:encode(setting_to_id(Key)),
+        roadrunner_quic_varint:encode(Value)
+        | encode_settings_pairs(Rest)
+    ].
+
+%% =============================================================================
+%% Frame decoding
+%% =============================================================================
+
+-doc """
+Decode the leading HTTP/3 frame from `Bin`.
+
+- `{ok, Frame, Rest}` — a complete frame; `Rest` is the buffer after it.
+- `{more, Need}` — the type/length varints or the payload are not all
+  buffered yet; at least `Need` more bytes are required.
+- `{error, Reason}` — an oversized frame, a malformed payload, or an
+  HTTP/2-reserved frame type (RFC 9114 §7.1 / §7.2.8). `Reason` is a
+  term the caller maps to an HTTP/3 connection error code.
+""".
+-spec decode(binary()) -> decode_result().
+decode(Bin) ->
+    %% A failed `?=` (an incomplete type/length varint) returns its own
+    %% `{more, Need}` straight out of the block, so no `else` is needed.
+    maybe
+        {ok, Type, AfterType} ?= roadrunner_quic_varint:decode(Bin),
+        {ok, Length, AfterLength} ?= roadrunner_quic_varint:decode(AfterType),
+        decode_with_payload(Type, Length, AfterLength)
+    end.
+
+-spec decode_with_payload(non_neg_integer(), non_neg_integer(), binary()) -> decode_result().
+decode_with_payload(_Type, Length, _Bin) when Length > ?MAX_FRAME_SIZE ->
+    %% RFC 9114 §7.1: reject before allocating the payload buffer.
+    {error, {frame_error, oversized, Length}};
+decode_with_payload(Type, Length, Bin) when byte_size(Bin) >= Length ->
+    <<Payload:Length/binary, Rest/binary>> = Bin,
+    case decode_frame_payload(Type, Payload) of
+        {error, _} = Error -> Error;
+        Frame -> {ok, Frame, Rest}
+    end;
+decode_with_payload(_Type, Length, Bin) ->
+    {more, Length - byte_size(Bin)}.
+
+-spec decode_frame_payload(non_neg_integer(), binary()) -> frame() | {error, term()}.
+decode_frame_payload(?FRAME_DATA, Payload) ->
+    {data, Payload};
+decode_frame_payload(?FRAME_HEADERS, Payload) ->
+    {headers, Payload};
+decode_frame_payload(?FRAME_SETTINGS, Payload) ->
+    case decode_settings_pairs(Payload, #{}) of
+        {ok, Settings} -> {settings, Settings};
+        {error, Reason} -> {error, {frame_error, settings, Reason}}
+    end;
+decode_frame_payload(?FRAME_GOAWAY, Payload) ->
+    decode_single_id(goaway, Payload, fun(Id) -> {goaway, Id} end);
+decode_frame_payload(?FRAME_MAX_PUSH_ID, Payload) ->
+    decode_single_id(max_push_id, Payload, fun(Id) -> {max_push_id, Id} end);
+decode_frame_payload(?FRAME_CANCEL_PUSH, Payload) ->
+    decode_single_id(cancel_push, Payload, fun(Id) -> {cancel_push, Id} end);
+decode_frame_payload(?FRAME_PUSH_PROMISE, Payload) ->
+    case roadrunner_quic_varint:decode(Payload) of
+        {ok, PushId, HeaderBlock} -> {push_promise, PushId, HeaderBlock};
+        {more, _} -> {error, {frame_error, push_promise, malformed_varint}}
+    end;
+%% RFC 9114 §7.2.8: the frame types HTTP/2 uses are reserved in HTTP/3 and
+%% receiving one is a connection error of type H3_FRAME_UNEXPECTED.
+decode_frame_payload(16#02, _Payload) ->
+    {error, {h2_reserved_frame, 16#02}};
+decode_frame_payload(16#06, _Payload) ->
+    {error, {h2_reserved_frame, 16#06}};
+decode_frame_payload(16#08, _Payload) ->
+    {error, {h2_reserved_frame, 16#08}};
+decode_frame_payload(16#09, _Payload) ->
+    {error, {h2_reserved_frame, 16#09}};
+decode_frame_payload(Type, Payload) ->
+    %% Unknown / grease type (0x1f*N + 0x21) — surfaced so the caller can
+    %% ignore it per RFC 9114 §9.
+    {unknown, Type, Payload}.
+
+%% A frame whose payload is exactly one varint id (GOAWAY / MAX_PUSH_ID /
+%% CANCEL_PUSH); trailing bytes after it are malformed.
+-spec decode_single_id(atom(), binary(), fun((non_neg_integer()) -> frame())) ->
+    frame() | {error, term()}.
+decode_single_id(Name, Payload, Build) ->
+    case roadrunner_quic_varint:decode(Payload) of
+        {ok, Id, <<>>} -> Build(Id);
+        {ok, _Id, _Extra} -> {error, {frame_error, Name, extra_data}};
+        {more, _} -> {error, {frame_error, Name, malformed_varint}}
+    end.
+
+-doc """
+Decode the leading stream-type varint of a peer unidirectional stream
+(RFC 9114 §6.2): `{ok, Type, Rest} | {more, Need}`, where `Type` is
+`control | qpack_encoder | qpack_decoder | push | {unknown, Id}`.
+""".
+-spec decode_stream_type(binary()) -> {ok, stream_type(), binary()} | {more, pos_integer()}.
+decode_stream_type(Bin) ->
+    case roadrunner_quic_varint:decode(Bin) of
+        {ok, ?STREAM_CONTROL, Rest} -> {ok, control, Rest};
+        {ok, ?STREAM_PUSH, Rest} -> {ok, push, Rest};
+        {ok, ?STREAM_QPACK_ENCODER, Rest} -> {ok, qpack_encoder, Rest};
+        {ok, ?STREAM_QPACK_DECODER, Rest} -> {ok, qpack_decoder, Rest};
+        {ok, Type, Rest} -> {ok, {unknown, Type}, Rest};
+        {more, Need} -> {more, Need}
+    end.
+
+%% =============================================================================
+%% SETTINGS payload (RFC 9114 §7.2.4)
+%% =============================================================================
+
+%% Decode id+value varint pairs into a map. A forbidden HTTP/2 setting or
+%% a duplicate identifier is an error (H3_SETTINGS_ERROR upstream);
+%% unknown ids are kept under their integer key (RFC 9114 §7.2.4.1).
+-spec decode_settings_pairs(binary(), map()) -> {ok, map()} | {error, term()}.
+decode_settings_pairs(<<>>, Acc) ->
+    {ok, Acc};
+decode_settings_pairs(Data, Acc) ->
+    maybe
+        {ok, Id, AfterId} ?= roadrunner_quic_varint:decode(Data),
+        {ok, Value, Rest} ?= roadrunner_quic_varint:decode(AfterId),
+        add_setting(Id, Value, Rest, Acc)
+    else
+        {more, _} -> {error, malformed_varint}
+    end.
+
+-spec add_setting(non_neg_integer(), non_neg_integer(), binary(), map()) ->
+    {ok, map()} | {error, term()}.
+add_setting(Id, Value, Rest, Acc) ->
+    case is_forbidden_setting(Id) of
+        true ->
+            {error, {forbidden_setting, Id}};
+        false ->
+            Key = id_to_setting(Id),
+            case Acc of
+                #{Key := _} -> {error, {duplicate_setting, Key}};
+                _ -> decode_settings_pairs(Rest, Acc#{Key => Value})
+            end
+    end.
+
+%% RFC 9114 §7.2.4.1: the HTTP/2 settings ENABLE_PUSH / MAX_CONCURRENT_STREAMS
+%% / INITIAL_WINDOW_SIZE / MAX_FRAME_SIZE have no meaning in HTTP/3 and their
+%% receipt is a connection error.
+-spec is_forbidden_setting(non_neg_integer()) -> boolean().
+is_forbidden_setting(16#02) -> true;
+is_forbidden_setting(16#03) -> true;
+is_forbidden_setting(16#04) -> true;
+is_forbidden_setting(16#05) -> true;
+is_forbidden_setting(_) -> false.
+
+-spec setting_to_id(atom() | non_neg_integer()) -> non_neg_integer().
+setting_to_id(qpack_max_table_capacity) -> ?SETTINGS_QPACK_MAX_TABLE_CAPACITY;
+setting_to_id(max_field_section_size) -> ?SETTINGS_MAX_FIELD_SECTION_SIZE;
+setting_to_id(qpack_blocked_streams) -> ?SETTINGS_QPACK_BLOCKED_STREAMS;
+setting_to_id(enable_connect_protocol) -> ?SETTINGS_ENABLE_CONNECT_PROTOCOL;
+setting_to_id(Id) when is_integer(Id) -> Id.
+
+-spec id_to_setting(non_neg_integer()) -> atom() | non_neg_integer().
+id_to_setting(?SETTINGS_QPACK_MAX_TABLE_CAPACITY) -> qpack_max_table_capacity;
+id_to_setting(?SETTINGS_MAX_FIELD_SECTION_SIZE) -> max_field_section_size;
+id_to_setting(?SETTINGS_QPACK_BLOCKED_STREAMS) -> qpack_blocked_streams;
+id_to_setting(?SETTINGS_ENABLE_CONNECT_PROTOCOL) -> enable_connect_protocol;
+id_to_setting(Id) -> Id.

--- a/src/roadrunner_quic_varint.erl
+++ b/src/roadrunner_quic_varint.erl
@@ -1,0 +1,81 @@
+-module(roadrunner_quic_varint).
+-moduledoc false.
+
+%% QUIC variable-length integer codec (RFC 9000 §16).
+%%
+%% The two most significant bits of the first byte select the length
+%% class; the remaining bits are the value, big-endian:
+%%
+%% | Prefix | Bytes | Bits | Range |
+%% |--------|-------|------|-------|
+%% | 2#00   | 1     | 6    | 0 .. 63 |
+%% | 2#01   | 2     | 14   | 0 .. 16383 |
+%% | 2#10   | 4     | 30   | 0 .. 1073741823 |
+%% | 2#11   | 8     | 62   | 0 .. 4611686018427387903 |
+%%
+%% Pure wire syntax: `encode/1` always emits the minimal-length form, and
+%% `decode/1` reports `{more, Need}` for a truncated buffer rather than
+%% crashing, so callers (`roadrunner_quic_h3_frame`, the packet/frame
+%% codecs) can thread incremental input without a `try`.
+
+-export([encode/1, decode/1]).
+
+-export_type([decode_result/0]).
+
+%% 2^6 - 1
+-define(MAX_1, 63).
+%% 2^14 - 1
+-define(MAX_2, 16383).
+%% 2^30 - 1
+-define(MAX_4, 1073741823).
+%% 2^62 - 1
+-define(MAX_8, 4611686018427387903).
+
+-type decode_result() ::
+    {ok, non_neg_integer(), Rest :: binary()}
+    | {more, Need :: pos_integer()}.
+
+%% =============================================================================
+%% encode/1
+%% =============================================================================
+
+-doc """
+Encode a non-negative integer as a QUIC varint, in the minimal-length
+form per RFC 9000 §16. The value must fit in 62 bits (0 ..
+4611686018427387903); a larger value has no encoding and raises a
+`function_clause`.
+""".
+-spec encode(non_neg_integer()) -> binary().
+encode(V) when is_integer(V), V >= 0, V =< ?MAX_1 -> <<0:2, V:6>>;
+encode(V) when is_integer(V), V > ?MAX_1, V =< ?MAX_2 -> <<1:2, V:14>>;
+encode(V) when is_integer(V), V > ?MAX_2, V =< ?MAX_4 -> <<2:2, V:30>>;
+encode(V) when is_integer(V), V > ?MAX_4, V =< ?MAX_8 -> <<3:2, V:62>>.
+
+%% =============================================================================
+%% decode/1
+%% =============================================================================
+
+-doc """
+Decode the leading QUIC varint from `Bin`.
+
+Returns:
+- `{ok, Value, Rest}` — a full varint was present; `Rest` is the
+  buffer that follows it.
+- `{more, Need}` — the buffer is shorter than the length class its
+  first byte selects (or empty); `Need` more bytes are required.
+""".
+-spec decode(binary()) -> decode_result().
+decode(<<0:2, V:6, Rest/binary>>) ->
+    {ok, V, Rest};
+decode(<<1:2, V:14, Rest/binary>>) ->
+    {ok, V, Rest};
+decode(<<2:2, V:30, Rest/binary>>) ->
+    {ok, V, Rest};
+decode(<<3:2, V:62, Rest/binary>>) ->
+    {ok, V, Rest};
+decode(<<Prefix:2, _/bitstring>> = Bin) ->
+    %% First byte present, but the selected length class wants more bytes.
+    %% Prefix 0/1/2/3 maps to a total length of 1/2/4/8 bytes.
+    {more, (1 bsl Prefix) - byte_size(Bin)};
+decode(<<>>) ->
+    {more, 1}.

--- a/test/property_test/roadrunner_quic_varint_props.erl
+++ b/test/property_test/roadrunner_quic_varint_props.erl
@@ -1,0 +1,27 @@
+-module(roadrunner_quic_varint_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_varint`.
+
+Two invariants over the whole 62-bit domain: the encoding is
+byte-for-byte identical to the `quic` dep (the differential oracle),
+and `decode(encode(V))` round-trips back to `{ok, V, <<>>}`.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+%% 2^62 - 1, the largest value a QUIC varint can carry.
+-define(MAX_62, 4611686018427387903).
+
+prop_encode_matches_dep_and_round_trips() ->
+    ?FORALL(
+        V,
+        integer(0, ?MAX_62),
+        begin
+            Bin = roadrunner_quic_varint:encode(V),
+            Bin =:= quic_varint:encode(V) andalso
+                roadrunner_quic_varint:decode(Bin) =:= {ok, V, <<>>}
+        end
+    ).

--- a/test/roadrunner_conn_loop_http3_tests.erl
+++ b/test/roadrunner_conn_loop_http3_tests.erl
@@ -19,9 +19,11 @@ decode(Buf, MaxLen, MaxHdrBlock) ->
     roadrunner_conn_loop_http3:decode_request_frames(Buf, new(), MaxLen, MaxHdrBlock).
 
 %% A HEADERS frame wrapping an arbitrary field block (the block is only
-%% QPACK-decoded later, in the conn loop's dispatch, not here).
-hf(Block) -> quic_h3_frame:encode_headers(Block).
-df(Bin) -> quic_h3_frame:encode_data(Bin).
+%% QPACK-decoded later, in the conn loop's dispatch, not here). The native
+%% encoders return iodata; these build on-wire frames (binary) fed to the
+%% decoder, so flatten them.
+hf(Block) -> iolist_to_binary(roadrunner_quic_h3_frame:encode_headers(Block)).
+df(Bin) -> iolist_to_binary(roadrunner_quic_h3_frame:encode_data(Bin)).
 
 new_request_stream_test() ->
     ?assertEqual(
@@ -69,7 +71,10 @@ frame_after_trailers_test() ->
 
 settings_on_request_stream_test() ->
     %% A control-stream-only frame on a request stream → H3_FRAME_UNEXPECTED.
-    ?assertMatch({conn_error, 16#0105, _}, decode(quic_h3_frame:encode_settings(#{}), 1000)).
+    ?assertMatch(
+        {conn_error, 16#0105, _},
+        decode(iolist_to_binary(roadrunner_quic_h3_frame:encode_settings(#{})), 1000)
+    ).
 
 unknown_frame_ignored_test() ->
     %% Grease frame type 0x21 (empty payload) — ignored (RFC 9114 §9).
@@ -86,7 +91,9 @@ h2_reserved_frame_test() ->
 
 oversized_frame_test() ->
     %% A frame declaring a length above the cap → H3_FRAME_ERROR (§7.1).
-    Oversized = iolist_to_binary([quic_varint:encode(0), quic_varint:encode(16#FFFFFFFF)]),
+    Oversized = iolist_to_binary([
+        roadrunner_quic_varint:encode(0), roadrunner_quic_varint:encode(16#FFFFFFFF)
+    ]),
     ?assertMatch({conn_error, 16#0106, _}, decode(Oversized, 1000)).
 
 oversized_header_block_test() ->

--- a/test/roadrunner_conn_loop_http3_uni_tests.erl
+++ b/test/roadrunner_conn_loop_http3_uni_tests.erl
@@ -16,12 +16,25 @@ ev(UniState, Critical, Data, Fin) ->
 
 %% --- frame / stream-type builders ---
 
-t(Type) -> quic_h3_frame:encode_stream_type(Type).
-settings() -> quic_h3_frame:encode_settings(#{qpack_max_table_capacity => 0}).
-goaway() -> quic_h3_frame:encode_goaway(0).
-data() -> quic_h3_frame:encode_data(~"x").
-headers() -> quic_h3_frame:encode_headers(~"blk").
-push_promise() -> quic_h3_frame:encode_push_promise(0, ~"blk").
+%% The native encoders return iodata; these helpers build on-wire frames
+%% (binary) fed into the decode-side state machine, so flatten them.
+%% `encode_stream_type/1` is already a single varint binary.
+t(Type) -> roadrunner_quic_h3_frame:encode_stream_type(Type).
+settings() ->
+    iolist_to_binary(roadrunner_quic_h3_frame:encode_settings(#{qpack_max_table_capacity => 0})).
+goaway() -> iolist_to_binary(roadrunner_quic_h3_frame:encode_goaway(0)).
+data() -> iolist_to_binary(roadrunner_quic_h3_frame:encode_data(~"x")).
+headers() -> iolist_to_binary(roadrunner_quic_h3_frame:encode_headers(~"blk")).
+%% PUSH_PROMISE (type 0x05): a server never sends one, so the native h3
+%% codec has no encoder for it; build the wire frame directly to exercise
+%% the decode-side rejection on the control stream.
+push_promise() ->
+    Payload = [roadrunner_quic_varint:encode(0), ~"blk"],
+    iolist_to_binary([
+        roadrunner_quic_varint:encode(16#05),
+        roadrunner_quic_varint:encode(iolist_size(Payload)),
+        Payload
+    ]).
 
 %% --- stream-type classification (from {pending, ...}) ---
 
@@ -118,13 +131,15 @@ control_h2_reserved_frame_test() ->
     ?assertMatch({conn_error, 16#0105, _}, ev({control, <<>>, true}, #{}, <<2, 0>>, false)).
 
 control_oversized_frame_test() ->
-    Oversized = iolist_to_binary([quic_varint:encode(0), quic_varint:encode(16#FFFFFFFF)]),
+    Oversized = iolist_to_binary([
+        roadrunner_quic_varint:encode(0), roadrunner_quic_varint:encode(16#FFFFFFFF)
+    ]),
     ?assertMatch({conn_error, 16#0106, _}, ev({control, <<>>, true}, #{}, Oversized, false)).
 
 control_forbidden_setting_test() ->
     %% An HTTP/2-only setting (MAX_CONCURRENT_STREAMS = 0x03) is
     %% forbidden in HTTP/3 → H3_SETTINGS_ERROR.
-    Forbidden = quic_h3_frame:encode_settings(#{16#03 => 100}),
+    Forbidden = iolist_to_binary(roadrunner_quic_h3_frame:encode_settings(#{16#03 => 100})),
     ?assertMatch({conn_error, 16#0109, _}, ev({control, <<>>, false}, #{}, Forbidden, false)).
 
 control_stream_closed_test() ->

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -32,7 +32,8 @@ Add a new property:
     http1_parse_chunk_incremental/1,
     loop_terminates_normal_on_random_inputs/1,
     loop_request_start_and_stop_share_request_id/1,
-    router_param_bindings_round_trip/1
+    router_param_bindings_round_trip/1,
+    quic_varint_encode_matches_dep/1
 ]).
 
 suite() ->
@@ -55,7 +56,8 @@ all() ->
         http1_parse_chunk_incremental,
         loop_terminates_normal_on_random_inputs,
         loop_request_start_and_stop_share_request_id,
-        router_param_bindings_round_trip
+        router_param_bindings_round_trip,
+        quic_varint_encode_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -157,5 +159,11 @@ loop_request_start_and_stop_share_request_id(Config) ->
 router_param_bindings_round_trip(Config) ->
     ct_property_test:quickcheck(
         roadrunner_router_props:prop_param_bindings_round_trip(),
+        Config
+    ).
+
+quic_varint_encode_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_varint_props:prop_encode_matches_dep_and_round_trips(),
         Config
     ).

--- a/test/roadrunner_qpack_tests.erl
+++ b/test/roadrunner_qpack_tests.erl
@@ -1,0 +1,172 @@
+-module(roadrunner_qpack_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_qpack).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_qpack).
+
+%% =============================================================================
+%% Differential oracle vs the dep: byte-for-byte encode + cross-decode.
+%%
+%% Cross-decode (dep decodes our bytes and we decode the dep's, both back to
+%% the original) is the real interop guarantee. Byte-for-byte holds too here
+%% because both pick the lowest static index and the same Huffman table.
+%% =============================================================================
+
+oracle_header_sets() ->
+    [
+        [],
+        [{~":status", ~"200"}],
+        [{~"content-type", ~"text/plain"}],
+        [{~"accept-encoding", ~"gzip, deflate, br"}],
+        %% Typical request: exact pseudo-headers + a name-ref :authority.
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"https"},
+            {~":path", ~"/"},
+            {~":authority", ~"example.com"}
+        ],
+        %% Name reference, non-table value (name has concrete siblings).
+        [{~":status", ~"599"}],
+        %% Name-only static names used as name references.
+        [{~"server", ~"roadrunner"}],
+        [{~"set-cookie", ~"sid=abc; HttpOnly"}],
+        %% Literal name (not in the table) with a Huffman-worthy value.
+        [{~"x-custom-header", ~"a fairly long custom value that compresses"}],
+        %% Short value that does not benefit from Huffman (raw branch).
+        [{~"x-flag", ~"x"}]
+    ].
+
+oracle_encode_is_byte_identical_test() ->
+    [?assertEqual(?DEP:encode(H), ?M:encode(H)) || H <- oracle_header_sets()].
+
+oracle_dep_decodes_our_encoding_test() ->
+    [?assertEqual({ok, H}, ?DEP:decode(?M:encode(H))) || H <- oracle_header_sets()].
+
+oracle_we_decode_dep_encoding_test() ->
+    [?assertEqual({ok, H}, ?M:decode(?DEP:encode(H))) || H <- oracle_header_sets()].
+
+%% =============================================================================
+%% Static table — full clause coverage via the public API.
+%% =============================================================================
+
+%% Decode an indexed-static field line for every index 0..98 (exercising each
+%% static_entry clause), then re-encode the decoded entry and confirm it round
+%% trips. Concrete entries re-encode as an Indexed Field Line (exercising the
+%% static_full_match clauses); name-only entries (empty value) re-encode as a
+%% Literal with Name Reference.
+roundtrip_every_static_index_test() ->
+    [
+        begin
+            {ok, [Entry]} = ?M:decode(indexed_section(I)),
+            ?assertEqual({ok, [Entry]}, ?M:decode(?M:encode([Entry])))
+        end
+     || I <- lists:seq(0, 98)
+    ].
+
+%% For every distinct static name, a header carrying that name with a value
+%% absent from the table encodes as a Literal with Name Reference, exercising
+%% each static_name_match clause.
+name_reference_every_static_name_test() ->
+    Names = lists:usort([
+        element(1, Entry)
+     || I <- lists:seq(0, 98), {ok, [Entry]} <- [?M:decode(indexed_section(I))]
+    ]),
+    [
+        ?assertEqual(
+            {ok, [{Name, ~"zzz-not-in-table"}]}, ?M:decode(?M:encode([{Name, ~"zzz-not-in-table"}]))
+        )
+     || Name <- Names
+    ].
+
+%% A name absent from the table encodes as a Literal with Literal Name.
+literal_literal_name_test() ->
+    H = [{~"x-totally-unknown", ~"value"}],
+    ?assertEqual({ok, H}, ?M:decode(?M:encode(H))),
+    ?assertEqual(?DEP:encode(H), ?M:encode(H)).
+
+%% =============================================================================
+%% Encode string: Huffman vs raw branch.
+%% =============================================================================
+
+encode_string_branches_test() ->
+    %% A long repetitive value compresses (Huffman branch); a 1-char value
+    %% does not (raw branch). Both round-trip.
+    Huffy = [{~"x-h", binary:copy(~"a", 40)}],
+    Raw = [{~"x-r", ~"q"}],
+    ?assertEqual({ok, Huffy}, ?M:decode(?M:encode(Huffy))),
+    ?assertEqual({ok, Raw}, ?M:decode(?M:encode(Raw))),
+    %% Cross-check the Huffman decision against the dep byte-for-byte.
+    ?assertEqual(?DEP:encode(Huffy), ?M:encode(Huffy)),
+    ?assertEqual(?DEP:encode(Raw), ?M:encode(Raw)).
+
+%% =============================================================================
+%% Decode error paths.
+%% =============================================================================
+
+decode_non_zero_ric_test() ->
+    %% A Required Insert Count > 0 references the dynamic table we never enable.
+    ?assertEqual({error, {qpack, dynamic_table_required}}, ?M:decode(<<5, 0, 16#80>>)).
+
+decode_truncated_prefix_test() ->
+    ?assertEqual({error, {qpack, truncated}}, ?M:decode(<<0>>)),
+    ?assertEqual({error, {qpack, truncated}}, ?M:decode(<<>>)).
+
+decode_bad_delta_base_test() ->
+    %% RIC byte 0, then a Delta Base varint (7-bit prefix) that promises a
+    %% continuation byte that never arrives.
+    ?assertEqual({error, {qpack, bad_integer}}, ?M:decode(<<0, 16#FF>>)).
+
+decode_dynamic_field_line_test() ->
+    %% 0x80 = 10xxxxxx, a dynamic Indexed Field Line.
+    ?assertEqual({error, {qpack, dynamic_field_line, 16#80}}, ?M:decode(<<0, 0, 16#80>>)).
+
+decode_bad_index_varint_test() ->
+    %% 0xFF = 11xxxxxx (indexed static) whose 6-bit index promises a
+    %% continuation byte that never arrives.
+    ?assertEqual({error, {qpack, bad_integer}}, ?M:decode(<<0, 0, 16#FF>>)).
+
+decode_invalid_static_index_test() ->
+    %% Indexed static field line referencing index 200 (out of range).
+    Section = indexed_section(200),
+    ?assertEqual({error, {qpack, invalid_static_index, 200}}, ?M:decode(Section)),
+    %% Name-reference field line referencing name index 200.
+    NameRef = <<0, 0, (name_ref_prefix(200))/binary, 0>>,
+    ?assertEqual({error, {qpack, invalid_static_index, 200}}, ?M:decode(NameRef)).
+
+decode_truncated_value_string_test() ->
+    %% Name reference index 0, then no value-string bytes at all.
+    NoValue = <<0, 0, (name_ref_prefix(0))/binary>>,
+    ?assertEqual({error, {qpack, truncated}}, ?M:decode(NoValue)),
+    %% Value string claims length 5 but only 2 bytes follow.
+    ShortValue = <<0, 0, (name_ref_prefix(0))/binary, 16#05, 1, 2>>,
+    ?assertEqual({error, {qpack, truncated}}, ?M:decode(ShortValue)).
+
+decode_bad_huffman_value_test() ->
+    %% Value string H=1, length 1, byte 0xFF: 8 one-bits is invalid Huffman
+    %% padding (RFC 7541 §5.2).
+    Bad = <<0, 0, (name_ref_prefix(0))/binary, 2#10000001, 16#FF>>,
+    ?assertEqual({error, {qpack, huffman}}, ?M:decode(Bad)).
+
+decode_second_field_line_error_propagates_test() ->
+    %% A valid Indexed Field Line (:method GET) followed by a dynamic byte:
+    %% the error from the recursive tail must surface.
+    Section = <<0, 0, (iolist_to_binary(indexed_prefix(17)))/binary, 16#80>>,
+    ?assertEqual({error, {qpack, dynamic_field_line, 16#80}}, ?M:decode(Section)).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+%% A field section whose single field line is an Indexed Field Line (static)
+%% for `Index`.
+indexed_section(Index) ->
+    <<0, 0, (iolist_to_binary(indexed_prefix(Index)))/binary>>.
+
+indexed_prefix(Index) ->
+    roadrunner_http2_hpack:encode_integer(6, 2#11000000, Index).
+
+%% The leading bytes of a Literal Field Line with Name Reference (static).
+name_ref_prefix(Index) ->
+    iolist_to_binary(roadrunner_http2_hpack:encode_integer(4, 2#01010000, Index)).

--- a/test/roadrunner_qpack_tests.erl
+++ b/test/roadrunner_qpack_tests.erl
@@ -39,10 +39,10 @@ oracle_header_sets() ->
     ].
 
 oracle_encode_is_byte_identical_test() ->
-    [?assertEqual(?DEP:encode(H), ?M:encode(H)) || H <- oracle_header_sets()].
+    [?assertEqual(?DEP:encode(H), enc(H)) || H <- oracle_header_sets()].
 
 oracle_dep_decodes_our_encoding_test() ->
-    [?assertEqual({ok, H}, ?DEP:decode(?M:encode(H))) || H <- oracle_header_sets()].
+    [?assertEqual({ok, H}, ?DEP:decode(enc(H))) || H <- oracle_header_sets()].
 
 oracle_we_decode_dep_encoding_test() ->
     [?assertEqual({ok, H}, ?M:decode(?DEP:encode(H))) || H <- oracle_header_sets()].
@@ -60,7 +60,7 @@ roundtrip_every_static_index_test() ->
     [
         begin
             {ok, [Entry]} = ?M:decode(indexed_section(I)),
-            ?assertEqual({ok, [Entry]}, ?M:decode(?M:encode([Entry])))
+            ?assertEqual({ok, [Entry]}, ?M:decode(enc([Entry])))
         end
      || I <- lists:seq(0, 98)
     ].
@@ -75,7 +75,7 @@ name_reference_every_static_name_test() ->
     ]),
     [
         ?assertEqual(
-            {ok, [{Name, ~"zzz-not-in-table"}]}, ?M:decode(?M:encode([{Name, ~"zzz-not-in-table"}]))
+            {ok, [{Name, ~"zzz-not-in-table"}]}, ?M:decode(enc([{Name, ~"zzz-not-in-table"}]))
         )
      || Name <- Names
     ].
@@ -83,8 +83,8 @@ name_reference_every_static_name_test() ->
 %% A name absent from the table encodes as a Literal with Literal Name.
 literal_literal_name_test() ->
     H = [{~"x-totally-unknown", ~"value"}],
-    ?assertEqual({ok, H}, ?M:decode(?M:encode(H))),
-    ?assertEqual(?DEP:encode(H), ?M:encode(H)).
+    ?assertEqual({ok, H}, ?M:decode(enc(H))),
+    ?assertEqual(?DEP:encode(H), enc(H)).
 
 %% =============================================================================
 %% Encode string: Huffman vs raw branch.
@@ -95,11 +95,11 @@ encode_string_branches_test() ->
     %% does not (raw branch). Both round-trip.
     Huffy = [{~"x-h", binary:copy(~"a", 40)}],
     Raw = [{~"x-r", ~"q"}],
-    ?assertEqual({ok, Huffy}, ?M:decode(?M:encode(Huffy))),
-    ?assertEqual({ok, Raw}, ?M:decode(?M:encode(Raw))),
+    ?assertEqual({ok, Huffy}, ?M:decode(enc(Huffy))),
+    ?assertEqual({ok, Raw}, ?M:decode(enc(Raw))),
     %% Cross-check the Huffman decision against the dep byte-for-byte.
-    ?assertEqual(?DEP:encode(Huffy), ?M:encode(Huffy)),
-    ?assertEqual(?DEP:encode(Raw), ?M:encode(Raw)).
+    ?assertEqual(?DEP:encode(Huffy), enc(Huffy)),
+    ?assertEqual(?DEP:encode(Raw), enc(Raw)).
 
 %% =============================================================================
 %% Decode error paths.
@@ -158,6 +158,12 @@ decode_second_field_line_error_propagates_test() ->
 %% =============================================================================
 %% Helpers
 %% =============================================================================
+
+%% `roadrunner_qpack:encode/1` returns iodata (it is framed and sent as
+%% iodata in production); flatten it here, where the dep oracle and the
+%% native decoder both want the on-wire binary.
+enc(Headers) ->
+    iolist_to_binary(roadrunner_qpack:encode(Headers)).
 
 %% A field section whose single field line is an Indexed Field Line (static)
 %% for `Index`.

--- a/test/roadrunner_quic_h3_frame_tests.erl
+++ b/test/roadrunner_quic_h3_frame_tests.erl
@@ -1,0 +1,198 @@
+-module(roadrunner_quic_h3_frame_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_h3_frame).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_h3_frame).
+
+%% =============================================================================
+%% Encoding — byte-for-byte vs the dep oracle.
+%%
+%% The native encoders return iodata (so a large payload is never
+%% recopied); flatten before comparing to the dep's binary output.
+%% =============================================================================
+
+encode_data_matches_dep_test() ->
+    [
+        ?assertEqual(?DEP:encode_data(P), iolist_to_binary(?M:encode_data(P)))
+     || P <- [<<>>, <<"hello">>, binary:copy(<<"x">>, 1000)]
+    ].
+
+encode_headers_matches_dep_test() ->
+    [
+        ?assertEqual(?DEP:encode_headers(B), iolist_to_binary(?M:encode_headers(B)))
+     || B <- [<<>>, <<1, 2, 3>>, binary:copy(<<0>>, 500)]
+    ].
+
+encode_goaway_matches_dep_test() ->
+    [
+        ?assertEqual(?DEP:encode_goaway(Id), iolist_to_binary(?M:encode_goaway(Id)))
+     || Id <- [0, 4, 1000, 16383, 16384]
+    ].
+
+encode_settings_matches_dep_test() ->
+    Maps = [
+        #{},
+        #{qpack_max_table_capacity => 0},
+        #{
+            qpack_max_table_capacity => 0,
+            qpack_blocked_streams => 0,
+            max_field_section_size => 65536
+        },
+        #{enable_connect_protocol => 1},
+        %% Unknown integer id round-trips through the integer setting_to_id clause.
+        #{16#0b => 5}
+    ],
+    [
+        ?assertEqual(?DEP:encode_settings(M), iolist_to_binary(?M:encode_settings(M)))
+     || M <- Maps
+    ].
+
+encode_stream_type_matches_dep_test() ->
+    [
+        ?assertEqual(?DEP:encode_stream_type(T), ?M:encode_stream_type(T))
+     || T <- [control, qpack_encoder, qpack_decoder, push, 16#21, 0]
+    ].
+
+%% =============================================================================
+%% Decoding — equivalence vs the dep on complete frames.
+%% =============================================================================
+
+decode_complete_frames_match_dep_test() ->
+    Frames = [
+        ?DEP:encode_data(<<"body">>),
+        ?DEP:encode_headers(<<9, 8, 7>>),
+        ?DEP:encode_goaway(12),
+        ?DEP:encode_settings(#{qpack_max_table_capacity => 0, max_field_section_size => 65536}),
+        ?DEP:encode_max_push_id(3),
+        ?DEP:encode_cancel_push(7),
+        ?DEP:encode_push_promise(5, <<1, 2>>)
+    ],
+    [?assertEqual(?DEP:decode(F), ?M:decode(F)) || F <- Frames].
+
+decode_keeps_trailing_bytes_test() ->
+    Frame = iolist_to_binary(?M:encode_data(<<"ab">>)),
+    Buf = <<Frame/binary, 16#ff, 16#ee>>,
+    ?assertEqual({ok, {data, <<"ab">>}, <<16#ff, 16#ee>>}, ?M:decode(Buf)),
+    ?assertEqual(?DEP:decode(Buf), ?M:decode(Buf)).
+
+decode_unknown_grease_frame_test() ->
+    %% Type 0x21 (a reserved/grease type) with a 2-byte payload.
+    Buf = <<16#21, 2, 16#aa, 16#bb>>,
+    ?assertEqual({ok, {unknown, 16#21, <<16#aa, 16#bb>>}, <<>>}, ?M:decode(Buf)),
+    ?assertEqual(?DEP:decode(Buf), ?M:decode(Buf)).
+
+decode_h2_reserved_frames_test() ->
+    [
+        begin
+            Buf = <<Type, 0>>,
+            ?assertEqual({error, {h2_reserved_frame, Type}}, ?M:decode(Buf)),
+            ?assertEqual(?DEP:decode(Buf), ?M:decode(Buf))
+        end
+     || Type <- [16#02, 16#06, 16#08, 16#09]
+    ].
+
+decode_oversized_frame_test() ->
+    %% A Length varint past the 1 MiB cap is rejected before allocation.
+    Oversized = 16#100000 + 1,
+    Buf = <<0, (roadrunner_quic_varint:encode(Oversized))/binary>>,
+    ?assertMatch({error, {frame_error, oversized, Oversized}}, ?M:decode(Buf)).
+
+decode_incomplete_returns_more_test() ->
+    %% Empty buffer, a partial header, and a complete header with a
+    %% short payload all report {more, _}.
+    ?assertMatch({more, _}, ?M:decode(<<>>)),
+    ?assertMatch({more, _}, ?M:decode(<<16#40>>)),
+    %% DATA type 0, length 5, but only 2 payload bytes buffered.
+    ?assertEqual({more, 3}, ?M:decode(<<0, 5, 1, 2>>)),
+    %% Type present, length varint truncated (needs more).
+    ?assertMatch({more, _}, ?M:decode(<<0, 16#40>>)).
+
+decode_single_id_extra_and_malformed_test() ->
+    %% GOAWAY (type 0x07) whose payload carries a trailing byte after the id.
+    Extra = <<16#07, 2, 5, 16#ff>>,
+    ?assertEqual({error, {frame_error, goaway, extra_data}}, ?M:decode(Extra)),
+    %% MAX_PUSH_ID with a truncated (multi-byte) varint as its whole payload.
+    Malformed = <<16#0d, 1, 16#40>>,
+    ?assertEqual({error, {frame_error, max_push_id, malformed_varint}}, ?M:decode(Malformed)).
+
+decode_push_promise_malformed_test() ->
+    %% PUSH_PROMISE (type 5) whose payload is a truncated push-id varint.
+    Buf = <<16#05, 1, 16#40>>,
+    ?assertEqual({error, {frame_error, push_promise, malformed_varint}}, ?M:decode(Buf)).
+
+%% =============================================================================
+%% SETTINGS payload edge cases.
+%% =============================================================================
+
+decode_settings_forbidden_and_duplicate_test() ->
+    %% Each HTTP/2 setting forbidden in HTTP/3 (RFC 9114 §7.2.4.1):
+    %% ENABLE_PUSH, MAX_CONCURRENT_STREAMS, INITIAL_WINDOW_SIZE, MAX_FRAME_SIZE.
+    [
+        begin
+            Forbidden = <<16#04, 2, Id, 0>>,
+            ?assertEqual(
+                {error, {frame_error, settings, {forbidden_setting, Id}}}, ?M:decode(Forbidden)
+            ),
+            ?assertEqual(?DEP:decode(Forbidden), ?M:decode(Forbidden))
+        end
+     || Id <- [16#02, 16#03, 16#04, 16#05]
+    ],
+    %% Duplicate identifier 0x06 (max_field_section_size).
+    Dup = <<16#04, 4, 16#06, 1, 16#06, 2>>,
+    ?assertEqual(
+        {error, {frame_error, settings, {duplicate_setting, max_field_section_size}}},
+        ?M:decode(Dup)
+    ),
+    ?assertEqual(?DEP:decode(Dup), ?M:decode(Dup)).
+
+decode_settings_malformed_pairs_test() ->
+    %% SETTINGS payload with an id but a truncated value varint.
+    BadValue = <<16#04, 2, 16#06, 16#40>>,
+    ?assertEqual({error, {frame_error, settings, malformed_varint}}, ?M:decode(BadValue)),
+    %% SETTINGS payload that is a single truncated id varint.
+    BadId = <<16#04, 1, 16#40>>,
+    ?assertEqual({error, {frame_error, settings, malformed_varint}}, ?M:decode(BadId)).
+
+decode_settings_unknown_id_kept_as_integer_test() ->
+    %% Unknown id 0x0b survives as its integer key (RFC 9114 §7.2.4.1).
+    Buf = iolist_to_binary(?M:encode_settings(#{16#0b => 9})),
+    ?assertEqual({ok, {settings, #{16#0b => 9}}, <<>>}, ?M:decode(Buf)).
+
+decode_settings_all_standard_ids_test() ->
+    %% Every id that maps to an atom (ids 1, 6, 7, 8) decodes to its atom key.
+    Buf = iolist_to_binary(
+        ?M:encode_settings(#{
+            qpack_max_table_capacity => 0,
+            max_field_section_size => 65536,
+            qpack_blocked_streams => 0,
+            enable_connect_protocol => 1
+        })
+    ),
+    Expected = #{
+        qpack_max_table_capacity => 0,
+        max_field_section_size => 65536,
+        qpack_blocked_streams => 0,
+        enable_connect_protocol => 1
+    },
+    ?assertEqual({ok, {settings, Expected}, <<>>}, ?M:decode(Buf)),
+    ?assertEqual(?DEP:decode(Buf), ?M:decode(Buf)).
+
+%% =============================================================================
+%% decode_stream_type/1 — all classes vs the dep.
+%% =============================================================================
+
+decode_stream_type_matches_dep_test() ->
+    [
+        begin
+            Bin = ?DEP:encode_stream_type(T),
+            ?assertEqual(?DEP:decode_stream_type(Bin), ?M:decode_stream_type(Bin))
+        end
+     || T <- [control, push, qpack_encoder, qpack_decoder, 16#21]
+    ].
+
+decode_stream_type_more_test() ->
+    ?assertMatch({more, _}, ?M:decode_stream_type(<<>>)),
+    %% A multi-byte stream-type varint that is not fully buffered.
+    ?assertMatch({more, _}, ?M:decode_stream_type(<<16#40>>)).

--- a/test/roadrunner_quic_varint_tests.erl
+++ b/test/roadrunner_quic_varint_tests.erl
@@ -1,0 +1,120 @@
+-module(roadrunner_quic_varint_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% =============================================================================
+%% RFC 9000 Appendix A.1 fixed vectors — the authority.
+%%
+%% The four worked examples plus the §16 two-byte "151" example. Encoding
+%% is minimal-length, so each value has exactly one valid binary.
+%% =============================================================================
+
+rfc_a1_one_byte_vector_test() ->
+    %% 37 -> 0x25
+    ?assertEqual(<<16#25>>, roadrunner_quic_varint:encode(37)),
+    ?assertEqual({ok, 37, <<>>}, roadrunner_quic_varint:decode(<<16#25>>)).
+
+rfc_a1_two_byte_vector_test() ->
+    %% 15293 -> 0x7b 0xbd
+    ?assertEqual(<<16#7b, 16#bd>>, roadrunner_quic_varint:encode(15293)),
+    ?assertEqual({ok, 15293, <<>>}, roadrunner_quic_varint:decode(<<16#7b, 16#bd>>)).
+
+rfc_a1_four_byte_vector_test() ->
+    %% 494878333 -> 0x9d 0x7f 0x3e 0x7d
+    Bytes = <<16#9d, 16#7f, 16#3e, 16#7d>>,
+    ?assertEqual(Bytes, roadrunner_quic_varint:encode(494878333)),
+    ?assertEqual({ok, 494878333, <<>>}, roadrunner_quic_varint:decode(Bytes)).
+
+rfc_a1_eight_byte_vector_test() ->
+    %% 151288809941952652 -> 0xc2 0x19 0x7c 0x5e 0xff 0x14 0xe8 0x8c
+    Bytes = <<16#c2, 16#19, 16#7c, 16#5e, 16#ff, 16#14, 16#e8, 16#8c>>,
+    ?assertEqual(Bytes, roadrunner_quic_varint:encode(151288809941952652)),
+    ?assertEqual({ok, 151288809941952652, <<>>}, roadrunner_quic_varint:decode(Bytes)).
+
+rfc_two_byte_151_test() ->
+    %% RFC 9000 §16 worked example: 151 is two-byte 0x40 0x97 (NOT 0x40b7).
+    ?assertEqual(<<16#40, 16#97>>, roadrunner_quic_varint:encode(151)),
+    ?assertEqual({ok, 151, <<>>}, roadrunner_quic_varint:decode(<<16#40, 16#97>>)).
+
+%% =============================================================================
+%% Length-class boundaries — cover every encode clause at its edges.
+%% =============================================================================
+
+encode_class_boundaries_test() ->
+    %% Each clause's first and last value, so the minimal-length selection
+    %% (first matching clause wins) is exercised at every boundary.
+    ?assertEqual(<<0:2, 0:6>>, roadrunner_quic_varint:encode(0)),
+    ?assertEqual(<<0:2, 63:6>>, roadrunner_quic_varint:encode(63)),
+    ?assertEqual(<<1:2, 64:14>>, roadrunner_quic_varint:encode(64)),
+    ?assertEqual(<<1:2, 16383:14>>, roadrunner_quic_varint:encode(16383)),
+    ?assertEqual(<<2:2, 16384:30>>, roadrunner_quic_varint:encode(16384)),
+    ?assertEqual(<<2:2, 1073741823:30>>, roadrunner_quic_varint:encode(1073741823)),
+    ?assertEqual(<<3:2, 1073741824:62>>, roadrunner_quic_varint:encode(1073741824)),
+    ?assertEqual(
+        <<3:2, 4611686018427387903:62>>,
+        roadrunner_quic_varint:encode(4611686018427387903)
+    ).
+
+%% A value beyond 2^62-1 has no encoding (function_clause, let it crash).
+encode_above_max_crashes_test() ->
+    ?assertError(function_clause, roadrunner_quic_varint:encode(4611686018427387904)).
+
+%% =============================================================================
+%% decode/1 — trailing bytes, incomplete buffers, empty buffer.
+%% =============================================================================
+
+decode_keeps_trailing_bytes_test() ->
+    ?assertEqual(
+        {ok, 37, <<16#ff, 16#ee>>}, roadrunner_quic_varint:decode(<<16#25, 16#ff, 16#ee>>)
+    ).
+
+decode_incomplete_returns_more_test() ->
+    %% First byte selects the 8-byte class but only 3 bytes are buffered.
+    ?assertEqual({more, 5}, roadrunner_quic_varint:decode(<<3:2, 0:22>>)),
+    %% Two-byte class, one byte buffered.
+    ?assertEqual({more, 1}, roadrunner_quic_varint:decode(<<1:2, 0:6>>)),
+    %% Four-byte class, two bytes buffered.
+    ?assertEqual({more, 2}, roadrunner_quic_varint:decode(<<2:2, 0:14>>)).
+
+decode_empty_returns_more_test() ->
+    ?assertEqual({more, 1}, roadrunner_quic_varint:decode(<<>>)).
+
+%% =============================================================================
+%% Differential oracle vs the `quic` dep (kept as a test-profile dep).
+%% =============================================================================
+
+%% Encode is byte-for-byte identical (both emit the minimal form).
+oracle_encode_matches_dep_test() ->
+    [
+        ?assertEqual(quic_varint:encode(V), roadrunner_quic_varint:encode(V))
+     || V <- oracle_values()
+    ].
+
+%% Cross-decode: the dep yields {V, Rest}; the native form is {ok, V, Rest}.
+%% Decode each dep-encoded value and assert the value + remainder agree.
+oracle_decode_matches_dep_test() ->
+    [
+        begin
+            Bin = quic_varint:encode(V),
+            {DepV, DepRest} = quic_varint:decode(Bin),
+            ?assertEqual({ok, DepV, DepRest}, roadrunner_quic_varint:decode(Bin))
+        end
+     || V <- oracle_values()
+    ].
+
+oracle_values() ->
+    [
+        0,
+        37,
+        63,
+        64,
+        151,
+        15293,
+        16383,
+        16384,
+        494878333,
+        1073741823,
+        1073741824,
+        151288809941952652,
+        4611686018427387903
+    ].


### PR DESCRIPTION
# Description

The HTTP/3 layer now uses native codecs (a QUIC varint, an HTTP/3 frame codec, and a static-table QPACK codec) in place of the `quic` dep's. The dep stays for QUIC transport and as a test-profile differential oracle; the existing h3 suite drives a dep client against the native server, proving byte-for-byte interop.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)