### PR TITLE
Add the native QUIC anti-amplification limit

### DIFF
--- a/src/roadrunner_quic_amp.erl
+++ b/src/roadrunner_quic_amp.erl
@@ -1,0 +1,68 @@
+-module(roadrunner_quic_amp).
+-moduledoc false.
+
+%% Server anti-amplification accounting (RFC 9000 §8.1).
+%%
+%% Before it has validated the client's address, a server MUST NOT send
+%% more than three times the number of bytes it has received, which limits
+%% its use as a packet-amplification reflector. This module is the pure
+%% byte accounting: the connection records received and sent datagram
+%% sizes, asks how much it may still send (or whether a given datagram
+%% fits), and marks the address validated once a Handshake packet from the
+%% client decrypts (proof the client received the server's Initial), which
+%% lifts the limit. Holding back an over-budget datagram until more is
+%% received is the send pipeline's job; this module only does the counting.
+
+-export([new/0, received/2, sent/2, validate/1, budget/1, can_send/2]).
+
+-export_type([t/0]).
+
+%% RFC 9000 §8.1: the pre-validation send cap is three times bytes received.
+-define(FACTOR, 3).
+
+-record(amp, {
+    rx = 0 :: non_neg_integer(),
+    tx = 0 :: non_neg_integer(),
+    validated = false :: boolean()
+}).
+
+-opaque t() :: #amp{}.
+
+-doc "A fresh accounting state: nothing received or sent, address not yet validated.".
+-spec new() -> t().
+new() ->
+    #amp{}.
+
+-doc "Record `Bytes` received from the client; this raises the send budget.".
+-spec received(non_neg_integer(), t()) -> t().
+received(Bytes, #amp{rx = Rx} = Amp) ->
+    Amp#amp{rx = Rx + Bytes}.
+
+-doc "Record `Bytes` sent to the client; this spends the send budget.".
+-spec sent(non_neg_integer(), t()) -> t().
+sent(Bytes, #amp{tx = Tx} = Amp) ->
+    Amp#amp{tx = Tx + Bytes}.
+
+-doc "Mark the client's address validated (RFC 9000 §8.1), lifting the limit.".
+-spec validate(t()) -> t().
+validate(Amp) ->
+    Amp#amp{validated = true}.
+
+-doc """
+Bytes the server may still send: `infinity` once the address is
+validated, otherwise three times the bytes received minus the bytes sent
+(never negative). `infinity` orders above any integer, so a caller can
+cap a datagram with `min(MaxSize, budget(Amp))`.
+""".
+-spec budget(t()) -> non_neg_integer() | infinity.
+budget(#amp{validated = true}) ->
+    infinity;
+budget(#amp{rx = Rx, tx = Tx}) ->
+    max(0, ?FACTOR * Rx - Tx).
+
+-doc "Whether a datagram of `Bytes` fits within the remaining send budget.".
+-spec can_send(non_neg_integer(), t()) -> boolean().
+can_send(_Bytes, #amp{validated = true}) ->
+    true;
+can_send(Bytes, Amp) ->
+    Bytes =< budget(Amp).

--- a/test/property_test/roadrunner_quic_amp_props.erl
+++ b/test/property_test/roadrunner_quic_amp_props.erl
@@ -1,0 +1,46 @@
+-module(roadrunner_quic_amp_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_amp`.
+
+Over a random interleaving of received/sent/validate operations, the
+remaining budget is never negative, and `can_send/2` agrees with
+`budget/1` at every size (including the `infinity` case once the address
+is validated).
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_invariants() ->
+    ?FORALL(
+        Ops,
+        list(op()),
+        begin
+            Amp = lists:foldl(fun apply_op/2, roadrunner_quic_amp:new(), Ops),
+            Budget = roadrunner_quic_amp:budget(Amp),
+            budget_ok(Budget) andalso can_send_agrees(Amp, Budget)
+        end
+    ).
+
+budget_ok(infinity) -> true;
+budget_ok(Budget) -> Budget >= 0.
+
+can_send_agrees(Amp, Budget) ->
+    lists:all(
+        fun(N) ->
+            roadrunner_quic_amp:can_send(N, Amp) =:= fits(N, Budget)
+        end,
+        [0, 1, 100, 1200, 1 bsl 20]
+    ).
+
+fits(_N, infinity) -> true;
+fits(N, Budget) -> N =< Budget.
+
+op() ->
+    oneof([{received, integer(0, 5000)}, {sent, integer(0, 5000)}, validate]).
+
+apply_op({received, N}, Amp) -> roadrunner_quic_amp:received(N, Amp);
+apply_op({sent, N}, Amp) -> roadrunner_quic_amp:sent(N, Amp);
+apply_op(validate, Amp) -> roadrunner_quic_amp:validate(Amp).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -36,7 +36,8 @@ Add a new property:
     quic_varint_encode_matches_dep/1,
     quic_hkdf_matches_dep/1,
     quic_keys_matches_dep/1,
-    quic_aead_matches_dep/1
+    quic_aead_matches_dep/1,
+    quic_amp_invariants/1
 ]).
 
 suite() ->
@@ -63,7 +64,8 @@ all() ->
         quic_varint_encode_matches_dep,
         quic_hkdf_matches_dep,
         quic_keys_matches_dep,
-        quic_aead_matches_dep
+        quic_aead_matches_dep,
+        quic_amp_invariants
     ].
 
 init_per_suite(Config) ->
@@ -189,5 +191,11 @@ quic_keys_matches_dep(Config) ->
 quic_aead_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_aead_props:prop_matches_dep(),
+        Config
+    ).
+
+quic_amp_invariants(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_amp_props:prop_invariants(),
         Config
     ).

--- a/test/roadrunner_quic_amp_tests.erl
+++ b/test/roadrunner_quic_amp_tests.erl
@@ -1,0 +1,50 @@
+-module(roadrunner_quic_amp_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_amp).
+
+%% A fresh state has received nothing, so the 3x cap is zero: a server
+%% must receive the client's Initial before it can send.
+new_starts_blocked_test() ->
+    Amp = ?M:new(),
+    ?assertEqual(0, ?M:budget(Amp)),
+    ?assert(?M:can_send(0, Amp)),
+    ?assertNot(?M:can_send(1, Amp)).
+
+budget_is_three_times_received_test() ->
+    ?assertEqual(300, ?M:budget(?M:received(100, ?M:new()))).
+
+sent_spends_budget_test() ->
+    Amp = ?M:sent(120, ?M:received(100, ?M:new())),
+    ?assertEqual(180, ?M:budget(Amp)).
+
+%% Sending more than 3x received (a padded Initial before the client's
+%% next datagram arrives) floors the budget at zero, never negative.
+budget_never_negative_test() ->
+    Amp = ?M:sent(400, ?M:received(100, ?M:new())),
+    ?assertEqual(0, ?M:budget(Amp)),
+    %% can_send stays consistent with the floored budget: a zero-byte send
+    %% is always allowed, a non-zero one is not.
+    ?assert(?M:can_send(0, Amp)),
+    ?assertNot(?M:can_send(1, Amp)).
+
+can_send_at_and_over_limit_test() ->
+    Amp = ?M:received(100, ?M:new()),
+    ?assert(?M:can_send(300, Amp)),
+    ?assertNot(?M:can_send(301, Amp)),
+    Spent = ?M:sent(300, Amp),
+    ?assert(?M:can_send(0, Spent)),
+    ?assertNot(?M:can_send(1, Spent)).
+
+%% After validation the limit is gone regardless of the byte counters.
+validation_lifts_the_limit_test() ->
+    Amp = ?M:validate(?M:sent(999, ?M:received(1, ?M:new()))),
+    ?assertEqual(infinity, ?M:budget(Amp)),
+    ?assert(?M:can_send(1000000, Amp)).
+
+%% `infinity` orders above any integer, so min/2 caps a datagram size
+%% cleanly whether or not the address is validated.
+budget_caps_with_min_test() ->
+    ?assertEqual(1200, min(1200, ?M:budget(?M:validate(?M:new())))),
+    ?assertEqual(300, min(1200, ?M:budget(?M:received(100, ?M:new())))).


### PR DESCRIPTION
# Description

Native anti-amplification accounting for the QUIC server, following RFC 9000 §8.1: until it has confirmed the client's address, a server must not send more than three times the number of bytes it has received, so it cannot be used to amplify traffic at a spoofed victim. This tracks the bytes received and sent, reports how much may still be sent, and lifts the limit once the address is confirmed. It is pure counting with no connection state, so the live QUIC stack keeps working unchanged.

The two queries it exposes (how much may still be sent, and whether a given datagram fits) always agree, checked both by unit tests and a property over random send/receive orderings, with full test coverage.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)