### PR TITLE
Add the native QUIC TLS server handshake sequencer

### DIFF
--- a/src/roadrunner_quic_tls_server.erl
+++ b/src/roadrunner_quic_tls_server.erl
@@ -1,0 +1,299 @@
+-module(roadrunner_quic_tls_server).
+-moduledoc false.
+
+%% TLS 1.3 server-handshake sequencer (RFC 8446 §4, RFC 9001 §4-5) for a
+%% server-only QUIC v1 endpoint: the pure decision core that drives the
+%% handshake forward over the message-layer modules
+%% (`roadrunner_quic_tls_hello`, `_auth`, `_crypto`, `_transport_params`,
+%% `roadrunner_quic_keys`). It is not a process and touches no socket; the
+%% connection loop reassembles CRYPTO frames, calls these functions with
+%% the deframed handshake-message bodies, emits the returned flight at the
+%% named encryption levels, and installs the returned packet-protection
+%% keys.
+%%
+%% `process_client_hello/2` consumes the ClientHello body and produces the
+%% whole server flight grouped by QUIC encryption level (ServerHello at
+%% Initial; EncryptedExtensions, Certificate, CertificateVerify, Finished
+%% at Handshake) plus the ordered key installs each level unlocks.
+%% `process_client_finished/2` verifies the client's Finished. The running
+%% TLS transcript is threaded across the four transcript-hash points
+%% (RFC 8446 §7.1/§4.4): handshake traffic secrets from the transcript
+%% through ServerHello, the CertificateVerify signature from the transcript
+%% through Certificate, the server Finished verify_data from the transcript
+%% through CertificateVerify, and the application traffic secrets (plus the
+%% client Finished it must check) from the transcript through the server
+%% Finished.
+%%
+%% Negotiation that the codec layer leaves out is done here: the x25519
+%% shared secret (ECDHE over the client's key_share), the CertificateVerify
+%% signature scheme (the cert key's scheme intersected with the client's
+%% offer), and the ALPN protocol (the client must offer the configured one,
+%% RFC 7301 §3.2). Attacker-controlled inputs fail with a flat
+%% `{error, atom()}` (a malformed ClientHello, a missing x25519 key_share,
+%% no common signature scheme, no offered ALPN match, a client Finished
+%% mismatch); a cert/key whose type is unsupported is server config and
+%% legitimately crashes.
+%%
+%% The server's x25519 ephemeral key pair and ServerHello random are
+%% inputs (the connection loop generates them per connection), which keeps
+%% the core deterministic and testable against fixed vectors.
+
+-include_lib("public_key/include/public_key.hrl").
+
+-export([new/1, process_client_hello/2, process_client_finished/2]).
+
+-export_type([t/0, config/0, flight/0, install/0]).
+
+%% ClientHello handshake type (RFC 8446 §4), for re-framing the body into
+%% the transcript; the server messages are framed by their builders.
+-define(CLIENT_HELLO, 1).
+
+%% Signature schemes (RFC 8446 §4.2.3) supported in v1, one per key type.
+-define(SIG_RSA_PSS_RSAE_SHA256, 16#0804).
+-define(SIG_ECDSA_SECP256R1_SHA256, 16#0403).
+-define(SIG_ED25519, 16#0807).
+
+-record(server, {
+    cert_chain :: [binary()],
+    priv_key :: public_key:private_key(),
+    alpn :: binary(),
+    transport_params :: roadrunner_quic_transport_params:params(),
+    eph_pub :: binary(),
+    eph_priv :: binary(),
+    server_random :: binary(),
+    %% Filled by process_client_hello/2, read by process_client_finished/2.
+    client_hs_secret = <<>> :: binary(),
+    client_finished_hash = <<>> :: binary()
+}).
+
+-opaque t() :: #server{}.
+
+-type config() :: #{
+    cert_chain := [binary()],
+    priv_key := public_key:private_key(),
+    alpn := binary(),
+    transport_params := roadrunner_quic_transport_params:params(),
+    eph_pub := binary(),
+    eph_priv := binary(),
+    server_random := binary()
+}.
+
+-type flight() :: #{initial := iolist(), handshake := iolist()}.
+
+-type install() ::
+    {handshake | application, server | client, roadrunner_quic_keys:keys()}.
+
+-doc """
+Build the handshake state from the per-connection config: the server's DER
+certificate chain (leaf first) and private key, the selected ALPN
+protocol, the server transport parameters (already carrying the
+`original_destination_connection_id` and `initial_source_connection_id`
+the loop fills in), the server's x25519 ephemeral key pair, and the
+ServerHello random.
+""".
+-spec new(config()) -> t().
+new(#{
+    cert_chain := CertChain,
+    priv_key := PrivKey,
+    alpn := Alpn,
+    transport_params := TransportParams,
+    eph_pub := EphPub,
+    eph_priv := EphPriv,
+    server_random := ServerRandom
+}) ->
+    #server{
+        cert_chain = CertChain,
+        priv_key = PrivKey,
+        alpn = Alpn,
+        transport_params = TransportParams,
+        eph_pub = EphPub,
+        eph_priv = EphPriv,
+        server_random = ServerRandom
+    }.
+
+-doc """
+Process the client's ClientHello body (as handed up by
+`roadrunner_quic_tls_handshake:decode/1`) and produce the server's whole
+first flight.
+
+Returns `{ok, Flight, Installs, State}` where `Flight` groups the framed
+handshake messages by QUIC encryption level (`initial` carries the
+ServerHello; `handshake` carries EncryptedExtensions, Certificate,
+CertificateVerify, and the server Finished) and `Installs` is the ordered
+list of packet-protection keys the loop must arm: the handshake keys (so
+it can read the client's encrypted Finished) before the application keys.
+The returned `State` carries what `process_client_finished/2` needs.
+
+Fails with `{error, Reason}` on a malformed ClientHello, a missing x25519
+key_share (`missing_key_share`), no signature scheme shared between the
+cert key and the client's offer (`no_common_sig_alg`), or a client that
+did not offer the configured ALPN protocol (`no_application_protocol`).
+""".
+-spec process_client_hello(binary(), t()) ->
+    {ok, flight(), [install()], t()} | {error, atom()}.
+process_client_hello(ClientHelloBody, #server{priv_key = PrivKey, alpn = Alpn} = State) ->
+    maybe
+        {ok,
+            #{
+                session_id := SessionId,
+                signature_algorithms := SigAlgs,
+                alpn_protocols := ClientAlpns
+            } = ClientHello} ?=
+            roadrunner_quic_tls_hello:parse_client_hello(ClientHelloBody),
+        {ok, ClientKeyShare} ?= client_key_share(ClientHello),
+        {ok, Scheme} ?= negotiate_scheme(PrivKey, SigAlgs),
+        ok ?= check_alpn(Alpn, ClientAlpns),
+        build_flight(ClientHelloBody, SessionId, ClientKeyShare, Scheme, State)
+    end.
+
+-doc """
+Verify the client's Finished body (RFC 8446 §4.4.4) against the transcript
+through the server Finished, using the client handshake traffic secret.
+Returns `ok` on success or `{error, handshake_failure}` on a mismatch.
+After this the loop confirms the handshake and emits HANDSHAKE_DONE.
+""".
+-spec process_client_finished(binary(), t()) -> ok | {error, handshake_failure}.
+process_client_finished(ClientFinishedBody, #server{
+    client_hs_secret = ClientHsSecret, client_finished_hash = TranscriptHash
+}) ->
+    case
+        roadrunner_quic_tls_auth:verify_client_finished(
+            ClientFinishedBody, ClientHsSecret, TranscriptHash
+        )
+    of
+        true -> ok;
+        false -> {error, handshake_failure}
+    end.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% The client's x25519 public key, or an error when it offered none (v1
+%% requires an x25519 key_share; HelloRetryRequest is not implemented).
+-spec client_key_share(roadrunner_quic_tls_hello:client_hello()) ->
+    {ok, binary()} | {error, missing_key_share}.
+client_key_share(#{key_share := ClientPub}) -> {ok, ClientPub};
+client_key_share(#{}) -> {error, missing_key_share}.
+
+%% The CertificateVerify scheme for the cert key, if the client offered it
+%% in its signature_algorithms. The scheme is fixed by the key type (v1
+%% supports one per type); a cert key of an unsupported type is server
+%% config and crashes here.
+-spec negotiate_scheme(public_key:private_key(), [non_neg_integer()]) ->
+    {ok, non_neg_integer()} | {error, no_common_sig_alg}.
+negotiate_scheme(PrivKey, Offered) ->
+    Scheme = scheme_for_key(PrivKey),
+    case lists:member(Scheme, Offered) of
+        true -> {ok, Scheme};
+        false -> {error, no_common_sig_alg}
+    end.
+
+%% v1 offers a single ALPN protocol, so negotiation degenerates to the
+%% client having offered it; no overlap is a no_application_protocol alert
+%% (RFC 7301 §3.2).
+-spec check_alpn(binary(), [binary()]) -> ok | {error, no_application_protocol}.
+check_alpn(Configured, Offered) ->
+    case lists:member(Configured, Offered) of
+        true -> ok;
+        false -> {error, no_application_protocol}
+    end.
+
+-spec scheme_for_key(public_key:private_key()) -> non_neg_integer().
+scheme_for_key(#'RSAPrivateKey'{}) ->
+    ?SIG_RSA_PSS_RSAE_SHA256;
+scheme_for_key(#'ECPrivateKey'{parameters = {namedCurve, ?'id-Ed25519'}}) ->
+    ?SIG_ED25519;
+scheme_for_key(#'ECPrivateKey'{parameters = {namedCurve, ?'secp256r1'}}) ->
+    ?SIG_ECDSA_SECP256R1_SHA256.
+
+%% Build the full server flight, threading the transcript across the four
+%% hash boundaries and deriving the handshake then application keys. The
+%% transcript is an iolist of framed messages; `transcript_hash/1` accepts
+%% iodata, so it is never flattened here.
+-spec build_flight(
+    binary(),
+    binary(),
+    binary(),
+    non_neg_integer(),
+    t()
+) -> {ok, flight(), [install()], t()}.
+build_flight(
+    ClientHelloBody,
+    SessionId,
+    ClientKeyShare,
+    Scheme,
+    #server{
+        cert_chain = CertChain,
+        priv_key = PrivKey,
+        alpn = Alpn,
+        transport_params = TransportParams,
+        eph_pub = EphPub,
+        eph_priv = EphPriv,
+        server_random = ServerRandom
+    } = State
+) ->
+    %% ServerHello (Initial level); the running transcript starts with the
+    %% re-framed ClientHello (byte-identical to the wire message).
+    ClientHelloFramed = roadrunner_quic_tls_handshake:encode(?CLIENT_HELLO, ClientHelloBody),
+    ServerHello = roadrunner_quic_tls_hello:build_server_hello(#{
+        random => ServerRandom, session_id => SessionId, key_share => EphPub
+    }),
+    ThroughServerHello = [ClientHelloFramed, ServerHello],
+
+    %% Handshake traffic secrets from the transcript through ServerHello.
+    SharedSecret = crypto:compute_key(ecdh, ClientKeyShare, EphPriv, x25519),
+    HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
+        roadrunner_quic_tls_crypto:early_secret(), SharedSecret
+    ),
+    HelloHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughServerHello),
+    ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, handshake, HandshakeSecret, HelloHash
+    ),
+    ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, handshake, HandshakeSecret, HelloHash
+    ),
+
+    %% EncryptedExtensions + Certificate (Handshake level).
+    EncryptedExtensions = roadrunner_quic_tls_hello:build_encrypted_extensions(#{
+        alpn => Alpn, transport_params => TransportParams
+    }),
+    Certificate = roadrunner_quic_tls_auth:build_certificate(CertChain),
+    ThroughCertificate = [ThroughServerHello, EncryptedExtensions, Certificate],
+
+    %% CertificateVerify signs the transcript through Certificate; the
+    %% emitted (randomized) bytes feed the transcript, not a rebuild.
+    CertificateHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughCertificate),
+    CertificateVerify = roadrunner_quic_tls_auth:build_certificate_verify(
+        Scheme, PrivKey, CertificateHash
+    ),
+    ThroughCertificateVerify = [ThroughCertificate, CertificateVerify],
+
+    %% Server Finished verify_data over the transcript through CertVerify.
+    CertVerifyHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughCertificateVerify),
+    Finished = roadrunner_quic_tls_auth:build_finished(ServerHsSecret, CertVerifyHash),
+    ThroughFinished = [ThroughCertificateVerify, Finished],
+
+    %% Application traffic secrets from the transcript through the server
+    %% Finished; the client Finished is verified over the same hash.
+    MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
+    FinishedHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughFinished),
+    ClientApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, application, MasterSecret, FinishedHash
+    ),
+    ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, application, MasterSecret, FinishedHash
+    ),
+
+    Flight = #{
+        initial => ServerHello,
+        handshake => [EncryptedExtensions, Certificate, CertificateVerify, Finished]
+    },
+    Installs = [
+        {handshake, server, roadrunner_quic_keys:traffic_keys(ServerHsSecret)},
+        {handshake, client, roadrunner_quic_keys:traffic_keys(ClientHsSecret)},
+        {application, server, roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+        {application, client, roadrunner_quic_keys:traffic_keys(ClientApSecret)}
+    ],
+    State1 = State#server{client_hs_secret = ClientHsSecret, client_finished_hash = FinishedHash},
+    {ok, Flight, Installs, State1}.

--- a/test/roadrunner_quic_tls_server_tests.erl
+++ b/test/roadrunner_quic_tls_server_tests.erl
@@ -1,0 +1,307 @@
+-module(roadrunner_quic_tls_server_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
+
+-define(M, roadrunner_quic_tls_server).
+
+%% Handshake message types (RFC 8446 §4).
+-define(SERVER_HELLO, 2).
+-define(ENCRYPTED_EXTENSIONS, 8).
+-define(CERTIFICATE, 11).
+-define(CERTIFICATE_VERIFY, 15).
+-define(FINISHED, 20).
+
+%% ClientHello wire constants.
+-define(LEGACY_VERSION, 16#0303).
+-define(CIPHER_AES_128_GCM_SHA256, 16#1301).
+-define(GROUP_X25519, 16#001D).
+-define(EXT_SIGNATURE_ALGORITHMS, 16#000D).
+-define(EXT_ALPN, 16#0010).
+-define(EXT_KEY_SHARE, 16#0033).
+-define(EXT_QUIC_TRANSPORT_PARAMS, 16#0039).
+
+-define(CERT_VERIFY_CONTEXT, ~"TLS 1.3, server CertificateVerify").
+
+%% =============================================================================
+%% Full-handshake integration, one per cert key type. Each drives the
+%% sequencer with a fixed server ephemeral + a hand-built ClientHello, then
+%% re-derives every boundary independently from the OUTPUT flight messages
+%% (not from the production state) and checks the flight grouping, the key
+%% installs, the CertificateVerify signature, the server Finished
+%% verify_data, and the client Finished round-trip.
+%% =============================================================================
+
+rsa_handshake_test() ->
+    assert_full_handshake(rsa).
+
+ecdsa_handshake_test() ->
+    assert_full_handshake(ecdsa).
+
+ed25519_handshake_test() ->
+    assert_full_handshake(ed25519).
+
+assert_full_handshake(KeyType) ->
+    {Scheme, PrivKey, VerifyKey, {SigAlg, HashAlg, SigOpts}} = key_material(KeyType),
+    {ClientPub, ClientPriv} = crypto:generate_key(ecdh, x25519),
+    {ServerPub, ServerPriv} = crypto:generate_key(ecdh, x25519),
+    ServerRandom = crypto:strong_rand_bytes(32),
+    TransportParams = #{
+        original_destination_connection_id => <<5, 6, 7, 8>>,
+        initial_source_connection_id => <<1, 2, 3, 4>>
+    },
+    ClientHelloBody = client_hello_body(#{
+        key_share => ClientPub, sig_algs => [Scheme], alpn => ~"h3", session_id => <<>>
+    }),
+    State = ?M:new(#{
+        cert_chain => [~"leaf-cert-der", ~"intermediate-cert-der"],
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => TransportParams,
+        eph_pub => ServerPub,
+        eph_priv => ServerPriv,
+        server_random => ServerRandom
+    }),
+
+    {ok, Flight, Installs, State1} = ?M:process_client_hello(ClientHelloBody, State),
+
+    %% Flight grouping: ServerHello at Initial; EE/Cert/CertVerify/Finished
+    %% at Handshake, in order, each properly framed and concatenable.
+    #{initial := InitialGroup, handshake := [Ee, Cert, CertVerify, Finished]} = Flight,
+    ?assertEqual([?SERVER_HELLO], [T || {T, _} <- deframe_all(InitialGroup)]),
+    ?assertEqual(
+        [?ENCRYPTED_EXTENSIONS, ?CERTIFICATE, ?CERTIFICATE_VERIFY, ?FINISHED],
+        [T || {T, _} <- deframe_all([Ee, Cert, CertVerify, Finished])]
+    ),
+
+    %% Config routing: the emitted ServerHello carries the server ephemeral
+    %% pubkey (the byte the client runs ECDHE against), the EE carries the
+    %% selected ALPN and the encoded transport params, and the Certificate
+    %% carries the configured DER chain. Without these, a wrong-pubkey or
+    %% dropped-config flight would still pass the transcript checks.
+    ?assertEqual(ServerPub, server_hello_key_share(InitialGroup)),
+    {AlpnProtocol, TransportParamsExt} = encrypted_extensions(Ee),
+    ?assertEqual(~"h3", AlpnProtocol),
+    ?assertEqual(
+        iolist_to_binary(roadrunner_quic_transport_params:encode(TransportParams)),
+        TransportParamsExt
+    ),
+    ?assertEqual([~"leaf-cert-der", ~"intermediate-cert-der"], certificate_chain(Cert)),
+
+    %% Re-derive the schedule independently from the emitted messages.
+    Shared = crypto:compute_key(ecdh, ServerPub, ClientPriv, x25519),
+    HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
+        roadrunner_quic_tls_crypto:early_secret(), Shared
+    ),
+    ClientHelloFramed = roadrunner_quic_tls_handshake:encode(1, ClientHelloBody),
+    ThroughServerHello = [ClientHelloFramed, InitialGroup],
+    HelloHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughServerHello),
+    ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, handshake, HandshakeSecret, HelloHash
+    ),
+    ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, handshake, HandshakeSecret, HelloHash
+    ),
+    ThroughCertificate = [ThroughServerHello, Ee, Cert],
+    CertificateHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughCertificate),
+    ThroughCertVerify = [ThroughCertificate, CertVerify],
+    CertVerifyHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughCertVerify),
+    ThroughFinished = [ThroughCertVerify, Finished],
+    FinishedHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughFinished),
+    MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
+    ClientApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, application, MasterSecret, FinishedHash
+    ),
+    ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, application, MasterSecret, FinishedHash
+    ),
+
+    %% Installs: handshake keys before application keys, server then client.
+    ?assertEqual(
+        [
+            {handshake, server, roadrunner_quic_keys:traffic_keys(ServerHsSecret)},
+            {handshake, client, roadrunner_quic_keys:traffic_keys(ClientHsSecret)},
+            {application, server, roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+            {application, client, roadrunner_quic_keys:traffic_keys(ClientApSecret)}
+        ],
+        Installs
+    ),
+
+    %% CertificateVerify signs the transcript through Certificate.
+    {?CERTIFICATE_VERIFY, CertVerifyBody, <<>>} = deframe(CertVerify),
+    <<Scheme:16, SigLen:16, Signature:SigLen/binary>> = CertVerifyBody,
+    Content = iolist_to_binary([
+        binary:copy(<<16#20>>, 64), ?CERT_VERIFY_CONTEXT, 0, CertificateHash
+    ]),
+    ?assert(crypto:verify(SigAlg, HashAlg, Content, Signature, VerifyKey, SigOpts)),
+
+    %% Server Finished verify_data over the transcript through CertVerify.
+    {?FINISHED, ServerFinishedBody, <<>>} = deframe(Finished),
+    ?assertEqual(
+        roadrunner_quic_tls_crypto:verify_data(
+            roadrunner_quic_tls_crypto:finished_key(ServerHsSecret), CertVerifyHash
+        ),
+        ServerFinishedBody
+    ),
+
+    %% Client Finished round-trip: a correct one is accepted, a tampered
+    %% one rejected. Built with the client handshake secret over the
+    %% transcript through the server Finished.
+    ClientFinishedBody = roadrunner_quic_tls_crypto:verify_data(
+        roadrunner_quic_tls_crypto:finished_key(ClientHsSecret), FinishedHash
+    ),
+    ?assertEqual(ok, ?M:process_client_finished(ClientFinishedBody, State1)),
+    <<First, Rest/binary>> = ClientFinishedBody,
+    Tampered = <<(First bxor 1), Rest/binary>>,
+    ?assertEqual({error, handshake_failure}, ?M:process_client_finished(Tampered, State1)).
+
+%% =============================================================================
+%% Error paths
+%% =============================================================================
+
+missing_key_share_rejected_test() ->
+    State = rsa_state(),
+    %% Offer a scheme the RSA cert does NOT match (0x0403), so a passing
+    %% missing_key_share (rather than no_common_sig_alg) pins key_share as
+    %% the earlier gate.
+    Body = client_hello_body(#{sig_algs => [16#0403], alpn => ~"h3", session_id => <<>>}),
+    ?assertEqual({error, missing_key_share}, ?M:process_client_hello(Body, State)).
+
+no_application_protocol_rejected_test() ->
+    State = rsa_state(),
+    {ClientPub, _} = crypto:generate_key(ecdh, x25519),
+    %% Valid key_share and the RSA cert's scheme, but the client offers
+    %% only h2: the configured h3 is not on offer.
+    Body = client_hello_body(#{
+        key_share => ClientPub, sig_algs => [16#0804], alpn => ~"h2", session_id => <<>>
+    }),
+    ?assertEqual({error, no_application_protocol}, ?M:process_client_hello(Body, State)).
+
+no_common_sig_alg_rejected_test() ->
+    State = rsa_state(),
+    {ClientPub, _} = crypto:generate_key(ecdh, x25519),
+    %% Offer only ecdsa; the cert key is RSA (rsa_pss_rsae_sha256, 0x0804).
+    Body = client_hello_body(#{
+        key_share => ClientPub, sig_algs => [16#0403], alpn => ~"h3", session_id => <<>>
+    }),
+    ?assertEqual({error, no_common_sig_alg}, ?M:process_client_hello(Body, State)).
+
+malformed_client_hello_rejected_test() ->
+    State = rsa_state(),
+    ?assertEqual(
+        {error, malformed_client_hello}, ?M:process_client_hello(~"not a client hello", State)
+    ).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+rsa_state() ->
+    {_, PrivKey, _, _} = key_material(rsa),
+    {ServerPub, ServerPriv} = crypto:generate_key(ecdh, x25519),
+    ?M:new(#{
+        cert_chain => [~"leaf-cert-der"],
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => #{initial_source_connection_id => <<1, 2, 3, 4>>},
+        eph_pub => ServerPub,
+        eph_priv => ServerPriv,
+        server_random => crypto:strong_rand_bytes(32)
+    }).
+
+%% A generated key pair per scheme, plus the crypto:verify inputs for its
+%% public half (mirrors roadrunner_quic_tls_auth_props:signing_keys/0).
+key_material(rsa) ->
+    #'RSAPrivateKey'{publicExponent = E, modulus = N} =
+        PrivKey = public_key:generate_key({rsa, 2048, 65537}),
+    {16#0804, PrivKey, [E, N],
+        {rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]}};
+key_material(ecdsa) ->
+    #'ECPrivateKey'{publicKey = Pub} = PrivKey = public_key:generate_key({namedCurve, secp256r1}),
+    {16#0403, PrivKey, [Pub, secp256r1], {ecdsa, sha256, []}};
+key_material(ed25519) ->
+    #'ECPrivateKey'{publicKey = Pub} = PrivKey = public_key:generate_key({namedCurve, ed25519}),
+    {16#0807, PrivKey, [Pub, ed25519], {eddsa, none, []}}.
+
+%% Build a ClientHello body (RFC 8446 §4.1.2) carrying the requested
+%% extensions; the x25519 key_share is omitted when no key is given.
+client_hello_body(Opts) ->
+    Random = maps:get(random, Opts, crypto:strong_rand_bytes(32)),
+    SessionId = maps:get(session_id, Opts, <<>>),
+    SigAlgs = maps:get(sig_algs, Opts, [16#0804]),
+    Alpn = maps:get(alpn, Opts, ~"h3"),
+    Extensions = iolist_to_binary([
+        signature_algorithms_ext(SigAlgs),
+        alpn_ext(Alpn),
+        key_share_ext(maps:get(key_share, Opts, undefined))
+    ]),
+    CipherSuites = <<?CIPHER_AES_128_GCM_SHA256:16>>,
+    <<?LEGACY_VERSION:16, Random/binary, (byte_size(SessionId)):8, SessionId/binary,
+        (byte_size(CipherSuites)):16, CipherSuites/binary, 1:8, 0:8, (byte_size(Extensions)):16,
+        Extensions/binary>>.
+
+signature_algorithms_ext(Schemes) ->
+    List = <<<<S:16>> || S <- Schemes>>,
+    extension(?EXT_SIGNATURE_ALGORITHMS, <<(byte_size(List)):16, List/binary>>).
+
+alpn_ext(Protocol) ->
+    Entry = <<(byte_size(Protocol)):8, Protocol/binary>>,
+    extension(?EXT_ALPN, <<(byte_size(Entry)):16, Entry/binary>>).
+
+key_share_ext(undefined) ->
+    <<>>;
+key_share_ext(PubKey) ->
+    Entry = <<?GROUP_X25519:16, (byte_size(PubKey)):16, PubKey/binary>>,
+    extension(?EXT_KEY_SHARE, <<(byte_size(Entry)):16, Entry/binary>>).
+
+extension(Type, Data) ->
+    <<Type:16, (byte_size(Data)):16, Data/binary>>.
+
+%% The server's x25519 public key from a ServerHello's key_share extension.
+server_hello_key_share(ServerHello) ->
+    {?SERVER_HELLO, Body, <<>>} = deframe(ServerHello),
+    <<_LegacyVersion:16, _Random:32/binary, SessionLen:8, _Session:SessionLen/binary, _Cipher:16,
+        _Compression:8, _ExtsLen:16, Extensions/binary>> = Body,
+    <<?GROUP_X25519:16, KeyLen:16, PubKey:KeyLen/binary>> =
+        extract_extension(?EXT_KEY_SHARE, Extensions),
+    PubKey.
+
+%% The selected ALPN protocol and the raw transport-params extension body
+%% from an EncryptedExtensions message.
+encrypted_extensions(EncryptedExtensions) ->
+    {?ENCRYPTED_EXTENSIONS, Body, <<>>} = deframe(EncryptedExtensions),
+    <<_ExtsLen:16, Extensions/binary>> = Body,
+    <<_ListLen:16, ProtocolLen:8, Protocol:ProtocolLen/binary>> =
+        extract_extension(?EXT_ALPN, Extensions),
+    {Protocol, extract_extension(?EXT_QUIC_TRANSPORT_PARAMS, Extensions)}.
+
+%% The DER certificate chain (leaf first) from a Certificate message.
+certificate_chain(Certificate) ->
+    {?CERTIFICATE, Body, <<>>} = deframe(Certificate),
+    <<0:8, _ListLen:24, CertList/binary>> = Body,
+    cert_entries(CertList).
+
+cert_entries(<<>>) ->
+    [];
+cert_entries(<<CertLen:24, Cert:CertLen/binary, ExtLen:16, _Exts:ExtLen/binary, Rest/binary>>) ->
+    [Cert | cert_entries(Rest)].
+
+%% The data of the first extension of Type in an extension vector; crashes
+%% if it is absent, which a caller asserting its presence wants.
+extract_extension(Type, <<Type:16, Len:16, Data:Len/binary, _/binary>>) ->
+    Data;
+extract_extension(Type, <<_OtherType:16, Len:16, _Data:Len/binary, Rest/binary>>) ->
+    extract_extension(Type, Rest).
+
+deframe(Iolist) ->
+    {ok, {Type, Body}, Rest} = roadrunner_quic_tls_handshake:decode(iolist_to_binary(Iolist)),
+    {Type, Body, Rest}.
+
+deframe_all(Iolist) ->
+    deframe_all_bin(iolist_to_binary(Iolist)).
+
+deframe_all_bin(<<>>) ->
+    [];
+deframe_all_bin(Bin) ->
+    {ok, {Type, Body}, Rest} = roadrunner_quic_tls_handshake:decode(Bin),
+    [{Type, Body} | deframe_all_bin(Rest)].


### PR DESCRIPTION
# Description

The pure decision core that drives the server side of the TLS 1.3 handshake for QUIC: given the client's ClientHello it produces the whole server flight grouped by encryption level (ServerHello at Initial; EncryptedExtensions, Certificate, CertificateVerify, Finished at Handshake) plus the ordered packet-protection key installs, and it verifies the client's Finished. It orchestrates the existing message-layer modules and adds the x25519 ECDH, the signature-scheme negotiation, and the ALPN check; the connection loop will drive it. No process or socket, so it is exhaustively unit-tested across RSA, ECDSA-P256, and Ed25519 by re-deriving every transcript boundary from the emitted flight.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)