### PR TITLE
Add the native QUIC wire codecs

### DIFF
--- a/src/roadrunner_quic_error.erl
+++ b/src/roadrunner_quic_error.erl
@@ -1,0 +1,100 @@
+-module(roadrunner_quic_error).
+-moduledoc false.
+
+%% QUIC transport error codes (RFC 9000 §20.1).
+%%
+%% `code_int/1` maps an atom (or a `{crypto_error, Alert}` pair, or a raw
+%% integer) to its wire value for a CONNECTION_CLOSE frame; `code_atom/1`
+%% is the inverse for a received code. The CRYPTO_ERROR range
+%% (0x0100-0x01ff) carries the TLS alert in its low byte (RFC 9000 §20.1,
+%% RFC 9001 §4.8), surfaced as `{crypto_error, Alert}`. Any code outside
+%% the registered set passes through as its integer (application error
+%% codes and codes reserved for future use), mirroring
+%% `roadrunner_http2_frame`'s `code_atom/1` / `code_int/1`.
+
+-export([code_int/1, code_atom/1]).
+
+-export_type([code/0]).
+
+-type code() ::
+    no_error
+    | internal_error
+    | connection_refused
+    | flow_control_error
+    | stream_limit_error
+    | stream_state_error
+    | final_size_error
+    | frame_encoding_error
+    | transport_parameter_error
+    | connection_id_limit_error
+    | protocol_violation
+    | invalid_token
+    | application_error
+    | crypto_buffer_exceeded
+    | key_update_error
+    | aead_limit_reached
+    | no_viable_path
+    | {crypto_error, 0..255}
+    | non_neg_integer().
+
+-doc "Map an error atom (or `{crypto_error, Alert}`, or a raw code) to its wire value.".
+-spec code_int(code()) -> non_neg_integer().
+code_int(no_error) ->
+    16#00;
+code_int(internal_error) ->
+    16#01;
+code_int(connection_refused) ->
+    16#02;
+code_int(flow_control_error) ->
+    16#03;
+code_int(stream_limit_error) ->
+    16#04;
+code_int(stream_state_error) ->
+    16#05;
+code_int(final_size_error) ->
+    16#06;
+code_int(frame_encoding_error) ->
+    16#07;
+code_int(transport_parameter_error) ->
+    16#08;
+code_int(connection_id_limit_error) ->
+    16#09;
+code_int(protocol_violation) ->
+    16#0A;
+code_int(invalid_token) ->
+    16#0B;
+code_int(application_error) ->
+    16#0C;
+code_int(crypto_buffer_exceeded) ->
+    16#0D;
+code_int(key_update_error) ->
+    16#0E;
+code_int(aead_limit_reached) ->
+    16#0F;
+code_int(no_viable_path) ->
+    16#10;
+code_int({crypto_error, Alert}) when is_integer(Alert), Alert >= 0, Alert =< 255 ->
+    16#0100 bor Alert;
+code_int(Code) when is_integer(Code), Code >= 0 -> Code.
+
+-doc "Map a received wire error code to its atom, `{crypto_error, Alert}`, or the raw integer.".
+-spec code_atom(non_neg_integer()) -> code().
+code_atom(16#00) -> no_error;
+code_atom(16#01) -> internal_error;
+code_atom(16#02) -> connection_refused;
+code_atom(16#03) -> flow_control_error;
+code_atom(16#04) -> stream_limit_error;
+code_atom(16#05) -> stream_state_error;
+code_atom(16#06) -> final_size_error;
+code_atom(16#07) -> frame_encoding_error;
+code_atom(16#08) -> transport_parameter_error;
+code_atom(16#09) -> connection_id_limit_error;
+code_atom(16#0A) -> protocol_violation;
+code_atom(16#0B) -> invalid_token;
+code_atom(16#0C) -> application_error;
+code_atom(16#0D) -> crypto_buffer_exceeded;
+code_atom(16#0E) -> key_update_error;
+code_atom(16#0F) -> aead_limit_reached;
+code_atom(16#10) -> no_viable_path;
+code_atom(Code) when Code >= 16#0100, Code =< 16#01FF -> {crypto_error, Code - 16#0100};
+code_atom(Code) when is_integer(Code), Code >= 0 -> Code.

--- a/src/roadrunner_quic_frame.erl
+++ b/src/roadrunner_quic_frame.erl
@@ -1,0 +1,436 @@
+-module(roadrunner_quic_frame).
+-moduledoc false.
+
+%% QUIC transport frame codec (RFC 9000 §19), pure wire syntax.
+%%
+%% Covers the core frame set a server-only v1 endpoint sends and receives;
+%% the 0-RTT/datagram/reliable-reset extension frames are out of scope.
+%% `encode/1` returns iodata (CRYPTO and STREAM keep their payload by
+%% reference, never copied); `decode/1` reads one frame and never crashes
+%% on a malformed packet (a short read is `{error, truncated}`);
+%% `decode_all/1` reads a whole packet payload into a frame list.
+%%
+%% The ACK frame holds the raw wire fields (Largest Acknowledged, ACK
+%% Delay, First ACK Range, the Gap/Range pairs, and ECN counts); turning
+%% those into acknowledged packet-number ranges is `roadrunner_quic_ack`'s
+%% job (RFC 9000 §19.3).
+
+-export([encode/1, decode/1, decode_all/1]).
+
+-export_type([frame/0, ecn_counts/0]).
+
+%% RFC 9000 §19 frame types.
+-define(PADDING, 16#00).
+-define(PING, 16#01).
+-define(ACK, 16#02).
+-define(ACK_ECN, 16#03).
+-define(RESET_STREAM, 16#04).
+-define(STOP_SENDING, 16#05).
+-define(CRYPTO, 16#06).
+-define(NEW_TOKEN, 16#07).
+%% STREAM is 0x08-0x0f: 0x08 with the low 3 bits as the FIN/LEN/OFF flags.
+-define(STREAM, 16#08).
+-define(STREAM_MAX, 16#0F).
+-define(STREAM_FIN, 16#01).
+-define(STREAM_LEN, 16#02).
+-define(STREAM_OFF, 16#04).
+-define(MAX_DATA, 16#10).
+-define(MAX_STREAM_DATA, 16#11).
+-define(MAX_STREAMS_BIDI, 16#12).
+-define(MAX_STREAMS_UNI, 16#13).
+-define(DATA_BLOCKED, 16#14).
+-define(STREAM_DATA_BLOCKED, 16#15).
+-define(STREAMS_BLOCKED_BIDI, 16#16).
+-define(STREAMS_BLOCKED_UNI, 16#17).
+-define(NEW_CONNECTION_ID, 16#18).
+-define(RETIRE_CONNECTION_ID, 16#19).
+-define(PATH_CHALLENGE, 16#1A).
+-define(PATH_RESPONSE, 16#1B).
+-define(CONNECTION_CLOSE, 16#1C).
+-define(CONNECTION_CLOSE_APP, 16#1D).
+-define(HANDSHAKE_DONE, 16#1E).
+
+-type stream_id() :: non_neg_integer().
+-type ecn_counts() :: {
+    ECT0 :: non_neg_integer(), ECT1 :: non_neg_integer(), CE :: non_neg_integer()
+}.
+
+-type frame() ::
+    padding
+    | ping
+    | handshake_done
+    | {ack, Largest :: non_neg_integer(), AckDelay :: non_neg_integer(),
+        FirstRange :: non_neg_integer(), Ranges :: [{non_neg_integer(), non_neg_integer()}],
+        Ecn :: ecn_counts() | undefined}
+    | {reset_stream, stream_id(), ErrorCode :: non_neg_integer(), FinalSize :: non_neg_integer()}
+    | {stop_sending, stream_id(), ErrorCode :: non_neg_integer()}
+    | {crypto, Offset :: non_neg_integer(), Data :: binary()}
+    | {new_token, Token :: binary()}
+    | {stream, stream_id(), Offset :: non_neg_integer(), Data :: binary(), Fin :: boolean()}
+    | {max_data, non_neg_integer()}
+    | {max_stream_data, stream_id(), non_neg_integer()}
+    | {max_streams, bidi | uni, non_neg_integer()}
+    | {data_blocked, non_neg_integer()}
+    | {stream_data_blocked, stream_id(), non_neg_integer()}
+    | {streams_blocked, bidi | uni, non_neg_integer()}
+    | {new_connection_id, Seq :: non_neg_integer(), RetirePrior :: non_neg_integer(),
+        CID :: binary(), StatelessResetToken :: binary()}
+    | {retire_connection_id, Seq :: non_neg_integer()}
+    | {path_challenge, binary()}
+    | {path_response, binary()}
+    | {connection_close, transport | application, ErrorCode :: non_neg_integer(),
+        FrameType :: non_neg_integer() | undefined, Reason :: binary()}.
+
+%% =============================================================================
+%% encode/1
+%% =============================================================================
+
+-doc "Encode one frame to iodata (CRYPTO and STREAM keep their payload by reference).".
+-spec encode(frame()) -> iodata().
+encode(padding) ->
+    <<?PADDING>>;
+encode(ping) ->
+    <<?PING>>;
+encode(handshake_done) ->
+    <<?HANDSHAKE_DONE>>;
+encode({ack, Largest, AckDelay, FirstRange, Ranges, Ecn}) ->
+    encode_ack(Largest, AckDelay, FirstRange, Ranges, Ecn);
+encode({reset_stream, StreamId, ErrorCode, FinalSize}) ->
+    <<?RESET_STREAM, (vint(StreamId))/binary, (vint(ErrorCode))/binary, (vint(FinalSize))/binary>>;
+encode({stop_sending, StreamId, ErrorCode}) ->
+    <<?STOP_SENDING, (vint(StreamId))/binary, (vint(ErrorCode))/binary>>;
+encode({crypto, Offset, Data}) ->
+    [<<?CRYPTO, (vint(Offset))/binary, (vint(byte_size(Data)))/binary>>, Data];
+encode({new_token, Token}) ->
+    [<<?NEW_TOKEN, (vint(byte_size(Token)))/binary>>, Token];
+encode({stream, StreamId, Offset, Data, Fin}) ->
+    [stream_header(StreamId, Offset, byte_size(Data), Fin), Data];
+encode({max_data, Max}) ->
+    <<?MAX_DATA, (vint(Max))/binary>>;
+encode({max_stream_data, StreamId, Max}) ->
+    <<?MAX_STREAM_DATA, (vint(StreamId))/binary, (vint(Max))/binary>>;
+encode({max_streams, bidi, Max}) ->
+    <<?MAX_STREAMS_BIDI, (vint(Max))/binary>>;
+encode({max_streams, uni, Max}) ->
+    <<?MAX_STREAMS_UNI, (vint(Max))/binary>>;
+encode({data_blocked, Limit}) ->
+    <<?DATA_BLOCKED, (vint(Limit))/binary>>;
+encode({stream_data_blocked, StreamId, Limit}) ->
+    <<?STREAM_DATA_BLOCKED, (vint(StreamId))/binary, (vint(Limit))/binary>>;
+encode({streams_blocked, bidi, Limit}) ->
+    <<?STREAMS_BLOCKED_BIDI, (vint(Limit))/binary>>;
+encode({streams_blocked, uni, Limit}) ->
+    <<?STREAMS_BLOCKED_UNI, (vint(Limit))/binary>>;
+encode({new_connection_id, Seq, RetirePrior, CID, Token}) when byte_size(Token) =:= 16 ->
+    <<?NEW_CONNECTION_ID, (vint(Seq))/binary, (vint(RetirePrior))/binary, (byte_size(CID)):8,
+        CID/binary, Token/binary>>;
+encode({retire_connection_id, Seq}) ->
+    <<?RETIRE_CONNECTION_ID, (vint(Seq))/binary>>;
+encode({path_challenge, Data}) when byte_size(Data) =:= 8 ->
+    <<?PATH_CHALLENGE, Data/binary>>;
+encode({path_response, Data}) when byte_size(Data) =:= 8 ->
+    <<?PATH_RESPONSE, Data/binary>>;
+encode({connection_close, transport, ErrorCode, FrameType, Reason}) ->
+    [
+        <<?CONNECTION_CLOSE, (vint(ErrorCode))/binary, (vint(FrameType))/binary,
+            (vint(byte_size(Reason)))/binary>>,
+        Reason
+    ];
+encode({connection_close, application, ErrorCode, _FrameType, Reason}) ->
+    [
+        <<?CONNECTION_CLOSE_APP, (vint(ErrorCode))/binary, (vint(byte_size(Reason)))/binary>>,
+        Reason
+    ].
+
+%% STREAM frame header (everything before the data): the type's low 3 bits
+%% carry OFF/LEN/FIN. LEN is always set, so the frame is self-delimiting
+%% even when coalesced with later frames (RFC 9000 §19.8).
+-spec stream_header(stream_id(), non_neg_integer(), non_neg_integer(), boolean()) -> binary().
+stream_header(StreamId, Offset, Length, Fin) ->
+    Type = ?STREAM bor offset_flag(Offset) bor ?STREAM_LEN bor fin_flag(Fin),
+    OffsetBin =
+        case Offset of
+            0 -> <<>>;
+            _ -> vint(Offset)
+        end,
+    <<Type, (vint(StreamId))/binary, OffsetBin/binary, (vint(Length))/binary>>.
+
+-spec offset_flag(non_neg_integer()) -> 0 | 16#04.
+offset_flag(0) -> 0;
+offset_flag(_) -> ?STREAM_OFF.
+
+-spec fin_flag(boolean()) -> 0 | 16#01.
+fin_flag(true) -> ?STREAM_FIN;
+fin_flag(false) -> 0.
+
+-spec encode_ack(
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    [{non_neg_integer(), non_neg_integer()}],
+    ecn_counts() | undefined
+) -> iolist().
+encode_ack(Largest, AckDelay, FirstRange, Ranges, Ecn) ->
+    Type =
+        case Ecn of
+            undefined -> ?ACK;
+            _ -> ?ACK_ECN
+        end,
+    Head =
+        <<Type, (vint(Largest))/binary, (vint(AckDelay))/binary, (vint(length(Ranges)))/binary,
+            (vint(FirstRange))/binary>>,
+    [Head, encode_ack_ranges(Ranges) | encode_ecn(Ecn)].
+
+-spec encode_ack_ranges([{non_neg_integer(), non_neg_integer()}]) -> iolist().
+encode_ack_ranges([]) ->
+    [];
+encode_ack_ranges([{Gap, Range} | Rest]) ->
+    [vint(Gap), vint(Range) | encode_ack_ranges(Rest)].
+
+-spec encode_ecn(ecn_counts() | undefined) -> iolist().
+encode_ecn(undefined) ->
+    [];
+encode_ecn({ECT0, ECT1, CE}) ->
+    [vint(ECT0), vint(ECT1), vint(CE)].
+
+%% =============================================================================
+%% decode/1
+%% =============================================================================
+
+-doc """
+Decode one frame, returning `{ok, Frame, Rest}` or `{error, Reason}`.
+A truncated frame (the packet ended mid-field) is `{error, truncated}`;
+an unrecognised type is `{error, {unknown_frame_type, Type}}`.
+""".
+-spec decode(binary()) -> {ok, frame(), binary()} | {error, term()}.
+decode(<<?PADDING, Rest/binary>>) ->
+    {ok, padding, Rest};
+decode(<<?PING, Rest/binary>>) ->
+    {ok, ping, Rest};
+decode(<<?ACK, Rest/binary>>) ->
+    decode_ack(Rest, no_ecn);
+decode(<<?ACK_ECN, Rest/binary>>) ->
+    decode_ack(Rest, ecn);
+decode(<<?RESET_STREAM, Rest/binary>>) ->
+    maybe
+        {ok, StreamId, R1} ?= take_varint(Rest),
+        {ok, ErrorCode, R2} ?= take_varint(R1),
+        {ok, FinalSize, R3} ?= take_varint(R2),
+        {ok, {reset_stream, StreamId, ErrorCode, FinalSize}, R3}
+    end;
+decode(<<?STOP_SENDING, Rest/binary>>) ->
+    maybe
+        {ok, StreamId, R1} ?= take_varint(Rest),
+        {ok, ErrorCode, R2} ?= take_varint(R1),
+        {ok, {stop_sending, StreamId, ErrorCode}, R2}
+    end;
+decode(<<?CRYPTO, Rest/binary>>) ->
+    maybe
+        {ok, Offset, R1} ?= take_varint(Rest),
+        {ok, Length, R2} ?= take_varint(R1),
+        {ok, Data, R3} ?= take_data(Length, R2),
+        {ok, {crypto, Offset, Data}, R3}
+    end;
+decode(<<?NEW_TOKEN, Rest/binary>>) ->
+    maybe
+        {ok, Length, R1} ?= take_varint(Rest),
+        {ok, Token, R2} ?= take_data(Length, R1),
+        {ok, {new_token, Token}, R2}
+    end;
+decode(<<Type, Rest/binary>>) when Type >= ?STREAM, Type =< ?STREAM_MAX ->
+    decode_stream(Type, Rest);
+decode(<<?MAX_DATA, Rest/binary>>) ->
+    decode_one_varint(Rest, fun(Max) -> {max_data, Max} end);
+decode(<<?MAX_STREAM_DATA, Rest/binary>>) ->
+    maybe
+        {ok, StreamId, R1} ?= take_varint(Rest),
+        {ok, Max, R2} ?= take_varint(R1),
+        {ok, {max_stream_data, StreamId, Max}, R2}
+    end;
+decode(<<?MAX_STREAMS_BIDI, Rest/binary>>) ->
+    decode_one_varint(Rest, fun(Max) -> {max_streams, bidi, Max} end);
+decode(<<?MAX_STREAMS_UNI, Rest/binary>>) ->
+    decode_one_varint(Rest, fun(Max) -> {max_streams, uni, Max} end);
+decode(<<?DATA_BLOCKED, Rest/binary>>) ->
+    decode_one_varint(Rest, fun(Limit) -> {data_blocked, Limit} end);
+decode(<<?STREAM_DATA_BLOCKED, Rest/binary>>) ->
+    maybe
+        {ok, StreamId, R1} ?= take_varint(Rest),
+        {ok, Limit, R2} ?= take_varint(R1),
+        {ok, {stream_data_blocked, StreamId, Limit}, R2}
+    end;
+decode(<<?STREAMS_BLOCKED_BIDI, Rest/binary>>) ->
+    decode_one_varint(Rest, fun(Limit) -> {streams_blocked, bidi, Limit} end);
+decode(<<?STREAMS_BLOCKED_UNI, Rest/binary>>) ->
+    decode_one_varint(Rest, fun(Limit) -> {streams_blocked, uni, Limit} end);
+decode(<<?NEW_CONNECTION_ID, Rest/binary>>) ->
+    maybe
+        {ok, Seq, R1} ?= take_varint(Rest),
+        {ok, RetirePrior, R2} ?= take_varint(R1),
+        decode_new_cid(Seq, RetirePrior, R2)
+    end;
+decode(<<?RETIRE_CONNECTION_ID, Rest/binary>>) ->
+    decode_one_varint(Rest, fun(Seq) -> {retire_connection_id, Seq} end);
+decode(<<?PATH_CHALLENGE, Data:8/binary, Rest/binary>>) ->
+    {ok, {path_challenge, Data}, Rest};
+decode(<<?PATH_RESPONSE, Data:8/binary, Rest/binary>>) ->
+    {ok, {path_response, Data}, Rest};
+decode(<<?CONNECTION_CLOSE, Rest/binary>>) ->
+    maybe
+        {ok, ErrorCode, R1} ?= take_varint(Rest),
+        {ok, FrameType, R2} ?= take_varint(R1),
+        {ok, ReasonLen, R3} ?= take_varint(R2),
+        {ok, Reason, R4} ?= take_data(ReasonLen, R3),
+        {ok, {connection_close, transport, ErrorCode, FrameType, Reason}, R4}
+    end;
+decode(<<?CONNECTION_CLOSE_APP, Rest/binary>>) ->
+    maybe
+        {ok, ErrorCode, R1} ?= take_varint(Rest),
+        {ok, ReasonLen, R2} ?= take_varint(R1),
+        {ok, Reason, R3} ?= take_data(ReasonLen, R2),
+        {ok, {connection_close, application, ErrorCode, undefined, Reason}, R3}
+    end;
+decode(<<?HANDSHAKE_DONE, Rest/binary>>) ->
+    {ok, handshake_done, Rest};
+decode(<<Type, _/binary>>) ->
+    %% Includes a PATH_CHALLENGE/PATH_RESPONSE with fewer than 8 data bytes.
+    case Type of
+        ?PATH_CHALLENGE -> {error, truncated};
+        ?PATH_RESPONSE -> {error, truncated};
+        _ -> {error, {unknown_frame_type, Type}}
+    end;
+decode(<<>>) ->
+    {error, empty}.
+
+%% A frame whose body is exactly one varint.
+-spec decode_one_varint(binary(), fun((non_neg_integer()) -> frame())) ->
+    {ok, frame(), binary()} | {error, term()}.
+decode_one_varint(Bin, Build) ->
+    maybe
+        {ok, Value, Rest} ?= take_varint(Bin),
+        {ok, Build(Value), Rest}
+    end.
+
+-spec decode_stream(byte(), binary()) -> {ok, frame(), binary()} | {error, term()}.
+decode_stream(Type, Rest) ->
+    HasOff = (Type band ?STREAM_OFF) =/= 0,
+    HasLen = (Type band ?STREAM_LEN) =/= 0,
+    Fin = (Type band ?STREAM_FIN) =/= 0,
+    maybe
+        {ok, StreamId, R1} ?= take_varint(Rest),
+        {ok, Offset, R2} ?= take_stream_offset(HasOff, R1),
+        decode_stream_data(StreamId, Offset, Fin, HasLen, R2)
+    end.
+
+-spec take_stream_offset(boolean(), binary()) ->
+    {ok, non_neg_integer(), binary()} | {error, term()}.
+take_stream_offset(true, Bin) -> take_varint(Bin);
+take_stream_offset(false, Bin) -> {ok, 0, Bin}.
+
+-spec decode_stream_data(stream_id(), non_neg_integer(), boolean(), boolean(), binary()) ->
+    {ok, frame(), binary()} | {error, term()}.
+decode_stream_data(StreamId, Offset, Fin, true, Bin) ->
+    maybe
+        {ok, Length, R1} ?= take_varint(Bin),
+        {ok, Data, R2} ?= take_data(Length, R1),
+        {ok, {stream, StreamId, Offset, Data, Fin}, R2}
+    end;
+decode_stream_data(StreamId, Offset, Fin, false, Bin) ->
+    %% No length flag: the data runs to the end of the packet payload.
+    {ok, {stream, StreamId, Offset, Bin, Fin}, <<>>}.
+
+-spec decode_new_cid(non_neg_integer(), non_neg_integer(), binary()) ->
+    {ok, frame(), binary()} | {error, term()}.
+decode_new_cid(Seq, RetirePrior, <<CIDLen, Rest/binary>>) when CIDLen >= 1, CIDLen =< 20 ->
+    case Rest of
+        <<CID:CIDLen/binary, Token:16/binary, R/binary>> ->
+            {ok, {new_connection_id, Seq, RetirePrior, CID, Token}, R};
+        _ ->
+            {error, truncated}
+    end;
+decode_new_cid(_Seq, _RetirePrior, _Bin) ->
+    %% RFC 9000 §19.15: the connection ID length must be 1..20.
+    {error, frame_encoding_error}.
+
+-spec decode_ack(binary(), no_ecn | ecn) -> {ok, frame(), binary()} | {error, term()}.
+decode_ack(Bin, EcnFlag) ->
+    maybe
+        {ok, Largest, R1} ?= take_varint(Bin),
+        {ok, AckDelay, R2} ?= take_varint(R1),
+        {ok, RangeCount, R3} ?= take_varint(R2),
+        {ok, FirstRange, R4} ?= take_varint(R3),
+        {ok, Ranges, R5} ?= take_ack_ranges(RangeCount, R4),
+        decode_ack_ecn(Largest, AckDelay, FirstRange, Ranges, EcnFlag, R5)
+    end.
+
+%% Body recursion: cons each {Gap, Range} pair on the way out.
+-spec take_ack_ranges(non_neg_integer(), binary()) ->
+    {ok, [{non_neg_integer(), non_neg_integer()}], binary()} | {error, term()}.
+take_ack_ranges(0, Bin) ->
+    {ok, [], Bin};
+take_ack_ranges(N, Bin) ->
+    maybe
+        {ok, Gap, R1} ?= take_varint(Bin),
+        {ok, Range, R2} ?= take_varint(R1),
+        {ok, Rest, R3} ?= take_ack_ranges(N - 1, R2),
+        {ok, [{Gap, Range} | Rest], R3}
+    end.
+
+-spec decode_ack_ecn(
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    [{non_neg_integer(), non_neg_integer()}],
+    no_ecn | ecn,
+    binary()
+) -> {ok, frame(), binary()} | {error, term()}.
+decode_ack_ecn(Largest, AckDelay, FirstRange, Ranges, no_ecn, Bin) ->
+    {ok, {ack, Largest, AckDelay, FirstRange, Ranges, undefined}, Bin};
+decode_ack_ecn(Largest, AckDelay, FirstRange, Ranges, ecn, Bin) ->
+    maybe
+        {ok, ECT0, R1} ?= take_varint(Bin),
+        {ok, ECT1, R2} ?= take_varint(R1),
+        {ok, CE, R3} ?= take_varint(R2),
+        {ok, {ack, Largest, AckDelay, FirstRange, Ranges, {ECT0, ECT1, CE}}, R3}
+    end.
+
+%% =============================================================================
+%% decode_all/1
+%% =============================================================================
+
+-doc "Decode every frame in a packet payload into a list, in order.".
+-spec decode_all(binary()) -> {ok, [frame()]} | {error, term()}.
+decode_all(<<>>) ->
+    {ok, []};
+decode_all(Bin) ->
+    maybe
+        {ok, Frame, Rest} ?= decode(Bin),
+        {ok, Frames} ?= decode_all(Rest),
+        {ok, [Frame | Frames]}
+    end.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+-spec vint(non_neg_integer()) -> binary().
+vint(N) ->
+    roadrunner_quic_varint:encode(N).
+
+%% `roadrunner_quic_varint:decode/1` yields `{ok, V, Rest} | {more, _}`;
+%% an incomplete varint inside a packet is a malformed frame, normalised
+%% to `{error, truncated}` so decode never crashes.
+-spec take_varint(binary()) -> {ok, non_neg_integer(), binary()} | {error, truncated}.
+take_varint(Bin) ->
+    case roadrunner_quic_varint:decode(Bin) of
+        {ok, _Value, _Rest} = Ok -> Ok;
+        {more, _Need} -> {error, truncated}
+    end.
+
+%% Take `Length` octets, or `{error, truncated}` if the packet is short.
+-spec take_data(non_neg_integer(), binary()) -> {ok, binary(), binary()} | {error, truncated}.
+take_data(Length, Bin) ->
+    case Bin of
+        <<Data:Length/binary, Rest/binary>> -> {ok, Data, Rest};
+        _ -> {error, truncated}
+    end.

--- a/src/roadrunner_quic_packet.erl
+++ b/src/roadrunner_quic_packet.erl
@@ -1,0 +1,379 @@
+-module(roadrunner_quic_packet).
+-moduledoc false.
+
+%% QUIC packet header codec (RFC 9000 §17), pure wire syntax.
+%%
+%% Long header (Initial / Handshake / 0-RTT) and short header (1-RTT)
+%% parse and build, the truncated packet-number coding (§17.1), and the
+%% two helpers the receive path needs before header protection is removed
+%% (RFC 9001 §5.4):
+%%
+%% - `dcid/2` extracts the Destination Connection ID so the listener can
+%%   route a datagram to its connection, and
+%% - `pn_offset/2` locates the Packet Number field so the AEAD layer can
+%%   take its header-protection sample (16 bytes at `pn_offset + 4`).
+%%
+%% Both read only header-protection-independent bytes, so they work on a
+%% still-protected packet. `decode/2` reads the packet number and slices
+%% the payload, so it runs only after header protection has been removed.
+%% Packet/header protection itself lives in `roadrunner_quic_aead`; this
+%% module is the header layout alone, and it never crashes on a malformed
+%% datagram (every short read returns `{error, truncated}`).
+%%
+%% Encoders return an iolist (the payload, already AEAD-sealed by the
+%% caller, is kept by reference); the leading element is the header that
+%% doubles as the AEAD associated data.
+
+-export([
+    encode_long/5,
+    encode_short/4,
+    encode_short/5,
+    encode_version_negotiation/3,
+    decode/2,
+    dcid/2,
+    pn_offset/2,
+    encode_pn/2,
+    decode_pn/2,
+    pn_length/1,
+    key_phase/1
+]).
+
+-export_type([packet/0, long_type/0]).
+
+%% RFC 9000 §17.2: a Connection ID is at most 20 bytes.
+-define(MAX_CID, 20).
+%% A defensive cap on an address-validation token (RFC 9000 §8.1).
+-define(MAX_TOKEN, 512).
+
+-type long_type() :: initial | handshake | zero_rtt.
+
+-type packet() ::
+    #{
+        type := initial | handshake | zero_rtt | one_rtt,
+        version => non_neg_integer(),
+        dcid := binary(),
+        scid => binary(),
+        token => binary(),
+        pn := non_neg_integer(),
+        payload := binary()
+    }.
+
+-type long_opts() :: #{
+    token => binary(),
+    pn => non_neg_integer(),
+    payload => iodata()
+}.
+
+%% =============================================================================
+%% Packet building
+%% =============================================================================
+
+-doc """
+Build a long-header packet (RFC 9000 §17.2). `payload` is the already
+AEAD-sealed ciphertext; the returned iolist's first element is the
+unprotected header (through the packet number), which the caller uses as
+the AEAD associated data and then header-protects.
+""".
+-spec encode_long(long_type(), non_neg_integer(), binary(), binary(), long_opts()) -> iolist().
+encode_long(Type, Version, DCID, SCID, Opts) ->
+    PN = maps:get(pn, Opts, 0),
+    Payload = maps:get(payload, Opts, <<>>),
+    PNLen = pn_length(PN),
+    %% First byte: 1 (long) 1 (fixed) TT (type) RR (reserved 0) PP (pnlen-1).
+    FirstByte = 2#11000000 bor (type_bits(Type) bsl 4) bor (PNLen - 1),
+    Length = PNLen + iolist_size(Payload),
+    Header = <<
+        FirstByte,
+        Version:32,
+        (byte_size(DCID)):8,
+        DCID/binary,
+        (byte_size(SCID)):8,
+        SCID/binary,
+        (long_prefix(Type, Opts))/binary,
+        (roadrunner_quic_varint:encode(Length))/binary,
+        (encode_pn(PN, PNLen))/binary
+    >>,
+    [Header, Payload].
+
+%% Initial packets carry a token (RFC 9000 §17.2.2); the other long types
+%% have nothing between the connection IDs and the Length field.
+-spec long_prefix(long_type(), long_opts()) -> binary().
+long_prefix(initial, Opts) ->
+    Token = maps:get(token, Opts, <<>>),
+    <<(roadrunner_quic_varint:encode(byte_size(Token)))/binary, Token/binary>>;
+long_prefix(_Type, _Opts) ->
+    <<>>.
+
+-doc "Build a 1-RTT short-header packet (RFC 9000 §17.3) with key phase 0.".
+-spec encode_short(binary(), non_neg_integer(), iodata(), boolean()) -> iolist().
+encode_short(DCID, PN, Payload, SpinBit) ->
+    encode_short(DCID, PN, Payload, SpinBit, 0).
+
+-doc "Build a 1-RTT short-header packet (RFC 9000 §17.3) with an explicit key phase.".
+-spec encode_short(binary(), non_neg_integer(), iodata(), boolean(), 0 | 1) -> iolist().
+encode_short(DCID, PN, Payload, SpinBit, KeyPhase) ->
+    PNLen = pn_length(PN),
+    %% First byte: 0 (short) 1 (fixed) S (spin) RR (reserved 0) K (key phase) PP.
+    FirstByte =
+        2#01000000 bor (bool_bit(SpinBit) bsl 5) bor ((KeyPhase band 1) bsl 2) bor (PNLen - 1),
+    [<<FirstByte, DCID/binary, (encode_pn(PN, PNLen))/binary>>, Payload].
+
+-doc """
+Build a Version Negotiation packet (RFC 9000 §17.2.1). The unused bits of
+the first byte are arbitrary; a fixed value is used so captures are
+stable. `DCID`/`SCID` are the received SCID/DCID (swapped).
+""".
+-spec encode_version_negotiation(binary(), binary(), [non_neg_integer()]) -> iolist().
+encode_version_negotiation(DCID, SCID, Versions) ->
+    [
+        <<
+            16#C0,
+            %% Version 0 marks a Version Negotiation packet.
+            0:32,
+            (byte_size(DCID)):8,
+            DCID/binary,
+            (byte_size(SCID)):8,
+            SCID/binary
+        >>
+        | [<<V:32>> || V <- Versions]
+    ].
+
+%% =============================================================================
+%% Receive-side helpers (header-protection independent)
+%% =============================================================================
+
+-doc """
+Extract the Destination Connection ID so a datagram can be routed to its
+connection. Reads only header-protection-independent bytes, so it works
+on a still-protected packet. `DCIDLen` is the server's fixed connection-ID
+length, used for short headers (which omit the length).
+""".
+-spec dcid(binary(), non_neg_integer()) -> {ok, binary()} | {error, term()}.
+dcid(<<1:1, _:7, _Version:32, DCIDLen, Rest/binary>>, _DCIDLen) when DCIDLen =< ?MAX_CID ->
+    case Rest of
+        <<DCID:DCIDLen/binary, _/binary>> -> {ok, DCID};
+        _ -> {error, truncated}
+    end;
+dcid(<<0:1, _:7, Rest/binary>>, DCIDLen) ->
+    case Rest of
+        <<DCID:DCIDLen/binary, _/binary>> -> {ok, DCID};
+        _ -> {error, truncated}
+    end;
+dcid(_, _) ->
+    {error, invalid_packet}.
+
+-doc """
+Locate the Packet Number field's byte offset, so the AEAD layer can take
+the header-protection sample (16 bytes starting `pn_offset + 4`,
+RFC 9001 §5.4.2). Reads only header-protection-independent bytes.
+""".
+-spec pn_offset(binary(), non_neg_integer()) -> {ok, non_neg_integer()} | {error, term()}.
+pn_offset(<<0:1, _:7, _/binary>>, DCIDLen) ->
+    %% Short header: first byte + the (implicit-length) DCID.
+    {ok, 1 + DCIDLen};
+pn_offset(<<FirstByte, _Version:32, DCIDLen, Rest/binary>> = Bin, _DCIDLen) when
+    (FirstByte band 16#80) =:= 16#80, DCIDLen =< ?MAX_CID
+->
+    maybe
+        {ok, AfterCids} ?= skip_scid(DCIDLen, Rest),
+        {ok, AfterPrefix} ?= skip_token(bits_to_type((FirstByte bsr 4) band 2#11), AfterCids),
+        %% After the Length varint comes the packet number.
+        {ok, _Length, AfterLength} ?= take_varint(AfterPrefix),
+        {ok, byte_size(Bin) - byte_size(AfterLength)}
+    end;
+pn_offset(_, _) ->
+    {error, invalid_packet}.
+
+%% Skip the DCID, the SCID length, and the SCID, given that `Bin` starts
+%% at the DCID and the DCID is `DCIDLen` bytes.
+-spec skip_scid(non_neg_integer(), binary()) -> {ok, binary()} | {error, truncated}.
+skip_scid(DCIDLen, Bin) ->
+    case Bin of
+        <<_DCID:DCIDLen/binary, SCIDLen, Rest/binary>> when SCIDLen =< ?MAX_CID ->
+            case Rest of
+                <<_SCID:SCIDLen/binary, AfterCids/binary>> -> {ok, AfterCids};
+                _ -> {error, truncated}
+            end;
+        _ ->
+            {error, truncated}
+    end.
+
+%% Skip an Initial packet's token (length varint + token); the other long
+%% types have no token.
+-spec skip_token(long_type() | retry, binary()) -> {ok, binary()} | {error, truncated}.
+skip_token(initial, Bin) ->
+    maybe
+        {ok, TokenLen, AfterTokenLen} ?= take_varint(Bin),
+        case AfterTokenLen of
+            <<_Token:TokenLen/binary, Rest/binary>> -> {ok, Rest};
+            _ -> {error, truncated}
+        end
+    end;
+skip_token(_Type, Bin) ->
+    {ok, Bin}.
+
+%% =============================================================================
+%% Full decode (after header protection has been removed)
+%% =============================================================================
+
+-doc """
+Decode a packet whose header protection has already been removed, into a
+map plus any following coalesced-packet bytes. `DCIDLen` is the server's
+fixed connection-ID length, used for short headers.
+""".
+-spec decode(binary(), non_neg_integer()) -> {ok, packet(), binary()} | {error, term()}.
+decode(<<1:1, _:7, _/binary>> = Bin, _DCIDLen) ->
+    decode_long(Bin);
+decode(<<0:1, _:7, _/binary>> = Bin, DCIDLen) ->
+    decode_short(Bin, DCIDLen);
+decode(_, _) ->
+    {error, invalid_packet}.
+
+-spec decode_long(binary()) -> {ok, packet(), binary()} | {error, term()}.
+decode_long(<<_FirstByte, 0:32, _/binary>>) ->
+    %% Version 0 is a Version Negotiation packet, which a server never
+    %% receives; reject rather than parse.
+    {error, unexpected_version_negotiation};
+decode_long(<<FirstByte, Version:32, DCIDLen, Rest/binary>>) when DCIDLen =< ?MAX_CID ->
+    maybe
+        {ok, DCID, SCID, AfterCids} ?= split_cids(DCIDLen, Rest),
+        Type = bits_to_type((FirstByte bsr 4) band 2#11),
+        PNLen = (FirstByte band 2#11) + 1,
+        decode_long_body(Type, Version, DCID, SCID, PNLen, AfterCids)
+    end;
+decode_long(_) ->
+    {error, invalid_packet}.
+
+-spec split_cids(non_neg_integer(), binary()) ->
+    {ok, binary(), binary(), binary()} | {error, term()}.
+split_cids(DCIDLen, Bin) ->
+    case Bin of
+        <<DCID:DCIDLen/binary, SCIDLen, Rest/binary>> when SCIDLen =< ?MAX_CID ->
+            case Rest of
+                <<SCID:SCIDLen/binary, AfterCids/binary>> -> {ok, DCID, SCID, AfterCids};
+                _ -> {error, truncated}
+            end;
+        _ ->
+            {error, invalid_cid_length}
+    end.
+
+-spec decode_long_body(long_type() | retry, non_neg_integer(), binary(), binary(), 1..4, binary()) ->
+    {ok, packet(), binary()} | {error, term()}.
+decode_long_body(initial, Version, DCID, SCID, PNLen, Bin) ->
+    maybe
+        {ok, TokenLen, AfterTokenLen} ?= take_varint(Bin),
+        {ok, Token, AfterToken} ?= take_token(TokenLen, AfterTokenLen),
+        Base = #{type => initial, version => Version, dcid => DCID, scid => SCID, token => Token},
+        decode_long_pn_payload(Base, PNLen, AfterToken)
+    end;
+decode_long_body(retry, _Version, _DCID, _SCID, _PNLen, _Bin) ->
+    %% Retry is a client-only inbound packet; a server never receives one.
+    {error, unexpected_retry};
+decode_long_body(Type, Version, DCID, SCID, PNLen, Bin) ->
+    Base = #{type => Type, version => Version, dcid => DCID, scid => SCID},
+    decode_long_pn_payload(Base, PNLen, Bin).
+
+-spec take_token(non_neg_integer(), binary()) -> {ok, binary(), binary()} | {error, term()}.
+take_token(TokenLen, _Bin) when TokenLen > ?MAX_TOKEN ->
+    {error, token_too_large};
+take_token(TokenLen, Bin) ->
+    case Bin of
+        <<Token:TokenLen/binary, Rest/binary>> -> {ok, Token, Rest};
+        _ -> {error, truncated}
+    end.
+
+-spec decode_long_pn_payload(map(), 1..4, binary()) -> {ok, packet(), binary()} | {error, term()}.
+decode_long_pn_payload(Base, PNLen, Bin) ->
+    maybe
+        {ok, Length, AfterLength} ?= take_varint(Bin),
+        decode_long_slice(Base, PNLen, Length - PNLen, AfterLength)
+    end.
+
+-spec decode_long_slice(map(), 1..4, integer(), binary()) ->
+    {ok, packet(), binary()} | {error, term()}.
+decode_long_slice(Base, PNLen, PayloadSize, Bin) when PayloadSize >= 0 ->
+    case Bin of
+        <<PNBin:PNLen/binary, Payload:PayloadSize/binary, Rest/binary>> ->
+            {PN, <<>>} = decode_pn(PNBin, PNLen),
+            {ok, Base#{pn => PN, payload => Payload}, Rest};
+        _ ->
+            {error, truncated}
+    end;
+decode_long_slice(_Base, _PNLen, _PayloadSize, _Bin) ->
+    {error, invalid_length}.
+
+-spec decode_short(binary(), non_neg_integer()) -> {ok, packet(), binary()} | {error, term()}.
+decode_short(<<FirstByte, Rest/binary>>, DCIDLen) ->
+    case Rest of
+        <<DCID:DCIDLen/binary, AfterDCID/binary>> ->
+            PNLen = (FirstByte band 2#11) + 1,
+            case AfterDCID of
+                <<PNBin:PNLen/binary, Payload/binary>> ->
+                    {PN, <<>>} = decode_pn(PNBin, PNLen),
+                    %% A short-header packet runs to the end of the datagram.
+                    {ok, #{type => one_rtt, dcid => DCID, pn => PN, payload => Payload}, <<>>};
+                _ ->
+                    {error, truncated}
+            end;
+        _ ->
+            {error, truncated}
+    end.
+
+%% =============================================================================
+%% Packet number coding (RFC 9000 §17.1, §A)
+%% =============================================================================
+
+-doc "Encode a packet number in its minimal-width truncated form.".
+-spec encode_pn(non_neg_integer(), 1..4) -> binary().
+encode_pn(PN, 1) -> <<PN:8>>;
+encode_pn(PN, 2) -> <<PN:16>>;
+encode_pn(PN, 3) -> <<PN:24>>;
+encode_pn(PN, 4) -> <<PN:32>>.
+
+-doc "Decode a truncated packet number of the given byte width.".
+-spec decode_pn(binary(), 1..4) -> {non_neg_integer(), binary()}.
+decode_pn(<<PN:8, Rest/binary>>, 1) -> {PN, Rest};
+decode_pn(<<PN:16, Rest/binary>>, 2) -> {PN, Rest};
+decode_pn(<<PN:24, Rest/binary>>, 3) -> {PN, Rest};
+decode_pn(<<PN:32, Rest/binary>>, 4) -> {PN, Rest}.
+
+-doc "Minimal number of bytes needed to encode a packet number.".
+-spec pn_length(non_neg_integer()) -> 1..4.
+pn_length(PN) when PN < 16#100 -> 1;
+pn_length(PN) when PN < 16#10000 -> 2;
+pn_length(PN) when PN < 16#1000000 -> 3;
+pn_length(_PN) -> 4.
+
+-doc "Extract the key-phase bit from an unprotected short-header first byte.".
+-spec key_phase(byte()) -> 0 | 1.
+key_phase(FirstByte) ->
+    (FirstByte bsr 2) band 1.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+-spec type_bits(long_type()) -> 0..2.
+type_bits(initial) -> 0;
+type_bits(zero_rtt) -> 1;
+type_bits(handshake) -> 2.
+
+-spec bits_to_type(0..3) -> long_type() | retry.
+bits_to_type(0) -> initial;
+bits_to_type(1) -> zero_rtt;
+bits_to_type(2) -> handshake;
+bits_to_type(3) -> retry.
+
+-spec bool_bit(boolean()) -> 0 | 1.
+bool_bit(true) -> 1;
+bool_bit(false) -> 0.
+
+%% `roadrunner_quic_varint:decode/1` yields `{ok, V, Rest} | {more, _}`;
+%% normalise an incomplete varint to `{error, truncated}` so the header
+%% parsers never crash on a short datagram.
+-spec take_varint(binary()) -> {ok, non_neg_integer(), binary()} | {error, truncated}.
+take_varint(Bin) ->
+    case roadrunner_quic_varint:decode(Bin) of
+        {ok, _Value, _Rest} = Ok -> Ok;
+        {more, _Need} -> {error, truncated}
+    end.

--- a/test/roadrunner_quic_error_tests.erl
+++ b/test/roadrunner_quic_error_tests.erl
@@ -1,0 +1,54 @@
+-module(roadrunner_quic_error_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_error).
+
+%% RFC 9000 §20.1 registered transport error codes.
+named_codes() ->
+    [
+        {no_error, 16#00},
+        {internal_error, 16#01},
+        {connection_refused, 16#02},
+        {flow_control_error, 16#03},
+        {stream_limit_error, 16#04},
+        {stream_state_error, 16#05},
+        {final_size_error, 16#06},
+        {frame_encoding_error, 16#07},
+        {transport_parameter_error, 16#08},
+        {connection_id_limit_error, 16#09},
+        {protocol_violation, 16#0A},
+        {invalid_token, 16#0B},
+        {application_error, 16#0C},
+        {crypto_buffer_exceeded, 16#0D},
+        {key_update_error, 16#0E},
+        {aead_limit_reached, 16#0F},
+        {no_viable_path, 16#10}
+    ].
+
+named_codes_round_trip_test() ->
+    [
+        begin
+            ?assertEqual(Int, ?M:code_int(Atom)),
+            ?assertEqual(Atom, ?M:code_atom(Int))
+        end
+     || {Atom, Int} <- named_codes()
+    ].
+
+crypto_error_test() ->
+    %% RFC 9000 §20.1: CRYPTO_ERROR is 0x0100-0x01ff, the TLS alert in the
+    %% low byte (RFC 9001 §4.8).
+    ?assertEqual(16#0100, ?M:code_int({crypto_error, 0})),
+    ?assertEqual(16#0128, ?M:code_int({crypto_error, 16#28})),
+    ?assertEqual(16#01FF, ?M:code_int({crypto_error, 255})),
+    ?assertEqual({crypto_error, 0}, ?M:code_atom(16#0100)),
+    ?assertEqual({crypto_error, 16#28}, ?M:code_atom(16#0128)),
+    ?assertEqual({crypto_error, 255}, ?M:code_atom(16#01FF)).
+
+passthrough_test() ->
+    %% Unregistered codes (application error codes, codes reserved for
+    %% future use) pass through as their integer in both directions.
+    ?assertEqual(16#3FFF, ?M:code_int(16#3FFF)),
+    ?assertEqual(16#3FFF, ?M:code_atom(16#3FFF)),
+    %% Just past the CRYPTO_ERROR range.
+    ?assertEqual(16#0200, ?M:code_atom(16#0200)).

--- a/test/roadrunner_quic_frame_tests.erl
+++ b/test/roadrunner_quic_frame_tests.erl
@@ -1,0 +1,152 @@
+-module(roadrunner_quic_frame_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_frame).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_frame).
+
+enc(F) -> iolist_to_binary(?M:encode(F)).
+
+%% Frames that share the dep's tuple representation (everything but ACK).
+frames() ->
+    [
+        padding,
+        ping,
+        handshake_done,
+        {reset_stream, 4, 16#0A, 1000},
+        {stop_sending, 8, 5},
+        {crypto, 0, <<"clienthello">>},
+        {crypto, 100, <<>>},
+        {new_token, <<"token-bytes">>},
+        %% STREAM: no offset + fin, offset + no fin, empty + fin.
+        {stream, 0, 0, <<"req">>, true},
+        {stream, 4, 50, <<"data">>, false},
+        {stream, 8, 0, <<>>, true},
+        {max_data, 1000000},
+        {max_stream_data, 4, 65536},
+        {max_streams, bidi, 100},
+        {max_streams, uni, 3},
+        {data_blocked, 999},
+        {stream_data_blocked, 4, 500},
+        {streams_blocked, bidi, 10},
+        {streams_blocked, uni, 1},
+        {new_connection_id, 1, 0, <<1, 2, 3, 4>>, binary:copy(<<7>>, 16)},
+        {retire_connection_id, 2},
+        {path_challenge, <<1, 2, 3, 4, 5, 6, 7, 8>>},
+        {path_response, <<8, 7, 6, 5, 4, 3, 2, 1>>},
+        {connection_close, transport, 16#0A, 0, <<"bad">>},
+        {connection_close, application, 16#0100, undefined, <<>>}
+    ].
+
+%% ACK frames in the native (raw-wire-field) representation.
+ack_frames() ->
+    [
+        {ack, 10, 25, 5, [], undefined},
+        {ack, 100, 0, 3, [{1, 2}, {0, 4}], undefined},
+        {ack, 50, 10, 0, [], {1, 2, 3}}
+    ].
+
+%% =============================================================================
+%% Encode: byte-for-byte vs the dep oracle.
+%% =============================================================================
+
+encode_matches_dep_test() ->
+    [?assertEqual(?DEP:encode(F), enc(F)) || F <- frames()].
+
+encode_ack_matches_dep_test() ->
+    [?assertEqual(?DEP:encode(dep_ack(Ack)), enc(Ack)) || Ack <- ack_frames()].
+
+%% The dep represents ACK as `{ack, [{Largest, First} | GapRanges], Delay, Ecn}`.
+dep_ack({ack, Largest, AckDelay, FirstRange, Ranges, Ecn}) ->
+    {ack, [{Largest, FirstRange} | Ranges], AckDelay, Ecn}.
+
+%% =============================================================================
+%% Round-trip: encode then decode every frame.
+%% =============================================================================
+
+roundtrip_test() ->
+    [?assertEqual({ok, F, <<>>}, ?M:decode(enc(F))) || F <- frames() ++ ack_frames()].
+
+%% A STREAM frame without the LEN flag: its data runs to the end of the
+%% packet. The native encoder always sets LEN, so build this one by hand.
+stream_without_length_test() ->
+    Bin = <<16#08, (roadrunner_quic_varint:encode(12))/binary, "tail-data">>,
+    ?assertEqual({ok, {stream, 12, 0, <<"tail-data">>, false}, <<>>}, ?M:decode(Bin)).
+
+%% =============================================================================
+%% decode_all/1.
+%% =============================================================================
+
+decode_all_test() ->
+    Frames = [ping, {max_data, 1000}, {crypto, 0, <<"hi">>}, padding],
+    Payload = iolist_to_binary([?M:encode(F) || F <- Frames]),
+    ?assertEqual({ok, Frames}, ?M:decode_all(Payload)),
+    ?assertEqual({ok, []}, ?M:decode_all(<<>>)).
+
+decode_all_propagates_error_test() ->
+    %% A valid PING followed by a CRYPTO frame truncated mid-field.
+    Bin = <<16#01, 16#06, 16#00>>,
+    ?assertEqual({error, truncated}, ?M:decode_all(Bin)).
+
+%% =============================================================================
+%% Malformed input: errors, never a crash.
+%% =============================================================================
+
+decode_empty_test() ->
+    ?assertEqual({error, empty}, ?M:decode(<<>>)).
+
+decode_unknown_frame_type_test() ->
+    ?assertEqual({error, {unknown_frame_type, 16#20}}, ?M:decode(<<16#20, 1, 2>>)).
+
+decode_truncated_varint_test() ->
+    %% RESET_STREAM type byte with no stream-id varint following.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#04>>)),
+    %% MAX_DATA whose varint is missing (covers decode_one_varint failure).
+    ?assertEqual({error, truncated}, ?M:decode(<<16#10>>)).
+
+decode_truncated_data_test() ->
+    %% CRYPTO offset 0, length 5, but only 2 data bytes present.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#06, 0, 5, 1, 2>>)).
+
+decode_stream_truncated_test() ->
+    %% STREAM with OFF+LEN+FIN flags but no stream-id following.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#0F>>)).
+
+decode_path_frames_truncated_test() ->
+    %% PATH_CHALLENGE / PATH_RESPONSE need exactly 8 data bytes.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#1A, 1, 2, 3>>)),
+    ?assertEqual({error, truncated}, ?M:decode(<<16#1B, 1, 2, 3>>)).
+
+decode_new_cid_errors_test() ->
+    %% Connection ID length 0 is invalid (RFC 9000 §19.15: 1..20).
+    Zero =
+        <<16#18, (roadrunner_quic_varint:encode(1))/binary,
+            (roadrunner_quic_varint:encode(0))/binary, 0>>,
+    ?assertEqual({error, frame_encoding_error}, ?M:decode(Zero)),
+    %% Connection ID length 21 is out of range.
+    TooLong =
+        <<16#18, (roadrunner_quic_varint:encode(1))/binary,
+            (roadrunner_quic_varint:encode(0))/binary, 21>>,
+    ?assertEqual({error, frame_encoding_error}, ?M:decode(TooLong)),
+    %% Valid length but the CID + reset token are truncated.
+    ShortToken =
+        <<16#18, (roadrunner_quic_varint:encode(1))/binary,
+            (roadrunner_quic_varint:encode(0))/binary, 4, 1, 2, 3, 4, 0, 0>>,
+    ?assertEqual({error, truncated}, ?M:decode(ShortToken)).
+
+decode_connection_close_truncated_test() ->
+    %% Transport CONNECTION_CLOSE whose reason is shorter than its length.
+    Bin =
+        <<16#1C, (roadrunner_quic_varint:encode(16#0A))/binary,
+            (roadrunner_quic_varint:encode(0))/binary, (roadrunner_quic_varint:encode(5))/binary, 1,
+            2>>,
+    ?assertEqual({error, truncated}, ?M:decode(Bin)).
+
+decode_ack_truncated_test() ->
+    %% ACK whose ECN counts are promised (type 0x03) but missing.
+    Bin =
+        <<16#03, (roadrunner_quic_varint:encode(10))/binary,
+            (roadrunner_quic_varint:encode(0))/binary, (roadrunner_quic_varint:encode(0))/binary,
+            (roadrunner_quic_varint:encode(5))/binary>>,
+    ?assertEqual({error, truncated}, ?M:decode(Bin)).

--- a/test/roadrunner_quic_packet_tests.erl
+++ b/test/roadrunner_quic_packet_tests.erl
@@ -1,0 +1,264 @@
+-module(roadrunner_quic_packet_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_packet).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_packet).
+
+%% QUIC v1.
+-define(V1, 16#00000001).
+%% RFC 9001 Appendix A example client DCID.
+-define(DCID, <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>).
+-define(SCID, <<1, 2, 3, 4>>).
+
+enc(Iolist) -> iolist_to_binary(Iolist).
+
+%% =============================================================================
+%% Encode: byte-for-byte vs the dep oracle.
+%% =============================================================================
+
+encode_long_matches_dep_test() ->
+    [
+        ?assertEqual(
+            ?DEP:encode_long(Type, ?V1, ?DCID, ?SCID, Opts),
+            enc(?M:encode_long(Type, ?V1, ?DCID, ?SCID, Opts))
+        )
+     || Type <- [initial, handshake, zero_rtt],
+        Opts <- long_opts_cases(Type)
+    ].
+
+long_opts_cases(initial) ->
+    [
+        #{token => <<>>, pn => 0, payload => <<>>},
+        #{token => <<"tok">>, pn => 2, payload => <<"frames">>},
+        %% Packet numbers spanning each truncated width.
+        #{token => <<>>, pn => 255, payload => <<1, 2, 3>>},
+        #{token => <<>>, pn => 256, payload => <<1, 2, 3>>},
+        #{token => <<>>, pn => 65536, payload => <<1, 2, 3>>},
+        #{token => <<>>, pn => 16777216, payload => binary:copy(<<0>>, 100)}
+    ];
+long_opts_cases(_Type) ->
+    [
+        #{pn => 0, payload => <<>>},
+        #{pn => 1000, payload => <<"abc">>},
+        #{pn => 16777216, payload => binary:copy(<<9>>, 50)}
+    ].
+
+encode_short_matches_dep_test() ->
+    [
+        ?assertEqual(
+            ?DEP:encode_short(?DCID, PN, Payload, Spin, KeyPhase),
+            enc(?M:encode_short(?DCID, PN, Payload, Spin, KeyPhase))
+        )
+     || PN <- [0, 200, 70000, 20000000],
+        Payload <- [<<>>, <<"data">>],
+        Spin <- [true, false],
+        KeyPhase <- [0, 1]
+    ].
+
+encode_short_default_key_phase_test() ->
+    ?assertEqual(
+        enc(?M:encode_short(?DCID, 5, <<"x">>, false, 0)),
+        enc(?M:encode_short(?DCID, 5, <<"x">>, false))
+    ).
+
+%% =============================================================================
+%% Round-trip: encode then decode (header protection is not applied here).
+%% =============================================================================
+
+roundtrip_long_test() ->
+    [
+        begin
+            Bin = enc(?M:encode_long(Type, ?V1, ?DCID, ?SCID, Opts)),
+            #{pn := PN, payload := Payload} = Opts1 = expected_long(Type, Opts),
+            ?assertEqual({ok, Opts1, <<>>}, ?M:decode(Bin, byte_size(?DCID))),
+            %% pn_offset points exactly at the encoded packet number.
+            {ok, Off} = ?M:pn_offset(Bin, byte_size(?DCID)),
+            PNLen = ?M:pn_length(PN),
+            <<_:Off/binary, PNBin:PNLen/binary, Rest/binary>> = Bin,
+            ?assertEqual(?M:encode_pn(PN, PNLen), PNBin),
+            ?assertEqual(Payload, Rest)
+        end
+     || Type <- [initial, handshake, zero_rtt], Opts <- long_opts_cases(Type)
+    ].
+
+expected_long(initial, #{token := Token, pn := PN, payload := Payload}) ->
+    #{
+        type => initial,
+        version => ?V1,
+        dcid => ?DCID,
+        scid => ?SCID,
+        token => Token,
+        pn => PN,
+        payload => Payload
+    };
+expected_long(Type, #{pn := PN, payload := Payload}) ->
+    #{type => Type, version => ?V1, dcid => ?DCID, scid => ?SCID, pn => PN, payload => Payload}.
+
+roundtrip_short_test() ->
+    DCIDLen = byte_size(?DCID),
+    [
+        begin
+            Bin = enc(?M:encode_short(?DCID, PN, Payload, false, KeyPhase)),
+            ?assertEqual(
+                {ok, #{type => one_rtt, dcid => ?DCID, pn => PN, payload => Payload}, <<>>},
+                ?M:decode(Bin, DCIDLen)
+            ),
+            {ok, Off} = ?M:pn_offset(Bin, DCIDLen),
+            ?assertEqual(1 + DCIDLen, Off),
+            <<FirstByte, _/binary>> = Bin,
+            ?assertEqual(KeyPhase, ?M:key_phase(FirstByte))
+        end
+     || PN <- [0, 300, 70000], Payload <- [<<>>, <<"body">>], KeyPhase <- [0, 1]
+    ].
+
+%% =============================================================================
+%% Cross-decode: the dep builds, we decode.
+%% =============================================================================
+
+decode_dep_long_test() ->
+    Opts = #{token => <<"t">>, pn => 9, payload => <<"crypto">>},
+    Bin = ?DEP:encode_long(initial, ?V1, ?DCID, ?SCID, Opts),
+    ?assertEqual({ok, expected_long(initial, Opts), <<>>}, ?M:decode(Bin, byte_size(?DCID))).
+
+decode_dep_short_test() ->
+    Bin = ?DEP:encode_short(?DCID, 42, <<"1rtt">>, true, 1),
+    ?assertEqual(
+        {ok, #{type => one_rtt, dcid => ?DCID, pn => 42, payload => <<"1rtt">>}, <<>>},
+        ?M:decode(Bin, byte_size(?DCID))
+    ).
+
+%% A coalesced datagram (Initial followed by a short-header packet): the
+%% Initial decodes and leaves the short-header bytes as the remainder.
+decode_coalesced_test() ->
+    First = enc(?M:encode_long(initial, ?V1, ?DCID, ?SCID, #{pn => 1, payload => <<"a">>})),
+    Second = enc(?M:encode_short(?DCID, 2, <<"b">>, false)),
+    {ok, #{type := initial}, Rest} = ?M:decode(<<First/binary, Second/binary>>, byte_size(?DCID)),
+    ?assertEqual(Second, Rest).
+
+%% =============================================================================
+%% dcid/2 routing (works on a still-protected packet).
+%% =============================================================================
+
+dcid_test() ->
+    Long = enc(?M:encode_long(handshake, ?V1, ?DCID, ?SCID, #{pn => 0, payload => <<>>})),
+    ?assertEqual({ok, ?DCID}, ?M:dcid(Long, 0)),
+    Short = enc(?M:encode_short(?DCID, 0, <<>>, false)),
+    ?assertEqual({ok, ?DCID}, ?M:dcid(Short, byte_size(?DCID))).
+
+%% =============================================================================
+%% Packet-number coding.
+%% =============================================================================
+
+pn_length_boundaries_test() ->
+    ?assertEqual(1, ?M:pn_length(0)),
+    ?assertEqual(1, ?M:pn_length(255)),
+    ?assertEqual(2, ?M:pn_length(256)),
+    ?assertEqual(2, ?M:pn_length(65535)),
+    ?assertEqual(3, ?M:pn_length(65536)),
+    ?assertEqual(3, ?M:pn_length(16777215)),
+    ?assertEqual(4, ?M:pn_length(16777216)).
+
+pn_roundtrip_test() ->
+    [
+        begin
+            Len = ?M:pn_length(PN),
+            ?assertEqual(
+                {PN, <<16#ff>>}, ?M:decode_pn(<<(?M:encode_pn(PN, Len))/binary, 16#ff>>, Len)
+            )
+        end
+     || PN <- [0, 1, 255, 256, 65535, 65536, 16777215, 16777216, 4294967295]
+    ].
+
+%% =============================================================================
+%% Malformed input: every short read is {error, truncated}, never a crash.
+%% =============================================================================
+
+decode_errors_test() ->
+    DCIDLen = byte_size(?DCID),
+    ?assertEqual({error, invalid_packet}, ?M:decode(<<>>, DCIDLen)),
+    %% Long header truncated mid connection-id.
+    ?assertEqual({error, invalid_cid_length}, ?M:decode(<<16#C0, ?V1:32, 8, 1, 2, 3>>, DCIDLen)),
+    %% Long header with a connection id longer than 20 bytes.
+    ?assertEqual({error, invalid_packet}, ?M:decode(<<16#C0, ?V1:32, 21, 0:168>>, DCIDLen)),
+    %% Long header whose SCID bytes are truncated (length 5, only 2 present).
+    ?assertEqual({error, truncated}, ?M:decode(<<16#C0, ?V1:32, 0, 5, 1, 2>>, DCIDLen)),
+    %% Short header truncated before the DCID is complete.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#40, 1, 2>>, DCIDLen)),
+    %% Short header with no room for the packet number.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#40, ?DCID/binary>>, DCIDLen)).
+
+decode_version_negotiation_rejected_test() ->
+    %% Version 0 marks a Version Negotiation packet; a server never gets one.
+    VN = <<16#C0, 0:32, 0, 0>>,
+    ?assertEqual({error, unexpected_version_negotiation}, ?M:decode(VN, 0)).
+
+decode_retry_rejected_test() ->
+    %% Type bits 11 = Retry, a client-only inbound packet.
+    Retry = <<16#F0, ?V1:32, 0, 0>>,
+    ?assertEqual({error, unexpected_retry}, ?M:decode(Retry, 0)).
+
+decode_token_too_large_test() ->
+    %% Initial whose token length varint claims more than the cap.
+    Bin = <<16#C0, ?V1:32, 0, 0, (roadrunner_quic_varint:encode(1000))/binary, 0:8000>>,
+    ?assertEqual({error, token_too_large}, ?M:decode(Bin, 0)).
+
+decode_invalid_length_test() ->
+    %% Handshake whose Length varint (0) is smaller than the packet-number
+    %% length (>= 1), so the payload size is negative.
+    Bin = <<16#E0, ?V1:32, 0, 0, (roadrunner_quic_varint:encode(0))/binary>>,
+    ?assertEqual({error, invalid_length}, ?M:decode(Bin, 0)).
+
+decode_truncated_token_and_length_test() ->
+    %% Initial whose token length varint promises bytes that are not there.
+    BadToken = <<16#C0, ?V1:32, 0, 0, (roadrunner_quic_varint:encode(5))/binary, 1, 2>>,
+    ?assertEqual({error, truncated}, ?M:decode(BadToken, 0)),
+    %% Initial that ends right after a zero-length token (no Length varint).
+    NoLength = <<16#C0, ?V1:32, 0, 0, 0>>,
+    ?assertEqual({error, truncated}, ?M:decode(NoLength, 0)),
+    %% Length present but the packet-number/payload bytes are missing.
+    ShortBody = <<16#C0, ?V1:32, 0, 0, 0, (roadrunner_quic_varint:encode(5))/binary>>,
+    ?assertEqual({error, truncated}, ?M:decode(ShortBody, 0)).
+
+dcid_errors_test() ->
+    ?assertEqual({error, invalid_packet}, ?M:dcid(<<>>, 0)),
+    %% Long header claiming a 21-byte (too long) connection id.
+    ?assertEqual({error, invalid_packet}, ?M:dcid(<<16#C0, ?V1:32, 21, 0>>, 0)),
+    %% Long header truncated before the DCID is complete.
+    ?assertEqual({error, truncated}, ?M:dcid(<<16#C0, ?V1:32, 8, 1, 2>>, 0)),
+    %% Short header truncated before the DCID is complete.
+    ?assertEqual({error, truncated}, ?M:dcid(<<16#40, 1, 2>>, 8)).
+
+pn_offset_errors_test() ->
+    ?assertEqual({error, invalid_packet}, ?M:pn_offset(<<>>, 0)),
+    %% Long header that ends inside the connection ids.
+    ?assertEqual({error, truncated}, ?M:pn_offset(<<16#C0, ?V1:32, 8, 1, 2, 3>>, 0)),
+    %% Long header missing its SCID-length byte.
+    ?assertEqual({error, truncated}, ?M:pn_offset(<<16#C0, ?V1:32, 0>>, 0)),
+    %% Long header whose SCID bytes are truncated (length 5, only 2 present).
+    ?assertEqual({error, truncated}, ?M:pn_offset(<<16#C0, ?V1:32, 0, 5, 1, 2>>, 0)),
+    %% Initial whose token length varint is truncated.
+    ?assertEqual({error, truncated}, ?M:pn_offset(<<16#C0, ?V1:32, 0, 0, 16#40>>, 0)),
+    %% Initial whose token bytes are truncated (length 3, only 2 present).
+    ?assertEqual({error, truncated}, ?M:pn_offset(<<16#C0, ?V1:32, 0, 0, 3, 1, 2>>, 0)),
+    %% Initial whose Length varint is missing.
+    ?assertEqual({error, truncated}, ?M:pn_offset(<<16#C0, ?V1:32, 0, 0, 0>>, 0)).
+
+%% =============================================================================
+%% Version Negotiation packet (no dep oracle: the dep randomises the first
+%% byte, so check the structure instead).
+%% =============================================================================
+
+version_negotiation_structure_test() ->
+    Versions = [?V1, 16#FF000020],
+    Bin = enc(?M:encode_version_negotiation(?DCID, ?SCID, Versions)),
+    DCIDLen = byte_size(?DCID),
+    SCIDLen = byte_size(?SCID),
+    ?assertMatch(
+        <<16#C0, 0:32, DCIDLen, _:DCIDLen/binary, SCIDLen, _:SCIDLen/binary, _/binary>>, Bin
+    ),
+    <<16#C0, 0:32, DCIDLen, D:DCIDLen/binary, SCIDLen, S:SCIDLen/binary, VBytes/binary>> = Bin,
+    ?assertEqual(?DCID, D),
+    ?assertEqual(?SCID, S),
+    ?assertEqual([V || <<V:32>> <= VBytes], Versions).


### PR DESCRIPTION
# Description

Native QUIC wire codecs: packet headers (RFC 9000 §17), transport frames (§19), and transport error codes (§20.1). Pure modules, byte-for-byte oracle-tested against the `quic` dep, off the live path.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)