### PR TITLE
Widen the h3 bench-client test timeouts to stop CI flakes under load

### DIFF
--- a/test/roadrunner_bench_client.erl
+++ b/test/roadrunner_bench_client.erl
@@ -103,10 +103,13 @@ open(Host, Port, h3) ->
     %% QUIC over UDP via the turnkey `quic_h3` client; `wait_connected`
     %% blocks through the handshake so the first `request/5` can issue a
     %% stream straight away (mirrors the h2 SETTINGS round-trip above).
+    %% The deadline is generous: under CI load the UDP/QUIC handshake can
+    %% take several seconds, and a tight one flakes the h3 tests. It still
+    %% bounds a genuinely stuck handshake to a clean `{error, timeout}`.
     HostBin = host_to_authority(Host),
     case quic_h3:connect(HostBin, Port, #{verify => verify_none}) of
         {ok, Conn} ->
-            case quic_h3:wait_connected(Conn, 5000) of
+            case quic_h3:wait_connected(Conn, 15000) of
                 ok ->
                     {ok, #h3_conn{conn = Conn, authority = HostBin}};
                 {error, _} = E ->

--- a/test/roadrunner_bench_client_tests.erl
+++ b/test/roadrunner_bench_client_tests.erl
@@ -9,19 +9,29 @@
 %% so the leak vector is narrower here, but the discipline is
 %% project-wide.
 all_test_() ->
-    Tests = [
+    %% Fast TCP/TLS tests run at eunit's default per-test timeout.
+    Fast = [
         fun h1_get_returns_200/0,
         fun h1_post_echoes_body/0,
         fun h1_keepalive_n_requests/0,
         fun h2_get_returns_200/0,
         fun h2_post_echoes_body/0,
         fun h2_keepalive_n_requests/0,
-        fun h3_get_returns_200/0,
-        fun h3_post_echoes_body/0,
-        fun h3_keepalive_n_requests/0,
         fun open_h1_to_dead_port_errors/0
     ],
-    [{spawn, F} || F <- Tests].
+    %% The h3 tests run a real QUIC/UDP handshake (dep `quic_h3` client ->
+    %% roadrunner h3 server). Under CI load that handshake can exceed
+    %% eunit's 5s default per-test timeout, which aborts the test as
+    %% "cancelled" while it is still inside `wait_connected`. Give them a
+    %% timeout above `open/3`'s own `wait_connected` deadline so a
+    %% slow-but-progressing handshake still completes, and a genuinely
+    %% stuck one surfaces as a clean error rather than a cancel.
+    H3 = [
+        fun h3_get_returns_200/0,
+        fun h3_post_echoes_body/0,
+        fun h3_keepalive_n_requests/0
+    ],
+    [{spawn, F} || F <- Fast] ++ [{timeout, 30, {spawn, F}} || F <- H3].
 
 h1_get_returns_200() ->
     Port = start_h1_listener(client_h1_get, roadrunner_hello_handler),


### PR DESCRIPTION
# Description

The `h3_*` bench-client eunit tests run a real QUIC/UDP handshake (the `quic` dependency's `quic_h3` client against the roadrunner h3 server). Under CI load that handshake can take longer than eunit's 5 second default per-test timeout, so the test is aborted ("cancelled") while still inside `wait_connected`, which fails the whole run even though nothing is actually broken. This gives those three tests a 30 second eunit timeout, above the handshake's own (now 15 second) deadline, so a slow-but-progressing handshake finishes and a genuinely stuck one reports a clean error instead of a cancel. The fast HTTP/1 and HTTP/2 tests keep the default timeout.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)