### PR TITLE
Add the native QUIC congestion control

### DIFF
--- a/src/roadrunner_quic_cc_newreno.erl
+++ b/src/roadrunner_quic_cc_newreno.erl
@@ -1,0 +1,105 @@
+-module(roadrunner_quic_cc_newreno).
+-moduledoc false.
+
+%% NewReno congestion control (RFC 9002 §7), pure.
+%%
+%% Tracks the congestion window and slow-start threshold for one
+%% connection and decides how much may be in flight. In slow start
+%% (`cwnd < ssthresh`) the window grows by the acknowledged bytes; in
+%% congestion avoidance it grows by about one maximum datagram per window.
+%% A loss starts a congestion recovery period: the window halves (floored
+%% at the minimum) and further losses from packets sent during that period
+%% are ignored, so one round trip of loss reduces the window once
+%% (§7.3.2). The clock is passed in, so every decision is deterministic.
+%%
+%% The bytes in flight live in `roadrunner_quic_loss`; `can_send/2` takes
+%% that count rather than tracking a second copy.
+
+-export([
+    new/0,
+    on_packets_acked/3,
+    on_congestion_event/3,
+    can_send/2,
+    cwnd/1,
+    ssthresh/1,
+    in_slow_start/1
+]).
+
+-export_type([t/0]).
+
+%% RFC 9000 §14: the QUIC v1 fixed datagram size this server uses.
+-define(MAX_DATAGRAM_SIZE, 1200).
+%% RFC 9002 §7.2 initial window: min(10*MSS, max(2*MSS, 14720)) = 12000.
+-define(INITIAL_WINDOW, 12000).
+%% RFC 9002 §7.2 minimum window: 2 * MSS.
+-define(MINIMUM_WINDOW, 2400).
+
+-record(cc, {
+    cwnd = ?INITIAL_WINDOW :: non_neg_integer(),
+    ssthresh = infinity :: non_neg_integer() | infinity,
+    %% Time of the latest congestion event; a packet sent at or before it
+    %% is "in recovery" (RFC 9002 §7.3.2).
+    recovery_start = undefined :: non_neg_integer() | undefined
+}).
+
+-opaque t() :: #cc{}.
+
+-doc "A fresh congestion-control state: the RFC 9002 §7.2 initial window, no threshold yet.".
+-spec new() -> t().
+new() ->
+    #cc{}.
+
+-doc """
+Grow the window for acknowledged bytes (RFC 9002 §7.3.1).
+`LargestAckedSentTime` is the send time of the largest acknowledged
+packet: while it falls within the current recovery period the window is
+held, otherwise it grows by the acknowledged bytes in slow start or by
+about one datagram per window in congestion avoidance.
+""".
+-spec on_packets_acked(non_neg_integer(), non_neg_integer(), t()) -> t().
+on_packets_acked(_AckedBytes, LargestAckedSentTime, #cc{recovery_start = Start} = Cc) when
+    Start =/= undefined, LargestAckedSentTime =< Start
+->
+    Cc;
+on_packets_acked(AckedBytes, _LargestAckedSentTime, #cc{cwnd = Cwnd, ssthresh = SsThresh} = Cc) ->
+    NewCwnd =
+        case Cwnd < SsThresh of
+            true -> Cwnd + AckedBytes;
+            false -> Cwnd + ?MAX_DATAGRAM_SIZE * AckedBytes div Cwnd
+        end,
+    Cc#cc{cwnd = NewCwnd}.
+
+-doc """
+Enter congestion recovery for a lost packet sent at `SentTime` (RFC 9002
+§7.3.2): if it was sent after the current recovery period started, halve
+the window (floored at the minimum) and begin a new recovery period at
+`Now`. A loss from a packet already within the period is ignored.
+""".
+-spec on_congestion_event(non_neg_integer(), non_neg_integer(), t()) -> t().
+on_congestion_event(SentTime, Now, #cc{cwnd = Cwnd, recovery_start = Start} = Cc) when
+    Start =:= undefined; SentTime > Start
+->
+    SsThresh = Cwnd div 2,
+    Cc#cc{ssthresh = SsThresh, cwnd = max(SsThresh, ?MINIMUM_WINDOW), recovery_start = Now};
+on_congestion_event(_SentTime, _Now, Cc) ->
+    Cc.
+
+-doc "Whether more bytes may be sent: the bytes in flight are below the window.".
+-spec can_send(non_neg_integer(), t()) -> boolean().
+can_send(BytesInFlight, #cc{cwnd = Cwnd}) ->
+    BytesInFlight < Cwnd.
+
+-doc "The congestion window in bytes.".
+-spec cwnd(t()) -> non_neg_integer().
+cwnd(#cc{cwnd = Cwnd}) ->
+    Cwnd.
+
+-doc "The slow-start threshold in bytes, or `infinity` before the first loss.".
+-spec ssthresh(t()) -> non_neg_integer() | infinity.
+ssthresh(#cc{ssthresh = SsThresh}) ->
+    SsThresh.
+
+-doc "Whether the window is still in slow start (below the threshold).".
+-spec in_slow_start(t()) -> boolean().
+in_slow_start(#cc{cwnd = Cwnd, ssthresh = SsThresh}) ->
+    Cwnd < SsThresh.

--- a/test/property_test/roadrunner_quic_cc_newreno_props.erl
+++ b/test/property_test/roadrunner_quic_cc_newreno_props.erl
@@ -1,0 +1,49 @@
+-module(roadrunner_quic_cc_newreno_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_cc_newreno`.
+
+Over a random sequence of acknowledgements and congestion events, driven
+by a monotonic clock so each event lands after the previous one (so a
+congestion event is a genuine reduction, not a deduplicated no-op): the
+congestion window never drops below the minimum (2 * max_datagram_size,
+RFC 9002 §7.2), an acknowledgement never shrinks it, and a congestion
+event never grows it.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+%% RFC 9002 §7.2 minimum window for a 1200-byte datagram.
+-define(MINIMUM_WINDOW, 2400).
+
+prop_cwnd_never_below_minimum() ->
+    ?FORALL(
+        Ops,
+        list(op()),
+        check(Ops, 0, roadrunner_quic_cc_newreno:new())
+    ).
+
+%% A monotonic clock (one tick per op) drives every event "now", so a
+%% congestion event always sees SentTime past the prior recovery start and
+%% genuinely halves the window, exercising the floor under repeated loss.
+check([], _Clock, _Cc) ->
+    true;
+check([Op | Rest], Clock, Cc) ->
+    Before = roadrunner_quic_cc_newreno:cwnd(Cc),
+    Next = apply_op(Op, Clock, Cc),
+    After = roadrunner_quic_cc_newreno:cwnd(Next),
+    After >= ?MINIMUM_WINDOW andalso direction_ok(Op, Before, After) andalso
+        check(Rest, Clock + 1, Next).
+
+direction_ok({acked, _}, Before, After) -> After >= Before;
+direction_ok(congestion, Before, After) -> After =< Before.
+
+op() ->
+    oneof([{acked, integer(0, 5000)}, congestion]).
+
+apply_op({acked, AckedBytes}, Clock, Cc) ->
+    roadrunner_quic_cc_newreno:on_packets_acked(AckedBytes, Clock, Cc);
+apply_op(congestion, Clock, Cc) ->
+    roadrunner_quic_cc_newreno:on_congestion_event(Clock, Clock, Cc).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -40,7 +40,8 @@ Add a new property:
     quic_amp_invariants/1,
     quic_ack_matches_dep/1,
     quic_loss_rtt_matches_dep/1,
-    quic_loss_matches_dep/1
+    quic_loss_matches_dep/1,
+    quic_cc_newreno_invariants/1
 ]).
 
 suite() ->
@@ -71,7 +72,8 @@ all() ->
         quic_amp_invariants,
         quic_ack_matches_dep,
         quic_loss_rtt_matches_dep,
-        quic_loss_matches_dep
+        quic_loss_matches_dep,
+        quic_cc_newreno_invariants
     ].
 
 init_per_suite(Config) ->
@@ -221,5 +223,11 @@ quic_loss_rtt_matches_dep(Config) ->
 quic_loss_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_loss_props:prop_loss_matches_dep(),
+        Config
+    ).
+
+quic_cc_newreno_invariants(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_cc_newreno_props:prop_cwnd_never_below_minimum(),
         Config
     ).

--- a/test/roadrunner_quic_cc_newreno_tests.erl
+++ b/test/roadrunner_quic_cc_newreno_tests.erl
@@ -1,0 +1,69 @@
+-module(roadrunner_quic_cc_newreno_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_cc_newreno).
+
+%% =============================================================================
+%% Initial state (RFC 9002 §7.2).
+%% =============================================================================
+
+new_test() ->
+    Cc = ?M:new(),
+    ?assertEqual(12000, ?M:cwnd(Cc)),
+    ?assertEqual(infinity, ?M:ssthresh(Cc)),
+    ?assert(?M:in_slow_start(Cc)),
+    ?assert(?M:can_send(0, Cc)),
+    ?assert(?M:can_send(11999, Cc)),
+    ?assertNot(?M:can_send(12000, Cc)).
+
+%% =============================================================================
+%% Window growth (RFC 9002 §7.3.1).
+%% =============================================================================
+
+slow_start_grows_by_acked_bytes_test() ->
+    Cc = ?M:on_packets_acked(1200, 0, ?M:new()),
+    ?assertEqual(13200, ?M:cwnd(Cc)),
+    ?assert(?M:in_slow_start(Cc)).
+
+congestion_avoidance_grows_by_one_datagram_per_window_test() ->
+    %% After a loss the window leaves slow start; growth is
+    %% max_datagram_size * acked div cwnd = 1200 * 1200 div 6600 = 218.
+    AfterLoss = ?M:on_congestion_event(5, 100, ?M:on_packets_acked(1200, 0, ?M:new())),
+    ?assertEqual(6600, ?M:cwnd(AfterLoss)),
+    ?assertNot(?M:in_slow_start(AfterLoss)),
+    Grown = ?M:on_packets_acked(1200, 200, AfterLoss),
+    ?assertEqual(6818, ?M:cwnd(Grown)).
+
+%% =============================================================================
+%% Congestion recovery (RFC 9002 §7.3.2).
+%% =============================================================================
+
+congestion_event_halves_window_test() ->
+    Cc = ?M:on_congestion_event(5, 100, ?M:on_packets_acked(1200, 0, ?M:new())),
+    ?assertEqual(6600, ?M:cwnd(Cc)),
+    ?assertEqual(6600, ?M:ssthresh(Cc)).
+
+%% A second loss from a packet sent within the recovery period is ignored;
+%% one sent after it starts a new reduction.
+recovery_period_deduplicates_loss_test() ->
+    Cc = ?M:on_congestion_event(5, 100, ?M:on_packets_acked(1200, 0, ?M:new())),
+    Same = ?M:on_congestion_event(50, 200, Cc),
+    ?assertEqual(6600, ?M:cwnd(Same)),
+    Newer = ?M:on_congestion_event(150, 200, Cc),
+    ?assertEqual(3300, ?M:cwnd(Newer)).
+
+%% The window is held while the largest acked was sent during recovery.
+no_growth_during_recovery_test() ->
+    Cc = ?M:on_congestion_event(5, 100, ?M:on_packets_acked(1200, 0, ?M:new())),
+    Held = ?M:on_packets_acked(1200, 50, Cc),
+    ?assertEqual(6600, ?M:cwnd(Held)).
+
+%% Repeated losses floor the window at the minimum (2 * max_datagram_size).
+minimum_window_floor_test() ->
+    Cc0 = ?M:new(),
+    Cc1 = ?M:on_congestion_event(10, 10, Cc0),
+    Cc2 = ?M:on_congestion_event(20, 20, Cc1),
+    Cc3 = ?M:on_congestion_event(30, 30, Cc2),
+    ?assertEqual(1500, ?M:ssthresh(Cc3)),
+    ?assertEqual(2400, ?M:cwnd(Cc3)).


### PR DESCRIPTION
# Description

Native congestion control for QUIC, the NewReno algorithm from RFC 9002. It keeps a congestion window that grows quickly while ramping up and gently once it settles, and on packet loss it halves the window and holds steady for a round trip so a single burst of loss is counted once. The window never falls below a small floor. It is pure: the clock is passed in, and the bytes in flight come from the loss-recovery module, so this module just decides how large the window may be and whether there is room to send.

It follows the standard RFC values and is checked against the RFC algorithm with unit tests and a property that drives the window down to its floor over random loss, with full test coverage.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)