### PR TITLE
Add the native QUIC transport parameters codec

### DIFF
--- a/src/roadrunner_quic_transport_params.erl
+++ b/src/roadrunner_quic_transport_params.erl
@@ -1,0 +1,352 @@
+-module(roadrunner_quic_transport_params).
+-moduledoc false.
+
+%% QUIC transport parameters codec (RFC 9000 §18 + §18.2). Each parameter
+%% is a triple `varint(Id), varint(Length), Value[Length]`; the whole set
+%% is the concatenation of triples, carried as the TLS
+%% `quic_transport_parameters` extension body (this module produces and
+%% parses that body, with no outer length of its own).
+%%
+%% Parameters are a map keyed by their RFC name (an atom, see
+%% `param_key/0`), mirroring `roadrunner_quic_h3_frame`'s `{settings,
+%% map()}` and the dep's own representation. Values are typed by
+%% parameter: an integer for the varint parameters, a `binary()` for the
+%% connection-id parameters, and `true` for the zero-length
+%% `disable_active_migration` flag.
+%%
+%% `encode/1` emits every parameter in the map as an iolist (in
+%% map-iteration order; RFC 9000 §18 permits any order); choosing which
+%% parameters to send, and omitting ones left at their default, is the
+%% caller's concern. `decode/1` parses the peer's set with the §18.2
+%% validation a server applies to a client: range checks, duplicate
+%% rejection, rejection of the server-only parameters a client must not
+%% send, and silently ignoring unknown/reserved ids.
+
+-export([encode/1, decode/1]).
+
+-export_type([param_key/0, params/0]).
+
+-type param_key() ::
+    original_destination_connection_id
+    | max_idle_timeout
+    | max_udp_payload_size
+    | initial_max_data
+    | initial_max_stream_data_bidi_local
+    | initial_max_stream_data_bidi_remote
+    | initial_max_stream_data_uni
+    | initial_max_streams_bidi
+    | initial_max_streams_uni
+    | ack_delay_exponent
+    | max_ack_delay
+    | disable_active_migration
+    | active_connection_id_limit
+    | initial_source_connection_id.
+
+-type params() :: #{
+    original_destination_connection_id => binary(),
+    max_idle_timeout => non_neg_integer(),
+    max_udp_payload_size => non_neg_integer(),
+    initial_max_data => non_neg_integer(),
+    initial_max_stream_data_bidi_local => non_neg_integer(),
+    initial_max_stream_data_bidi_remote => non_neg_integer(),
+    initial_max_stream_data_uni => non_neg_integer(),
+    initial_max_streams_bidi => non_neg_integer(),
+    initial_max_streams_uni => non_neg_integer(),
+    ack_delay_exponent => non_neg_integer(),
+    max_ack_delay => non_neg_integer(),
+    disable_active_migration => true,
+    active_connection_id_limit => non_neg_integer(),
+    initial_source_connection_id => binary()
+}.
+
+%% Ids already seen while decoding a set, for the RFC 9000 §7.4 duplicate
+%% check (a set: only the keys matter).
+-type seen() :: #{non_neg_integer() => []}.
+
+%% One parameter's decode verdict: keep it, ignore it (unknown/reserved),
+%% or reject the whole set.
+-type decoded() ::
+    {param, param_key(), non_neg_integer() | binary() | true}
+    | ignore
+    | {error, atom()}.
+
+%% RFC 9000 §18.2 transport parameter ids.
+-define(TP_ORIGINAL_DESTINATION_CONNECTION_ID, 16#00).
+-define(TP_MAX_IDLE_TIMEOUT, 16#01).
+-define(TP_STATELESS_RESET_TOKEN, 16#02).
+-define(TP_MAX_UDP_PAYLOAD_SIZE, 16#03).
+-define(TP_INITIAL_MAX_DATA, 16#04).
+-define(TP_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL, 16#05).
+-define(TP_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE, 16#06).
+-define(TP_INITIAL_MAX_STREAM_DATA_UNI, 16#07).
+-define(TP_INITIAL_MAX_STREAMS_BIDI, 16#08).
+-define(TP_INITIAL_MAX_STREAMS_UNI, 16#09).
+-define(TP_ACK_DELAY_EXPONENT, 16#0A).
+-define(TP_MAX_ACK_DELAY, 16#0B).
+-define(TP_DISABLE_ACTIVE_MIGRATION, 16#0C).
+-define(TP_PREFERRED_ADDRESS, 16#0D).
+-define(TP_ACTIVE_CONNECTION_ID_LIMIT, 16#0E).
+-define(TP_INITIAL_SOURCE_CONNECTION_ID, 16#0F).
+-define(TP_RETRY_SOURCE_CONNECTION_ID, 16#10).
+
+%% RFC 9000 §18.2 value bounds.
+%% max_ack_delay must be < 2^14; ack_delay_exponent <= 20;
+%% max_udp_payload_size >= 1200; active_connection_id_limit >= 2;
+%% initial_max_streams_* <= 2^60.
+-define(MAX_ACK_DELAY_LIMIT, 16384).
+-define(ACK_DELAY_EXPONENT_LIMIT, 20).
+-define(MIN_MAX_UDP_PAYLOAD_SIZE, 1200).
+-define(MIN_ACTIVE_CONNECTION_ID_LIMIT, 2).
+-define(MAX_STREAMS_LIMIT, 1152921504606846976).
+
+%% =============================================================================
+%% encode/1
+%% =============================================================================
+
+-doc """
+Encode a transport-parameters map to its wire form (RFC 9000 §18), as an
+iolist, one `varint(Id), varint(Length), Value` triple per entry (in
+map-iteration order; §18 permits any order). The map holds only the
+parameters to send (the connection ids the server must include, plus
+whichever limits it advertises); a parameter left at its default is
+simply absent from the map.
+""".
+-spec encode(params()) -> iolist().
+encode(Params) ->
+    [encode_param(Key, Value) || Key := Value <- Params].
+
+%% =============================================================================
+%% decode/1
+%% =============================================================================
+
+-doc """
+Decode a peer's transport-parameters wire body to a map. Applies the
+RFC 9000 §18.2 validation a server runs on a client's set:
+
+- range checks (`ack_delay_exponent` =< 20, `max_ack_delay` < 2^14,
+  `max_udp_payload_size` >= 1200, `active_connection_id_limit` >= 2,
+  `initial_max_streams_*` =< 2^60);
+- a duplicated parameter is rejected;
+- the server-only parameters a client must not send
+  (`original_destination_connection_id`, `stateless_reset_token`,
+  `preferred_address`, `retry_source_connection_id`) are rejected;
+- unknown and reserved ids are ignored (RFC 9000 §18.1).
+
+Returns `{ok, Params}` or `{error, Reason}` (a flat atom).
+""".
+-spec decode(binary()) -> {ok, params()} | {error, atom()}.
+decode(Data) ->
+    decode_params(Data, #{}, #{}).
+
+%% =============================================================================
+%% Internal — encode
+%% =============================================================================
+
+%% One parameter as a `varint(Id), varint(Length), Value` iolist. The
+%% connection-id parameters carry raw bytes, the flag carries an empty
+%% value, the rest carry a varint value. A parameter this server does not
+%% send (e.g. stateless_reset_token) has no clause and raises, rather than
+%% emitting an out-of-scope parameter.
+-spec encode_param(param_key(), non_neg_integer() | binary() | true) -> iolist().
+encode_param(original_destination_connection_id, Cid) ->
+    tlv(?TP_ORIGINAL_DESTINATION_CONNECTION_ID, Cid);
+encode_param(initial_source_connection_id, Cid) ->
+    tlv(?TP_INITIAL_SOURCE_CONNECTION_ID, Cid);
+encode_param(disable_active_migration, true) ->
+    tlv(?TP_DISABLE_ACTIVE_MIGRATION, <<>>);
+encode_param(max_idle_timeout, V) ->
+    tlv_varint(?TP_MAX_IDLE_TIMEOUT, V);
+encode_param(max_udp_payload_size, V) ->
+    tlv_varint(?TP_MAX_UDP_PAYLOAD_SIZE, V);
+encode_param(initial_max_data, V) ->
+    tlv_varint(?TP_INITIAL_MAX_DATA, V);
+encode_param(initial_max_stream_data_bidi_local, V) ->
+    tlv_varint(?TP_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL, V);
+encode_param(initial_max_stream_data_bidi_remote, V) ->
+    tlv_varint(?TP_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE, V);
+encode_param(initial_max_stream_data_uni, V) ->
+    tlv_varint(?TP_INITIAL_MAX_STREAM_DATA_UNI, V);
+encode_param(initial_max_streams_bidi, V) ->
+    tlv_varint(?TP_INITIAL_MAX_STREAMS_BIDI, V);
+encode_param(initial_max_streams_uni, V) ->
+    tlv_varint(?TP_INITIAL_MAX_STREAMS_UNI, V);
+encode_param(ack_delay_exponent, V) ->
+    tlv_varint(?TP_ACK_DELAY_EXPONENT, V);
+encode_param(max_ack_delay, V) ->
+    tlv_varint(?TP_MAX_ACK_DELAY, V);
+encode_param(active_connection_id_limit, V) ->
+    tlv_varint(?TP_ACTIVE_CONNECTION_ID_LIMIT, V).
+
+%% Frame a varint-valued parameter: its value is the encoded varint, and
+%% the Length is that varint's byte size.
+-spec tlv_varint(non_neg_integer(), non_neg_integer()) -> iolist().
+tlv_varint(Id, Value) ->
+    tlv(Id, roadrunner_quic_varint:encode(Value)).
+
+-spec tlv(non_neg_integer(), binary()) -> iolist().
+tlv(Id, Value) ->
+    [
+        roadrunner_quic_varint:encode(Id),
+        roadrunner_quic_varint:encode(byte_size(Value)),
+        Value
+    ].
+
+%% =============================================================================
+%% Internal — decode
+%% =============================================================================
+
+%% Peel one parameter triple off the front, reject a duplicate id (RFC
+%% 9000 §7.4, across known, unknown, and reserved ids alike), accumulate
+%% it, and recurse until the body is consumed. `Acc` holds the known
+%% parameters kept; `Seen` records every id encountered. A short or
+%% malformed buffer is a flat error, not a crash.
+-spec decode_params(binary(), params(), seen()) -> {ok, params()} | {error, atom()}.
+decode_params(<<>>, Acc, _Seen) ->
+    {ok, Acc};
+decode_params(Data, Acc, Seen) ->
+    maybe
+        {ok, Id, AfterId} ?= take_varint(Data),
+        {ok, Len, AfterLen} ?= take_varint(AfterId),
+        {ok, Value, Rest} ?= take_bytes(Len, AfterLen),
+        unseen ?= dup_check(Id, Seen),
+        accumulate(decode_param(Id, Value), Id, Rest, Acc, Seen)
+    end.
+
+%% Reject an id already seen in this set (RFC 9000 §7.4), known or not.
+-spec dup_check(non_neg_integer(), seen()) -> unseen | {error, atom()}.
+dup_check(Id, Seen) ->
+    case Seen of
+        #{Id := _} -> {error, duplicate_transport_parameter};
+        #{} -> unseen
+    end.
+
+%% Fold one parameter's verdict into the accumulator and recurse, marking
+%% its id seen. A kept parameter joins `Acc`; an ignored (unknown/reserved)
+%% one is dropped but still recorded, so a later duplicate of it is caught.
+-spec accumulate(decoded(), non_neg_integer(), binary(), params(), seen()) ->
+    {ok, params()} | {error, atom()}.
+accumulate({param, Key, Value}, Id, Rest, Acc, Seen) ->
+    decode_params(Rest, Acc#{Key => Value}, Seen#{Id => []});
+accumulate(ignore, Id, Rest, Acc, Seen) ->
+    decode_params(Rest, Acc, Seen#{Id => []});
+accumulate({error, _} = Error, _Id, _Rest, _Acc, _Seen) ->
+    Error.
+
+%% Decode a parameter by id to its verdict. Server-only parameters are
+%% rejected (a client must not send them); known client/both parameters
+%% are typed and range-checked; unknown and reserved (RFC 9000 §18.1) ids
+%% are ignored.
+-spec decode_param(non_neg_integer(), binary()) -> decoded().
+decode_param(?TP_ORIGINAL_DESTINATION_CONNECTION_ID, _) ->
+    {error, server_only_transport_parameter};
+decode_param(?TP_STATELESS_RESET_TOKEN, _) ->
+    {error, server_only_transport_parameter};
+decode_param(?TP_PREFERRED_ADDRESS, _) ->
+    {error, server_only_transport_parameter};
+decode_param(?TP_RETRY_SOURCE_CONNECTION_ID, _) ->
+    {error, server_only_transport_parameter};
+decode_param(?TP_MAX_IDLE_TIMEOUT, Value) ->
+    varint_param(max_idle_timeout, Value);
+decode_param(?TP_MAX_UDP_PAYLOAD_SIZE, Value) ->
+    checked_varint_param(max_udp_payload_size, Value, fun check_max_udp_payload_size/1);
+decode_param(?TP_INITIAL_MAX_DATA, Value) ->
+    varint_param(initial_max_data, Value);
+decode_param(?TP_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL, Value) ->
+    varint_param(initial_max_stream_data_bidi_local, Value);
+decode_param(?TP_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE, Value) ->
+    varint_param(initial_max_stream_data_bidi_remote, Value);
+decode_param(?TP_INITIAL_MAX_STREAM_DATA_UNI, Value) ->
+    varint_param(initial_max_stream_data_uni, Value);
+decode_param(?TP_INITIAL_MAX_STREAMS_BIDI, Value) ->
+    checked_varint_param(initial_max_streams_bidi, Value, fun check_max_streams/1);
+decode_param(?TP_INITIAL_MAX_STREAMS_UNI, Value) ->
+    checked_varint_param(initial_max_streams_uni, Value, fun check_max_streams/1);
+decode_param(?TP_ACK_DELAY_EXPONENT, Value) ->
+    checked_varint_param(ack_delay_exponent, Value, fun check_ack_delay_exponent/1);
+decode_param(?TP_MAX_ACK_DELAY, Value) ->
+    checked_varint_param(max_ack_delay, Value, fun check_max_ack_delay/1);
+decode_param(?TP_ACTIVE_CONNECTION_ID_LIMIT, Value) ->
+    checked_varint_param(active_connection_id_limit, Value, fun check_active_connection_id_limit/1);
+decode_param(?TP_INITIAL_SOURCE_CONNECTION_ID, Value) ->
+    {param, initial_source_connection_id, Value};
+decode_param(?TP_DISABLE_ACTIVE_MIGRATION, <<>>) ->
+    {param, disable_active_migration, true};
+decode_param(?TP_DISABLE_ACTIVE_MIGRATION, _) ->
+    {error, malformed_transport_parameter};
+decode_param(_Id, _Value) ->
+    ignore.
+
+%% Decode a varint parameter that has no §18.2 range check.
+-spec varint_param(param_key(), binary()) ->
+    {param, param_key(), non_neg_integer()} | {error, atom()}.
+varint_param(Key, Value) ->
+    maybe
+        {ok, N} ?= take_varint_value(Value),
+        {param, Key, N}
+    end.
+
+%% As varint_param/2, but range-check the decoded value first.
+-spec checked_varint_param(
+    param_key(), binary(), fun((non_neg_integer()) -> ok | {error, atom()})
+) ->
+    {param, param_key(), non_neg_integer()} | {error, atom()}.
+checked_varint_param(Key, Value, Check) ->
+    maybe
+        {ok, N} ?= take_varint_value(Value),
+        ok ?= Check(N),
+        {param, Key, N}
+    end.
+
+%% The single varint filling a parameter's value field; any trailing
+%% bytes after it make the parameter malformed.
+-spec take_varint_value(binary()) -> {ok, non_neg_integer()} | {error, atom()}.
+take_varint_value(Value) ->
+    case take_varint(Value) of
+        {ok, N, <<>>} -> {ok, N};
+        {ok, _, _} -> {error, malformed_transport_parameter};
+        {error, _} = Error -> Error
+    end.
+
+%% =============================================================================
+%% Internal — §18.2 range checks
+%% =============================================================================
+
+-spec check_max_udp_payload_size(non_neg_integer()) -> ok | {error, atom()}.
+check_max_udp_payload_size(N) when N >= ?MIN_MAX_UDP_PAYLOAD_SIZE -> ok;
+check_max_udp_payload_size(_) -> {error, max_udp_payload_size_too_small}.
+
+-spec check_ack_delay_exponent(non_neg_integer()) -> ok | {error, atom()}.
+check_ack_delay_exponent(N) when N =< ?ACK_DELAY_EXPONENT_LIMIT -> ok;
+check_ack_delay_exponent(_) -> {error, ack_delay_exponent_too_large}.
+
+-spec check_max_ack_delay(non_neg_integer()) -> ok | {error, atom()}.
+check_max_ack_delay(N) when N < ?MAX_ACK_DELAY_LIMIT -> ok;
+check_max_ack_delay(_) -> {error, max_ack_delay_too_large}.
+
+-spec check_active_connection_id_limit(non_neg_integer()) -> ok | {error, atom()}.
+check_active_connection_id_limit(N) when N >= ?MIN_ACTIVE_CONNECTION_ID_LIMIT -> ok;
+check_active_connection_id_limit(_) -> {error, active_connection_id_limit_too_small}.
+
+-spec check_max_streams(non_neg_integer()) -> ok | {error, atom()}.
+check_max_streams(N) when N =< ?MAX_STREAMS_LIMIT -> ok;
+check_max_streams(_) -> {error, initial_max_streams_too_large}.
+
+%% =============================================================================
+%% Internal — wire helpers
+%% =============================================================================
+
+%% A leading varint, with a short buffer normalised to a flat error
+%% (transport parameters arrive whole, not streamed).
+-spec take_varint(binary()) -> {ok, non_neg_integer(), binary()} | {error, truncated}.
+take_varint(Bin) ->
+    case roadrunner_quic_varint:decode(Bin) of
+        {ok, _, _} = Ok -> Ok;
+        {more, _} -> {error, truncated}
+    end.
+
+-spec take_bytes(non_neg_integer(), binary()) -> {ok, binary(), binary()} | {error, truncated}.
+take_bytes(Len, Bin) ->
+    case Bin of
+        <<Value:Len/binary, Rest/binary>> -> {ok, Value, Rest};
+        _ -> {error, truncated}
+    end.

--- a/test/property_test/roadrunner_quic_transport_params_props.erl
+++ b/test/property_test/roadrunner_quic_transport_params_props.erl
@@ -1,0 +1,68 @@
+-module(roadrunner_quic_transport_params_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_transport_params`.
+
+Over random client parameter sets: the native codec round-trips
+(`decode(encode(M)) =:= {ok, M}`) and the `quic` dep (the oracle)
+decodes the native wire to the same values. The set excludes the
+server-only parameters a client must not send (the native decoder
+rejects those, by design).
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+%% 2^62 - 1, the largest value a QUIC varint can carry.
+-define(MAX_VARINT, 4611686018427387903).
+%% 2^60, the RFC 9000 §18.2 ceiling for initial_max_streams_*.
+-define(MAX_STREAMS, 1152921504606846976).
+
+prop_encode_decode_matches_dep() ->
+    ?FORALL(
+        Params,
+        params_gen(),
+        begin
+            Wire = iolist_to_binary(roadrunner_quic_transport_params:encode(Params)),
+            roadrunner_quic_transport_params:decode(Wire) =:= {ok, Params} andalso
+                quic_tls:decode_transport_params(Wire) =:= {ok, dep_params(Params)}
+        end
+    ).
+
+%% A map of a random subset of client parameters with in-range values.
+%% maps:from_list dedupes keys, so the set never has a duplicate.
+params_gen() ->
+    ?LET(Pairs, list(param_gen()), maps:from_list(Pairs)).
+
+param_gen() ->
+    oneof([
+        {max_idle_timeout, varint()},
+        {max_udp_payload_size, integer(1200, ?MAX_VARINT)},
+        {initial_max_data, varint()},
+        {initial_max_stream_data_bidi_local, varint()},
+        {initial_max_stream_data_bidi_remote, varint()},
+        {initial_max_stream_data_uni, varint()},
+        {initial_max_streams_bidi, integer(0, ?MAX_STREAMS)},
+        {initial_max_streams_uni, integer(0, ?MAX_STREAMS)},
+        {ack_delay_exponent, integer(0, 20)},
+        {max_ack_delay, integer(0, 16383)},
+        {active_connection_id_limit, integer(2, 1000)},
+        {disable_active_migration, true},
+        {initial_source_connection_id, cid()}
+    ]).
+
+varint() -> integer(0, ?MAX_VARINT).
+
+cid() -> ?LET(N, integer(0, 20), binary(N)).
+
+%% The dep names the connection-id parameter differently.
+dep_params(M) ->
+    maps:fold(
+        fun
+            (initial_source_connection_id, V, Acc) -> Acc#{initial_scid => V};
+            (K, V, Acc) -> Acc#{K => V}
+        end,
+        #{},
+        M
+    ).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -44,7 +44,8 @@ Add a new property:
     quic_cc_newreno_invariants/1,
     quic_flow_matches_dep/1,
     quic_tls_crypto_matches_dep/1,
-    quic_tls_handshake_matches_dep/1
+    quic_tls_handshake_matches_dep/1,
+    quic_transport_params_matches_dep/1
 ]).
 
 suite() ->
@@ -79,7 +80,8 @@ all() ->
         quic_cc_newreno_invariants,
         quic_flow_matches_dep,
         quic_tls_crypto_matches_dep,
-        quic_tls_handshake_matches_dep
+        quic_tls_handshake_matches_dep,
+        quic_transport_params_matches_dep
     ].
 
 init_per_suite(Config) ->
@@ -253,5 +255,11 @@ quic_tls_crypto_matches_dep(Config) ->
 quic_tls_handshake_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_tls_handshake_props:prop_encode_decode_matches_dep(),
+        Config
+    ).
+
+quic_transport_params_matches_dep(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_transport_params_props:prop_encode_decode_matches_dep(),
         Config
     ).

--- a/test/roadrunner_quic_transport_params_tests.erl
+++ b/test/roadrunner_quic_transport_params_tests.erl
@@ -1,0 +1,275 @@
+-module(roadrunner_quic_transport_params_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_transport_params).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_tls).
+
+%% =============================================================================
+%% RFC 9000 §18 framing structure — the authority.
+%%
+%% Each parameter is varint(Id), varint(Length), Value[Length].
+%% =============================================================================
+
+encode_varint_param_test() ->
+    %% initial_max_streams_bidi (id 0x08) = 3: value is the 1-byte varint <<3>>.
+    ?assertEqual(<<16#08, 16#01, 16#03>>, enc(#{initial_max_streams_bidi => 3})).
+
+encode_connection_id_params_test() ->
+    %% original_destination_connection_id (0x00) and
+    %% initial_source_connection_id (0x0f) carry raw bytes.
+    ?assertEqual(
+        <<16#00, 16#02, 16#aa, 16#bb>>,
+        enc(#{original_destination_connection_id => <<16#aa, 16#bb>>})
+    ),
+    ?assertEqual(
+        <<16#0F, 16#04, 1, 2, 3, 4>>,
+        enc(#{initial_source_connection_id => <<1, 2, 3, 4>>})
+    ).
+
+encode_flag_param_test() ->
+    %% disable_active_migration (0x0c) is a zero-length flag.
+    ?assertEqual(<<16#0C, 16#00>>, enc(#{disable_active_migration => true})).
+
+encode_all_params_decoded_by_dep_test() ->
+    %% Every encodable parameter at once (including the server-only
+    %% original_destination_connection_id), exercising each encode clause.
+    %% The dep decoder (which does not reject server-only params) reads it
+    %% back to the same values, order-independently.
+    All = all_encodable_params(),
+    {ok, DepMap} = ?DEP:decode_transport_params(enc(All)),
+    ?assertEqual(All, from_dep_params(DepMap)).
+
+%% =============================================================================
+%% decode/1 — round-trips and value types.
+%% =============================================================================
+
+decode_round_trips_client_set_test() ->
+    M = client_param_set(),
+    ?assertEqual({ok, M}, ?M:decode(enc(M))).
+
+decode_each_value_type_test() ->
+    ?assertEqual({ok, #{initial_max_data => 3}}, ?M:decode(<<16#04, 16#01, 16#03>>)),
+    ?assertEqual(
+        {ok, #{initial_source_connection_id => <<1, 2, 3, 4>>}},
+        ?M:decode(<<16#0F, 16#04, 1, 2, 3, 4>>)
+    ),
+    ?assertEqual(
+        {ok, #{disable_active_migration => true}},
+        ?M:decode(<<16#0C, 16#00>>)
+    ).
+
+decode_empty_is_empty_map_test() ->
+    ?assertEqual({ok, #{}}, ?M:decode(<<>>)).
+
+%% =============================================================================
+%% decode/1 — §18.2 validation.
+%% =============================================================================
+
+decode_rejects_server_only_params_test() ->
+    %% A client MUST NOT send these (RFC 9000 §18.2); decode rejects each.
+    ?assertEqual(
+        {error, server_only_transport_parameter},
+        ?M:decode(<<16#00, 16#01, 16#aa>>)
+    ),
+    ?assertEqual(
+        {error, server_only_transport_parameter},
+        ?M:decode(<<16#02, 16#10, 0:128>>)
+    ),
+    ?assertEqual(
+        {error, server_only_transport_parameter},
+        ?M:decode(<<16#0D, 16#00>>)
+    ),
+    ?assertEqual(
+        {error, server_only_transport_parameter},
+        ?M:decode(<<16#10, 16#01, 16#cc>>)
+    ).
+
+decode_rejects_duplicate_test() ->
+    %% RFC 9000 §7.4: a duplicate is rejected regardless of whether the id
+    %% is known, unknown, or reserved.
+    %% A known parameter twice.
+    ?assertEqual(
+        {error, duplicate_transport_parameter},
+        ?M:decode(<<16#04, 16#01, 16#01, 16#04, 16#01, 16#02>>)
+    ),
+    %% An unknown id (0x2A) twice.
+    ?assertEqual(
+        {error, duplicate_transport_parameter},
+        ?M:decode(<<16#2A, 16#01, 16#ff, 16#2A, 16#01, 16#ee>>)
+    ),
+    %% A reserved id (27 = 31*0+27) twice.
+    ?assertEqual(
+        {error, duplicate_transport_parameter},
+        ?M:decode(<<27, 16#00, 27, 16#00>>)
+    ).
+
+decode_range_checks_test() ->
+    %% encode does not validate, so it builds the boundary and over-limit
+    %% wires; decode is what enforces each §18.2 bound.
+    Max = 1152921504606846976,
+    ?assertEqual({ok, #{ack_delay_exponent => 20}}, redecode(#{ack_delay_exponent => 20})),
+    ?assertEqual(
+        {error, ack_delay_exponent_too_large}, redecode(#{ack_delay_exponent => 21})
+    ),
+    ?assertEqual({ok, #{max_ack_delay => 16383}}, redecode(#{max_ack_delay => 16383})),
+    ?assertEqual({error, max_ack_delay_too_large}, redecode(#{max_ack_delay => 16384})),
+    ?assertEqual({ok, #{max_udp_payload_size => 1200}}, redecode(#{max_udp_payload_size => 1200})),
+    ?assertEqual(
+        {error, max_udp_payload_size_too_small}, redecode(#{max_udp_payload_size => 1199})
+    ),
+    ?assertEqual(
+        {ok, #{active_connection_id_limit => 2}}, redecode(#{active_connection_id_limit => 2})
+    ),
+    ?assertEqual(
+        {error, active_connection_id_limit_too_small},
+        redecode(#{active_connection_id_limit => 1})
+    ),
+    ?assertEqual(
+        {ok, #{initial_max_streams_bidi => Max}}, redecode(#{initial_max_streams_bidi => Max})
+    ),
+    ?assertEqual(
+        {error, initial_max_streams_too_large}, redecode(#{initial_max_streams_uni => Max + 1})
+    ).
+
+decode_ignores_unknown_and_reserved_test() ->
+    %% Unknown id 0x2A (42) and a reserved id (27 = 31*0+27) are skipped;
+    %% the known parameter between them still decodes. (0x2A is a 1-byte
+    %% varint: its high bits are 00.)
+    Wire = <<16#2A, 16#01, 16#ff, 16#04, 16#01, 16#07, 27, 16#00>>,
+    ?assertEqual({ok, #{initial_max_data => 7}}, ?M:decode(Wire)).
+
+decode_malformed_flag_test() ->
+    %% disable_active_migration with a non-empty value is malformed.
+    ?assertEqual(
+        {error, malformed_transport_parameter},
+        ?M:decode(<<16#0C, 16#01, 16#00>>)
+    ).
+
+decode_malformed_varint_value_test() ->
+    %% A varint parameter whose value field has trailing bytes after the
+    %% varint is malformed.
+    ?assertEqual(
+        {error, malformed_transport_parameter},
+        ?M:decode(<<16#04, 16#02, 16#01, 16#ff>>)
+    ).
+
+decode_truncated_test() ->
+    %% Truncated id, truncated length, and a length that overruns the body.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#40>>)),
+    ?assertEqual({error, truncated}, ?M:decode(<<16#04, 16#40>>)),
+    ?assertEqual({error, truncated}, ?M:decode(<<16#04, 16#08, 1, 2>>)),
+    %% A varint value field too short for the varint class it declares.
+    ?assertEqual({error, truncated}, ?M:decode(<<16#04, 16#01, 16#80>>)).
+
+%% =============================================================================
+%% Differential oracle vs the `quic` dep (kept as a test-profile dep).
+%% =============================================================================
+
+%% Per single parameter the wire is order-independent, so byte-for-byte
+%% equality with the dep holds (the dep emits a whole map in maps:fold
+%% order, which is unspecified).
+oracle_encode_matches_dep_test() ->
+    [
+        ?assertEqual(
+            ?DEP:encode_transport_params(dep_params(#{Key => Value})),
+            enc(#{Key => Value})
+        )
+     || {Key, Value} <- oracle_single_params()
+    ].
+
+%% The dep decodes the native wire to the same values, and the native
+%% decoder round-trips the same client set.
+oracle_decode_matches_dep_test() ->
+    [
+        begin
+            Wire = enc(M),
+            ?assertEqual({ok, M}, ?M:decode(Wire)),
+            {ok, DepMap} = ?DEP:decode_transport_params(Wire),
+            ?assertEqual(M, from_dep_params(DepMap))
+        end
+     || M <- oracle_client_sets()
+    ].
+
+%% =============================================================================
+%% Fixtures and helpers
+%% =============================================================================
+
+%% Every parameter the encoder supports (one of each value type / clause).
+all_encodable_params() ->
+    #{
+        original_destination_connection_id => <<16#a1, 16#a2>>,
+        max_idle_timeout => 30000,
+        max_udp_payload_size => 1500,
+        initial_max_data => 1048576,
+        initial_max_stream_data_bidi_local => 262144,
+        initial_max_stream_data_bidi_remote => 262144,
+        initial_max_stream_data_uni => 131072,
+        initial_max_streams_bidi => 100,
+        initial_max_streams_uni => 3,
+        ack_delay_exponent => 3,
+        max_ack_delay => 25,
+        disable_active_migration => true,
+        active_connection_id_limit => 4,
+        initial_source_connection_id => <<16#b1, 16#b2, 16#b3>>
+    }.
+
+%% A representative client set (no server-only parameters).
+client_param_set() ->
+    maps:remove(original_destination_connection_id, all_encodable_params()).
+
+oracle_client_sets() ->
+    [
+        #{initial_max_data => 1000000},
+        #{
+            initial_max_stream_data_bidi_local => 65536,
+            initial_max_streams_bidi => 16,
+            max_idle_timeout => 10000
+        },
+        #{disable_active_migration => true, active_connection_id_limit => 8},
+        client_param_set()
+    ].
+
+oracle_single_params() ->
+    [
+        {original_destination_connection_id, <<1, 2, 3, 4, 5>>},
+        {max_idle_timeout, 0},
+        {max_udp_payload_size, 65527},
+        {initial_max_data, 4611686018427387903},
+        {initial_max_stream_data_bidi_local, 16383},
+        {initial_max_stream_data_bidi_remote, 64},
+        {initial_max_stream_data_uni, 63},
+        {initial_max_streams_bidi, 100},
+        {initial_max_streams_uni, 0},
+        {ack_delay_exponent, 3},
+        {max_ack_delay, 25},
+        {disable_active_migration, true},
+        {active_connection_id_limit, 2},
+        {initial_source_connection_id, <<16#cc, 16#dd>>}
+    ].
+
+%% The dep names three connection-id parameters differently.
+dep_params(M) ->
+    maps:fold(fun(K, V, Acc) -> Acc#{to_dep_key(K) => V} end, #{}, M).
+
+to_dep_key(original_destination_connection_id) -> original_dcid;
+to_dep_key(initial_source_connection_id) -> initial_scid;
+to_dep_key(retry_source_connection_id) -> retry_scid;
+to_dep_key(K) -> K.
+
+from_dep_params(M) ->
+    maps:fold(fun(K, V, Acc) -> Acc#{from_dep_key(K) => V} end, #{}, M).
+
+from_dep_key(original_dcid) -> original_destination_connection_id;
+from_dep_key(initial_scid) -> initial_source_connection_id;
+from_dep_key(retry_scid) -> retry_source_connection_id;
+from_dep_key(K) -> K.
+
+%% Encode then decode, to check decode-side validation of values that
+%% encode (which does not validate) happily produces.
+redecode(Params) ->
+    ?M:decode(enc(Params)).
+
+enc(Params) ->
+    iolist_to_binary(?M:encode(Params)).


### PR DESCRIPTION
# Description

Adds the codec for QUIC transport parameters (RFC 9000 §18.2), the settings each side advertises during the handshake (flow-control limits, the connection ids, idle timeout, and so on), carried inside the TLS handshake. The server encodes its own set, and the decoder reads the client's set with the validation a server must apply: it range-checks values, rejects a repeated parameter, rejects the parameters only a server may send, and ignores ones it does not recognise.

For example, `encode(#{initial_max_data => 1048576, initial_source_connection_id => Cid})` produces the wire bytes, and `decode/1` turns a peer's bytes back into that map. It matches the `quic` dependency parameter-for-parameter.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)