### PR TITLE
Add the native QUIC packet protection

### DIFF
--- a/src/roadrunner_quic_aead.erl
+++ b/src/roadrunner_quic_aead.erl
@@ -1,0 +1,146 @@
+-module(roadrunner_quic_aead).
+-moduledoc false.
+
+%% QUIC v1 packet protection (RFC 9001 §5): AEAD payload seal/open plus
+%% header protection.
+%%
+%% v1 negotiates `TLS_AES_128_GCM_SHA256`, so the AEAD is AES-128-GCM (a
+%% 16-byte key, a 12-byte IV, a 16-byte tag) and header protection is
+%% AES-128-ECB. The nonce is the IV with the packet number XORed into its
+%% low 64 bits (§5.3). Header protection masks the low bits of the first
+%% byte and the packet-number bytes with a mask derived from a 16-byte
+%% ciphertext sample taken 4 bytes past the start of the packet number
+%% (§5.4.1). On receive the protection MUST be removed before the
+%% packet-number length or the key-phase bit can be trusted, so
+%% `unprotect_header/3` reports those only after unmasking.
+%%
+%% The packet number is carried truncated on the wire; reconstructing the
+%% full number from the largest received (RFC 9000 §A) is the receive
+%% path's job, so `seal/5` and `open/5` take the full number directly.
+
+-export([seal/5, open/5, protect_header/4, unprotect_header/3]).
+
+%% AEAD authentication tag length (RFC 9001 §5.3).
+-define(TAG_LEN, 16).
+%% Header-protection sample: 16 bytes, 4 past the packet-number start
+%% (RFC 9001 §5.4.2).
+-define(SAMPLE_OFFSET, 4).
+-define(SAMPLE_LEN, 16).
+
+-doc """
+Seal a packet payload with AES-128-GCM. `AAD` is the unprotected header,
+`PN` the full packet number; the 16-byte authentication tag is appended
+to the returned ciphertext.
+""".
+-spec seal(binary(), binary(), non_neg_integer(), binary(), binary()) -> binary().
+seal(Key, IV, PN, AAD, Plaintext) ->
+    {Ciphertext, Tag} = crypto:crypto_one_time_aead(
+        aes_128_gcm, Key, nonce(IV, PN), Plaintext, AAD, ?TAG_LEN, true
+    ),
+    <<Ciphertext/binary, Tag/binary>>.
+
+-doc """
+Open a sealed payload (ciphertext with its tag appended). Returns
+`{ok, Plaintext}`, or `error` if authentication fails or the input is
+too short to hold a tag, so the receive path drops the packet.
+""".
+-spec open(binary(), binary(), non_neg_integer(), binary(), binary()) -> {ok, binary()} | error.
+open(Key, IV, PN, AAD, Sealed) when byte_size(Sealed) >= ?TAG_LEN ->
+    CipherLen = byte_size(Sealed) - ?TAG_LEN,
+    <<Ciphertext:CipherLen/binary, Tag:?TAG_LEN/binary>> = Sealed,
+    case
+        crypto:crypto_one_time_aead(aes_128_gcm, Key, nonce(IV, PN), Ciphertext, AAD, Tag, false)
+    of
+        Plaintext when is_binary(Plaintext) -> {ok, Plaintext};
+        error -> error
+    end;
+open(_Key, _IV, _PN, _AAD, _Sealed) ->
+    error.
+
+-doc """
+Apply header protection (RFC 9001 §5.4). `Header` is the unprotected
+header through the packet number (it doubles as the AEAD associated
+data), `Ciphertext` is the sealed payload, and `PNOffset` is the byte
+offset of the packet number within `Header`. Returns the protected
+header; the wire packet is that followed by `Ciphertext`.
+""".
+-spec protect_header(binary(), binary(), binary(), non_neg_integer()) -> binary().
+protect_header(HPKey, Header, Ciphertext, PNOffset) ->
+    <<FirstByte, _/binary>> = Header,
+    PNLen = pn_len(FirstByte),
+    %% The sample is at PNOffset + 4 in the packet; the ciphertext begins
+    %% at PNOffset + PNLen, so within it the sample starts here.
+    Sample = binary:part(Ciphertext, ?SAMPLE_OFFSET - PNLen, ?SAMPLE_LEN),
+    <<M0, _/binary>> = Mask = hp_mask(HPKey, Sample),
+    MiddleLen = PNOffset - 1,
+    <<_FB, Middle:MiddleLen/binary, PN:PNLen/binary>> = Header,
+    MaskPN = binary:part(Mask, 1, PNLen),
+    <<
+        (FirstByte bxor first_byte_mask(FirstByte, M0)),
+        Middle/binary,
+        (xor_bytes(PN, MaskPN))/binary
+    >>.
+
+-doc """
+Remove header protection (RFC 9001 §5.4) from a received packet.
+`PNOffset` is the byte offset of the packet number, located on the
+still-protected packet via `roadrunner_quic_packet:pn_offset/2`. Returns
+the unprotected header (the AEAD associated data), the packet-number
+length, the truncated packet number, and the trailing ciphertext, or
+`{error, sample_too_short}` if the packet is too small to sample.
+""".
+-spec unprotect_header(binary(), binary(), non_neg_integer()) ->
+    {ok, binary(), 1..4, non_neg_integer(), binary()} | {error, sample_too_short}.
+unprotect_header(HPKey, Packet, PNOffset) ->
+    case Packet of
+        <<Header:PNOffset/binary, AfterHeader/binary>> when
+            byte_size(AfterHeader) >= ?SAMPLE_OFFSET + ?SAMPLE_LEN
+        ->
+            Sample = binary:part(AfterHeader, ?SAMPLE_OFFSET, ?SAMPLE_LEN),
+            <<M0, _/binary>> = Mask = hp_mask(HPKey, Sample),
+            <<ProtFirstByte, Middle/binary>> = Header,
+            FirstByte = ProtFirstByte bxor first_byte_mask(ProtFirstByte, M0),
+            PNLen = pn_len(FirstByte),
+            <<ProtPN:PNLen/binary, Ciphertext/binary>> = AfterHeader,
+            PN = xor_bytes(ProtPN, binary:part(Mask, 1, PNLen)),
+            {ok, <<FirstByte, Middle/binary, PN/binary>>, PNLen, binary:decode_unsigned(PN),
+                Ciphertext};
+        _ ->
+            {error, sample_too_short}
+    end.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% AEAD nonce (RFC 9001 §5.3): the 12-byte IV with the packet number
+%% XORed into its low 64 bits.
+-spec nonce(binary(), non_neg_integer()) -> binary().
+nonce(<<Prefix:32, Low:64>>, PN) ->
+    <<Prefix:32, (Low bxor PN):64>>.
+
+%% Header-protection mask (RFC 9001 §5.4.1): AES-128-ECB of the 16-byte
+%% sample. The first byte masks the first header byte; the next bytes mask
+%% the packet number.
+-spec hp_mask(binary(), binary()) -> binary().
+hp_mask(HPKey, Sample) ->
+    crypto:crypto_one_time(aes_128_ecb, HPKey, Sample, true).
+
+%% The low bits of the first byte that header protection masks: 4 for a
+%% long header, 5 for a short header (RFC 9001 §5.4.1). Bit 7 (the form
+%% bit) is never masked, so it reads the same protected or not.
+-spec first_byte_mask(byte(), byte()) -> byte().
+first_byte_mask(FirstByte, M0) when (FirstByte band 16#80) =:= 16#80 -> M0 band 16#0F;
+first_byte_mask(_FirstByte, M0) -> M0 band 16#1F.
+
+%% Packet-number length encoded in the low 2 bits of the first byte
+%% (RFC 9000 §17.2/§17.3).
+-spec pn_len(byte()) -> 1..4.
+pn_len(FirstByte) -> (FirstByte band 2#11) + 1.
+
+%% XOR two equal-length byte strings (the 1-4 byte packet number against
+%% its mask); body recursion, no `crypto:exor/2` NIF call for so few
+%% bytes.
+-spec xor_bytes(binary(), binary()) -> binary().
+xor_bytes(<<>>, <<>>) -> <<>>;
+xor_bytes(<<A, As/binary>>, <<B, Bs/binary>>) -> <<(A bxor B), (xor_bytes(As, Bs))/binary>>.

--- a/test/property_test/roadrunner_quic_aead_props.erl
+++ b/test/property_test/roadrunner_quic_aead_props.erl
@@ -1,0 +1,62 @@
+-module(roadrunner_quic_aead_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_aead`.
+
+Differential invariant over random inputs: AES-128-GCM sealing is
+byte-for-byte identical to the `quic` dep (the oracle), opening reverses
+sealing, and header protection applied to a real short-header packet is
+removed exactly, recovering the header and ciphertext.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+%% 2^62 - 1, the largest QUIC packet number.
+-define(MAX_PN, 4611686018427387903).
+
+prop_matches_dep() ->
+    ?FORALL(
+        {Key, IV, HP, PN, DCID, Plaintext},
+        {binary(16), binary(12), binary(16), pn(), dcid(), payload()},
+        begin
+            %% A short-header packet's header depends only on DCID + PN, so
+            %% it can be built before sealing and used as the AEAD AAD.
+            [HeaderIo, _] = roadrunner_quic_packet:encode_short(DCID, PN, <<>>, false),
+            Header = iolist_to_binary(HeaderIo),
+            PNOffset = 1 + byte_size(DCID),
+            PNLen = roadrunner_quic_packet:pn_length(PN),
+            %% The wire carries the packet number truncated to its width, so
+            %% unprotect_header returns that truncated value (full-number
+            %% reconstruction from the largest received is the conn's job).
+            WirePN = binary:decode_unsigned(roadrunner_quic_packet:encode_pn(PN, PNLen)),
+            Ciphertext = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+            Protected = roadrunner_quic_aead:protect_header(HP, Header, Ciphertext, PNOffset),
+            Packet = <<Protected/binary, Ciphertext/binary>>,
+            Ciphertext =:= quic_aead:encrypt(Key, IV, PN, Header, Plaintext) andalso
+                roadrunner_quic_aead:open(Key, IV, PN, Header, Ciphertext) =:= {ok, Plaintext} andalso
+                roadrunner_quic_aead:unprotect_header(HP, Packet, PNOffset) =:=
+                    {ok, Header, PNLen, WirePN, Ciphertext}
+        end
+    ).
+
+%% A packet number, one band per wire width (1-4 bytes) plus a band above
+%% 2^32 for the AEAD nonce's high bits. Banding by lower bound forces every
+%% width to be produced; a single `integer(0, ?MAX_PN)` scales with the
+%% PropEr size and would only ever yield tiny, 1-byte numbers.
+pn() ->
+    oneof([
+        integer(0, 16#FF),
+        integer(16#100, 16#FFFF),
+        integer(16#10000, 16#FFFFFF),
+        integer(16#1000000, 16#FFFFFFFF),
+        integer(16#100000000, ?MAX_PN)
+    ]).
+
+%% A Destination Connection ID, 0..20 bytes (RFC 9000 §17.2).
+dcid() -> ?LET(N, integer(0, 20), binary(N)).
+
+%% A payload large enough that the ciphertext always holds the 16-byte
+%% header-protection sample taken 4 bytes past the packet number.
+payload() -> ?LET(N, integer(16, 256), binary(N)).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -35,7 +35,8 @@ Add a new property:
     router_param_bindings_round_trip/1,
     quic_varint_encode_matches_dep/1,
     quic_hkdf_matches_dep/1,
-    quic_keys_matches_dep/1
+    quic_keys_matches_dep/1,
+    quic_aead_matches_dep/1
 ]).
 
 suite() ->
@@ -61,7 +62,8 @@ all() ->
         router_param_bindings_round_trip,
         quic_varint_encode_matches_dep,
         quic_hkdf_matches_dep,
-        quic_keys_matches_dep
+        quic_keys_matches_dep,
+        quic_aead_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -181,5 +183,11 @@ quic_hkdf_matches_dep(Config) ->
 quic_keys_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_keys_props:prop_matches_dep(),
+        Config
+    ).
+
+quic_aead_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_aead_props:prop_matches_dep(),
         Config
     ).

--- a/test/roadrunner_quic_aead_tests.erl
+++ b/test/roadrunner_quic_aead_tests.erl
@@ -1,0 +1,108 @@
+-module(roadrunner_quic_aead_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_aead).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_aead).
+
+%% =============================================================================
+%% RFC 9001 Appendix A.3 (Server Initial) — the authority.
+%%
+%% A full packet-protection round trip against the published vector: seal
+%% the payload, apply header protection to reproduce the on-wire packet,
+%% then reverse both. The server Initial uses a 2-byte packet number
+%% (first byte 0xc1) at offset 18 and is not padded to 1200 bytes.
+%% =============================================================================
+
+rfc9001_a3_server_initial_test() ->
+    Key = hex(~"cf3a5331653c364c88f0f379b6067e37"),
+    IV = hex(~"0ac1493ca1905853b0bba03e"),
+    HP = hex(~"c206b8d9b9f0f37644430b490eeaa314"),
+    PN = 1,
+    PNOffset = 18,
+    Header = hex(~"c1000000010008f067a5502a4262b50040750001"),
+    Plaintext = hex(
+        ~"02000000000600405a020000560303eefce7f7b37ba1d1632e96677825ddf73988cfc79825df566dc5430b9a045a1200130100002e00330024001d00209d3c940d89690b84d08a60993c144eca684d1081287c834d5311bcf32bb9da1a002b00020304"
+    ),
+    Ciphertext = hex(
+        ~"5a482cd0991cd25b0aac406a5816b6394100f37a1c69797554780bb38cc5a99f5ede4cf73c3ec2493a1839b3dbcba3f6ea46c5b7684df3548e7ddeb9c3bf9c73cc3f3bded74b562bfb19fb84022f8ef4cdd93795d77d06edbb7aaf2f58891850abbdca3d20398c276456cbc42158407dd074ee"
+    ),
+    Packet = hex(
+        ~"cf000000010008f067a5502a4262b5004075c0d95a482cd0991cd25b0aac406a5816b6394100f37a1c69797554780bb38cc5a99f5ede4cf73c3ec2493a1839b3dbcba3f6ea46c5b7684df3548e7ddeb9c3bf9c73cc3f3bded74b562bfb19fb84022f8ef4cdd93795d77d06edbb7aaf2f58891850abbdca3d20398c276456cbc42158407dd074ee"
+    ),
+    ?assertEqual(Ciphertext, ?M:seal(Key, IV, PN, Header, Plaintext)),
+    ?assertEqual({ok, Plaintext}, ?M:open(Key, IV, PN, Header, Ciphertext)),
+    Protected = ?M:protect_header(HP, Header, Ciphertext, PNOffset),
+    ?assertEqual(Packet, <<Protected/binary, Ciphertext/binary>>),
+    ?assertEqual({ok, Header, 2, PN, Ciphertext}, ?M:unprotect_header(HP, Packet, PNOffset)).
+
+%% =============================================================================
+%% AEAD seal/open: byte-for-byte vs the dep, round-trip across inputs.
+%% =============================================================================
+
+seal_open_matches_dep_test() ->
+    Key = hex(~"00112233445566778899aabbccddeeff"),
+    IV = hex(~"0102030405060708090a0b0c"),
+    Cases = [
+        {0, <<>>, ~"x"},
+        {1, ~"associated-data", binary:copy(<<7>>, 100)},
+        {16#3fffffff, ~"hdr", ~"payload"},
+        {16#ffffffffffff, <<>>, binary:copy(<<0>>, 64)}
+    ],
+    [
+        begin
+            CT = ?M:seal(Key, IV, PN, AAD, PT),
+            ?assertEqual(?DEP:encrypt(Key, IV, PN, AAD, PT), CT),
+            ?assertEqual({ok, PT}, ?M:open(Key, IV, PN, AAD, CT))
+        end
+     || {PN, AAD, PT} <- Cases
+    ].
+
+%% =============================================================================
+%% Header protection: byte-for-byte vs the dep, removed exactly. Built on a
+%% real short-header packet (the A.3 vector covers the long-header form).
+%% =============================================================================
+
+header_protection_matches_dep_test() ->
+    HP = hex(~"33333333333333333333333333333333"),
+    DCID = binary:copy(<<16#ab>>, 8),
+    Ciphertext = binary:copy(<<16#5c>>, 40),
+    PN = 42,
+    [HeaderIo, _] = roadrunner_quic_packet:encode_short(DCID, PN, <<>>, false),
+    Header = iolist_to_binary(HeaderIo),
+    PNOffset = 1 + byte_size(DCID),
+    Protected = ?M:protect_header(HP, Header, Ciphertext, PNOffset),
+    ?assertEqual(?DEP:protect_header(aes_128_gcm, HP, Header, Ciphertext, PNOffset), Protected),
+    Packet = <<Protected/binary, Ciphertext/binary>>,
+    ?assertEqual({ok, Header, 1, PN, Ciphertext}, ?M:unprotect_header(HP, Packet, PNOffset)).
+
+%% =============================================================================
+%% Failure paths: open and unprotect never crash on bad input.
+%% =============================================================================
+
+open_rejects_tampered_payload_test() ->
+    Key = hex(~"000102030405060708090a0b0c0d0e0f"),
+    IV = hex(~"0a0b0c0d0e0f000102030405"),
+    CT = ?M:seal(Key, IV, 7, ~"aad", ~"secret payload over the tag"),
+    Size = byte_size(CT),
+    <<Body:(Size - 1)/binary, Last>> = CT,
+    Tampered = <<Body/binary, (Last bxor 1)>>,
+    ?assertEqual(error, ?M:open(Key, IV, 7, ~"aad", Tampered)).
+
+open_rejects_short_input_test() ->
+    Key = hex(~"000102030405060708090a0b0c0d0e0f"),
+    IV = hex(~"0a0b0c0d0e0f000102030405"),
+    %% Fewer than the 16 tag bytes: cannot hold a tag.
+    ?assertEqual(error, ?M:open(Key, IV, 0, <<>>, <<1, 2, 3>>)).
+
+unprotect_header_rejects_short_packet_test() ->
+    HP = hex(~"33333333333333333333333333333333"),
+    %% Header present but the payload is too short to sample.
+    ?assertEqual({error, sample_too_short}, ?M:unprotect_header(HP, <<16#40, 1, 2, 3>>, 1)),
+    %% Packet shorter than the packet-number offset itself.
+    ?assertEqual({error, sample_too_short}, ?M:unprotect_header(HP, <<1, 2>>, 5)).
+
+%% Uppercase before decoding so the literals are portable across OTP
+%% versions regardless of `binary:decode_hex/1`'s lowercase handling.
+hex(Hex) -> binary:decode_hex(string:uppercase(Hex)).


### PR DESCRIPTION
# Description

Native QUIC packet protection, following RFC 9001: encrypts and decrypts a packet's contents, and hides the packet number and the header flags on the wire. On receive it removes that header masking before reading the packet number, the way the spec requires. These are pure functions with no connection state, so the live QUIC stack keeps working unchanged.

It reproduces the worked example packet published in RFC 9001 byte for byte, and is also checked against the current `quic` dependency across random inputs, with full test coverage.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)