### PR TITLE
Add the native QUIC TLS traffic secrets and Finished keys

### DIFF
--- a/src/roadrunner_quic_tls_crypto.erl
+++ b/src/roadrunner_quic_tls_crypto.erl
@@ -13,8 +13,22 @@
 %% Derive-Secret takes the already-computed transcript hash rather than
 %% the raw messages, so the caller is explicit about what is hashed (use
 %% `transcript_hash(<<>>)` for the empty context of the "derived" steps).
+%%
+%% From the Handshake and Master Secrets it derives the client/server
+%% handshake and application traffic secrets, and from a traffic secret
+%% the Finished key and a Finished message's verify_data (RFC 8446
+%% §4.4.4), used to authenticate the handshake.
 
--export([transcript_hash/1, derive_secret/3, early_secret/0, handshake_secret/2, master_secret/1]).
+-export([
+    transcript_hash/1,
+    derive_secret/3,
+    early_secret/0,
+    handshake_secret/2,
+    master_secret/1,
+    traffic_secret/4,
+    finished_key/1,
+    verify_data/2
+]).
 
 %% SHA-256 output length (the negotiated hash for v1).
 -define(HASH_LEN, 32).
@@ -56,6 +70,40 @@ salted by the "derived" secret of the Handshake Secret.
 master_secret(HandshakeSecret) ->
     Salt = derive_secret(HandshakeSecret, ~"derived", transcript_hash(<<>>)),
     roadrunner_quic_hkdf:extract(Salt, zeros()).
+
+-doc """
+A traffic secret (RFC 8446 §7.1), selected by `Direction` (client or
+server) and `Level` (handshake or application), derived from the base
+secret for that level (the Handshake Secret for `handshake`, the Master
+Secret for `application`) and the transcript hash up to that point.
+""".
+-spec traffic_secret(client | server, handshake | application, binary(), binary()) -> binary().
+traffic_secret(client, handshake, HandshakeSecret, TranscriptHash) ->
+    derive_secret(HandshakeSecret, ~"c hs traffic", TranscriptHash);
+traffic_secret(server, handshake, HandshakeSecret, TranscriptHash) ->
+    derive_secret(HandshakeSecret, ~"s hs traffic", TranscriptHash);
+traffic_secret(client, application, MasterSecret, TranscriptHash) ->
+    derive_secret(MasterSecret, ~"c ap traffic", TranscriptHash);
+traffic_secret(server, application, MasterSecret, TranscriptHash) ->
+    derive_secret(MasterSecret, ~"s ap traffic", TranscriptHash).
+
+-doc """
+The Finished key for a traffic secret (RFC 8446 §4.4.4):
+`HKDF-Expand-Label(TrafficSecret, "finished", "", 32)`.
+""".
+-spec finished_key(binary()) -> binary().
+finished_key(TrafficSecret) ->
+    roadrunner_quic_hkdf:expand_label(TrafficSecret, ~"finished", <<>>, ?HASH_LEN).
+
+-doc """
+A Finished message's verify_data (RFC 8446 §4.4.4):
+`HMAC(FinishedKey, TranscriptHash)` over the handshake context. The
+server computes it with its own Finished key and verifies the client's
+with the client's.
+""".
+-spec verify_data(binary(), binary()) -> binary().
+verify_data(FinishedKey, TranscriptHash) ->
+    crypto:mac(hmac, sha256, FinishedKey, TranscriptHash).
 
 %% =============================================================================
 %% Internal

--- a/test/property_test/roadrunner_quic_tls_crypto_props.erl
+++ b/test/property_test/roadrunner_quic_tls_crypto_props.erl
@@ -18,6 +18,7 @@ prop_matches_dep() ->
         {Secret, Label, Hash, Shared, Messages},
         {binary(32), non_empty(binary()), binary(32), binary(32), binary()},
         begin
+            FinishedKey = roadrunner_quic_tls_crypto:finished_key(Secret),
             roadrunner_quic_tls_crypto:transcript_hash(Messages) =:=
                 quic_crypto:transcript_hash(Messages) andalso
                 roadrunner_quic_tls_crypto:derive_secret(Secret, Label, Hash) =:=
@@ -25,6 +26,17 @@ prop_matches_dep() ->
                 roadrunner_quic_tls_crypto:handshake_secret(Secret, Shared) =:=
                     quic_crypto:derive_handshake_secret(Secret, Shared) andalso
                 roadrunner_quic_tls_crypto:master_secret(Secret) =:=
-                    quic_crypto:derive_master_secret(Secret)
+                    quic_crypto:derive_master_secret(Secret) andalso
+                roadrunner_quic_tls_crypto:traffic_secret(client, handshake, Secret, Hash) =:=
+                    quic_crypto:derive_client_handshake_secret(Secret, Hash) andalso
+                roadrunner_quic_tls_crypto:traffic_secret(server, handshake, Secret, Hash) =:=
+                    quic_crypto:derive_server_handshake_secret(Secret, Hash) andalso
+                roadrunner_quic_tls_crypto:traffic_secret(client, application, Secret, Hash) =:=
+                    quic_crypto:derive_client_app_secret(Secret, Hash) andalso
+                roadrunner_quic_tls_crypto:traffic_secret(server, application, Secret, Hash) =:=
+                    quic_crypto:derive_server_app_secret(Secret, Hash) andalso
+                FinishedKey =:= quic_crypto:derive_finished_key(Secret) andalso
+                roadrunner_quic_tls_crypto:verify_data(FinishedKey, Hash) =:=
+                    quic_crypto:compute_finished_verify(FinishedKey, Hash)
         end
     ).

--- a/test/roadrunner_quic_tls_crypto_tests.erl
+++ b/test/roadrunner_quic_tls_crypto_tests.erl
@@ -74,6 +74,87 @@ matches_dep_test() ->
      || Shared <- [binary:copy(<<16#2a>>, 32), shared_secret()]
     ].
 
+%% =============================================================================
+%% Traffic secrets, Finished key, and verify_data vs the dep oracle (the
+%% dep is RFC-8448-faithful, confirmed by the backbone vectors above).
+%% =============================================================================
+
+traffic_secrets_match_dep_test() ->
+    HandshakeSecret = ?M:handshake_secret(?M:early_secret(), shared_secret()),
+    MasterSecret = ?M:master_secret(HandshakeSecret),
+    HsHash = ?M:transcript_hash(~"client-hello..server-hello"),
+    ApHash = ?M:transcript_hash(~"client-hello..server-finished"),
+    ?assertEqual(
+        ?DEP:derive_client_handshake_secret(HandshakeSecret, HsHash),
+        ?M:traffic_secret(client, handshake, HandshakeSecret, HsHash)
+    ),
+    ?assertEqual(
+        ?DEP:derive_server_handshake_secret(HandshakeSecret, HsHash),
+        ?M:traffic_secret(server, handshake, HandshakeSecret, HsHash)
+    ),
+    ?assertEqual(
+        ?DEP:derive_client_app_secret(MasterSecret, ApHash),
+        ?M:traffic_secret(client, application, MasterSecret, ApHash)
+    ),
+    ?assertEqual(
+        ?DEP:derive_server_app_secret(MasterSecret, ApHash),
+        ?M:traffic_secret(server, application, MasterSecret, ApHash)
+    ).
+
+finished_and_verify_data_match_dep_test() ->
+    HandshakeSecret = ?M:handshake_secret(?M:early_secret(), shared_secret()),
+    Hash = ?M:transcript_hash(~"client-hello..server-hello"),
+    ServerSecret = ?M:traffic_secret(server, handshake, HandshakeSecret, Hash),
+    FinishedKey = ?M:finished_key(ServerSecret),
+    ?assertEqual(?DEP:derive_finished_key(ServerSecret), FinishedKey),
+    ?assertEqual(
+        ?DEP:compute_finished_verify(FinishedKey, Hash),
+        ?M:verify_data(FinishedKey, Hash)
+    ).
+
+%% =============================================================================
+%% RFC 8448 §3 traffic secrets + Finished — the authority (hardcoded, not
+%% via the dep). The transcript-hash contexts are the §3 values.
+%% =============================================================================
+
+rfc8448_traffic_secrets_test() ->
+    HandshakeSecret = ?M:handshake_secret(?M:early_secret(), shared_secret()),
+    MasterSecret = ?M:master_secret(HandshakeSecret),
+    HsHash = hex(~"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8"),
+    ApHash = hex(~"96088718a85d2c0d2b21a16a7f637eba132bd1a01feac57b8f8ec571ef41c47c"),
+    ?assertEqual(
+        hex(~"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"),
+        ?M:traffic_secret(client, handshake, HandshakeSecret, HsHash)
+    ),
+    ?assertEqual(
+        hex(~"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"),
+        ?M:traffic_secret(server, handshake, HandshakeSecret, HsHash)
+    ),
+    ?assertEqual(
+        hex(~"775fae04efd2ee7a546c9544a5070c639fe9a67945b7d18310b269e0e9e98069"),
+        ?M:traffic_secret(client, application, MasterSecret, ApHash)
+    ),
+    ?assertEqual(
+        hex(~"40d3a34fd7b0c9651bb55866a650eddf179237a2923b2124be7f6eae319aeca0"),
+        ?M:traffic_secret(server, application, MasterSecret, ApHash)
+    ).
+
+rfc8448_finished_test() ->
+    HandshakeSecret = ?M:handshake_secret(?M:early_secret(), shared_secret()),
+    HsHash = hex(~"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8"),
+    ServerSecret = ?M:traffic_secret(server, handshake, HandshakeSecret, HsHash),
+    FinishedKey = ?M:finished_key(ServerSecret),
+    ?assertEqual(
+        hex(~"008d3b66f816ea559f96b537e885c31fc068bf492c652f01f288a1d8cdc19fc8"),
+        FinishedKey
+    ),
+    %% Transcript hash over ClientHello..server CertificateVerify.
+    FinishedInput = hex(~"91208a9082bb48b14e2f607d839c0d3a55c4f8e1fbb88e3c1ba0e2a32be88a59"),
+    ?assertEqual(
+        hex(~"5d84b2762deff4fcd2a765d6567d94a9f32e4553166893ad86769457e40564ca"),
+        ?M:verify_data(FinishedKey, FinishedInput)
+    ).
+
 %% RFC 8448 §3 ECDHE (x25519) shared secret.
 shared_secret() ->
     hex(~"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d").


### PR DESCRIPTION
# Description

Adds the next piece of the native QUIC handshake, building on the key schedule from #119. From the handshake and master secrets it derives the keys each side uses to protect the rest of the handshake and the application data, plus the keys that let each side prove the handshake was not tampered with. Verified against the official TLS 1.3 test vectors.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)