### PR TITLE
Add the native QUIC TLS key schedule

### DIFF
--- a/src/roadrunner_quic_tls_crypto.erl
+++ b/src/roadrunner_quic_tls_crypto.erl
@@ -1,0 +1,68 @@
+-module(roadrunner_quic_tls_crypto).
+-moduledoc false.
+
+%% TLS 1.3 key-schedule core (RFC 8446 §7.1) for the QUIC handshake.
+%%
+%% Builds the chain of secrets the handshake derives keys from: the Early
+%% Secret (no pre-shared key in v1), the Handshake Secret (from the
+%% (EC)DHE shared secret), and the Master Secret. `derive_secret/3` is the
+%% TLS 1.3 Derive-Secret over `roadrunner_quic_hkdf`, and
+%% `transcript_hash/1` hashes the running handshake transcript. v1
+%% negotiates `TLS_AES_128_GCM_SHA256`, so the hash is SHA-256 throughout.
+%%
+%% Derive-Secret takes the already-computed transcript hash rather than
+%% the raw messages, so the caller is explicit about what is hashed (use
+%% `transcript_hash(<<>>)` for the empty context of the "derived" steps).
+
+-export([transcript_hash/1, derive_secret/3, early_secret/0, handshake_secret/2, master_secret/1]).
+
+%% SHA-256 output length (the negotiated hash for v1).
+-define(HASH_LEN, 32).
+
+-doc "Transcript-Hash (RFC 8446 §4.4.1): SHA-256 over the concatenated handshake messages.".
+-spec transcript_hash(iodata()) -> binary().
+transcript_hash(Messages) ->
+    crypto:hash(sha256, Messages).
+
+-doc """
+Derive-Secret (RFC 8446 §7.1): an HKDF-Expand-Label keyed by `Secret`,
+labelled `Label`, over the transcript hash `TranscriptHash` (the output
+of `transcript_hash/1`; pass `transcript_hash(<<>>)` for the empty
+context).
+""".
+-spec derive_secret(binary(), binary(), binary()) -> binary().
+derive_secret(Secret, Label, TranscriptHash) ->
+    roadrunner_quic_hkdf:expand_label(Secret, Label, TranscriptHash, ?HASH_LEN).
+
+-doc "The no-PSK Early Secret (RFC 8446 §7.1): `HKDF-Extract(0, 0)`.".
+-spec early_secret() -> binary().
+early_secret() ->
+    roadrunner_quic_hkdf:extract(zeros(), zeros()).
+
+-doc """
+The Handshake Secret (RFC 8446 §7.1): `HKDF-Extract` over the (EC)DHE
+shared secret, salted by the "derived" secret of the Early Secret.
+""".
+-spec handshake_secret(binary(), binary()) -> binary().
+handshake_secret(EarlySecret, SharedSecret) ->
+    Salt = derive_secret(EarlySecret, ~"derived", transcript_hash(<<>>)),
+    roadrunner_quic_hkdf:extract(Salt, SharedSecret).
+
+-doc """
+The Master Secret (RFC 8446 §7.1): `HKDF-Extract` over a zero input,
+salted by the "derived" secret of the Handshake Secret.
+""".
+-spec master_secret(binary()) -> binary().
+master_secret(HandshakeSecret) ->
+    Salt = derive_secret(HandshakeSecret, ~"derived", transcript_hash(<<>>)),
+    roadrunner_quic_hkdf:extract(Salt, zeros()).
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% A SHA-256-length string of zero bytes (the "0" of RFC 8446 §7.1's
+%% Extract inputs).
+-spec zeros() -> binary().
+zeros() ->
+    <<0:(?HASH_LEN * 8)>>.

--- a/test/property_test/roadrunner_quic_tls_crypto_props.erl
+++ b/test/property_test/roadrunner_quic_tls_crypto_props.erl
@@ -1,0 +1,30 @@
+-module(roadrunner_quic_tls_crypto_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_tls_crypto`.
+
+Differential invariant over random inputs: the transcript hash,
+Derive-Secret, and the early/handshake/master secret chain are
+byte-for-byte identical to the `quic` dep (the oracle), which implements
+the same RFC 8446 §7.1 key schedule.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_matches_dep() ->
+    ?FORALL(
+        {Secret, Label, Hash, Shared, Messages},
+        {binary(32), non_empty(binary()), binary(32), binary(32), binary()},
+        begin
+            roadrunner_quic_tls_crypto:transcript_hash(Messages) =:=
+                quic_crypto:transcript_hash(Messages) andalso
+                roadrunner_quic_tls_crypto:derive_secret(Secret, Label, Hash) =:=
+                    quic_crypto:derive_secret(Secret, Label, Hash) andalso
+                roadrunner_quic_tls_crypto:handshake_secret(Secret, Shared) =:=
+                    quic_crypto:derive_handshake_secret(Secret, Shared) andalso
+                roadrunner_quic_tls_crypto:master_secret(Secret) =:=
+                    quic_crypto:derive_master_secret(Secret)
+        end
+    ).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -42,7 +42,8 @@ Add a new property:
     quic_loss_rtt_matches_dep/1,
     quic_loss_matches_dep/1,
     quic_cc_newreno_invariants/1,
-    quic_flow_matches_dep/1
+    quic_flow_matches_dep/1,
+    quic_tls_crypto_matches_dep/1
 ]).
 
 suite() ->
@@ -75,7 +76,8 @@ all() ->
         quic_loss_rtt_matches_dep,
         quic_loss_matches_dep,
         quic_cc_newreno_invariants,
-        quic_flow_matches_dep
+        quic_flow_matches_dep,
+        quic_tls_crypto_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -237,5 +239,11 @@ quic_cc_newreno_invariants(Config) ->
 quic_flow_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_flow_props:prop_matches_dep(),
+        Config
+    ).
+
+quic_tls_crypto_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_tls_crypto_props:prop_matches_dep(),
         Config
     ).

--- a/test/roadrunner_quic_tls_crypto_tests.erl
+++ b/test/roadrunner_quic_tls_crypto_tests.erl
@@ -1,0 +1,83 @@
+-module(roadrunner_quic_tls_crypto_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_tls_crypto).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_crypto).
+
+%% =============================================================================
+%% RFC 8448 §3 (Simple 1-RTT Handshake) key schedule — the authority.
+%% =============================================================================
+
+transcript_hash_empty_test() ->
+    %% SHA-256 of the empty string, the canonical digest.
+    ?assertEqual(
+        hex(~"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+        ?M:transcript_hash(<<>>)
+    ).
+
+early_secret_test() ->
+    %% The no-PSK Early Secret, HKDF-Extract(0, 0).
+    ?assertEqual(
+        hex(~"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a"),
+        ?M:early_secret()
+    ).
+
+derive_secret_test() ->
+    %% Derive-Secret(early_secret, "derived", "").
+    ?assertEqual(
+        hex(~"6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba"),
+        ?M:derive_secret(?M:early_secret(), ~"derived", ?M:transcript_hash(<<>>))
+    ).
+
+handshake_secret_test() ->
+    %% handshake_secret from the §3 x25519 shared secret.
+    ?assertEqual(
+        hex(~"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"),
+        ?M:handshake_secret(?M:early_secret(), shared_secret())
+    ).
+
+master_secret_test() ->
+    HandshakeSecret = ?M:handshake_secret(?M:early_secret(), shared_secret()),
+    ?assertEqual(
+        hex(~"18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"),
+        ?M:master_secret(HandshakeSecret)
+    ).
+
+%% =============================================================================
+%% Differential equivalence vs the dep oracle.
+%% =============================================================================
+
+matches_dep_test() ->
+    [
+        ?assertEqual(?DEP:transcript_hash(Msg), ?M:transcript_hash(Msg))
+     || Msg <- [<<>>, ~"x", ~"the running handshake transcript", binary:copy(<<7>>, 200)]
+    ],
+    Early = ?M:early_secret(),
+    [
+        ?assertEqual(?DEP:derive_secret(Early, Label, Hash), ?M:derive_secret(Early, Label, Hash))
+     || {Label, Hash} <- [
+            {~"c hs traffic", ?M:transcript_hash(~"abc")},
+            {~"s hs traffic", ?M:transcript_hash(<<>>)},
+            {~"derived", ?M:transcript_hash(~"xyz")}
+        ]
+    ],
+    [
+        begin
+            HandshakeSecret = ?M:handshake_secret(Early, Shared),
+            ?assertEqual(?DEP:derive_handshake_secret(Early, Shared), HandshakeSecret),
+            ?assertEqual(
+                ?DEP:derive_master_secret(HandshakeSecret), ?M:master_secret(HandshakeSecret)
+            )
+        end
+     || Shared <- [binary:copy(<<16#2a>>, 32), shared_secret()]
+    ].
+
+%% RFC 8448 §3 ECDHE (x25519) shared secret.
+shared_secret() ->
+    hex(~"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d").
+
+%% Uppercase before decoding so the literals are portable across OTP
+%% versions regardless of `binary:decode_hex/1`'s lowercase handling.
+hex(Hex) -> binary:decode_hex(string:uppercase(Hex)).


### PR DESCRIPTION
# Description

The start of the native TLS 1.3 handshake for QUIC: the key-schedule core from RFC 8446 §7.1. It hashes the running handshake transcript and derives the chain of secrets the handshake is built on, the early secret, the handshake secret (from the key-exchange shared secret), and the master secret, with the Derive-Secret step shared by all of them. It builds on the existing HKDF code and is pure (no connection state); v1 uses SHA-256 throughout.

It reproduces the worked example in RFC 8448 byte for byte and matches the current `quic` dependency across random inputs, with full test coverage.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)