### PR TITLE
Retry the h3 bench-client handshake to stop CI flakes

### DIFF
--- a/test/roadrunner_bench_client.erl
+++ b/test/roadrunner_bench_client.erl
@@ -100,24 +100,32 @@ open(Host, Port, h2c) ->
         {error, _} = E -> E
     end;
 open(Host, Port, h3) ->
-    %% QUIC over UDP via the turnkey `quic_h3` client; `wait_connected`
-    %% blocks through the handshake so the first `request/5` can issue a
-    %% stream straight away (mirrors the h2 SETTINGS round-trip above).
-    %% The deadline is generous: under CI load the UDP/QUIC handshake can
-    %% take several seconds, and a tight one flakes the h3 tests. It still
-    %% bounds a genuinely stuck handshake to a clean `{error, timeout}`.
-    HostBin = host_to_authority(Host),
+    %% QUIC over UDP via the turnkey `quic_h3` client. Under CI load the
+    %% dep's handshake intermittently stalls (a single `wait_connected`
+    %% times out) even though a fresh connection handshakes immediately, so
+    %% retry with a new connection a few times rather than lean on one long
+    %% deadline. The common case connects on the first attempt in well under
+    %% a second. `wait_connected` blocks through the handshake so the first
+    %% `request/5` can issue a stream straight away.
+    open_h3(host_to_authority(Host), Port, 5).
+
+%% Connect over QUIC, retrying a stalled handshake with a fresh connection
+%% (see `open/3`). Each attempt bounds the handshake to 5s; the eunit
+%% per-test timeout covers the whole retry budget.
+open_h3(_HostBin, _Port, 0) ->
+    {error, timeout};
+open_h3(HostBin, Port, Attempts) ->
     case quic_h3:connect(HostBin, Port, #{verify => verify_none}) of
         {ok, Conn} ->
-            case quic_h3:wait_connected(Conn, 15000) of
+            case quic_h3:wait_connected(Conn, 5000) of
                 ok ->
                     {ok, #h3_conn{conn = Conn, authority = HostBin}};
-                {error, _} = E ->
+                {error, _} ->
                     _ = quic_h3:close(Conn),
-                    E
+                    open_h3(HostBin, Port, Attempts - 1)
             end;
-        {error, _} = E ->
-            E
+        {error, _} = Error ->
+            Error
     end.
 
 %% Shared post-connect handshake for h2 (TLS) and h2c (cleartext).

--- a/test/roadrunner_bench_client_tests.erl
+++ b/test/roadrunner_bench_client_tests.erl
@@ -20,18 +20,16 @@ all_test_() ->
         fun open_h1_to_dead_port_errors/0
     ],
     %% The h3 tests run a real QUIC/UDP handshake (dep `quic_h3` client ->
-    %% roadrunner h3 server). Under CI load that handshake can exceed
-    %% eunit's 5s default per-test timeout, which aborts the test as
-    %% "cancelled" while it is still inside `wait_connected`. Give them a
-    %% timeout above `open/3`'s own `wait_connected` deadline so a
-    %% slow-but-progressing handshake still completes, and a genuinely
-    %% stuck one surfaces as a clean error rather than a cancel.
+    %% roadrunner h3 server). `open/3` retries a stalled handshake a few
+    %% times (5 attempts x 5s each), so give these tests a timeout that
+    %% comfortably covers the whole retry budget, well above eunit's 5s
+    %% default (which would otherwise abort the test mid-retry).
     H3 = [
         fun h3_get_returns_200/0,
         fun h3_post_echoes_body/0,
         fun h3_keepalive_n_requests/0
     ],
-    [{spawn, F} || F <- Fast] ++ [{timeout, 30, {spawn, F}} || F <- H3].
+    [{spawn, F} || F <- Fast] ++ [{timeout, 60, {spawn, F}} || F <- H3].
 
 h1_get_returns_200() ->
     Port = start_h1_listener(client_h1_get, roadrunner_hello_handler),


### PR DESCRIPTION
# Description

The `h3_*` bench-client tests drive the `quic` dependency's QUIC client against the roadrunner HTTP/3 server over UDP loopback. Under CI load the dependency's handshake intermittently takes longer than a single connect deadline (its lost-packet recovery runs for many seconds, or the connection process is starved before its retransmit timer fires), so the test fails even though nothing is broken. Instead of leaning on one ever-longer deadline, the client now retries the handshake a few times with a fresh connection, which starts with fresh timers and almost always connects right away. The fast HTTP/1 and HTTP/2 tests are untouched.

Follows up #122, which widened the timeout but still hit the deadline mid-recovery.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)