### PR TITLE
Add the native QUIC UDP socket

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -86,6 +86,7 @@
         %% rule still flags them.
         {"test/roadrunner_http2_flow_control_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_http3_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_tls_tests.erl", unnecessary_function_arguments},
         {"test/roadrunner_conn_tests.erl", unnecessary_function_arguments},

--- a/src/roadrunner_quic_socket.erl
+++ b/src/roadrunner_quic_socket.erl
@@ -1,0 +1,113 @@
+-module(roadrunner_quic_socket).
+-moduledoc false.
+
+%% The gen_udp baseline for the native QUIC transport: open a UDP socket,
+%% receive whole datagrams, send datagrams. A thin tagged wrapper (like
+%% `roadrunner_transport`), not a process; the listener (D3) and
+%% connection (D2) processes own the socket and call these primitives.
+%%
+%% Deliberately just a byte mover. The RFC 9000 §8.1 anti-amplification
+%% accounting (`roadrunner_quic_amp`), the §14 padding of Initial
+%% datagrams to 1200 bytes, and the splitting of coalesced packets within
+%% a datagram are all per-connection concerns owned by the connection
+%% send/receive pipeline, not the shared socket. The socket delivers each
+%% UDP datagram whole, with its source address.
+
+-export([open/1, open/2, send/4, recv/2, close/1, sockname/1]).
+
+-export_type([socket/0, open_opts/0]).
+
+-opaque socket() :: {gen_udp, gen_udp:socket()}.
+
+-type open_opts() :: #{
+    recbuf => pos_integer(), sndbuf => pos_integer(), reuseport => boolean()
+}.
+
+%% Larger than the OS default, so a burst of datagrams is not dropped
+%% before the receiver drains them. Raise via `open/2` for a busy server.
+-define(DEFAULT_RECBUF, 1048576).
+-define(DEFAULT_SNDBUF, 1048576).
+
+-doc "Open a UDP socket on `Port` with the default buffer sizes.".
+-spec open(inet:port_number()) -> {ok, socket()} | {error, term()}.
+open(Port) ->
+    open(Port, #{}).
+
+-doc """
+Open a UDP socket on `Port`. The socket is binary and passive
+(`{active, false}`), with `reuseaddr` set; `recbuf` and `sndbuf` may be
+overridden via `Opts`. Port 0 picks an ephemeral port (read it back with
+`sockname/1`).
+
+Set `reuseport` to `true` to enable `SO_REUSEPORT`, which lets a pool
+of sockets share one concrete port with kernel datagram fan-out (the
+shape the listener pool uses); it defaults to `false` for a lone socket.
+""".
+-spec open(inet:port_number(), open_opts()) -> {ok, socket()} | {error, term()}.
+open(Port, Opts) ->
+    #{recbuf := RecBuf, sndbuf := SndBuf, reuseport := ReusePort} = validate_opts(Opts),
+    SocketOpts = [
+        binary,
+        {active, false},
+        {reuseaddr, true},
+        {reuseport, ReusePort},
+        {recbuf, RecBuf},
+        {sndbuf, SndBuf}
+    ],
+    case gen_udp:open(Port, SocketOpts) of
+        {ok, Socket} -> {ok, {gen_udp, Socket}};
+        {error, _} = Error -> Error
+    end.
+
+-doc "Send `Data` as one UDP datagram to `Ip`/`Port`.".
+-spec send(socket(), inet:ip_address(), inet:port_number(), iodata()) -> ok | {error, term()}.
+send({gen_udp, Socket}, Ip, Port, Data) ->
+    gen_udp:send(Socket, Ip, Port, Data).
+
+-doc """
+Receive the next whole datagram, blocking up to `Timeout` milliseconds.
+Returns the source address and the datagram bytes, or `{error, timeout}`
+when none arrives in time.
+""".
+-spec recv(socket(), timeout()) ->
+    {ok, {inet:ip_address(), inet:port_number()}, binary()} | {error, term()}.
+recv({gen_udp, Socket}, Timeout) ->
+    %% The 3-tuple shape assumes no ancillary-data options (pktinfo,
+    %% recvtos, ...) are enabled; gen_udp returns a 4-tuple with an
+    %% AncData element when they are, and open/2 enables none.
+    case gen_udp:recv(Socket, 0, Timeout) of
+        {ok, {Ip, Port, Data}} -> {ok, {Ip, Port}, Data};
+        {error, _} = Error -> Error
+    end.
+
+-doc "Close the socket.".
+-spec close(socket()) -> ok.
+close({gen_udp, Socket}) ->
+    gen_udp:close(Socket).
+
+-doc "The socket's local address and port.".
+-spec sockname(socket()) -> {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}.
+sockname({gen_udp, Socket}) ->
+    inet:sockname(Socket).
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% Merge the caller's options over the defaults, rejecting unknown keys
+%% and out-of-range values (mirrors the listener-opt validation idiom).
+-spec validate_opts(open_opts()) ->
+    #{recbuf := pos_integer(), sndbuf := pos_integer(), reuseport := boolean()}.
+validate_opts(Opts) ->
+    Defaults = #{recbuf => ?DEFAULT_RECBUF, sndbuf => ?DEFAULT_SNDBUF, reuseport => false},
+    maps:fold(fun validate_opt/3, Defaults, Opts).
+
+-spec validate_opt(atom(), term(), map()) -> map().
+validate_opt(recbuf, Value, Acc) when is_integer(Value), Value > 0 ->
+    Acc#{recbuf => Value};
+validate_opt(sndbuf, Value, Acc) when is_integer(Value), Value > 0 ->
+    Acc#{sndbuf => Value};
+validate_opt(reuseport, Value, Acc) when is_boolean(Value) ->
+    Acc#{reuseport => Value};
+validate_opt(Key, Value, _Acc) ->
+    error({invalid_quic_socket_opt, Key, Value}).

--- a/test/roadrunner_quic_socket_SUITE.erl
+++ b/test/roadrunner_quic_socket_SUITE.erl
@@ -1,0 +1,96 @@
+-module(roadrunner_quic_socket_SUITE).
+-moduledoc """
+Loopback I/O tests for `roadrunner_quic_socket`.
+
+A CT suite rather than eunit so each datagram round-trip runs in its
+own process with the suite timetrap as an outer guard. Covers the
+socket's I/O surface (open/send/recv/close/sockname and valid-opt
+acceptance) against real loopback UDP; the option-validation reject
+clause is unit-tested in `roadrunner_quic_socket_tests`.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0]).
+-export([
+    loopback_echo/1,
+    recv_timeout/1,
+    open_in_use_errors/1,
+    open_with_custom_buffers/1,
+    reuseport_allows_shared_bind/1
+]).
+
+-define(LOOPBACK, {127, 0, 0, 1}).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [
+        loopback_echo,
+        recv_timeout,
+        open_in_use_errors,
+        open_with_custom_buffers,
+        reuseport_allows_shared_bind
+    ].
+
+%% A datagram travels client -> server with its source address, then the
+%% server echoes back to that address. Exercises open/1 (default opts),
+%% sockname/1, send/4, recv/2's success clause, and close/1.
+loopback_echo(_Config) ->
+    {ok, Server} = roadrunner_quic_socket:open(0),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    %% Opened on port 0 -> bound to the wildcard address, so sockname
+    %% reports {0,0,0,0}; only the ephemeral port matters here. The
+    %% datagram source below is genuine loopback (traffic crosses lo).
+    {ok, {_ServerIp, ServerPort}} = roadrunner_quic_socket:sockname(Server),
+    {ok, {_ClientIp, ClientPort}} = roadrunner_quic_socket:sockname(Client),
+
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, ServerPort, ~"ping"),
+    ?assertEqual(
+        {ok, {?LOOPBACK, ClientPort}, ~"ping"},
+        roadrunner_quic_socket:recv(Server, 1000)
+    ),
+
+    ok = roadrunner_quic_socket:send(Server, ?LOOPBACK, ClientPort, ~"pong"),
+    ?assertEqual(
+        {ok, {?LOOPBACK, ServerPort}, ~"pong"},
+        roadrunner_quic_socket:recv(Client, 1000)
+    ),
+
+    ok = roadrunner_quic_socket:close(Server),
+    ok = roadrunner_quic_socket:close(Client).
+
+%% An idle socket returns {error, timeout} once the deadline elapses
+%% (recv/2's error clause).
+recv_timeout(_Config) ->
+    {ok, Socket} = roadrunner_quic_socket:open(0),
+    ?assertEqual({error, timeout}, roadrunner_quic_socket:recv(Socket, 50)),
+    ok = roadrunner_quic_socket:close(Socket).
+
+%% Binding a port already held by a socket without reuseaddr fails
+%% (open/2's error clause). A reuseaddr blocker would let the second
+%% bind through, so the blocker is a plain gen_udp socket.
+open_in_use_errors(_Config) ->
+    {ok, Blocker} = gen_udp:open(0, [binary, {active, false}]),
+    {ok, {_Ip, Port}} = inet:sockname(Blocker),
+    ?assertEqual({error, eaddrinuse}, roadrunner_quic_socket:open(Port)),
+    ok = gen_udp:close(Blocker).
+
+%% Custom recbuf/sndbuf are accepted (validate_opt's recbuf/sndbuf
+%% success clauses); gen_udp owns whether they reach the kernel.
+open_with_custom_buffers(_Config) ->
+    {ok, Socket} = roadrunner_quic_socket:open(0, #{recbuf => 131072, sndbuf => 131072}),
+    {ok, {_Ip, _Port}} = roadrunner_quic_socket:sockname(Socket),
+    ok = roadrunner_quic_socket:close(Socket).
+
+%% Two sockets share one concrete port when both set reuseport, the
+%% kernel-fan-out shape the listener pool relies on (validate_opt's
+%% reuseport clause + the {reuseport, true} bind).
+reuseport_allows_shared_bind(_Config) ->
+    {ok, First} = roadrunner_quic_socket:open(0, #{reuseport => true}),
+    {ok, {_Ip, Port}} = roadrunner_quic_socket:sockname(First),
+    {ok, Second} = roadrunner_quic_socket:open(Port, #{reuseport => true}),
+    ok = roadrunner_quic_socket:close(First),
+    ok = roadrunner_quic_socket:close(Second).

--- a/test/roadrunner_quic_socket_tests.erl
+++ b/test/roadrunner_quic_socket_tests.erl
@@ -1,0 +1,22 @@
+-module(roadrunner_quic_socket_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_socket).
+
+%% Option validation runs before any socket is opened, so these reject
+%% paths need no loopback fixture: a bad option raises before gen_udp is
+%% touched. The I/O paths (open/send/recv/close/sockname, valid opts)
+%% live in roadrunner_quic_socket_SUITE.
+
+open_rejects_unknown_opt_test() ->
+    ?assertError({invalid_quic_socket_opt, bogus, 1}, ?M:open(0, #{bogus => 1})).
+
+open_rejects_zero_recbuf_test() ->
+    ?assertError({invalid_quic_socket_opt, recbuf, 0}, ?M:open(0, #{recbuf => 0})).
+
+open_rejects_negative_sndbuf_test() ->
+    ?assertError({invalid_quic_socket_opt, sndbuf, -1}, ?M:open(0, #{sndbuf => -1})).
+
+open_rejects_non_boolean_reuseport_test() ->
+    ?assertError({invalid_quic_socket_opt, reuseport, yes}, ?M:open(0, #{reuseport => yes})).


### PR DESCRIPTION
# Description

The gen_udp baseline for the native QUIC transport: a thin tagged socket wrapper that opens a UDP socket, sends datagrams, and receives whole datagrams with their source address. `reuseport` is supported so a listener can build its `SO_REUSEPORT` pool on it. Anti-amplification, Initial-datagram padding, and coalesced-packet splitting stay in the connection pipeline.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)