### PR TITLE
Add the native QUIC TLS hello exchange

### DIFF
--- a/src/roadrunner_quic_tls_hello.erl
+++ b/src/roadrunner_quic_tls_hello.erl
@@ -1,0 +1,312 @@
+-module(roadrunner_quic_tls_hello).
+-moduledoc false.
+
+%% TLS 1.3 hello exchange (RFC 8446 §4.1.2/§4.1.3/§4.3.1) for a server-only
+%% QUIC v1 endpoint: parse the client's ClientHello, and build the server's
+%% ServerHello and EncryptedExtensions. v1 negotiates x25519
+%% (NamedGroup 0x001d) and TLS_AES_128_GCM_SHA256 (0x1301) only.
+%%
+%% This module owns the message bodies; `roadrunner_quic_tls_handshake`
+%% frames them (1-byte type + 24-bit length), and
+%% `roadrunner_quic_transport_params` is the body of the
+%% quic_transport_parameters extension (codepoint 0x0039, RFC 9001 §8.2).
+%% `parse_client_hello/1` takes the already-deframed ClientHello body and
+%% returns the fields a server needs as a map; the build functions return
+%% the fully framed handshake message as an iolist.
+%%
+%% Pure codec: it parses and builds wire bytes and never crashes on a
+%% malformed buffer (flat `{error, atom()}`). It does NOT negotiate or
+%% validate the peer's choices (TLS version, cipher, group selection,
+%% mandatory-extension presence) - that is the connection layer's job, so
+%% `parse_client_hello/1` extracts what is present and leaves absent
+%% extensions out of the map. The server build does not generate keys: the
+%% caller owns the x25519 key pair and passes the public key in.
+
+-export([parse_client_hello/1, build_server_hello/1, build_encrypted_extensions/1]).
+
+-export_type([client_hello/0]).
+
+%% Handshake message types (RFC 8446 §4), for framing via the C3 module.
+-define(SERVER_HELLO, 2).
+-define(ENCRYPTED_EXTENSIONS, 8).
+
+%% Extension codepoints (RFC 8446 §4.2 + RFC 9001 §8.2).
+-define(EXT_SERVER_NAME, 16#0000).
+-define(EXT_SIGNATURE_ALGORITHMS, 16#000D).
+-define(EXT_ALPN, 16#0010).
+-define(EXT_SUPPORTED_VERSIONS, 16#002B).
+-define(EXT_KEY_SHARE, 16#0033).
+-define(EXT_QUIC_TRANSPORT_PARAMS, 16#0039).
+
+%% Wire constants.
+-define(LEGACY_VERSION, 16#0303).
+-define(TLS_1_3, 16#0304).
+-define(GROUP_X25519, 16#001D).
+%% v1 cipher suite (the only suite the server offers).
+-define(CIPHER_AES_128_GCM_SHA256, 16#1301).
+%% SNI name_type 0 = host_name (RFC 6066 §3).
+-define(SNI_HOST_NAME, 16#00).
+
+-type client_hello() :: #{
+    random := binary(),
+    session_id := binary(),
+    cipher_suites := [non_neg_integer()],
+    alpn_protocols := [binary()],
+    signature_algorithms := [non_neg_integer()],
+    key_share => binary(),
+    server_name => binary(),
+    transport_params => roadrunner_quic_transport_params:params()
+}.
+
+%% =============================================================================
+%% parse_client_hello/1
+%% =============================================================================
+
+-doc """
+Parse a ClientHello body (RFC 8446 §4.1.2), as handed up by
+`roadrunner_quic_tls_handshake:decode/1`. Returns the fields a server
+needs as a map: the random and legacy session id (echoed in the
+ServerHello), the offered cipher suites, the client's x25519 key share,
+the offered ALPN protocols and signature schemes, and (when present) the
+SNI host name and decoded QUIC transport parameters. Absent extensions
+are simply left out of the map. Returns `{error, Reason}` on a malformed
+buffer.
+""".
+-spec parse_client_hello(binary()) -> {ok, client_hello()} | {error, atom()}.
+parse_client_hello(<<?LEGACY_VERSION:16, Random:32/binary, AfterRandom/binary>>) ->
+    maybe
+        {ok, SessionId, AfterSession} ?= take_u8_vector(AfterRandom),
+        {ok, CipherBytes, AfterCiphers} ?= take_u16_vector(AfterSession),
+        {ok, _Compression, AfterCompression} ?= take_u8_vector(AfterCiphers),
+        {ok, ExtBytes, _Rest} ?= take_u16_vector(AfterCompression),
+        {ok, Extensions} ?= parse_extensions(ExtBytes),
+        finalize_client_hello(Random, SessionId, parse_cipher_suites(CipherBytes), Extensions)
+    end;
+parse_client_hello(_) ->
+    {error, malformed_client_hello}.
+
+%% =============================================================================
+%% build_server_hello/1
+%% =============================================================================
+
+-doc """
+Build a ServerHello (RFC 8446 §4.1.3), framed, as an iolist. Inputs:
+`random` (32 bytes), `session_id` (the client's legacy session id, echoed
+verbatim), and `key_share` (the server's 32-byte x25519 public key). The
+cipher suite is fixed to TLS_AES_128_GCM_SHA256 and the group to x25519.
+The two server extensions are key_share then supported_versions
+(selecting TLS 1.3).
+""".
+-spec build_server_hello(#{
+    random := binary(), session_id := binary(), key_share := binary()
+}) -> iolist().
+build_server_hello(#{random := Random, session_id := SessionId, key_share := PubKey}) ->
+    Extensions = [
+        encode_extension(?EXT_KEY_SHARE, server_key_share(PubKey)),
+        encode_extension(?EXT_SUPPORTED_VERSIONS, <<?TLS_1_3:16>>)
+    ],
+    Body = [
+        <<?LEGACY_VERSION:16, Random:32/binary, (byte_size(SessionId)):8>>,
+        SessionId,
+        <<?CIPHER_AES_128_GCM_SHA256:16, 0:8, (iolist_size(Extensions)):16>>,
+        Extensions
+    ],
+    roadrunner_quic_tls_handshake:encode(?SERVER_HELLO, Body).
+
+%% =============================================================================
+%% build_encrypted_extensions/1
+%% =============================================================================
+
+-doc """
+Build an EncryptedExtensions message (RFC 8446 §4.3.1), framed, as an
+iolist. Carries the selected `alpn` protocol (RFC 7301) and the server's
+QUIC `transport_params` (RFC 9001 §8.2); each is omitted if absent or
+empty.
+""".
+-spec build_encrypted_extensions(#{
+    alpn => binary(), transport_params => roadrunner_quic_transport_params:params()
+}) -> iolist().
+build_encrypted_extensions(Opts) ->
+    Extensions = [alpn_extension(Opts), transport_params_extension(Opts)],
+    Body = [<<(iolist_size(Extensions)):16>>, Extensions],
+    roadrunner_quic_tls_handshake:encode(?ENCRYPTED_EXTENSIONS, Body).
+
+%% =============================================================================
+%% Internal - ClientHello field extraction
+%% =============================================================================
+
+%% Assemble the client_hello() map from the parsed pieces. The structural
+%% extractors are lenient (a malformed extension is treated as absent);
+%% only the transport parameters carry a validating decoder whose error
+%% is propagated.
+-spec finalize_client_hello(binary(), binary(), [non_neg_integer()], #{
+    non_neg_integer() => binary()
+}) ->
+    {ok, client_hello()} | {error, atom()}.
+finalize_client_hello(Random, SessionId, Ciphers, Extensions) ->
+    Base = #{
+        random => Random,
+        session_id => SessionId,
+        cipher_suites => Ciphers,
+        alpn_protocols => extract_alpn(Extensions),
+        signature_algorithms => extract_signature_algorithms(Extensions)
+    },
+    WithKeyShare = maybe_put(key_share, extract_x25519_key_share(Extensions), Base),
+    WithName = maybe_put(server_name, extract_server_name(Extensions), WithKeyShare),
+    case extract_transport_params(Extensions) of
+        none -> {ok, WithName};
+        {ok, Params} -> {ok, WithName#{transport_params => Params}};
+        {error, _} = Error -> Error
+    end.
+
+-spec maybe_put(atom(), undefined | term(), map()) -> map().
+maybe_put(_Key, undefined, Map) -> Map;
+maybe_put(Key, Value, Map) -> Map#{Key => Value}.
+
+%% The x25519 public key from the client's key_share list (RFC 8446
+%% §4.2.8), or undefined if the client offered no x25519 entry.
+-spec extract_x25519_key_share(#{non_neg_integer() => binary()}) -> binary() | undefined.
+extract_x25519_key_share(#{?EXT_KEY_SHARE := Data}) ->
+    case take_u16_vector(Data) of
+        {ok, Entries, _Rest} -> find_x25519_entry(Entries);
+        {error, _} -> undefined
+    end;
+extract_x25519_key_share(#{}) ->
+    undefined.
+
+-spec find_x25519_entry(binary()) -> binary() | undefined.
+find_x25519_entry(<<?GROUP_X25519:16, KeyLen:16, Key:KeyLen/binary, _Rest/binary>>) ->
+    Key;
+find_x25519_entry(<<_Group:16, KeyLen:16, _Key:KeyLen/binary, Rest/binary>>) ->
+    find_x25519_entry(Rest);
+find_x25519_entry(_) ->
+    undefined.
+
+%% The ALPN protocol list (RFC 7301), [] if absent or malformed.
+-spec extract_alpn(#{non_neg_integer() => binary()}) -> [binary()].
+extract_alpn(#{?EXT_ALPN := Data}) ->
+    case take_u16_vector(Data) of
+        {ok, List, _Rest} -> parse_alpn_list(List);
+        {error, _} -> []
+    end;
+extract_alpn(#{}) ->
+    [].
+
+-spec parse_alpn_list(binary()) -> [binary()].
+parse_alpn_list(<<Len:8, Proto:Len/binary, Rest/binary>>) ->
+    [Proto | parse_alpn_list(Rest)];
+parse_alpn_list(_) ->
+    [].
+
+%% The offered signature schemes (RFC 8446 §4.2.3), [] if absent.
+-spec extract_signature_algorithms(#{non_neg_integer() => binary()}) -> [non_neg_integer()].
+extract_signature_algorithms(#{?EXT_SIGNATURE_ALGORITHMS := Data}) ->
+    case take_u16_vector(Data) of
+        {ok, List, _Rest} -> parse_u16_list(List);
+        {error, _} -> []
+    end;
+extract_signature_algorithms(#{}) ->
+    [].
+
+%% The SNI host name (RFC 6066 §3, name_type 0), or undefined.
+-spec extract_server_name(#{non_neg_integer() => binary()}) -> binary() | undefined.
+extract_server_name(#{?EXT_SERVER_NAME := Data}) ->
+    case take_u16_vector(Data) of
+        {ok, <<?SNI_HOST_NAME:8, NameLen:16, Name:NameLen/binary, _/binary>>, _Rest} -> Name;
+        _ -> undefined
+    end;
+extract_server_name(#{}) ->
+    undefined.
+
+%% Decode the QUIC transport parameters extension (RFC 9001 §8.2) via the
+%% C4 codec, or `none` if the extension is absent.
+-spec extract_transport_params(#{non_neg_integer() => binary()}) ->
+    none | {ok, roadrunner_quic_transport_params:params()} | {error, atom()}.
+extract_transport_params(#{?EXT_QUIC_TRANSPORT_PARAMS := Data}) ->
+    roadrunner_quic_transport_params:decode(Data);
+extract_transport_params(#{}) ->
+    none.
+
+-spec parse_cipher_suites(binary()) -> [non_neg_integer()].
+parse_cipher_suites(Bin) ->
+    parse_u16_list(Bin).
+
+%% A packed list of 16-bit values; a trailing partial value is dropped.
+-spec parse_u16_list(binary()) -> [non_neg_integer()].
+parse_u16_list(<<Value:16, Rest/binary>>) ->
+    [Value | parse_u16_list(Rest)];
+parse_u16_list(_) ->
+    [].
+
+%% =============================================================================
+%% Internal - extension list codec (RFC 8446 §4.2)
+%% =============================================================================
+
+%% Parse the extension vector into a map of type => extension_data,
+%% rejecting a duplicated extension type (RFC 8446 §4.2).
+-spec parse_extensions(binary()) -> {ok, #{non_neg_integer() => binary()}} | {error, atom()}.
+parse_extensions(Bin) ->
+    parse_extensions(Bin, #{}).
+
+-spec parse_extensions(binary(), #{non_neg_integer() => binary()}) ->
+    {ok, #{non_neg_integer() => binary()}} | {error, atom()}.
+parse_extensions(<<>>, Acc) ->
+    {ok, Acc};
+parse_extensions(<<Type:16, Len:16, Data:Len/binary, Rest/binary>>, Acc) ->
+    case Acc of
+        #{Type := _} -> {error, duplicate_extension};
+        #{} -> parse_extensions(Rest, Acc#{Type => Data})
+    end;
+parse_extensions(_, _) ->
+    {error, malformed_extensions}.
+
+%% One extension as a Type:16, Length:16, Data record (RFC 8446 §4.2).
+-spec encode_extension(non_neg_integer(), iodata()) -> iolist().
+encode_extension(Type, Data) ->
+    [<<Type:16, (iolist_size(Data)):16>>, Data].
+
+%% A ServerHello key_share extension body: a single bare KeyShareEntry
+%% (RFC 8446 §4.2.8), no list-length prefix.
+-spec server_key_share(binary()) -> iolist().
+server_key_share(PubKey) ->
+    [<<?GROUP_X25519:16, (byte_size(PubKey)):16>>, PubKey].
+
+%% The EncryptedExtensions ALPN extension carrying the single selected
+%% protocol (RFC 7301 §3.1), or [] when no protocol was selected. An empty
+%% protocol is treated as absent: a zero-length ProtocolName is invalid
+%% (RFC 7301 §3.1), so it is omitted rather than emitted malformed.
+-spec alpn_extension(#{alpn => binary(), _ => _}) -> iolist().
+alpn_extension(#{alpn := Protocol}) when byte_size(Protocol) > 0 ->
+    NameList = [<<(byte_size(Protocol)):8>>, Protocol],
+    encode_extension(?EXT_ALPN, [<<(iolist_size(NameList)):16>>, NameList]);
+alpn_extension(#{}) ->
+    [].
+
+%% The EncryptedExtensions quic_transport_parameters extension (RFC 9001
+%% §8.2), or [] when no parameters were given (an empty map is absent).
+-spec transport_params_extension(#{
+    transport_params => roadrunner_quic_transport_params:params(), _ => _
+}) ->
+    iolist().
+transport_params_extension(#{transport_params := Params}) when map_size(Params) > 0 ->
+    encode_extension(?EXT_QUIC_TRANSPORT_PARAMS, roadrunner_quic_transport_params:encode(Params));
+transport_params_extension(#{}) ->
+    [].
+
+%% =============================================================================
+%% Internal - wire helpers
+%% =============================================================================
+
+%% Read an 8-bit length prefix, then exactly that many bytes.
+-spec take_u8_vector(binary()) -> {ok, binary(), binary()} | {error, atom()}.
+take_u8_vector(<<Len:8, Value:Len/binary, Rest/binary>>) ->
+    {ok, Value, Rest};
+take_u8_vector(_) ->
+    {error, truncated}.
+
+%% Read a 16-bit length prefix, then exactly that many bytes.
+-spec take_u16_vector(binary()) -> {ok, binary(), binary()} | {error, atom()}.
+take_u16_vector(<<Len:16, Value:Len/binary, Rest/binary>>) ->
+    {ok, Value, Rest};
+take_u16_vector(_) ->
+    {error, truncated}.

--- a/test/property_test/roadrunner_quic_tls_hello_props.erl
+++ b/test/property_test/roadrunner_quic_tls_hello_props.erl
@@ -1,0 +1,24 @@
+-module(roadrunner_quic_tls_hello_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_tls_hello`.
+
+Robustness invariant: `parse_client_hello/1` returns a flat
+`{ok, _} | {error, _}` for any input and never crashes, including on
+buffers that look like a ClientHello (the `0x0303` legacy-version prefix)
+but carry garbage in the nested length-prefixed vectors.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_parse_client_hello_never_crashes() ->
+    ?FORALL(
+        Bin,
+        oneof([binary(), ?LET(B, binary(), <<16#0303:16, B/binary>>)]),
+        case roadrunner_quic_tls_hello:parse_client_hello(Bin) of
+            {ok, Map} when is_map(Map) -> true;
+            {error, Reason} when is_atom(Reason) -> true
+        end
+    ).

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -45,7 +45,8 @@ Add a new property:
     quic_flow_matches_dep/1,
     quic_tls_crypto_matches_dep/1,
     quic_tls_handshake_matches_dep/1,
-    quic_transport_params_matches_dep/1
+    quic_transport_params_matches_dep/1,
+    quic_tls_hello_parse_never_crashes/1
 ]).
 
 suite() ->
@@ -81,7 +82,8 @@ all() ->
         quic_flow_matches_dep,
         quic_tls_crypto_matches_dep,
         quic_tls_handshake_matches_dep,
-        quic_transport_params_matches_dep
+        quic_transport_params_matches_dep,
+        quic_tls_hello_parse_never_crashes
     ].
 
 init_per_suite(Config) ->
@@ -261,5 +263,11 @@ quic_tls_handshake_matches_dep(Config) ->
 quic_transport_params_matches_dep(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_transport_params_props:prop_encode_decode_matches_dep(),
+        Config
+    ).
+
+quic_tls_hello_parse_never_crashes(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_tls_hello_props:prop_parse_client_hello_never_crashes(),
         Config
     ).

--- a/test/roadrunner_quic_tls_hello_tests.erl
+++ b/test/roadrunner_quic_tls_hello_tests.erl
@@ -1,0 +1,274 @@
+-module(roadrunner_quic_tls_hello_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_tls_hello).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_tls).
+-define(FRAME, roadrunner_quic_tls_handshake).
+
+%% =============================================================================
+%% RFC 8448 §3 "Simple 1-RTT Handshake" — the authority. Its ClientHello and
+%% ServerHello use x25519 + TLS_AES_128_GCM_SHA256, exactly v1's profile.
+%% =============================================================================
+
+rfc8448_client_hello_parse_test() ->
+    {ok, {1, Body}, <<>>} = ?FRAME:decode(rfc8448_client_hello()),
+    {ok, Parsed} = ?M:parse_client_hello(Body),
+    ?assertEqual(
+        hex("cb34ecb1e78163ba1c38c6dacb196a6dffa21a8d9912ec18a2ef6283024dece7"),
+        maps:get(random, Parsed)
+    ),
+    ?assertEqual(<<>>, maps:get(session_id, Parsed)),
+    ?assertEqual([16#1301, 16#1303, 16#1302], maps:get(cipher_suites, Parsed)),
+    ?assertEqual(
+        hex("99381de560e4bd43d23d8e435a7dbafeb3c06e51c13cae4d5413691e529aaf2c"),
+        maps:get(key_share, Parsed)
+    ),
+    ?assertEqual(<<"server">>, maps:get(server_name, Parsed)),
+    %% This ClientHello carries no ALPN and no quic_transport_parameters.
+    ?assertEqual([], maps:get(alpn_protocols, Parsed)),
+    ?assertNot(maps:is_key(transport_params, Parsed)),
+    ?assertEqual(
+        [
+            16#0403,
+            16#0503,
+            16#0603,
+            16#0203,
+            16#0804,
+            16#0805,
+            16#0806,
+            16#0401,
+            16#0501,
+            16#0601,
+            16#0201,
+            16#0402,
+            16#0502,
+            16#0602,
+            16#0202
+        ],
+        maps:get(signature_algorithms, Parsed)
+    ).
+
+rfc8448_server_hello_build_test() ->
+    Built = iolist_to_binary(
+        ?M:build_server_hello(#{
+            random => hex("a6af06a4121860dc5e6e60249cd34c95930c8ac5cb1434dac155772ed3e26928"),
+            session_id => <<>>,
+            key_share => hex("c9828876112095fe66762bdbf7c672e156d6cc253b833df1dd69b1b04e751f0f")
+        })
+    ),
+    ?assertEqual(rfc8448_server_hello(), Built).
+
+%% =============================================================================
+%% EncryptedExtensions build (QUIC: ALPN + transport parameters).
+%% =============================================================================
+
+encrypted_extensions_build_test() ->
+    Params = #{initial_max_data => 1048576, initial_max_streams_bidi => 16},
+    EE = iolist_to_binary(
+        ?M:build_encrypted_extensions(#{alpn => ~"h3", transport_params => Params})
+    ),
+    %% Framed message: type 8, then <<ExtLen:16, ALPN, TP>>.
+    {ok, {8, Body}, <<>>} = ?FRAME:decode(EE),
+    <<ExtLen:16, Exts:ExtLen/binary>> = Body,
+    %% ALPN extension (0x0010): ProtocolNameList = <<NamesLen:16, Len:8, "h3">>.
+    AlpnData = <<3:16, 2:8, "h3">>,
+    Alpn = <<16#0010:16, (byte_size(AlpnData)):16, AlpnData/binary>>,
+    %% Transport params extension (0x0039) carrying the C4-encoded body.
+    TPData = iolist_to_binary(roadrunner_quic_transport_params:encode(Params)),
+    TP = <<16#0039:16, (byte_size(TPData)):16, TPData/binary>>,
+    ?assertEqual(<<Alpn/binary, TP/binary>>, Exts).
+
+encrypted_extensions_omits_absent_test() ->
+    %% No alpn, no transport_params -> an empty extension list.
+    EE = iolist_to_binary(?M:build_encrypted_extensions(#{})),
+    {ok, {8, Body}, <<>>} = ?FRAME:decode(EE),
+    ?assertEqual(<<0:16>>, Body).
+
+encrypted_extensions_omits_empty_test() ->
+    %% A present-but-empty protocol or params map is treated as absent
+    %% (a zero-length ALPN ProtocolName would be invalid per RFC 7301).
+    EE = iolist_to_binary(?M:build_encrypted_extensions(#{alpn => <<>>, transport_params => #{}})),
+    {ok, {8, Body}, <<>>} = ?FRAME:decode(EE),
+    ?assertEqual(<<0:16>>, Body).
+
+%% =============================================================================
+%% parse_client_hello — extension extraction edges (crafted ClientHellos).
+%% =============================================================================
+
+parse_extracts_alpn_and_transport_params_test() ->
+    Params = #{initial_max_data => 4096},
+    TPData = iolist_to_binary(roadrunner_quic_transport_params:encode(Params)),
+    Exts = [
+        ext(16#0010, <<3:16, 2:8, "h3">>),
+        key_share_ext(hex("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")),
+        ext(16#0039, TPData)
+    ],
+    {ok, Parsed} = ?M:parse_client_hello(ch_body(<<>>, [16#1301], Exts)),
+    ?assertEqual([~"h3"], maps:get(alpn_protocols, Parsed)),
+    ?assertEqual({ok, Params}, {ok, maps:get(transport_params, Parsed)}),
+    ?assertEqual(
+        hex("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
+        maps:get(key_share, Parsed)
+    ).
+
+parse_key_share_without_x25519_test() ->
+    %% A key_share offering only secp256r1 (0x0017) -> no x25519 key extracted.
+    Entry = <<16#0017:16, 4:16, 1, 2, 3, 4>>,
+    Exts = [ext(16#0033, <<(byte_size(Entry)):16, Entry/binary>>)],
+    {ok, Parsed} = ?M:parse_client_hello(ch_body(<<>>, [16#1301], Exts)),
+    ?assertNot(maps:is_key(key_share, Parsed)),
+    ?assertEqual([], maps:get(alpn_protocols, Parsed)),
+    ?assertEqual([], maps:get(signature_algorithms, Parsed)).
+
+parse_key_share_skips_to_x25519_test() ->
+    %% A non-x25519 entry precedes the x25519 entry; find it past the first.
+    X25519 = hex("aa00000000000000000000000000000000000000000000000000000000000099"),
+    Entries = <<16#0017:16, 2:16, 9, 9, 16#001d:16, 32:16, X25519/binary>>,
+    Exts = [ext(16#0033, <<(byte_size(Entries)):16, Entries/binary>>)],
+    {ok, Parsed} = ?M:parse_client_hello(ch_body(<<>>, [16#1301], Exts)),
+    ?assertEqual(X25519, maps:get(key_share, Parsed)).
+
+parse_rejects_bad_transport_params_test() ->
+    %% A server-only transport parameter from a client is rejected by C4.
+    Bad = <<16#00, 16#01, 16#aa>>,
+    Exts = [ext(16#0039, Bad)],
+    ?assertEqual(
+        {error, server_only_transport_parameter},
+        ?M:parse_client_hello(ch_body(<<>>, [16#1301], Exts))
+    ).
+
+parse_empty_extensions_test() ->
+    {ok, Parsed} = ?M:parse_client_hello(ch_body(<<1, 2, 3>>, [16#1301, 16#1302], [])),
+    ?assertEqual(<<1, 2, 3>>, maps:get(session_id, Parsed)),
+    ?assertEqual([16#1301, 16#1302], maps:get(cipher_suites, Parsed)),
+    ?assertNot(maps:is_key(key_share, Parsed)),
+    ?assertNot(maps:is_key(server_name, Parsed)).
+
+parse_lenient_on_malformed_extension_data_test() ->
+    %% Each extension's inner length prefix overruns its data; extraction
+    %% is lenient (absent/empty), never a crash. The transport parameters
+    %% are the one extension whose decode error would propagate, so they
+    %% are not included here.
+    Exts = [
+        ext(16#0033, <<16#FF:16, 1, 2>>),
+        ext(16#0010, <<16#FF:16>>),
+        ext(16#000D, <<16#FF:16>>),
+        ext(16#0000, <<16#FF:16>>)
+    ],
+    {ok, Parsed} = ?M:parse_client_hello(ch_body(<<>>, [16#1301], Exts)),
+    ?assertNot(maps:is_key(key_share, Parsed)),
+    ?assertEqual([], maps:get(alpn_protocols, Parsed)),
+    ?assertEqual([], maps:get(signature_algorithms, Parsed)),
+    ?assertNot(maps:is_key(server_name, Parsed)).
+
+%% =============================================================================
+%% parse_client_hello — malformed input is a flat error, never a crash.
+%% =============================================================================
+
+parse_rejects_wrong_legacy_version_test() ->
+    ?assertEqual({error, malformed_client_hello}, ?M:parse_client_hello(<<16#0304:16, 0:256>>)).
+
+parse_rejects_truncated_test() ->
+    ?assertMatch({error, _}, ?M:parse_client_hello(<<>>)),
+    ?assertMatch({error, _}, ?M:parse_client_hello(<<16#0303:16>>)),
+    %% Header present, but the session-id length overruns.
+    ?assertEqual(
+        {error, truncated},
+        ?M:parse_client_hello(<<16#0303:16, 0:256, 5:8, 1, 2>>)
+    ).
+
+parse_rejects_duplicate_extension_test() ->
+    Exts = [ext(16#0010, <<0:16>>), ext(16#0010, <<0:16>>)],
+    ?assertEqual(
+        {error, duplicate_extension},
+        ?M:parse_client_hello(ch_body(<<>>, [16#1301], Exts))
+    ).
+
+parse_rejects_malformed_extensions_test() ->
+    %% An extension header that overruns the extensions block.
+    Exts = <<16#0010:16, 16#FF:16, 1, 2>>,
+    ?assertEqual(
+        {error, malformed_extensions},
+        ?M:parse_client_hello(ch_body_raw_exts(<<>>, [16#1301], Exts))
+    ).
+
+%% =============================================================================
+%% Differential oracle vs the `quic` dep.
+%% =============================================================================
+
+%% The dep parses the RFC 8448 §3 ClientHello to the same v1-subset values.
+oracle_parse_matches_dep_test() ->
+    {ok, {1, Body}, <<>>} = ?FRAME:decode(rfc8448_client_hello()),
+    {ok, Mine} = ?M:parse_client_hello(Body),
+    {ok, Dep} = ?DEP:parse_client_hello(Body),
+    ?assertEqual(maps:get(random, Dep), maps:get(random, Mine)),
+    ?assertEqual(maps:get(session_id, Dep), maps:get(session_id, Mine)),
+    ?assertEqual(maps:get(cipher_suites, Dep), maps:get(cipher_suites, Mine)),
+    ?assertEqual(maps:get(alpn_protocols, Dep), maps:get(alpn_protocols, Mine)),
+    ?assertEqual(maps:get(signature_algorithms, Dep), maps:get(signature_algorithms, Mine)),
+    %% The dep keeps key_share as [{Group, Key}]; compare the x25519 entry.
+    {16#001d, DepKey} = lists:keyfind(16#001d, 1, maps:get(key_share, Dep)),
+    ?assertEqual(DepKey, maps:get(key_share, Mine)).
+
+%% The dep decodes the native EncryptedExtensions to the same extension set.
+oracle_encrypted_extensions_matches_dep_test() ->
+    Params = #{initial_max_data => 65536, max_idle_timeout => 30000},
+    Opts = #{alpn => ~"h3", transport_params => Params},
+    Mine = iolist_to_binary(?M:build_encrypted_extensions(Opts)),
+    Dep = ?DEP:build_encrypted_extensions(Opts),
+    ?assertEqual(Dep, Mine).
+
+%% =============================================================================
+%% Fixtures and helpers
+%% =============================================================================
+
+%% Build a ClientHello body with the given session id, cipher list, and a
+%% list of already-encoded extensions.
+ch_body(SessionId, Ciphers, Exts) ->
+    ch_body_raw_exts(SessionId, Ciphers, iolist_to_binary(Exts)).
+
+ch_body_raw_exts(SessionId, Ciphers, ExtBytes) ->
+    CipherBytes = <<<<C:16>> || C <- Ciphers>>,
+    Random = binary:copy(<<7>>, 32),
+    iolist_to_binary([
+        <<16#0303:16, Random/binary, (byte_size(SessionId)):8>>,
+        SessionId,
+        <<(byte_size(CipherBytes)):16>>,
+        CipherBytes,
+        <<1:8, 0:8>>,
+        <<(byte_size(ExtBytes)):16>>,
+        ExtBytes
+    ]).
+
+%% One encoded extension: Type:16, Length:16, Data.
+ext(Type, Data) ->
+    <<Type:16, (byte_size(Data)):16, Data/binary>>.
+
+%% A client key_share extension carrying a single x25519 entry.
+key_share_ext(PubKey) ->
+    Entry = <<16#001d:16, (byte_size(PubKey)):16, PubKey/binary>>,
+    ext(16#0033, <<(byte_size(Entry)):16, Entry/binary>>).
+
+rfc8448_client_hello() ->
+    hex(
+        "010000c00303cb34ecb1e78163ba1c38c6dacb196a6dffa21a8d9912ec18a2ef6283024d"
+        "ece7000006130113031302010000910000000b0009000006736572766572ff0100010000"
+        "0a00140012001d00170018001901000101010201030104002300000033002600240"
+        "01d002099381de560e4bd43d23d8e435a7dbafeb3c06e51c13cae4d5413691e529aaf2c"
+        "002b0003020304000d0020001e040305030603020308040805080604010501060102010"
+        "402050206020202002d00020101001c00024001"
+    ).
+
+rfc8448_server_hello() ->
+    hex(
+        "0200005603 03a6af06a4121860dc5e6e60249cd34c95930c8ac5cb1434dac155772ed3e2"
+        "692800130100002e00330024001d0020c9828876112095fe66762bdbf7c672e156d6cc25"
+        "3b833df1dd69b1b04e751f0f002b00020304"
+    ).
+
+%% Decode a (possibly whitespace-formatted) hex string to bytes.
+hex(Hex) ->
+    Bytes = <<<<B>> || <<B>> <= iolist_to_binary(Hex), B =/= $\s, B =/= $\n>>,
+    binary:decode_hex(string:uppercase(Bytes)).


### PR DESCRIPTION
# Description

Adds the TLS 1.3 hello exchange for the native QUIC server: it parses the client's ClientHello (the random, the offered cipher suites, the x25519 key share, ALPN, SNI, signature schemes, and the QUIC transport parameters via #123) and builds the server's ServerHello and EncryptedExtensions. It covers the v1 profile, x25519 and TLS_AES_128_GCM_SHA256, reusing the message framing from #121 and the transport-parameters codec from #123.

For example, `parse_client_hello(Body)` returns a map of the fields a server needs, and `build_server_hello(#{random, session_id, key_share})` produces the framed ServerHello. It reproduces the RFC 8448 §3 ClientHello and ServerHello byte-for-byte and matches the `quic` dependency.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)