### PR TITLE
Add the native QUIC key schedule

### DIFF
--- a/src/roadrunner_quic_hkdf.erl
+++ b/src/roadrunner_quic_hkdf.erl
@@ -1,0 +1,56 @@
+-module(roadrunner_quic_hkdf).
+-moduledoc false.
+
+%% HKDF over HMAC-SHA-256 (RFC 5869) plus the TLS 1.3 HKDF-Expand-Label
+%% wrapper (RFC 8446 §7.1), the key-derivation primitive QUIC packet
+%% protection is built on (RFC 9001 §5).
+%%
+%% QUIC v1 negotiates `TLS_AES_128_GCM_SHA256` only, so the hash is fixed
+%% to SHA-256 (a 32-byte output); a wider cipher suite would carry the
+%% hash as a parameter. The Extract/Expand pair is kept RFC-complete (the
+%% multi-block expansion and the absent-salt default) so the RFC 5869
+%% vectors validate it, even though QUIC itself only ever expands to at
+%% most 32 bytes.
+
+-export([extract/2, expand/3, expand_label/4]).
+
+%% SHA-256 output length (RFC 5869 `HashLen`).
+-define(HASH_LEN, 32).
+%% RFC 5869 §2.3: HKDF-Expand emits at most 255 * HashLen octets.
+-define(MAX_EXPAND, 255 * ?HASH_LEN).
+
+-doc "HKDF-Extract (RFC 5869 §2.2): salt + input keying material to a pseudorandom key.".
+-spec extract(binary(), binary()) -> binary().
+extract(<<>>, IKM) ->
+    %% RFC 5869 §2.2: an absent salt defaults to HashLen zero bytes.
+    crypto:mac(hmac, sha256, binary:copy(<<0>>, ?HASH_LEN), IKM);
+extract(Salt, IKM) ->
+    crypto:mac(hmac, sha256, Salt, IKM).
+
+-doc "HKDF-Expand (RFC 5869 §2.3): a pseudorandom key to `Length` output octets.".
+-spec expand(binary(), binary(), non_neg_integer()) -> binary().
+expand(PRK, Info, Length) when Length =< ?MAX_EXPAND ->
+    N = (Length + ?HASH_LEN - 1) div ?HASH_LEN,
+    binary:part(iolist_to_binary(expand_blocks(PRK, Info, N, 1, <<>>)), 0, Length).
+
+-doc "HKDF-Expand-Label (RFC 8446 §7.1) with the `tls13 ` prefix QUIC reuses (RFC 9001 §5.1).".
+-spec expand_label(binary(), binary(), binary(), non_neg_integer()) -> binary().
+expand_label(Secret, Label, Context, Length) ->
+    FullLabel = <<"tls13 ", Label/binary>>,
+    Info =
+        <<Length:16, (byte_size(FullLabel)):8, FullLabel/binary, (byte_size(Context)):8,
+            Context/binary>>,
+    expand(Secret, Info, Length).
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% T(i) = HMAC(PRK, T(i-1) | Info | i), RFC 5869 §2.3; cons each block on
+%% the way out so the output is built without a growing accumulator.
+-spec expand_blocks(binary(), binary(), non_neg_integer(), pos_integer(), binary()) -> iolist().
+expand_blocks(_PRK, _Info, N, I, _Prev) when I > N ->
+    [];
+expand_blocks(PRK, Info, N, I, Prev) ->
+    T = crypto:mac(hmac, sha256, PRK, <<Prev/binary, Info/binary, I>>),
+    [T | expand_blocks(PRK, Info, N, I + 1, T)].

--- a/src/roadrunner_quic_keys.erl
+++ b/src/roadrunner_quic_keys.erl
@@ -1,0 +1,85 @@
+-module(roadrunner_quic_keys).
+-moduledoc false.
+
+%% QUIC v1 packet-protection key derivation (RFC 9001 §5).
+%%
+%% Initial keys come from the client's Destination Connection ID and the
+%% version-1 Initial salt (§5.2); handshake and 1-RTT keys come from a TLS
+%% 1.3 traffic secret. v1 negotiates `TLS_AES_128_GCM_SHA256`, so the AEAD
+%% is AES-128-GCM throughout: a 16-byte key, a 12-byte IV, and a 16-byte
+%% header-protection key, each via HKDF-Expand-Label over SHA-256
+%% (`roadrunner_quic_hkdf`). `update/1` derives the next generation's
+%% secret and keys so the server can answer a peer-initiated key update
+%% (§6.1), which a v1 endpoint MUST support.
+
+-export([
+    initial_secret/1,
+    initial_client/1,
+    initial_server/1,
+    traffic_keys/1,
+    update/1
+]).
+
+-export_type([keys/0]).
+
+-type keys() :: #{key := binary(), iv := binary(), hp := binary()}.
+
+%% RFC 9001 §5.2: the QUIC v1 Initial salt,
+%% 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a.
+-define(INITIAL_SALT,
+    <<16#38, 16#76, 16#2c, 16#f7, 16#f5, 16#59, 16#34, 16#b3, 16#4d, 16#17, 16#9a, 16#e6, 16#a4,
+        16#c8, 16#0c, 16#ad, 16#cc, 16#bb, 16#7f, 16#0a>>
+).
+
+-doc """
+Derive the Initial secret from a Destination Connection ID (RFC 9001
+§5.2): `HKDF-Extract(v1_salt, DCID)`. Both Initial-key directions start
+here.
+""".
+-spec initial_secret(binary()) -> binary().
+initial_secret(DCID) ->
+    roadrunner_quic_hkdf:extract(?INITIAL_SALT, DCID).
+
+-doc """
+Derive the client's Initial key/iv/hp from the DCID (RFC 9001 §5.2). The
+server decrypts the client's Initial packets and removes their header
+protection with these.
+""".
+-spec initial_client(binary()) -> keys().
+initial_client(DCID) ->
+    ClientSecret = roadrunner_quic_hkdf:expand_label(initial_secret(DCID), ~"client in", <<>>, 32),
+    traffic_keys(ClientSecret).
+
+-doc """
+Derive the server's Initial key/iv/hp from the DCID (RFC 9001 §5.2). The
+server protects its own Initial packets with these.
+""".
+-spec initial_server(binary()) -> keys().
+initial_server(DCID) ->
+    ServerSecret = roadrunner_quic_hkdf:expand_label(initial_secret(DCID), ~"server in", <<>>, 32),
+    traffic_keys(ServerSecret).
+
+-doc """
+Derive the AES-128-GCM packet-protection keys from a traffic secret
+(RFC 9001 §5.1): the AEAD key (`quic key`), the nonce IV (`quic iv`), and
+the header-protection key (`quic hp`).
+""".
+-spec traffic_keys(binary()) -> keys().
+traffic_keys(Secret) ->
+    #{
+        key => roadrunner_quic_hkdf:expand_label(Secret, ~"quic key", <<>>, 16),
+        iv => roadrunner_quic_hkdf:expand_label(Secret, ~"quic iv", <<>>, 12),
+        hp => roadrunner_quic_hkdf:expand_label(Secret, ~"quic hp", <<>>, 16)
+    }.
+
+-doc """
+Derive the next key generation for a key update (RFC 9001 §6.1):
+`HKDF-Expand-Label(current_secret, "quic ku", "", 32)` gives the updated
+secret, and the new keys follow from it. Returns `{UpdatedSecret, Keys}`;
+the caller keeps `UpdatedSecret` as the current secret for the following
+update.
+""".
+-spec update(binary()) -> {binary(), keys()}.
+update(Secret) ->
+    UpdatedSecret = roadrunner_quic_hkdf:expand_label(Secret, ~"quic ku", <<>>, 32),
+    {UpdatedSecret, traffic_keys(UpdatedSecret)}.

--- a/test/property_test/roadrunner_quic_hkdf_props.erl
+++ b/test/property_test/roadrunner_quic_hkdf_props.erl
@@ -1,0 +1,28 @@
+-module(roadrunner_quic_hkdf_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_hkdf`.
+
+Differential invariant over random inputs: HKDF-Extract, HKDF-Expand,
+and HKDF-Expand-Label are byte-for-byte identical to the `quic` dep (the
+oracle) for arbitrary salt, keying material, info, label, context, and
+output length, including the empty-salt default and multi-block
+expansion.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_matches_dep() ->
+    ?FORALL(
+        {Salt, IKM, Info, Label, Context, Len},
+        {binary(), binary(), binary(), binary(), binary(), integer(0, 96)},
+        begin
+            PRK = roadrunner_quic_hkdf:extract(Salt, IKM),
+            PRK =:= quic_hkdf:extract(Salt, IKM) andalso
+                roadrunner_quic_hkdf:expand(PRK, Info, Len) =:= quic_hkdf:expand(PRK, Info, Len) andalso
+                roadrunner_quic_hkdf:expand_label(PRK, Label, Context, Len) =:=
+                    quic_hkdf:expand_label(PRK, Label, Context, Len)
+        end
+    ).

--- a/test/property_test/roadrunner_quic_keys_props.erl
+++ b/test/property_test/roadrunner_quic_keys_props.erl
@@ -1,0 +1,35 @@
+-module(roadrunner_quic_keys_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_keys`.
+
+Differential invariant over random inputs: the Initial secret, both
+Initial-direction key bundles, the traffic keys, and the key-update
+derivation are byte-for-byte identical to the `quic` dep (the oracle) for
+an arbitrary Destination Connection ID and traffic secret.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_matches_dep() ->
+    ?FORALL(
+        {DCID, Secret},
+        {binary(), binary(32)},
+        begin
+            roadrunner_quic_keys:initial_secret(DCID) =:= quic_keys:derive_initial_secret(DCID) andalso
+                roadrunner_quic_keys:initial_server(DCID) =:=
+                    dep_keys(quic_keys:derive_initial_server(DCID)) andalso
+                roadrunner_quic_keys:initial_client(DCID) =:=
+                    dep_keys(quic_keys:derive_initial_client(DCID)) andalso
+                roadrunner_quic_keys:traffic_keys(Secret) =:=
+                    dep_keys(quic_keys:derive_traffic_keys(Secret)) andalso
+                roadrunner_quic_keys:update(Secret) =:=
+                    dep_update(quic_keys:derive_updated_keys(Secret, aes_128_gcm))
+        end
+    ).
+
+dep_keys({Key, IV, HP}) -> #{key => Key, iv => IV, hp => HP}.
+
+dep_update({Secret, Keys}) -> {Secret, dep_keys(Keys)}.

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -34,7 +34,8 @@ Add a new property:
     loop_request_start_and_stop_share_request_id/1,
     router_param_bindings_round_trip/1,
     quic_varint_encode_matches_dep/1,
-    quic_hkdf_matches_dep/1
+    quic_hkdf_matches_dep/1,
+    quic_keys_matches_dep/1
 ]).
 
 suite() ->
@@ -59,7 +60,8 @@ all() ->
         loop_request_start_and_stop_share_request_id,
         router_param_bindings_round_trip,
         quic_varint_encode_matches_dep,
-        quic_hkdf_matches_dep
+        quic_hkdf_matches_dep,
+        quic_keys_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -173,5 +175,11 @@ quic_varint_encode_matches_dep(Config) ->
 quic_hkdf_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_hkdf_props:prop_matches_dep(),
+        Config
+    ).
+
+quic_keys_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_keys_props:prop_matches_dep(),
         Config
     ).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -33,7 +33,8 @@ Add a new property:
     loop_terminates_normal_on_random_inputs/1,
     loop_request_start_and_stop_share_request_id/1,
     router_param_bindings_round_trip/1,
-    quic_varint_encode_matches_dep/1
+    quic_varint_encode_matches_dep/1,
+    quic_hkdf_matches_dep/1
 ]).
 
 suite() ->
@@ -57,7 +58,8 @@ all() ->
         loop_terminates_normal_on_random_inputs,
         loop_request_start_and_stop_share_request_id,
         router_param_bindings_round_trip,
-        quic_varint_encode_matches_dep
+        quic_varint_encode_matches_dep,
+        quic_hkdf_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -165,5 +167,11 @@ router_param_bindings_round_trip(Config) ->
 quic_varint_encode_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_varint_props:prop_encode_matches_dep_and_round_trips(),
+        Config
+    ).
+
+quic_hkdf_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_hkdf_props:prop_matches_dep(),
         Config
     ).

--- a/test/roadrunner_quic_hkdf_tests.erl
+++ b/test/roadrunner_quic_hkdf_tests.erl
@@ -1,0 +1,97 @@
+-module(roadrunner_quic_hkdf_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_hkdf).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_hkdf).
+
+%% =============================================================================
+%% RFC 5869 Appendix A SHA-256 test vectors — the authority.
+%%
+%% Each case fixes the HKDF-Extract PRK and the HKDF-Expand OKM. Cases 1
+%% and 2 exercise multi-block expansion (L=42 -> 2 blocks, L=82 -> 3); case
+%% 3 exercises the absent-salt default (a string of HashLen zero bytes).
+%% =============================================================================
+
+rfc5869_a1_basic_test() ->
+    IKM = binary:copy(<<16#0b>>, 22),
+    Salt = hex(~"000102030405060708090a0b0c"),
+    Info = hex(~"f0f1f2f3f4f5f6f7f8f9"),
+    PRK = hex(~"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"),
+    OKM = hex(
+        ~"3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+    ),
+    ?assertEqual(PRK, ?M:extract(Salt, IKM)),
+    ?assertEqual(OKM, ?M:expand(PRK, Info, 42)).
+
+rfc5869_a2_longer_inputs_test() ->
+    IKM = list_to_binary(lists:seq(16#00, 16#4f)),
+    Salt = list_to_binary(lists:seq(16#60, 16#af)),
+    Info = list_to_binary(lists:seq(16#b0, 16#ff)),
+    PRK = hex(~"06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"),
+    OKM = hex(
+        ~"b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
+    ),
+    ?assertEqual(PRK, ?M:extract(Salt, IKM)),
+    ?assertEqual(OKM, ?M:expand(PRK, Info, 82)).
+
+rfc5869_a3_empty_salt_test() ->
+    IKM = binary:copy(<<16#0b>>, 22),
+    PRK = hex(~"19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04"),
+    OKM = hex(
+        ~"8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"
+    ),
+    %% An empty salt defaults to HashLen zero bytes (RFC 5869 §2.2).
+    ?assertEqual(PRK, ?M:extract(<<>>, IKM)),
+    ?assertEqual(OKM, ?M:expand(PRK, <<>>, 42)).
+
+%% =============================================================================
+%% HKDF-Expand-Label (RFC 8446 §7.1) against RFC 9001 Appendix A.1, where
+%% the client/server Initial secrets are Expand-Label outputs over the
+%% Initial secret with the "tls13 " prefix.
+%% =============================================================================
+
+expand_label_rfc9001_test() ->
+    InitialSecret = hex(~"7db5df06e7a69e432496adedb00851923595221596ae2ae9fb8115c1e9ed0a44"),
+    ClientSecret = hex(~"c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"),
+    ServerSecret = hex(~"3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"),
+    ?assertEqual(ClientSecret, ?M:expand_label(InitialSecret, ~"client in", <<>>, 32)),
+    ?assertEqual(ServerSecret, ?M:expand_label(InitialSecret, ~"server in", <<>>, 32)).
+
+%% =============================================================================
+%% Differential equivalence vs the dep oracle, across varied inputs
+%% (empty salt, non-empty salt, several lengths, a non-empty context).
+%% =============================================================================
+
+oracle_matches_dep_test() ->
+    Inputs = [
+        {<<>>, ~"ikm", <<>>, ~"quic key", <<>>, 16},
+        {~"salt", ~"keying material", ~"info", ~"quic iv", <<>>, 12},
+        {~"the-salt", ~"the-ikm", ~"the-info", ~"quic hp", <<>>, 16},
+        {~"s", ~"i", ~"n", ~"derived", ~"context-bytes", 48},
+        {~"abc", ~"def", ~"ghi", ~"key", <<>>, 32}
+    ],
+    [
+        begin
+            PRK = ?M:extract(Salt, IKM),
+            ?assertEqual(?DEP:extract(Salt, IKM), PRK),
+            ?assertEqual(?DEP:expand(PRK, Info, Len), ?M:expand(PRK, Info, Len)),
+            ?assertEqual(
+                ?DEP:expand_label(PRK, Label, Ctx, Len),
+                ?M:expand_label(PRK, Label, Ctx, Len)
+            )
+        end
+     || {Salt, IKM, Info, Label, Ctx, Len} <- Inputs
+    ].
+
+%% A zero-length expansion yields the empty binary (RFC 5869 §2.3, N=0),
+%% pinned here independently of the differential property.
+expand_zero_length_test() ->
+    PRK = ?M:extract(~"salt", ~"ikm"),
+    ?assertEqual(<<>>, ?M:expand(PRK, ~"info", 0)),
+    ?assertEqual(<<>>, ?M:expand_label(PRK, ~"label", <<>>, 0)).
+
+%% Uppercase before decoding so the literals are portable across OTP
+%% versions regardless of `binary:decode_hex/1`'s lowercase handling.
+hex(Hex) -> binary:decode_hex(string:uppercase(Hex)).

--- a/test/roadrunner_quic_keys_tests.erl
+++ b/test/roadrunner_quic_keys_tests.erl
@@ -1,0 +1,125 @@
+-module(roadrunner_quic_keys_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_keys).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_keys).
+
+%% =============================================================================
+%% RFC 9001 Appendix A.1 — the authority.
+%%
+%% The worked example derives Initial keys for both directions from the
+%% client's DCID 0x8394c8f03e515708.
+%% =============================================================================
+
+rfc9001_a1_initial_secret_test() ->
+    ?assertEqual(
+        hex(~"7db5df06e7a69e432496adedb00851923595221596ae2ae9fb8115c1e9ed0a44"),
+        ?M:initial_secret(a1_dcid())
+    ).
+
+rfc9001_a1_server_keys_test() ->
+    ?assertEqual(
+        #{
+            key => hex(~"cf3a5331653c364c88f0f379b6067e37"),
+            iv => hex(~"0ac1493ca1905853b0bba03e"),
+            hp => hex(~"c206b8d9b9f0f37644430b490eeaa314")
+        },
+        ?M:initial_server(a1_dcid())
+    ).
+
+rfc9001_a1_client_keys_test() ->
+    ?assertEqual(
+        #{
+            key => hex(~"1f369613dd76d5467730efcbe3b1a22d"),
+            iv => hex(~"fa044b2f42a3fd3b46fb255c"),
+            hp => hex(~"9f50449e04a0e810283a1e9933adedd2")
+        },
+        ?M:initial_client(a1_dcid())
+    ).
+
+%% The server Initial keys derive straight from the server Initial secret
+%% (RFC 9001 A.1), so `traffic_keys/1` over that secret reproduces them.
+traffic_keys_test() ->
+    ServerSecret = hex(~"3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"),
+    ?assertEqual(
+        #{
+            key => hex(~"cf3a5331653c364c88f0f379b6067e37"),
+            iv => hex(~"0ac1493ca1905853b0bba03e"),
+            hp => hex(~"c206b8d9b9f0f37644430b490eeaa314")
+        },
+        ?M:traffic_keys(ServerSecret)
+    ).
+
+%% =============================================================================
+%% Key update (RFC 9001 §6.1), AES-128-GCM: the next secret is
+%% Expand-Label(current, "quic ku", "", 32), and the keys follow from it.
+%% Vector cross-checked against the dep oracle.
+%% =============================================================================
+
+key_update_test() ->
+    Secret = binary:copy(<<16#2a>>, 32),
+    {UpdatedSecret, Keys} = ?M:update(Secret),
+    ?assertEqual(
+        hex(~"c8dd004d0adc90d90ef286b8debce48f65a3ea342932fc5f4891207e96f8e862"),
+        UpdatedSecret
+    ),
+    ?assertEqual(
+        #{
+            key => hex(~"d77beffa17a12a7697276ab00c5faa0b"),
+            iv => hex(~"535303b03a85a983f4311f64"),
+            hp => hex(~"c77ac07f35beb8c618d0956b341206b5")
+        },
+        Keys
+    ).
+
+%% =============================================================================
+%% Differential equivalence vs the dep oracle, across several DCIDs (the
+%% A.1 example, a text CID, the 20-byte maximum, empty, one byte) and
+%% traffic secrets.
+%% =============================================================================
+
+initial_keys_match_dep_test() ->
+    DCIDs = [
+        a1_dcid(),
+        ~"roadrunner-cid",
+        list_to_binary(lists:seq(1, 20)),
+        <<>>,
+        ~"x"
+    ],
+    [
+        begin
+            ?assertEqual(?DEP:derive_initial_secret(DCID), ?M:initial_secret(DCID)),
+            ?assertEqual(dep_keys(?DEP:derive_initial_server(DCID)), ?M:initial_server(DCID)),
+            ?assertEqual(dep_keys(?DEP:derive_initial_client(DCID)), ?M:initial_client(DCID))
+        end
+     || DCID <- DCIDs
+    ].
+
+update_matches_dep_test() ->
+    Secrets = [
+        binary:copy(<<16#2a>>, 32),
+        binary:copy(<<16#00>>, 32),
+        list_to_binary(lists:seq(1, 32))
+    ],
+    [
+        begin
+            {DepSecret, DepKeys} = ?DEP:derive_updated_keys(Secret, aes_128_gcm),
+            ?assertEqual({DepSecret, dep_keys(DepKeys)}, ?M:update(Secret))
+        end
+     || Secret <- Secrets
+    ].
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+a1_dcid() -> hex(~"8394c8f03e515708").
+
+%% The dep returns key material as a {Key, IV, HP} tuple.
+dep_keys({Key, IV, HP}) -> #{key => Key, iv => IV, hp => HP}.
+
+%% Uppercase before decoding so the literals are portable across OTP
+%% versions regardless of `binary:decode_hex/1`'s lowercase handling.
+hex(Hex) -> binary:decode_hex(string:uppercase(Hex)).


### PR DESCRIPTION
# Description

Native QUIC key derivation: the code that turns a connection's identifiers and TLS secrets into the keys used to protect packets, following RFC 9001. It also produces the next set of keys when the peer rotates them, which a QUIC v1 server is required to handle. Both modules are pure functions with no connection state, so the live QUIC stack keeps working unchanged.

Every derived value is verified against the published RFC test vectors and against the current `quic` dependency, and both modules are fully covered by tests.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)