### PR TITLE
Add the native QUIC TLS server authentication flight

### DIFF
--- a/src/roadrunner_quic_tls_auth.erl
+++ b/src/roadrunner_quic_tls_auth.erl
@@ -1,0 +1,148 @@
+-module(roadrunner_quic_tls_auth).
+-moduledoc false.
+
+%% TLS 1.3 server authentication flight (RFC 8446 §4.4) for a server-only
+%% QUIC v1 endpoint: build the Certificate (§4.4.2), CertificateVerify
+%% (§4.4.3), and Finished (§4.4.4) messages, and verify the client's
+%% Finished. v1 signs with one of rsa_pss_rsae_sha256, ecdsa_secp256r1_sha256,
+%% or ed25519, all over SHA-256.
+%%
+%% `roadrunner_quic_tls_handshake` frames the messages, and
+%% `roadrunner_quic_tls_crypto` (finished_key/1 + verify_data/2) backs the
+%% Finished MAC. The chosen signature scheme and the signing key come from
+%% the connection layer (which owns negotiation), and the certificate chain
+%% from `roadrunner_listener:quic_cert_key/1`. Builders return the framed
+%% handshake message as an iolist.
+%%
+%% Signing legitimately crashes on an out-of-contract scheme or key (a
+%% function clause), unlike the pure wire codecs: the caller passes a
+%% negotiated, supported scheme with a matching key.
+
+-include_lib("public_key/include/public_key.hrl").
+
+-export([
+    build_certificate/1,
+    build_certificate_verify/3,
+    build_finished/2,
+    verify_client_finished/3
+]).
+
+%% Handshake message types (RFC 8446 §4).
+-define(CERTIFICATE, 11).
+-define(CERTIFICATE_VERIFY, 15).
+-define(FINISHED, 20).
+
+%% Signature schemes (RFC 8446 §4.2.3) supported in v1.
+-define(SIG_RSA_PSS_RSAE_SHA256, 16#0804).
+-define(SIG_ECDSA_SECP256R1_SHA256, 16#0403).
+-define(SIG_ED25519, 16#0807).
+
+%% The server CertificateVerify signature context (RFC 8446 §4.4.3).
+-define(CERT_VERIFY_CONTEXT, ~"TLS 1.3, server CertificateVerify").
+
+%% =============================================================================
+%% build_certificate/1
+%% =============================================================================
+
+-doc """
+Build a Certificate message (RFC 8446 §4.4.2) from the server's DER
+certificate chain (leaf first), framed as an iolist. The
+certificate_request_context is empty (a server responding to a
+ClientHello), and each entry carries an empty extensions vector.
+""".
+-spec build_certificate([binary()]) -> iolist().
+build_certificate(Certs) ->
+    CertList = cert_list(Certs),
+    Body = [<<0:8, (iolist_size(CertList)):24>>, CertList],
+    roadrunner_quic_tls_handshake:encode(?CERTIFICATE, Body).
+
+%% =============================================================================
+%% build_certificate_verify/3
+%% =============================================================================
+
+-doc """
+Build a CertificateVerify message (RFC 8446 §4.4.3), framed as an iolist.
+Signs the server CertificateVerify content (64 spaces, the context
+string, a 0 separator, then `TranscriptHash` through the Certificate
+message) with `PrivateKey` under `Scheme` (rsa_pss_rsae_sha256,
+ecdsa_secp256r1_sha256, or ed25519). RSA-PSS and ECDSA signatures are
+randomized, so the output is not reproducible byte-for-byte.
+""".
+-spec build_certificate_verify(non_neg_integer(), public_key:private_key(), binary()) -> iolist().
+build_certificate_verify(Scheme, PrivateKey, TranscriptHash) ->
+    Content = [binary:copy(<<16#20>>, 64), ?CERT_VERIFY_CONTEXT, 0, TranscriptHash],
+    Signature = sign(Scheme, PrivateKey, iolist_to_binary(Content)),
+    Body = [<<Scheme:16, (byte_size(Signature)):16>>, Signature],
+    roadrunner_quic_tls_handshake:encode(?CERTIFICATE_VERIFY, Body).
+
+%% =============================================================================
+%% build_finished/2 + verify_client_finished/3
+%% =============================================================================
+
+-doc """
+Build a Finished message (RFC 8446 §4.4.4), framed as an iolist. The
+verify_data is `HMAC(finished_key(TrafficSecret), TranscriptHash)`; the
+server passes its handshake traffic secret and the transcript hash
+through CertificateVerify.
+""".
+-spec build_finished(binary(), binary()) -> iolist().
+build_finished(TrafficSecret, TranscriptHash) ->
+    roadrunner_quic_tls_handshake:encode(
+        ?FINISHED, finished_verify_data(TrafficSecret, TranscriptHash)
+    ).
+
+-doc """
+Verify a client's Finished verify_data (RFC 8446 §4.4.4) in constant
+time. Recomputes `HMAC(finished_key(TrafficSecret), TranscriptHash)` (the
+client's handshake traffic secret, over the transcript through the server
+Finished) and compares it to `Received`.
+""".
+-spec verify_client_finished(binary(), binary(), binary()) -> boolean().
+verify_client_finished(Received, TrafficSecret, TranscriptHash) ->
+    crypto:hash_equals(Received, finished_verify_data(TrafficSecret, TranscriptHash)).
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% The CertificateEntry list (RFC 8446 §4.4.2): each cert is a 24-bit
+%% length-prefixed DER blob followed by an empty extensions vector. Body
+%% recursion, consing on the way out.
+-spec cert_list([binary()]) -> iolist().
+cert_list([]) ->
+    [];
+cert_list([Cert | Rest]) ->
+    [<<(byte_size(Cert)):24>>, Cert, <<0:16>> | cert_list(Rest)].
+
+%% The Finished verify_data via the C2 key schedule.
+-spec finished_verify_data(binary(), binary()) -> binary().
+finished_verify_data(TrafficSecret, TranscriptHash) ->
+    FinishedKey = roadrunner_quic_tls_crypto:finished_key(TrafficSecret),
+    roadrunner_quic_tls_crypto:verify_data(FinishedKey, TranscriptHash).
+
+%% Sign the CertificateVerify content under the negotiated scheme, using
+%% the same OTP crypto primitives as the dep.
+-spec sign(non_neg_integer(), public_key:private_key(), binary()) -> binary().
+sign(Scheme, PrivateKey, Content) ->
+    {SigAlg, HashAlg, Options} = signature_params(Scheme),
+    crypto:sign(SigAlg, HashAlg, Content, crypto_key(Scheme, PrivateKey), Options).
+
+-spec signature_params(non_neg_integer()) -> {atom(), atom(), [{atom(), atom() | integer()}]}.
+signature_params(?SIG_RSA_PSS_RSAE_SHA256) ->
+    {rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]};
+signature_params(?SIG_ECDSA_SECP256R1_SHA256) ->
+    {ecdsa, sha256, []};
+signature_params(?SIG_ED25519) ->
+    {eddsa, none, []}.
+
+%% Convert the public_key private-key record into the key form crypto:sign
+%% expects for the scheme.
+-spec crypto_key(non_neg_integer(), public_key:private_key()) -> [integer() | binary() | atom()].
+crypto_key(?SIG_RSA_PSS_RSAE_SHA256, #'RSAPrivateKey'{
+    publicExponent = E, modulus = N, privateExponent = D
+}) ->
+    [E, N, D];
+crypto_key(?SIG_ECDSA_SECP256R1_SHA256, #'ECPrivateKey'{privateKey = Priv}) ->
+    [Priv, secp256r1];
+crypto_key(?SIG_ED25519, #'ECPrivateKey'{privateKey = Priv}) ->
+    [Priv, ed25519].

--- a/test/property_test/roadrunner_quic_tls_auth_props.erl
+++ b/test/property_test/roadrunner_quic_tls_auth_props.erl
@@ -1,0 +1,47 @@
+-module(roadrunner_quic_tls_auth_props).
+-moduledoc """
+Property-based tests for `roadrunner_quic_tls_auth`.
+
+Round-trip invariant: a CertificateVerify built for any 32-byte
+transcript hash, under each supported signature scheme (rsa_pss_rsae_sha256,
+ecdsa_secp256r1_sha256, ed25519), carries a signature that verifies
+against the matching public key.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("public_key/include/public_key.hrl").
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_certificate_verify_roundtrips() ->
+    Keys = signing_keys(),
+    ?FORALL(
+        {Index, TranscriptHash},
+        {integer(1, length(Keys)), binary(32)},
+        begin
+            {Scheme, Private, Public, {SigAlg, HashAlg, Options}} = lists:nth(Index, Keys),
+            CV = iolist_to_binary(
+                roadrunner_quic_tls_auth:build_certificate_verify(Scheme, Private, TranscriptHash)
+            ),
+            {ok, {15, Body}, <<>>} = roadrunner_quic_tls_handshake:decode(CV),
+            <<Scheme:16, SigLen:16, Signature:SigLen/binary>> = Body,
+            Content =
+                <<(binary:copy(<<16#20>>, 64))/binary, "TLS 1.3, server CertificateVerify", 0,
+                    TranscriptHash/binary>>,
+            crypto:verify(SigAlg, HashAlg, Content, Signature, Public, Options)
+        end
+    ).
+
+%% One key pair per supported scheme, generated once for the whole run.
+signing_keys() ->
+    Rsa =
+        #'RSAPrivateKey'{publicExponent = E, modulus = N} =
+        public_key:generate_key({rsa, 2048, 65537}),
+    Ec = #'ECPrivateKey'{publicKey = EcPub} = public_key:generate_key({namedCurve, secp256r1}),
+    Ed = #'ECPrivateKey'{publicKey = EdPub} = public_key:generate_key({namedCurve, ed25519}),
+    [
+        {16#0804, Rsa, [E, N], {rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]}},
+        {16#0403, Ec, [EcPub, secp256r1], {ecdsa, sha256, []}},
+        {16#0807, Ed, [EdPub, ed25519], {eddsa, none, []}}
+    ].

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -46,7 +46,8 @@ Add a new property:
     quic_tls_crypto_matches_dep/1,
     quic_tls_handshake_matches_dep/1,
     quic_transport_params_matches_dep/1,
-    quic_tls_hello_parse_never_crashes/1
+    quic_tls_hello_parse_never_crashes/1,
+    quic_tls_auth_certificate_verify_roundtrips/1
 ]).
 
 suite() ->
@@ -83,7 +84,8 @@ all() ->
         quic_tls_crypto_matches_dep,
         quic_tls_handshake_matches_dep,
         quic_transport_params_matches_dep,
-        quic_tls_hello_parse_never_crashes
+        quic_tls_hello_parse_never_crashes,
+        quic_tls_auth_certificate_verify_roundtrips
     ].
 
 init_per_suite(Config) ->
@@ -269,5 +271,11 @@ quic_transport_params_matches_dep(Config) ->
 quic_tls_hello_parse_never_crashes(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_tls_hello_props:prop_parse_client_hello_never_crashes(),
+        Config
+    ).
+
+quic_tls_auth_certificate_verify_roundtrips(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_tls_auth_props:prop_certificate_verify_roundtrips(),
         Config
     ).

--- a/test/roadrunner_quic_tls_auth_tests.erl
+++ b/test/roadrunner_quic_tls_auth_tests.erl
@@ -1,0 +1,118 @@
+-module(roadrunner_quic_tls_auth_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
+
+-define(M, roadrunner_quic_tls_auth).
+%% The `quic` dep, kept as a test-profile differential oracle.
+-define(DEP, quic_tls).
+-define(FRAME, roadrunner_quic_tls_handshake).
+
+-define(SIG_RSA_PSS_RSAE_SHA256, 16#0804).
+-define(SIG_ECDSA_SECP256R1_SHA256, 16#0403).
+-define(SIG_ED25519, 16#0807).
+
+%% =============================================================================
+%% Certificate (RFC 8446 §4.4.2).
+%% =============================================================================
+
+build_certificate_structure_test() ->
+    Leaf = <<"leaf-cert-der">>,
+    Chain = <<"chain-cert-der">>,
+    {ok, {11, Body}, <<>>} = ?FRAME:decode(iolist_to_binary(?M:build_certificate([Leaf, Chain]))),
+    CertList =
+        <<(byte_size(Leaf)):24, Leaf/binary, 0:16, (byte_size(Chain)):24, Chain/binary, 0:16>>,
+    %% Empty certificate_request_context, then the CertificateEntry list.
+    ?assertEqual(<<0:8, (byte_size(CertList)):24, CertList/binary>>, Body).
+
+build_certificate_single_cert_test() ->
+    {ok, {11, Body}, <<>>} = ?FRAME:decode(iolist_to_binary(?M:build_certificate([<<"only">>]))),
+    ?assertEqual(<<0:8, 9:24, 4:24, "only", 0:16>>, Body).
+
+build_certificate_matches_dep_test() ->
+    Certs = [<<1, 2, 3>>, <<4, 5, 6, 7>>],
+    ?assertEqual(
+        ?DEP:build_certificate(<<>>, Certs),
+        iolist_to_binary(?M:build_certificate(Certs))
+    ).
+
+%% =============================================================================
+%% CertificateVerify (RFC 8446 §4.4.3) — sign, then verify the signature.
+%% RSA-PSS and ECDSA are randomized, so the test is a verify roundtrip.
+%% =============================================================================
+
+certificate_verify_rsa_test() ->
+    #'RSAPrivateKey'{publicExponent = E, modulus = N} =
+        Key = public_key:generate_key(
+            {rsa, 2048, 65537}
+        ),
+    certificate_verify_roundtrip(
+        ?SIG_RSA_PSS_RSAE_SHA256,
+        Key,
+        [E, N],
+        {
+            rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]
+        }
+    ).
+
+certificate_verify_ecdsa_test() ->
+    #'ECPrivateKey'{publicKey = Pub} = Key = public_key:generate_key({namedCurve, secp256r1}),
+    certificate_verify_roundtrip(
+        ?SIG_ECDSA_SECP256R1_SHA256,
+        Key,
+        [Pub, secp256r1],
+        {
+            ecdsa, sha256, []
+        }
+    ).
+
+certificate_verify_ed25519_test() ->
+    #'ECPrivateKey'{publicKey = Pub} = Key = public_key:generate_key({namedCurve, ed25519}),
+    certificate_verify_roundtrip(?SIG_ED25519, Key, [Pub, ed25519], {eddsa, none, []}).
+
+%% =============================================================================
+%% Finished (RFC 8446 §4.4.4) — deterministic, RFC 8448 §3 vectors.
+%% =============================================================================
+
+build_finished_rfc8448_test() ->
+    %% RFC 8448 §3: the server handshake traffic secret and the transcript
+    %% hash through CertificateVerify yield the server Finished verify_data
+    %% (the same vectors the C2 key-schedule tests pin).
+    ServerHsSecret = hex("b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"),
+    TranscriptHash = hex("91208a9082bb48b14e2f607d839c0d3a55c4f8e1fbb88e3c1ba0e2a32be88a59"),
+    VerifyData = hex("5d84b2762deff4fcd2a765d6567d94a9f32e4553166893ad86769457e40564ca"),
+    Built = iolist_to_binary(?M:build_finished(ServerHsSecret, TranscriptHash)),
+    ?assertEqual(<<20, 0, 0, 32, VerifyData/binary>>, Built).
+
+verify_client_finished_test() ->
+    Secret = hex("b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"),
+    Hash = hex("96088718a85d2c0d2b21a16a7f637eba132bd1a01feac57b8f8ec571ef41c47c"),
+    Expected = roadrunner_quic_tls_crypto:verify_data(
+        roadrunner_quic_tls_crypto:finished_key(Secret), Hash
+    ),
+    ?assert(?M:verify_client_finished(Expected, Secret, Hash)),
+    %% A single flipped byte fails the constant-time compare.
+    <<First, Rest/binary>> = Expected,
+    ?assertNot(?M:verify_client_finished(<<(First bxor 1), Rest/binary>>, Secret, Hash)).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+%% Sign a CertificateVerify, peel the framing, and verify the signature
+%% over the reconstructed signed content with the matching public key.
+certificate_verify_roundtrip(Scheme, PrivateKey, PublicKey, {SigAlg, HashAlg, Options}) ->
+    Hash = crypto:strong_rand_bytes(32),
+    {ok, {15, Body}, <<>>} = ?FRAME:decode(
+        iolist_to_binary(?M:build_certificate_verify(Scheme, PrivateKey, Hash))
+    ),
+    <<Scheme:16, SigLen:16, Signature:SigLen/binary>> = Body,
+    Content =
+        <<
+            (binary:copy(<<16#20>>, 64))/binary, "TLS 1.3, server CertificateVerify", 0, Hash/binary
+        >>,
+    ?assert(crypto:verify(SigAlg, HashAlg, Content, Signature, PublicKey, Options)).
+
+hex(Hex) ->
+    Bytes = <<<<B>> || <<B>> <= iolist_to_binary(Hex), B =/= $\s, B =/= $\n>>,
+    binary:decode_hex(string:uppercase(Bytes)).


### PR DESCRIPTION
# Description

Adds the server's authentication step of the native QUIC TLS 1.3 handshake: the Certificate, CertificateVerify, and Finished messages, plus verifying the client's Finished. It builds the certificate chain, signs the handshake transcript with the server's key (RSA-PSS, ECDSA-P256, or Ed25519), and produces and checks the Finished MAC, reusing the key schedule from #120 and the message framing from #121. With this, the whole TLS 1.3 server handshake message set is native.

For example, `build_certificate_verify(Scheme, Key, TranscriptHash)` returns the framed, signed CertificateVerify, and `verify_client_finished(Received, Secret, TranscriptHash)` checks the client's Finished in constant time. The Certificate framing and the Finished verify_data match the `quic` dependency and RFC 8448 §3.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)