### PR TITLE
Add the native QUIC flow control

### DIFF
--- a/src/roadrunner_quic_flow.erl
+++ b/src/roadrunner_quic_flow.erl
@@ -1,0 +1,161 @@
+-module(roadrunner_quic_flow).
+-moduledoc false.
+
+%% QUIC flow control for one window (RFC 9000 §4), connection-level or
+%% per-stream. The two are structurally identical (MAX_DATA vs
+%% MAX_STREAM_DATA), so a connection keeps one of these for the connection
+%% and one per stream.
+%%
+%% Send side: bytes sent are tracked against the peer's advertised limit;
+%% sending past it is refused and surfaced as blocked (the connection then
+%% sends DATA_BLOCKED), and a received MAX_DATA frame raises the limit.
+%% Receive side: bytes received are tracked against our advertised limit,
+%% an overrun is rejected as a flow-control error (§4.1), and once enough
+%% of the window has been consumed a fresh limit is granted so the peer is
+%% not stalled. Pure: the connection sends the frames and feeds the byte
+%% counts back in.
+
+-export([
+    new/1,
+    can_send/2,
+    on_data_sent/2,
+    on_max_data_received/2,
+    send_blocked/1,
+    on_data_received/2,
+    should_send_max_data/1,
+    grant_max_data/1,
+    send_window/1,
+    recv_window/1,
+    bytes_sent/1,
+    bytes_received/1
+]).
+
+-export_type([t/0, opts/0]).
+
+%% A reasonable default window when an option is omitted (RFC 9000 §4 sets
+%% no value; this matches the transport-parameter default used elsewhere).
+-define(DEFAULT_INITIAL_MAX_DATA, 786432).
+%% Grant a new limit once more than a quarter of the window has been
+%% consumed since the last grant (RFC 9000 §4.1 leaves the fraction to the
+%% implementation), keeping the peer in credit under sustained transfer.
+-define(REFILL_NUM, 3).
+-define(REFILL_DEN, 4).
+
+-record(flow, {
+    %% Send side: limited by the peer's MAX_DATA.
+    bytes_sent = 0 :: non_neg_integer(),
+    send_max :: non_neg_integer(),
+    send_blocked = false :: boolean(),
+    %% Receive side: our advertised limit on the peer.
+    bytes_received = 0 :: non_neg_integer(),
+    recv_max :: non_neg_integer(),
+    %% The window size granted each refill.
+    initial_max :: non_neg_integer()
+}).
+
+-opaque t() :: #flow{}.
+
+-type opts() :: #{
+    initial_max_data => non_neg_integer(),
+    peer_initial_max_data => non_neg_integer()
+}.
+
+%% =============================================================================
+%% State
+%% =============================================================================
+
+-doc """
+A fresh flow-control window. `initial_max_data` is the limit we advertise
+to the peer (our receive window); `peer_initial_max_data` is the peer's
+advertised limit on us (our send window).
+""".
+-spec new(opts()) -> t().
+new(Opts) ->
+    Initial = maps:get(initial_max_data, Opts, ?DEFAULT_INITIAL_MAX_DATA),
+    Peer = maps:get(peer_initial_max_data, Opts, ?DEFAULT_INITIAL_MAX_DATA),
+    #flow{send_max = Peer, recv_max = Initial, initial_max = Initial}.
+
+%% =============================================================================
+%% Send side
+%% =============================================================================
+
+-doc "Whether `Size` more bytes fit within the peer's current send limit.".
+-spec can_send(non_neg_integer(), t()) -> boolean().
+can_send(Size, #flow{bytes_sent = Sent, send_max = Max}) ->
+    Sent + Size =< Max.
+
+-doc """
+Record `Size` bytes sent. Returns `blocked` once the send limit is
+reached (the connection then sends DATA_BLOCKED), otherwise `ok`.
+""".
+-spec on_data_sent(non_neg_integer(), t()) -> {ok | blocked, t()}.
+on_data_sent(Size, #flow{bytes_sent = Sent, send_max = Max} = Flow) ->
+    NewSent = Sent + Size,
+    case NewSent >= Max of
+        true -> {blocked, Flow#flow{bytes_sent = NewSent, send_blocked = true}};
+        false -> {ok, Flow#flow{bytes_sent = NewSent, send_blocked = false}}
+    end.
+
+-doc "Raise the send limit from a received MAX_DATA frame (limits only increase).".
+-spec on_max_data_received(non_neg_integer(), t()) -> t().
+on_max_data_received(NewMax, #flow{send_max = OldMax} = Flow) ->
+    Flow#flow{send_max = max(OldMax, NewMax), send_blocked = false}.
+
+-doc "Whether sending is currently blocked by the peer's limit.".
+-spec send_blocked(t()) -> boolean().
+send_blocked(#flow{send_blocked = Blocked}) ->
+    Blocked.
+
+%% =============================================================================
+%% Receive side
+%% =============================================================================
+
+-doc """
+Record `Size` bytes received, or reject them as `flow_control_error`
+(RFC 9000 §4.1) if they exceed the limit we advertised.
+""".
+-spec on_data_received(non_neg_integer(), t()) -> {ok, t()} | {error, flow_control_error}.
+on_data_received(Size, #flow{bytes_received = Received, recv_max = Max} = Flow) ->
+    NewReceived = Received + Size,
+    case NewReceived > Max of
+        true -> {error, flow_control_error};
+        false -> {ok, Flow#flow{bytes_received = NewReceived}}
+    end.
+
+-doc "Whether enough of the window has been consumed to grant a new limit (RFC 9000 §4.1).".
+-spec should_send_max_data(t()) -> boolean().
+should_send_max_data(#flow{bytes_received = Received, recv_max = Max, initial_max = Initial}) ->
+    Received > Max - Initial * ?REFILL_NUM div ?REFILL_DEN.
+
+-doc """
+Grant a fresh receive limit: the bytes consumed so far plus a full window.
+Returns the new limit (to send in a MAX_DATA frame) and the updated state.
+""".
+-spec grant_max_data(t()) -> {non_neg_integer(), t()}.
+grant_max_data(#flow{bytes_received = Received, initial_max = Initial} = Flow) ->
+    NewMax = Received + Initial,
+    {NewMax, Flow#flow{recv_max = NewMax}}.
+
+%% =============================================================================
+%% Queries
+%% =============================================================================
+
+-doc "Bytes that may still be sent before hitting the peer's limit.".
+-spec send_window(t()) -> non_neg_integer().
+send_window(#flow{bytes_sent = Sent, send_max = Max}) ->
+    max(0, Max - Sent).
+
+-doc "Bytes the peer may still send before hitting our advertised limit.".
+-spec recv_window(t()) -> non_neg_integer().
+recv_window(#flow{bytes_received = Received, recv_max = Max}) ->
+    max(0, Max - Received).
+
+-doc "Total bytes sent on this window.".
+-spec bytes_sent(t()) -> non_neg_integer().
+bytes_sent(#flow{bytes_sent = Sent}) ->
+    Sent.
+
+-doc "Total bytes received on this window.".
+-spec bytes_received(t()) -> non_neg_integer().
+bytes_received(#flow{bytes_received = Received}) ->
+    Received.

--- a/test/property_test/roadrunner_quic_flow_props.erl
+++ b/test/property_test/roadrunner_quic_flow_props.erl
@@ -1,0 +1,69 @@
+-module(roadrunner_quic_flow_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_flow`.
+
+Differential invariant over a random sequence of send / receive /
+MAX_DATA / grant operations: every observable, the send and receive
+windows, the byte counts, the blocked flag, the should-grant decision,
+the granted value, and the flow-control-error result, stays identical to
+the `quic` dep (the oracle).
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_matches_dep() ->
+    ?FORALL(
+        {Initial, Peer, Ops},
+        {integer(1, 2000), integer(1, 2000), list(op())},
+        begin
+            Opts = #{initial_max_data => Initial, peer_initial_max_data => Peer},
+            run(Ops, roadrunner_quic_flow:new(Opts), quic_flow:new(Opts))
+        end
+    ).
+
+run([], Rr, Dep) ->
+    states_match(Rr, Dep);
+run([Op | Rest], Rr, Dep) ->
+    case apply_both(Op, Rr, Dep) of
+        mismatch -> false;
+        {Rr1, Dep1} -> states_match(Rr1, Dep1) andalso run(Rest, Rr1, Dep1)
+    end.
+
+apply_both({send, Size}, Rr, Dep) ->
+    {RrTag, Rr1} = roadrunner_quic_flow:on_data_sent(Size, Rr),
+    {DepTag, Dep1} = quic_flow:on_data_sent(Dep, Size),
+    same(RrTag =:= DepTag, Rr1, Dep1);
+apply_both({recv, Size}, Rr, Dep) ->
+    case {roadrunner_quic_flow:on_data_received(Size, Rr), quic_flow:on_data_received(Dep, Size)} of
+        {{ok, Rr1}, {ok, Dep1}} -> {Rr1, Dep1};
+        {{error, flow_control_error}, {error, flow_control_error}} -> {Rr, Dep};
+        _ -> mismatch
+    end;
+apply_both({max_data, NewMax}, Rr, Dep) ->
+    {roadrunner_quic_flow:on_max_data_received(NewMax, Rr), quic_flow:on_max_data_received(Dep, NewMax)};
+apply_both(grant, Rr, Dep) ->
+    {RrMax, Rr1} = roadrunner_quic_flow:grant_max_data(Rr),
+    {DepMax, Dep1} = quic_flow:generate_max_data(Dep),
+    same(RrMax =:= DepMax, Rr1, Dep1).
+
+same(true, Rr, Dep) -> {Rr, Dep};
+same(false, _Rr, _Dep) -> mismatch.
+
+states_match(Rr, Dep) ->
+    roadrunner_quic_flow:send_window(Rr) =:= quic_flow:send_window(Dep) andalso
+        roadrunner_quic_flow:recv_window(Rr) =:= quic_flow:recv_window(Dep) andalso
+        roadrunner_quic_flow:bytes_sent(Rr) =:= quic_flow:bytes_sent(Dep) andalso
+        roadrunner_quic_flow:bytes_received(Rr) =:= quic_flow:bytes_received(Dep) andalso
+        roadrunner_quic_flow:send_blocked(Rr) =:= quic_flow:send_blocked(Dep) andalso
+        roadrunner_quic_flow:should_send_max_data(Rr) =:= quic_flow:should_send_max_data(Dep).
+
+op() ->
+    oneof([
+        {send, integer(0, 2000)},
+        {recv, integer(0, 2000)},
+        {max_data, integer(0, 5000)},
+        grant
+    ]).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -41,7 +41,8 @@ Add a new property:
     quic_ack_matches_dep/1,
     quic_loss_rtt_matches_dep/1,
     quic_loss_matches_dep/1,
-    quic_cc_newreno_invariants/1
+    quic_cc_newreno_invariants/1,
+    quic_flow_matches_dep/1
 ]).
 
 suite() ->
@@ -73,7 +74,8 @@ all() ->
         quic_ack_matches_dep,
         quic_loss_rtt_matches_dep,
         quic_loss_matches_dep,
-        quic_cc_newreno_invariants
+        quic_cc_newreno_invariants,
+        quic_flow_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -229,5 +231,11 @@ quic_loss_matches_dep(Config) ->
 quic_cc_newreno_invariants(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_cc_newreno_props:prop_cwnd_never_below_minimum(),
+        Config
+    ).
+
+quic_flow_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_flow_props:prop_matches_dep(),
         Config
     ).

--- a/test/roadrunner_quic_flow_tests.erl
+++ b/test/roadrunner_quic_flow_tests.erl
@@ -1,0 +1,72 @@
+-module(roadrunner_quic_flow_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_flow).
+
+%% =============================================================================
+%% Initial state.
+%% =============================================================================
+
+new_defaults_test() ->
+    Flow = ?M:new(#{}),
+    ?assertEqual(786432, ?M:send_window(Flow)),
+    ?assertEqual(786432, ?M:recv_window(Flow)),
+    ?assertEqual(0, ?M:bytes_sent(Flow)),
+    ?assertEqual(0, ?M:bytes_received(Flow)),
+    ?assertNot(?M:send_blocked(Flow)).
+
+%% =============================================================================
+%% Send side (RFC 9000 §4): bounded by the peer's limit.
+%% =============================================================================
+
+send_side_test() ->
+    Flow = ?M:new(#{peer_initial_max_data => 1000}),
+    ?assert(?M:can_send(1000, Flow)),
+    ?assertNot(?M:can_send(1001, Flow)),
+    {ok, Flow1} = ?M:on_data_sent(400, Flow),
+    ?assertEqual(600, ?M:send_window(Flow1)),
+    ?assertEqual(400, ?M:bytes_sent(Flow1)),
+    ?assertNot(?M:send_blocked(Flow1)),
+    {blocked, Flow2} = ?M:on_data_sent(600, Flow1),
+    ?assert(?M:send_blocked(Flow2)),
+    ?assertEqual(0, ?M:send_window(Flow2)).
+
+%% A received MAX_DATA raises the limit and clears the block; a lower value
+%% is ignored (limits only increase).
+max_data_raises_and_never_lowers_test() ->
+    {blocked, Flow1} = ?M:on_data_sent(1000, ?M:new(#{peer_initial_max_data => 1000})),
+    Flow2 = ?M:on_max_data_received(1500, Flow1),
+    ?assertNot(?M:send_blocked(Flow2)),
+    ?assertEqual(500, ?M:send_window(Flow2)),
+    Flow3 = ?M:on_max_data_received(100, Flow2),
+    ?assertEqual(500, ?M:send_window(Flow3)).
+
+%% =============================================================================
+%% Receive side (RFC 9000 §4.1): an overrun is a flow-control error.
+%% =============================================================================
+
+recv_side_rejects_overrun_test() ->
+    Flow = ?M:new(#{initial_max_data => 1000}),
+    {ok, Flow1} = ?M:on_data_received(1000, Flow),
+    ?assertEqual(0, ?M:recv_window(Flow1)),
+    ?assertEqual(1000, ?M:bytes_received(Flow1)),
+    ?assertEqual({error, flow_control_error}, ?M:on_data_received(1, Flow1)),
+    ?assertEqual({error, flow_control_error}, ?M:on_data_received(1001, Flow)).
+
+%% A new limit is granted once more than a quarter of the window
+%% (1000 - 1000*3/4 = 250) has been consumed.
+should_send_max_data_threshold_test() ->
+    Flow = ?M:new(#{initial_max_data => 1000}),
+    {ok, Below} = ?M:on_data_received(250, Flow),
+    ?assertNot(?M:should_send_max_data(Below)),
+    {ok, Above} = ?M:on_data_received(251, Flow),
+    ?assert(?M:should_send_max_data(Above)).
+
+grant_extends_window_test() ->
+    Flow = ?M:new(#{initial_max_data => 1000}),
+    {ok, Flow1} = ?M:on_data_received(300, Flow),
+    {NewMax, Flow2} = ?M:grant_max_data(Flow1),
+    ?assertEqual(1300, NewMax),
+    ?assertEqual(1000, ?M:recv_window(Flow2)),
+    ?assertNot(?M:should_send_max_data(Flow2)).


### PR DESCRIPTION
# Description

Native flow control for QUIC, following RFC 9000 §4. It tracks how much data may be sent before reaching the peer's advertised limit (and reports when sending is blocked so the connection can say so), and on the receive side it tracks data against the limit we advertised, rejects an overrun as a flow-control error, and grants a fresh limit once enough of the window has been used so the peer is not stalled. One window-agnostic module serves both the connection (MAX_DATA) and each stream (MAX_STREAM_DATA). It is pure: the connection sends the frames and feeds the byte counts back in.

It matches the current `quic` dependency across random send/receive/grant sequences, with full test coverage.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)