### PR TITLE
Add the native QUIC ACK tracking

### DIFF
--- a/src/roadrunner_quic_ack.erl
+++ b/src/roadrunner_quic_ack.erl
@@ -1,0 +1,113 @@
+-module(roadrunner_quic_ack).
+-moduledoc false.
+
+%% Received-packet tracking and ACK generation for one packet-number
+%% space (RFC 9000 §13.2). A connection keeps one of these per space
+%% (Initial, Handshake, Application).
+%%
+%% Received packet numbers are held as a list of inclusive `{Start, End}`
+%% ranges, highest first and coalesced, so a long run of packets costs one
+%% range. `to_ack/1` turns that into an ACK frame's range fields (largest
+%% acknowledged, first range, then the gap/range pairs of RFC 9000 §19.3);
+%% the connection adds the ACK delay (from its own clock) and any ECN
+%% counts to assemble the frame. `needs_ack/1` reports whether an
+%% ack-eliciting packet is still awaiting acknowledgement.
+
+-export([new/0, record/3, largest/1, ranges/1, needs_ack/1, mark_ack_sent/1, to_ack/1]).
+
+-export_type([t/0, range/0]).
+
+-type range() :: {Start :: non_neg_integer(), End :: non_neg_integer()}.
+
+-record(ack, {
+    ranges = [] :: [range()],
+    pending = false :: boolean()
+}).
+
+-opaque t() :: #ack{}.
+
+-doc "A fresh ACK state for one packet-number space: nothing received yet.".
+-spec new() -> t().
+new() ->
+    #ack{}.
+
+-doc """
+Record a received packet number. `AckEliciting` says whether the packet
+carried an ack-eliciting frame, which is what later makes `needs_ack/1`
+true.
+""".
+-spec record(non_neg_integer(), boolean(), t()) -> t().
+record(PN, AckEliciting, #ack{ranges = Ranges, pending = Pending} = Ack) ->
+    Ack#ack{ranges = add(PN, Ranges), pending = Pending orelse AckEliciting}.
+
+-doc "The largest packet number received, or `undefined` if none.".
+-spec largest(t()) -> non_neg_integer() | undefined.
+largest(#ack{ranges = []}) -> undefined;
+largest(#ack{ranges = [{_Start, End} | _]}) -> End.
+
+-doc "The received ranges, each an inclusive `{Start, End}`, highest first.".
+-spec ranges(t()) -> [range()].
+ranges(#ack{ranges = Ranges}) ->
+    Ranges.
+
+-doc "Whether an ack-eliciting packet is still awaiting acknowledgement.".
+-spec needs_ack(t()) -> boolean().
+needs_ack(#ack{pending = Pending}) ->
+    Pending.
+
+-doc "Clear the pending flag once an ACK covering the received packets has been sent.".
+-spec mark_ack_sent(t()) -> t().
+mark_ack_sent(Ack) ->
+    Ack#ack{pending = false}.
+
+-doc """
+The ACK frame range fields for the current state, or `none` if nothing
+has been received: `{LargestAcked, FirstAckRange, AckRanges}`, where
+`AckRanges` is the list of `{Gap, Range}` pairs (RFC 9000 §19.3). The
+caller wraps these with an ACK delay and any ECN counts.
+""".
+-spec to_ack(t()) ->
+    {non_neg_integer(), non_neg_integer(), [{non_neg_integer(), non_neg_integer()}]} | none.
+to_ack(#ack{ranges = []}) ->
+    none;
+to_ack(#ack{ranges = [{FirstStart, FirstEnd} | Rest]}) ->
+    {FirstEnd, FirstEnd - FirstStart, gap_ranges(FirstStart, Rest)}.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% Insert a packet number into the high-to-low, coalesced range list
+%% (RFC 9000 §13.2.3 keeps received packets as ranges). Body recursion
+%% descends to the right range; extending a range down can bridge it with
+%% the next one, so that case re-merges.
+-spec add(non_neg_integer(), [range()]) -> [range()].
+add(PN, []) ->
+    [{PN, PN}];
+add(PN, [{_Start, End} | _] = Ranges) when PN > End + 1 ->
+    [{PN, PN} | Ranges];
+add(PN, [{Start, End} | Rest]) when PN =:= End + 1 ->
+    [{Start, PN} | Rest];
+add(PN, [{Start, End} | Rest]) when PN >= Start, PN =< End ->
+    [{Start, End} | Rest];
+add(PN, [{Start, End} | Rest]) when PN =:= Start - 1 ->
+    merge([{PN, End} | Rest]);
+add(PN, [Range | Rest]) ->
+    [Range | add(PN, Rest)].
+
+%% Coalesce the head range with the next when they touch or overlap.
+-spec merge([range()]) -> [range()].
+merge([{S1, E1}, {S2, E2} | Rest]) when E2 + 1 >= S1 ->
+    merge([{S2, max(E1, E2)} | Rest]);
+merge(Ranges) ->
+    Ranges.
+
+%% Encode the lower ranges as `{Gap, Range}` pairs relative to the
+%% previous range's start (RFC 9000 §19.3.1): Gap is the count of missing
+%% packets between ranges minus one, Range the packets in this range minus
+%% one.
+-spec gap_ranges(non_neg_integer(), [range()]) -> [{non_neg_integer(), non_neg_integer()}].
+gap_ranges(_PrevStart, []) ->
+    [];
+gap_ranges(PrevStart, [{Start, End} | Rest]) ->
+    [{PrevStart - End - 2, End - Start} | gap_ranges(Start, Rest)].

--- a/test/property_test/roadrunner_quic_ack_props.erl
+++ b/test/property_test/roadrunner_quic_ack_props.erl
@@ -1,0 +1,45 @@
+-module(roadrunner_quic_ack_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_ack`.
+
+Differential invariant over a random sequence of (packet number,
+ack-eliciting) receptions: the coalesced ranges, the largest received,
+the pending-ACK flag, and the generated ACK frame range fields all match
+the `quic` dep (the oracle).
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_matches_dep() ->
+    ?FORALL(
+        Events,
+        %% A dense packet-number domain so a random sequence routinely
+        %% produces adjacent, duplicate, and gap-bridging numbers, which is
+        %% where the coalescing and gap/range encoding could go wrong.
+        list({integer(0, 30), boolean()}),
+        begin
+            Rr = lists:foldl(fun record_rr/2, roadrunner_quic_ack:new(), Events),
+            Dep = lists:foldl(fun record_dep/2, quic_ack:new(), Events),
+            roadrunner_quic_ack:ranges(Rr) =:= quic_ack:ack_ranges(Dep) andalso
+                roadrunner_quic_ack:largest(Rr) =:= quic_ack:largest_received(Dep) andalso
+                roadrunner_quic_ack:needs_ack(Rr) =:= quic_ack:needs_ack(Dep) andalso
+                to_ack_matches(Rr, Dep)
+        end
+    ).
+
+record_rr({PN, Eliciting}, Acc) -> roadrunner_quic_ack:record(PN, Eliciting, Acc).
+
+record_dep({PN, Eliciting}, Acc) -> quic_ack:record_received(Acc, PN, Eliciting).
+
+%% The dep's generate_ack also carries an ACK delay (a timing value); only
+%% the range fields are compared here.
+to_ack_matches(Rr, Dep) ->
+    case quic_ack:generate_ack(Dep) of
+        {error, no_packets} ->
+            roadrunner_quic_ack:to_ack(Rr) =:= none;
+        {ok, {ack, Largest, _AckDelay, FirstRange, AckRanges}} ->
+            roadrunner_quic_ack:to_ack(Rr) =:= {Largest, FirstRange, AckRanges}
+    end.

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -37,7 +37,8 @@ Add a new property:
     quic_hkdf_matches_dep/1,
     quic_keys_matches_dep/1,
     quic_aead_matches_dep/1,
-    quic_amp_invariants/1
+    quic_amp_invariants/1,
+    quic_ack_matches_dep/1
 ]).
 
 suite() ->
@@ -65,7 +66,8 @@ all() ->
         quic_hkdf_matches_dep,
         quic_keys_matches_dep,
         quic_aead_matches_dep,
-        quic_amp_invariants
+        quic_amp_invariants,
+        quic_ack_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -197,5 +199,11 @@ quic_aead_matches_dep(Config) ->
 quic_amp_invariants(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_amp_props:prop_invariants(),
+        Config
+    ).
+
+quic_ack_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_ack_props:prop_matches_dep(),
         Config
     ).

--- a/test/roadrunner_quic_ack_tests.erl
+++ b/test/roadrunner_quic_ack_tests.erl
@@ -1,0 +1,95 @@
+-module(roadrunner_quic_ack_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_ack).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_ack).
+
+%% =============================================================================
+%% Range tracking: each branch of the insert/merge logic.
+%% =============================================================================
+
+empty_state_test() ->
+    Ack = ?M:new(),
+    ?assertEqual(undefined, ?M:largest(Ack)),
+    ?assertEqual([], ?M:ranges(Ack)),
+    ?assertEqual(none, ?M:to_ack(Ack)),
+    ?assertNot(?M:needs_ack(Ack)).
+
+single_run_coalesces_test() ->
+    Ack = record_all([0, 1, 2, 3], ?M:new()),
+    ?assertEqual([{0, 3}], ?M:ranges(Ack)),
+    ?assertEqual(3, ?M:largest(Ack)),
+    ?assertEqual({3, 3, []}, ?M:to_ack(Ack)).
+
+gap_creates_new_range_test() ->
+    ?assertEqual([{5, 5}, {0, 2}], ?M:ranges(record_all([0, 1, 2, 5], ?M:new()))).
+
+duplicate_is_ignored_test() ->
+    ?assertEqual([{0, 2}], ?M:ranges(record_all([0, 1, 2, 1], ?M:new()))).
+
+extend_down_test() ->
+    %% Recording Start-1 of the only range extends it downward.
+    ?assertEqual([{2, 5}], ?M:ranges(record_all([3, 4, 5, 2], ?M:new()))).
+
+bridge_merges_ranges_test() ->
+    %% Recording the one missing number between two ranges merges them.
+    ?assertEqual([{0, 5}], ?M:ranges(record_all([0, 1, 3, 4, 5, 2], ?M:new()))).
+
+extend_down_without_merge_test() ->
+    %% Extending downward but still short of the next range keeps both.
+    ?assertEqual([{4, 7}, {0, 1}], ?M:ranges(record_all([0, 1, 5, 6, 7, 4], ?M:new()))).
+
+insert_into_lower_range_test() ->
+    %% A number below the highest range descends into the rest of the list.
+    ?assertEqual([{5, 7}, {2, 2}], ?M:ranges(record_all([5, 6, 7, 2], ?M:new()))).
+
+%% =============================================================================
+%% ACK frame range fields (RFC 9000 §19.3 gap/range encoding).
+%% =============================================================================
+
+multi_range_ack_encoding_test() ->
+    %% Received 0,1,2,4,5,7: ranges {7},{4,5},{0,2}; first range 7 (size 0),
+    %% then gap 0/range 1 (4-5), gap 0/range 2 (0-2).
+    Ack = record_all([0, 1, 2, 4, 5, 7], ?M:new()),
+    ?assertEqual([{7, 7}, {4, 5}, {0, 2}], ?M:ranges(Ack)),
+    ?assertEqual({7, 0, [{0, 1}, {0, 2}]}, ?M:to_ack(Ack)).
+
+%% =============================================================================
+%% ACK-eliciting / pending tracking.
+%% =============================================================================
+
+needs_ack_tracks_eliciting_test() ->
+    NonEliciting = ?M:record(0, false, ?M:new()),
+    ?assertNot(?M:needs_ack(NonEliciting)),
+    Eliciting = ?M:record(1, true, NonEliciting),
+    ?assert(?M:needs_ack(Eliciting)),
+    ?assertNot(?M:needs_ack(?M:mark_ack_sent(Eliciting))).
+
+%% =============================================================================
+%% Differential equivalence vs the dep oracle (ranges, largest, ACK fields).
+%% =============================================================================
+
+matches_dep_test() ->
+    Sequences = [
+        [0, 1, 2, 3],
+        [0, 1, 2, 5],
+        [3, 1, 0, 2, 7, 6],
+        [10, 5, 0, 11, 6, 1, 12],
+        [0, 1, 2, 4, 5, 7]
+    ],
+    [
+        begin
+            Rr = record_all(Seq, ?M:new()),
+            Dep = lists:foldl(fun(PN, S) -> ?DEP:record_received(S, PN, true) end, ?DEP:new(), Seq),
+            ?assertEqual(?DEP:ack_ranges(Dep), ?M:ranges(Rr)),
+            ?assertEqual(?DEP:largest_received(Dep), ?M:largest(Rr)),
+            {ok, {ack, Largest, _AckDelay, FirstRange, AckRanges}} = ?DEP:generate_ack(Dep),
+            ?assertEqual({Largest, FirstRange, AckRanges}, ?M:to_ack(Rr))
+        end
+     || Seq <- Sequences
+    ].
+
+record_all(PNs, Ack) ->
+    lists:foldl(fun(PN, Acc) -> ?M:record(PN, true, Acc) end, Ack, PNs).


### PR DESCRIPTION
# Description

Native ACK tracking for the QUIC receiver, following RFC 9000 §13. It records which packets have arrived as compact ranges (a long run of packets costs one range), reports the largest one seen, and produces the range fields for an ACK frame to send back; the connection adds the acknowledgement delay and any ECN counts. It also flags when a packet that must be acknowledged is still waiting. This is pure bookkeeping with no connection state, kept per packet-number space, so the live QUIC stack keeps working unchanged.

Checked against the current `quic` dependency across random arrival orders, with full test coverage.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)