### PR TITLE
Add the native QUIC loss recovery

### DIFF
--- a/src/roadrunner_quic_loss.erl
+++ b/src/roadrunner_quic_loss.erl
@@ -1,0 +1,403 @@
+-module(roadrunner_quic_loss).
+-moduledoc false.
+
+%% Loss detection and RTT estimation for one packet-number space
+%% (RFC 9002 §5-§6). A connection keeps one of these per space.
+%%
+%% The module is pure: the monotonic clock is passed in as `Now`
+%% (milliseconds) on every state transition, so all timing decisions are
+%% deterministic and unit-testable. Sent packets are tracked newest-first
+%% (an O(1) prepend on send); on an ACK they are classified acknowledged,
+%% lost, or still in flight in one pass, the RTT is updated from the
+%% largest acknowledged ack-eliciting packet (RFC 9002 §5), and the rest
+%% are checked against the packet and time loss thresholds (§6.1). The
+%% caller retransmits the data carried by the returned lost packets and
+%% feeds the acknowledged/lost byte counts to congestion control.
+
+-export([
+    new/1,
+    on_packet_sent/6,
+    on_ack_received/3,
+    detect_lost/2,
+    loss_time/1,
+    update_rtt/3,
+    get_pto/1,
+    on_pto_expired/1,
+    smoothed_rtt/1,
+    rtt_var/1,
+    latest_rtt/1,
+    min_rtt/1,
+    has_rtt_sample/1,
+    largest_acked/1,
+    bytes_in_flight/1,
+    pto_count/1
+]).
+
+-export_type([t/0, opts/0]).
+
+%% RFC 9002 §6.1.1: a packet is lost if one numbered at least three higher
+%% has been acknowledged.
+-define(PACKET_THRESHOLD, 3).
+%% RFC 9002 §6.1.2: the time threshold is 9/8 of the larger of the latest
+%% and smoothed RTT (kept as integer arithmetic, matching trunc(1.125*x)).
+-define(TIME_THRESHOLD_NUM, 9).
+-define(TIME_THRESHOLD_DEN, 8).
+%% RFC 9002 §6.1.2 kGranularity (1ms) and §6.2.2 kInitialRtt (333ms).
+-define(GRANULARITY, 1).
+-define(DEFAULT_INITIAL_RTT, 333).
+%% RFC 9000 default max_ack_delay (§18.2), in milliseconds.
+-define(DEFAULT_MAX_ACK_DELAY, 25).
+%% RFC 9000 §18.2 default ack_delay_exponent: a peer's ACK Delay field is
+%% carried in units of 2^exponent microseconds.
+-define(DEFAULT_ACK_DELAY_EXPONENT, 3).
+%% Bound the packet numbers expanded from one received ACK frame, so a
+%% peer cannot make us materialise an enormous range (RFC 9000 §13.2.3).
+-define(MAX_ACK_RANGE, 65536).
+
+-record(sent, {
+    pn :: non_neg_integer(),
+    time_sent :: non_neg_integer(),
+    ack_eliciting :: boolean(),
+    size :: non_neg_integer(),
+    data :: term()
+}).
+
+-record(loss, {
+    %% Sent-but-not-resolved packets, newest first.
+    sent = [] :: [#sent{}],
+    %% RTT estimation (RFC 9002 §5).
+    latest_rtt = 0 :: non_neg_integer(),
+    smoothed_rtt :: non_neg_integer(),
+    rtt_var :: non_neg_integer(),
+    min_rtt = infinity :: non_neg_integer() | infinity,
+    has_sample = false :: boolean(),
+    %% Loss detection.
+    largest_acked = undefined :: non_neg_integer() | undefined,
+    %% Probe timeout (RFC 9002 §6.2).
+    pto_count = 0 :: non_neg_integer(),
+    %% Congestion-controlled bytes outstanding.
+    bytes_in_flight = 0 :: non_neg_integer(),
+    max_ack_delay :: non_neg_integer(),
+    ack_delay_exponent :: non_neg_integer()
+}).
+
+-opaque t() :: #loss{}.
+
+-type opts() :: #{
+    initial_rtt => non_neg_integer(),
+    max_ack_delay => non_neg_integer(),
+    ack_delay_exponent => non_neg_integer()
+}.
+
+%% =============================================================================
+%% State
+%% =============================================================================
+
+-doc """
+A fresh loss-detection state. `initial_rtt` seeds the smoothed RTT until
+the first sample (RFC 9002 §6.2.2, default 333ms); `max_ack_delay` and
+`ack_delay_exponent` are the peer's advertised values (defaults 25ms and
+3), the latter used to decode the ACK Delay field.
+""".
+-spec new(opts()) -> t().
+new(Opts) ->
+    InitialRtt = maps:get(initial_rtt, Opts, ?DEFAULT_INITIAL_RTT),
+    #loss{
+        smoothed_rtt = InitialRtt,
+        rtt_var = InitialRtt div 2,
+        max_ack_delay = maps:get(max_ack_delay, Opts, ?DEFAULT_MAX_ACK_DELAY),
+        ack_delay_exponent = maps:get(ack_delay_exponent, Opts, ?DEFAULT_ACK_DELAY_EXPONENT)
+    }.
+
+%% =============================================================================
+%% Packet tracking
+%% =============================================================================
+
+-doc """
+Record a sent packet. `Data` is an opaque term the caller can retrieve
+from the returned lost packets to retransmit. Ack-eliciting packets add
+to the bytes in flight (RFC 9002 §2); the PTO count is deliberately not
+reset here.
+""".
+-spec on_packet_sent(
+    non_neg_integer(), non_neg_integer(), boolean(), term(), non_neg_integer(), t()
+) ->
+    t().
+on_packet_sent(
+    PN, Size, AckEliciting, Data, Now, #loss{sent = Sent, bytes_in_flight = InFlight} = Loss
+) ->
+    Packet = #sent{
+        pn = PN, time_sent = Now, ack_eliciting = AckEliciting, size = Size, data = Data
+    },
+    Loss#loss{
+        sent = [Packet | Sent],
+        bytes_in_flight = InFlight + ack_eliciting_bytes(AckEliciting, Size)
+    }.
+
+%% =============================================================================
+%% ACK processing
+%% =============================================================================
+
+-doc """
+Process a received ACK frame (RFC 9002 §5-§6). Classifies the tracked
+packets, updates the RTT from the largest acknowledged ack-eliciting
+packet, detects losses among the rest, and returns the new state with the
+acknowledged and lost packets' caller data (the lost data is what to
+retransmit). `{error, ack_range_too_large}` rejects an ACK whose ranges
+would expand past a sane bound.
+""".
+-spec on_ack_received(tuple(), non_neg_integer(), t()) ->
+    {t(), Acked :: [term()], Lost :: [term()]} | {error, ack_range_too_large}.
+on_ack_received(Ack, Now, Loss) ->
+    {LargestAcked, AckDelay, FirstRange, AckRanges} = ack_fields(Ack),
+    case ack_to_ranges(LargestAcked, FirstRange, AckRanges) of
+        {error, _} = Error ->
+            Error;
+        Ranges ->
+            {Acked, Unacked} = classify(Loss#loss.sent, Ranges),
+            Loss1 = maybe_update_rtt(Loss, LargestAcked, Acked, AckDelay, Now),
+            NewLargest = max_largest_acked(Loss#loss.largest_acked, LargestAcked),
+            LossDelay = loss_delay(Loss1),
+            {Lost, Survivors} = split_lost(Unacked, NewLargest, Now, LossDelay),
+            AckedBytes = in_flight_bytes(Acked),
+            LostBytes = in_flight_bytes(Lost),
+            Loss2 = Loss1#loss{
+                sent = Survivors,
+                largest_acked = NewLargest,
+                pto_count = 0,
+                bytes_in_flight = max(0, Loss1#loss.bytes_in_flight - AckedBytes - LostBytes)
+            },
+            {Loss2, datas(Acked), datas(Lost)}
+    end.
+
+%% =============================================================================
+%% Loss detection
+%% =============================================================================
+
+-doc """
+Re-run loss detection when the loss timer fires (RFC 9002 §6.1), without a
+new ACK. Returns the new state and any packets now past the time
+threshold; `{State, []}` when nothing is lost or nothing has been
+acknowledged yet. The returned list is the lost packets' caller data, to
+retransmit.
+""".
+-spec detect_lost(non_neg_integer(), t()) -> {t(), Lost :: [term()]}.
+detect_lost(_Now, #loss{largest_acked = undefined} = Loss) ->
+    {Loss, []};
+detect_lost(Now, #loss{sent = Sent, largest_acked = LargestAcked} = Loss) ->
+    {Lost, Survivors} = split_lost(Sent, LargestAcked, Now, loss_delay(Loss)),
+    Loss1 = Loss#loss{
+        sent = Survivors,
+        bytes_in_flight = max(0, Loss#loss.bytes_in_flight - in_flight_bytes(Lost))
+    },
+    {Loss1, datas(Lost)}.
+
+-doc """
+When the loss timer should next fire: the oldest sent packet's send time
+plus the loss delay, or `undefined` if nothing is outstanding.
+""".
+-spec loss_time(t()) -> non_neg_integer() | undefined.
+loss_time(#loss{sent = []}) ->
+    undefined;
+loss_time(#loss{sent = Sent} = Loss) ->
+    #sent{time_sent = Oldest} = lists:last(Sent),
+    Oldest + loss_delay(Loss).
+
+%% =============================================================================
+%% RTT estimation (RFC 9002 §5)
+%% =============================================================================
+
+-doc """
+Fold a new RTT sample into the estimates (RFC 9002 §5.3). The first sample
+seeds every estimate; later samples adjust for the peer's ACK delay
+(capped at `max_ack_delay`) and update the smoothed RTT and its variance.
+""".
+-spec update_rtt(non_neg_integer(), non_neg_integer(), t()) -> t().
+update_rtt(LatestRtt, _AckDelay, #loss{has_sample = false} = Loss) ->
+    Loss#loss{
+        latest_rtt = LatestRtt,
+        smoothed_rtt = LatestRtt,
+        rtt_var = LatestRtt div 2,
+        min_rtt = LatestRtt,
+        has_sample = true
+    };
+update_rtt(
+    LatestRtt,
+    AckDelay,
+    #loss{smoothed_rtt = SRtt, rtt_var = RttVar, min_rtt = MinRtt, max_ack_delay = MaxAckDelay} =
+        Loss
+) ->
+    NewMinRtt = min(MinRtt, LatestRtt),
+    Adjusted =
+        case LatestRtt > NewMinRtt + AckDelay of
+            true -> LatestRtt - min(AckDelay, MaxAckDelay);
+            false -> LatestRtt
+        end,
+    Loss#loss{
+        latest_rtt = LatestRtt,
+        min_rtt = NewMinRtt,
+        rtt_var = (3 * RttVar + abs(SRtt - Adjusted)) div 4,
+        smoothed_rtt = (7 * SRtt + Adjusted) div 8
+    }.
+
+%% =============================================================================
+%% Probe timeout (RFC 9002 §6.2)
+%% =============================================================================
+
+-doc """
+The probe timeout: `smoothed_rtt + max(4 * rtt_var, granularity) +
+max_ack_delay`, doubled per consecutive PTO (RFC 9002 §6.2.1).
+""".
+-spec get_pto(t()) -> non_neg_integer().
+get_pto(#loss{smoothed_rtt = SRtt, rtt_var = RttVar, max_ack_delay = MaxAckDelay, pto_count = Count}) ->
+    Pto = SRtt + max(4 * RttVar, ?GRANULARITY) + MaxAckDelay,
+    Pto bsl Count.
+
+-doc "Record a PTO expiry, which doubles the next probe timeout.".
+-spec on_pto_expired(t()) -> t().
+on_pto_expired(#loss{pto_count = Count} = Loss) ->
+    Loss#loss{pto_count = Count + 1}.
+
+%% =============================================================================
+%% Queries
+%% =============================================================================
+
+-doc "The smoothed RTT estimate (milliseconds).".
+-spec smoothed_rtt(t()) -> non_neg_integer().
+smoothed_rtt(#loss{smoothed_rtt = SRtt}) -> SRtt.
+
+-doc "The RTT variance estimate (milliseconds).".
+-spec rtt_var(t()) -> non_neg_integer().
+rtt_var(#loss{rtt_var = RttVar}) -> RttVar.
+
+-doc "The most recent RTT sample (milliseconds), `0` before the first sample.".
+-spec latest_rtt(t()) -> non_neg_integer().
+latest_rtt(#loss{latest_rtt = Latest}) -> Latest.
+
+-doc "The minimum RTT observed, or `infinity` before the first sample.".
+-spec min_rtt(t()) -> non_neg_integer() | infinity.
+min_rtt(#loss{min_rtt = Min}) -> Min.
+
+-doc "Whether at least one RTT sample has been taken.".
+-spec has_rtt_sample(t()) -> boolean().
+has_rtt_sample(#loss{has_sample = Has}) -> Has.
+
+-doc "The largest packet number the peer has acknowledged, or `undefined`.".
+-spec largest_acked(t()) -> non_neg_integer() | undefined.
+largest_acked(#loss{largest_acked = Largest}) -> Largest.
+
+-doc "The congestion-controlled bytes currently outstanding.".
+-spec bytes_in_flight(t()) -> non_neg_integer().
+bytes_in_flight(#loss{bytes_in_flight = InFlight}) -> InFlight.
+
+-doc "The consecutive PTO count (RFC 9002 §6.2.1).".
+-spec pto_count(t()) -> non_neg_integer().
+pto_count(#loss{pto_count = Count}) -> Count.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% The B2 ACK frame carries the same fields with or without ECN counts.
+ack_fields({ack, LargestAcked, AckDelay, FirstRange, AckRanges, _Ecn}) ->
+    {LargestAcked, AckDelay, FirstRange, AckRanges};
+ack_fields({ack, LargestAcked, AckDelay, FirstRange, AckRanges}) ->
+    {LargestAcked, AckDelay, FirstRange, AckRanges}.
+
+ack_eliciting_bytes(true, Size) -> Size;
+ack_eliciting_bytes(false, _Size) -> 0.
+
+max_largest_acked(undefined, Largest) -> Largest;
+max_largest_acked(Current, Largest) -> max(Current, Largest).
+
+%% Body recursion (cons on the way out) preserves the newest-first order
+%% in both output lists.
+-spec classify([#sent{}], [{non_neg_integer(), non_neg_integer()}]) -> {[#sent{}], [#sent{}]}.
+classify([], _Ranges) ->
+    {[], []};
+classify([#sent{pn = PN} = Packet | Rest], Ranges) ->
+    {Acked, Unacked} = classify(Rest, Ranges),
+    case pn_in_ranges(PN, Ranges) of
+        true -> {[Packet | Acked], Unacked};
+        false -> {Acked, [Packet | Unacked]}
+    end.
+
+%% Split the unacknowledged packets into newly lost and still-in-flight by
+%% the packet threshold (a packet at least 3 below the largest acked) and
+%% the time threshold (RFC 9002 §6.1). Survivors keep their newest-first
+%% order for the next prepend.
+-spec split_lost([#sent{}], non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
+    {[#sent{}], [#sent{}]}.
+split_lost([], _LargestAcked, _Now, _LossDelay) ->
+    {[], []};
+split_lost([#sent{pn = PN, time_sent = Sent} = Packet | Rest], LargestAcked, Now, LossDelay) ->
+    {Lost, Survivors} = split_lost(Rest, LargestAcked, Now, LossDelay),
+    %% Only packets below the largest acknowledged are loss candidates
+    %% (RFC 9002 §6.1): declaring loss requires a later packet to have been
+    %% acknowledged, so packets above the largest acked stay in flight.
+    case
+        PN < LargestAcked andalso
+            (PN =< LargestAcked - ?PACKET_THRESHOLD orelse Now - Sent > LossDelay)
+    of
+        true -> {[Packet | Lost], Survivors};
+        false -> {Lost, [Packet | Survivors]}
+    end.
+
+%% RFC 9002 §6.1.2: max(time_threshold * max(latest, smoothed), granularity).
+loss_delay(#loss{latest_rtt = Latest, smoothed_rtt = SRtt}) ->
+    Rtt = max(Latest, SRtt),
+    max(?TIME_THRESHOLD_NUM * Rtt div ?TIME_THRESHOLD_DEN, ?GRANULARITY).
+
+%% Update the RTT from the largest acknowledged packet when it is
+%% ack-eliciting (RFC 9002 §5.1); ignore the ACK otherwise. The ACK Delay
+%% field is decoded from its 2^exponent-microsecond units to milliseconds
+%% (RFC 9000 §19.3) before it reaches the millisecond RTT estimator.
+maybe_update_rtt(#loss{ack_delay_exponent = Exp} = Loss, LargestAcked, Acked, AckDelay, Now) ->
+    case lists:keyfind(LargestAcked, #sent.pn, Acked) of
+        #sent{ack_eliciting = true, time_sent = Sent} ->
+            update_rtt(Now - Sent, (AckDelay bsl Exp) div 1000, Loss);
+        _ ->
+            Loss
+    end.
+
+-spec in_flight_bytes([#sent{}]) -> non_neg_integer().
+in_flight_bytes(Packets) ->
+    lists:sum([Size || #sent{ack_eliciting = true, size = Size} <- Packets]).
+
+%% The caller-supplied data of each packet, in order.
+-spec datas([#sent{}]) -> [term()].
+datas(Packets) ->
+    [Data || #sent{data = Data} <- Packets].
+
+%% Expand an ACK frame's largest/first-range/gap-range fields into the
+%% acknowledged {Start, End} ranges (RFC 9000 §19.3), rejecting a range
+%% that would materialise more than ?MAX_ACK_RANGE packet numbers.
+-spec ack_to_ranges(non_neg_integer(), non_neg_integer(), [{non_neg_integer(), non_neg_integer()}]) ->
+    [{non_neg_integer(), non_neg_integer()}] | {error, ack_range_too_large}.
+ack_to_ranges(LargestAcked, FirstRange, AckRanges) when FirstRange =< ?MAX_ACK_RANGE ->
+    Start = LargestAcked - FirstRange,
+    case gap_ranges(Start, AckRanges) of
+        {error, _} = Error -> Error;
+        Rest -> [{Start, LargestAcked} | Rest]
+    end;
+ack_to_ranges(_LargestAcked, _FirstRange, _AckRanges) ->
+    {error, ack_range_too_large}.
+
+gap_ranges(_PrevStart, []) ->
+    [];
+gap_ranges(PrevStart, [{Gap, Range} | Rest]) when Range =< ?MAX_ACK_RANGE ->
+    End = PrevStart - Gap - 2,
+    Start = End - Range,
+    case gap_ranges(Start, Rest) of
+        {error, _} = Error -> Error;
+        Tail -> [{Start, End} | Tail]
+    end;
+gap_ranges(_PrevStart, _Ranges) ->
+    {error, ack_range_too_large}.
+
+pn_in_ranges(_PN, []) ->
+    false;
+pn_in_ranges(PN, [{Start, End} | _]) when PN >= Start, PN =< End ->
+    true;
+pn_in_ranges(PN, [_ | Rest]) ->
+    pn_in_ranges(PN, Rest).

--- a/test/property_test/roadrunner_quic_loss_props.erl
+++ b/test/property_test/roadrunner_quic_loss_props.erl
@@ -1,0 +1,105 @@
+-module(roadrunner_quic_loss_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_loss`.
+
+Two differential invariants against the `quic` dep (the oracle):
+
+- over a random sequence of RTT samples, the smoothed/variance/min/latest
+  estimates and the probe timeout (with backoff) match; and
+- over a random send-then-acknowledge cycle (the ACK built from a random
+  acknowledged set via `roadrunner_quic_ack`), the acknowledged and lost
+  packet sets, the bytes in flight, and the smoothed RTT match.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+%% =============================================================================
+%% RTT estimation + PTO.
+%% =============================================================================
+
+prop_rtt_matches_dep() ->
+    ?FORALL(
+        {InitialRtt, MaxAckDelay, Samples, PtoCount},
+        {integer(1, 1000), integer(0, 100), list({integer(1, 500), integer(0, 100)}), integer(0, 8)},
+        begin
+            Opts = #{initial_rtt => InitialRtt, max_ack_delay => MaxAckDelay},
+            {Rr, Dep} = lists:foldl(
+                fun({Latest, AckDelay}, {R, D}) ->
+                    {roadrunner_quic_loss:update_rtt(Latest, AckDelay, R),
+                        quic_loss:update_rtt(D, Latest, AckDelay)}
+                end,
+                {roadrunner_quic_loss:new(Opts), quic_loss:new(Opts)},
+                Samples
+            ),
+            RrPto = apply_pto(PtoCount, Rr, fun roadrunner_quic_loss:on_pto_expired/1),
+            DepPto = apply_pto(PtoCount, Dep, fun quic_loss:on_pto_expired/1),
+            roadrunner_quic_loss:smoothed_rtt(Rr) =:= quic_loss:smoothed_rtt(Dep) andalso
+                roadrunner_quic_loss:rtt_var(Rr) =:= quic_loss:rtt_var(Dep) andalso
+                roadrunner_quic_loss:min_rtt(Rr) =:= quic_loss:min_rtt(Dep) andalso
+                roadrunner_quic_loss:latest_rtt(Rr) =:= quic_loss:latest_rtt(Dep) andalso
+                roadrunner_quic_loss:get_pto(RrPto) =:= quic_loss:get_pto(DepPto)
+        end
+    ).
+
+apply_pto(0, State, _Expire) -> State;
+apply_pto(N, State, Expire) -> apply_pto(N - 1, Expire(State), Expire).
+
+%% =============================================================================
+%% Send + acknowledge cycle.
+%% =============================================================================
+
+prop_loss_matches_dep() ->
+    ?FORALL(
+        {Eliciting, AckedSet, AckDelay, Now},
+        {non_empty(list(boolean())), list(integer(0, 19)), integer(0, 5000), integer(0, 2000)},
+        begin
+            Opts = #{initial_rtt => 100, max_ack_delay => 25},
+            NumPackets = length(Eliciting),
+            Sent = lists:zip(lists:seq(0, NumPackets - 1), Eliciting),
+            {RrSent, DepSent} = lists:foldl(
+                fun({PN, AckEliciting}, {R, D}) ->
+                    {roadrunner_quic_loss:on_packet_sent(PN, 100, AckEliciting, PN, PN, R),
+                        quic_loss:on_packet_sent(D, PN, 100, AckEliciting, PN, PN)}
+                end,
+                {roadrunner_quic_loss:new(Opts), quic_loss:new(Opts)},
+                Sent
+            ),
+            Acked = lists:usort([PN || PN <- AckedSet, PN < NumPackets]),
+            case build_ack(Acked) of
+                none ->
+                    true;
+                {Largest, FirstRange, AckRanges} ->
+                    Ack = {ack, Largest, AckDelay, FirstRange, AckRanges},
+                    {RrState, RrAcked, RrLost} = roadrunner_quic_loss:on_ack_received(Ack, Now, RrSent),
+                    {DepState, DepAckedL, DepLostL, _Meta} = quic_loss:on_ack_received(
+                        DepSent, Ack, Now
+                    ),
+                    lists:sort(RrAcked) =:= lists:sort(pns(DepAckedL)) andalso
+                        lists:sort(RrLost) =:= lists:sort(pns(DepLostL)) andalso
+                        roadrunner_quic_loss:bytes_in_flight(RrState) =:=
+                            quic_loss:bytes_in_flight(DepState) andalso
+                        roadrunner_quic_loss:smoothed_rtt(RrState) =:=
+                            quic_loss:smoothed_rtt(DepState)
+            end
+        end
+    ).
+
+%% Build a valid ACK frame's range fields from a set of acknowledged
+%% packet numbers, reusing the receive-side ACK generator.
+build_ack([]) ->
+    none;
+build_ack(PNs) ->
+    Ack = lists:foldl(
+        fun(PN, Acc) -> roadrunner_quic_ack:record(PN, true, Acc) end,
+        roadrunner_quic_ack:new(),
+        PNs
+    ),
+    roadrunner_quic_ack:to_ack(Ack).
+
+%% The dep stores each sent packet as a record whose first field is the
+%% packet number.
+pns(SentPackets) ->
+    [element(2, P) || P <- SentPackets].

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -38,7 +38,9 @@ Add a new property:
     quic_keys_matches_dep/1,
     quic_aead_matches_dep/1,
     quic_amp_invariants/1,
-    quic_ack_matches_dep/1
+    quic_ack_matches_dep/1,
+    quic_loss_rtt_matches_dep/1,
+    quic_loss_matches_dep/1
 ]).
 
 suite() ->
@@ -67,7 +69,9 @@ all() ->
         quic_keys_matches_dep,
         quic_aead_matches_dep,
         quic_amp_invariants,
-        quic_ack_matches_dep
+        quic_ack_matches_dep,
+        quic_loss_rtt_matches_dep,
+        quic_loss_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -205,5 +209,17 @@ quic_amp_invariants(Config) ->
 quic_ack_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_ack_props:prop_matches_dep(),
+        Config
+    ).
+
+quic_loss_rtt_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_loss_props:prop_rtt_matches_dep(),
+        Config
+    ).
+
+quic_loss_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_loss_props:prop_loss_matches_dep(),
         Config
     ).

--- a/test/roadrunner_quic_loss_tests.erl
+++ b/test/roadrunner_quic_loss_tests.erl
@@ -1,0 +1,193 @@
+-module(roadrunner_quic_loss_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_loss).
+
+%% =============================================================================
+%% State + queries.
+%% =============================================================================
+
+new_defaults_test() ->
+    Loss = ?M:new(#{}),
+    ?assertEqual(333, ?M:smoothed_rtt(Loss)),
+    ?assertEqual(166, ?M:rtt_var(Loss)),
+    ?assertEqual(infinity, ?M:min_rtt(Loss)),
+    ?assertEqual(0, ?M:latest_rtt(Loss)),
+    ?assertNot(?M:has_rtt_sample(Loss)),
+    ?assertEqual(undefined, ?M:largest_acked(Loss)),
+    ?assertEqual(0, ?M:bytes_in_flight(Loss)),
+    ?assertEqual(0, ?M:pto_count(Loss)).
+
+%% =============================================================================
+%% Packet tracking: ack-eliciting packets count toward bytes in flight.
+%% =============================================================================
+
+bytes_in_flight_counts_ack_eliciting_test() ->
+    Loss0 = ?M:new(#{}),
+    Loss1 = ?M:on_packet_sent(0, 1200, true, d0, 0, Loss0),
+    ?assertEqual(1200, ?M:bytes_in_flight(Loss1)),
+    %% A non-ack-eliciting packet (e.g. ACK-only) does not add.
+    Loss2 = ?M:on_packet_sent(1, 40, false, d1, 1, Loss1),
+    ?assertEqual(1200, ?M:bytes_in_flight(Loss2)).
+
+%% =============================================================================
+%% RTT estimation (RFC 9002 §5.3).
+%% =============================================================================
+
+update_rtt_first_sample_seeds_estimates_test() ->
+    Loss = ?M:update_rtt(50, 5, ?M:new(#{})),
+    ?assertEqual(50, ?M:smoothed_rtt(Loss)),
+    ?assertEqual(25, ?M:rtt_var(Loss)),
+    ?assertEqual(50, ?M:min_rtt(Loss)),
+    ?assertEqual(50, ?M:latest_rtt(Loss)),
+    ?assert(?M:has_rtt_sample(Loss)).
+
+update_rtt_subsequent_sample_test() ->
+    Base = ?M:update_rtt(50, 5, ?M:new(#{})),
+    %% Latest (40) within min + ack delay: no ack-delay adjustment.
+    NoAdjust = ?M:update_rtt(40, 2, Base),
+    ?assertEqual(40, ?M:min_rtt(NoAdjust)),
+    ?assert(?M:smoothed_rtt(NoAdjust) < 50),
+    %% Latest (70) beyond min + ack delay: subtract the (capped) ack delay.
+    Adjust = ?M:update_rtt(70, 10, Base),
+    ?assertEqual(50, ?M:min_rtt(Adjust)),
+    ?assert(?M:smoothed_rtt(Adjust) > 50).
+
+%% =============================================================================
+%% Probe timeout (RFC 9002 §6.2).
+%% =============================================================================
+
+pto_with_backoff_test() ->
+    Loss = ?M:new(#{initial_rtt => 100}),
+    %% 100 + max(4*50, 1) + 25 = 325.
+    ?assertEqual(325, ?M:get_pto(Loss)),
+    ?assertEqual(650, ?M:get_pto(?M:on_pto_expired(Loss))),
+    ?assertEqual(1, ?M:pto_count(?M:on_pto_expired(Loss))).
+
+%% =============================================================================
+%% ACK processing + loss detection (RFC 9002 §5-§6).
+%% =============================================================================
+
+%% Send 0..9 at times 0..9; ACK only packet 9 at time 20. Packet 9 is
+%% acknowledged, the RTT sample is 11; packets 0..6 fall to the packet
+%% threshold and 7 to the time threshold, leaving 8 in flight.
+on_ack_received_acks_and_detects_loss_test() ->
+    Loss = send_run(0, 9, ?M:new(#{})),
+    ?assertEqual(1000, ?M:bytes_in_flight(Loss)),
+    {Loss1, Acked, Lost} = ?M:on_ack_received({ack, 9, 0, 0, []}, 20, Loss),
+    ?assertEqual([9], Acked),
+    ?assertEqual([0, 1, 2, 3, 4, 5, 6, 7], lists:sort(Lost)),
+    ?assertEqual(100, ?M:bytes_in_flight(Loss1)),
+    ?assertEqual(11, ?M:smoothed_rtt(Loss1)),
+    ?assertEqual(9, ?M:largest_acked(Loss1)).
+
+%% A gap range acknowledges two disjoint runs.
+on_ack_received_gap_range_test() ->
+    Loss = send_run(0, 9, ?M:new(#{})),
+    %% Largest 9, first range [9,9], gap 0 / range 0 -> [7,7].
+    {_Loss1, Acked, _Lost} = ?M:on_ack_received({ack, 9, 0, 0, [{0, 0}]}, 20, Loss),
+    ?assertEqual([7, 9], lists:sort(Acked)).
+
+%% The ECN variant carries the same fields plus counts.
+on_ack_received_ecn_variant_test() ->
+    Loss = send_run(0, 9, ?M:new(#{})),
+    {_Loss1, Acked, _Lost} = ?M:on_ack_received({ack, 9, 0, 0, [], {1, 2, 3}}, 20, Loss),
+    ?assertEqual([9], Acked).
+
+%% A non-ack-eliciting largest acked, and a largest we never sent, both
+%% leave the RTT untouched (no sample taken).
+on_ack_received_no_rtt_sample_test() ->
+    NonElic = ?M:on_packet_sent(0, 40, false, d0, 5, ?M:new(#{})),
+    {Loss1, [d0], []} = ?M:on_ack_received({ack, 0, 0, 0, []}, 20, NonElic),
+    ?assertNot(?M:has_rtt_sample(Loss1)),
+    %% Largest acked 99 was never sent: nothing acked, no RTT sample.
+    Sent = ?M:on_packet_sent(0, 100, true, d0, 0, ?M:new(#{})),
+    {Loss2, [], _} = ?M:on_ack_received({ack, 99, 0, 0, []}, 20, Sent),
+    ?assertNot(?M:has_rtt_sample(Loss2)).
+
+%% Packets numbered above the largest acknowledged must stay in flight,
+%% even when old: loss requires a higher-numbered packet to be acked
+%% (RFC 9002 §6.1). Here the largest acked (1) is not ack-eliciting, so no
+%% RTT sample is taken and the loss delay stays small, yet 2..5 survive
+%% while 0 (below the largest, long past) is lost.
+on_ack_received_keeps_above_largest_test() ->
+    L0 = ?M:on_packet_sent(0, 100, true, d0, 0, ?M:new(#{})),
+    L1 = ?M:on_packet_sent(1, 100, false, d1, 1, L0),
+    L2 = lists:foldl(
+        fun(PN, Acc) -> ?M:on_packet_sent(PN, 100, true, PN, PN, Acc) end, L1, [2, 3, 4, 5]
+    ),
+    {Loss, Acked, Lost} = ?M:on_ack_received({ack, 1, 0, 0, []}, 500, L2),
+    ?assertEqual([d1], Acked),
+    ?assertEqual([d0], Lost),
+    ?assertEqual(400, ?M:bytes_in_flight(Loss)).
+
+%% The ACK Delay field is in 2^ack_delay_exponent microsecond units
+%% (RFC 9000 §19.3) and must be decoded to milliseconds. With a 50ms
+%% minimum and a 150ms sample, the decoded delay (8000 -> 64ms) triggers
+%% the ack-delay adjustment; the raw value (8000) never would.
+on_ack_received_decodes_ack_delay_test() ->
+    Opts = #{initial_rtt => 100, max_ack_delay => 1000},
+    L0 = ?M:on_packet_sent(0, 100, true, d0, 0, ?M:new(Opts)),
+    {L1, _, _} = ?M:on_ack_received({ack, 0, 0, 0, []}, 50, L0),
+    L2 = ?M:on_packet_sent(1, 100, true, d1, 100, L1),
+    {L3, _, _} = ?M:on_ack_received({ack, 1, 8000, 0, []}, 250, L2),
+    ?assertEqual(54, ?M:smoothed_rtt(L3)).
+
+%% The largest acked carries across ACKs (kept as the maximum).
+largest_acked_is_monotonic_test() ->
+    Loss = send_run(0, 9, ?M:new(#{})),
+    {Loss1, _, _} = ?M:on_ack_received({ack, 5, 0, 0, []}, 20, Loss),
+    ?assertEqual(5, ?M:largest_acked(Loss1)),
+    {Loss2, _, _} = ?M:on_ack_received({ack, 3, 0, 0, []}, 21, Loss1),
+    ?assertEqual(5, ?M:largest_acked(Loss2)).
+
+%% A malicious ACK whose ranges would expand hugely is rejected.
+on_ack_received_rejects_oversized_range_test() ->
+    Loss = send_run(0, 9, ?M:new(#{})),
+    %% Oversized first range; an oversized first gap range; and an
+    %% oversized gap range deeper in the list (which propagates the error
+    %% back up through the range expansion).
+    ?assertEqual(
+        {error, ack_range_too_large},
+        ?M:on_ack_received({ack, 9, 0, 16#FFFFFFFF, []}, 20, Loss)
+    ),
+    ?assertEqual(
+        {error, ack_range_too_large},
+        ?M:on_ack_received({ack, 9, 0, 0, [{0, 16#FFFFFFFF}]}, 20, Loss)
+    ),
+    ?assertEqual(
+        {error, ack_range_too_large},
+        ?M:on_ack_received({ack, 9, 0, 0, [{0, 0}, {0, 16#FFFFFFFF}]}, 20, Loss)
+    ).
+
+%% =============================================================================
+%% Timer-driven loss detection + the loss timer.
+%% =============================================================================
+
+detect_lost_test() ->
+    %% Nothing acknowledged yet: no loss decision possible.
+    Loss0 = send_run(0, 4, ?M:new(#{})),
+    ?assertEqual({Loss0, []}, ?M:detect_lost(100, Loss0)),
+    %% ACK packet 4 at time 100: the RTT sample (96) makes the loss delay
+    %% large enough that 2 and 3 survive the ACK (0 and 1 fall to the
+    %% packet threshold). A much later timer pass then declares 2 and 3
+    %% lost by the time threshold.
+    {Loss1, _, _} = ?M:on_ack_received({ack, 4, 0, 0, []}, 100, Loss0),
+    {_Loss2, Lost} = ?M:detect_lost(10000, Loss1),
+    ?assertEqual([2, 3], lists:sort(Lost)).
+
+loss_time_test() ->
+    ?assertEqual(undefined, ?M:loss_time(?M:new(#{}))),
+    %% First sample sets srtt; oldest packet sent at 0, loss delay 9*srtt/8.
+    Loss = ?M:update_rtt(40, 0, ?M:on_packet_sent(0, 100, true, d0, 0, ?M:new(#{}))),
+    ?assertEqual(0 + (9 * 40 div 8), ?M:loss_time(Loss)).
+
+%% Send packets PN First..Last, each 100 bytes ack-eliciting, sent at
+%% time = PN, carrying their own number as the retransmit data.
+send_run(First, Last, Loss) ->
+    lists:foldl(
+        fun(PN, Acc) -> ?M:on_packet_sent(PN, 100, true, PN, PN, Acc) end,
+        Loss,
+        lists:seq(First, Last)
+    ).


### PR DESCRIPTION
# Description

Native loss recovery for QUIC, following RFC 9002: it estimates the round-trip time from acknowledgements, works out the probe timeout, and decides which sent packets are lost (a packet is lost once a later one is acknowledged or it has been outstanding too long). It tracks what is in flight per packet-number space and reports the acknowledged and lost data so the connection can retransmit and feed congestion control. It is pure: the clock is passed in, so every timing decision is deterministic and testable.

Checked against the current `quic` dependency over random send/acknowledge sequences and round-trip samples, with full test coverage.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)