### PR TITLE
Add the native QUIC receive pipeline

### DIFF
--- a/src/roadrunner_quic_packet.erl
+++ b/src/roadrunner_quic_packet.erl
@@ -181,11 +181,12 @@ coalesced_split(<<>>) ->
 coalesced_split(<<FirstByte, _/binary>>) when (FirstByte band 16#40) =:= 0 ->
     %% Fixed bit clear (includes a zero padding byte): no more packets.
     done;
-coalesced_split(<<1:1, _:7, _Version:32, DCIDLen, Rest/binary>> = Bin) when DCIDLen =< ?MAX_CID ->
-    <<FirstByte, _/binary>> = Bin,
+coalesced_split(<<1:1, _:1, Type:2, _:4, _Version:32, DCIDLen, Rest/binary>> = Bin) when
+    DCIDLen =< ?MAX_CID
+->
     maybe
         {ok, AfterCids} ?= skip_scid(DCIDLen, Rest),
-        {ok, AfterPrefix} ?= skip_token(bits_to_type((FirstByte bsr 4) band 2#11), AfterCids),
+        {ok, AfterPrefix} ?= skip_token(bits_to_type(Type), AfterCids),
         {ok, Length, AfterLength} ?= take_varint(AfterPrefix),
         split_at(Bin, byte_size(Bin) - byte_size(AfterLength) + Length)
     end;

--- a/src/roadrunner_quic_packet.erl
+++ b/src/roadrunner_quic_packet.erl
@@ -31,6 +31,7 @@
     encode_version_negotiation/3,
     decode/2,
     dcid/2,
+    coalesced_split/1,
     pn_offset/2,
     encode_pn/2,
     decode_pn/2,
@@ -161,6 +162,45 @@ dcid(<<0:1, _:7, Rest/binary>>, DCIDLen) ->
     end;
 dcid(_, _) ->
     {error, invalid_packet}.
+
+-doc """
+Split the first packet of a (possibly coalesced) datagram (RFC 9000
+§12.2), reading only header-protection-independent bytes so it works on a
+still-protected datagram. A long-header packet is bounded by its Length
+field; a short-header packet carries no length and so runs to the end of
+the datagram (it can only be the last packet). Returns `{ok, Packet, Rest}`
+(`Rest` being the following coalesced packets), or `done` at the end of
+the datagram or on trailing padding (a zero first byte / cleared fixed
+bit), which the receive loop treats as a clean stop. A server never
+receives Retry or Version Negotiation, so their lengthless layout is not
+special-cased (such a packet mis-slices and is dropped downstream).
+""".
+-spec coalesced_split(binary()) -> {ok, binary(), binary()} | done | {error, term()}.
+coalesced_split(<<>>) ->
+    done;
+coalesced_split(<<FirstByte, _/binary>>) when (FirstByte band 16#40) =:= 0 ->
+    %% Fixed bit clear (includes a zero padding byte): no more packets.
+    done;
+coalesced_split(<<1:1, _:7, _Version:32, DCIDLen, Rest/binary>> = Bin) when DCIDLen =< ?MAX_CID ->
+    <<FirstByte, _/binary>> = Bin,
+    maybe
+        {ok, AfterCids} ?= skip_scid(DCIDLen, Rest),
+        {ok, AfterPrefix} ?= skip_token(bits_to_type((FirstByte bsr 4) band 2#11), AfterCids),
+        {ok, Length, AfterLength} ?= take_varint(AfterPrefix),
+        split_at(Bin, byte_size(Bin) - byte_size(AfterLength) + Length)
+    end;
+coalesced_split(<<0:1, _:7, _/binary>> = Bin) ->
+    %% Short header: the packet runs to the end of the datagram.
+    {ok, Bin, <<>>};
+coalesced_split(_) ->
+    {error, invalid_packet}.
+
+-spec split_at(binary(), non_neg_integer()) -> {ok, binary(), binary()} | {error, truncated}.
+split_at(Bin, PacketLen) ->
+    case Bin of
+        <<Packet:PacketLen/binary, Rest/binary>> -> {ok, Packet, Rest};
+        _ -> {error, truncated}
+    end.
 
 -doc """
 Locate the Packet Number field's byte offset, so the AEAD layer can take

--- a/src/roadrunner_quic_recv.erl
+++ b/src/roadrunner_quic_recv.erl
@@ -1,0 +1,171 @@
+-module(roadrunner_quic_recv).
+-moduledoc false.
+
+%% QUIC v1 receive pipeline (RFC 9001 §5, RFC 9000 §12.2/§A), pure.
+%%
+%% Turns one received UDP datagram into the decoded packets it carries: it
+%% splits coalesced packets, classifies each header's encryption level,
+%% selects that level's keys, removes header protection, reconstructs the
+%% full packet number from the largest received in that space (RFC 9000
+%% §A.3), AEAD-decrypts (the unprotected header is the associated data),
+%% and decodes the frames. It composes the leaves (`roadrunner_quic_packet`,
+%% `roadrunner_quic_aead`, `roadrunner_quic_frame`) and owns only the one
+%% step none of them does: packet-number reconstruction.
+%%
+%% Pure and stateless: the per-level keys and per-space largest-received
+%% packet number are inputs, never owned or mutated here. The connection
+%% loop owns the PN spaces, records each decoded PN, and applies the
+%% frames (ACK/stream/flow/CC, anti-amplification, events); this module's
+%% job ends at decoded frames. The largest-received map is a per-datagram
+%% snapshot, not re-threaded between coalesced packets of the same space
+%% (safe because the minimal packet-number window, 256, exceeds any
+%% coalesced run).
+%%
+%% Per packet it yields `{ok, Decoded}` (decrypted, frames decoded),
+%% `{drop, Reason}` for an undecryptable or unsupported packet (silently
+%% dropped, never the whole datagram, RFC 9001 §5.4.2), or
+%% `{frame_error, Level, Reason}` when an authenticated payload holds a
+%% malformed frame (a connection error the loop must act on, kept distinct
+%% from a drop). A decrypt failure drops only that packet and the loop
+%% continues with the rest of the datagram.
+
+-export([datagram/4]).
+%% Exported for direct unit coverage of the RFC 9000 §A.3 windows; the
+%% `+/-window` branches aren't reachable through the minimal-width encode
+%% path used by the round-trip tests.
+-export([reconstruct_pn/3]).
+
+-export_type([level/0, decoded/0, outcome/0]).
+
+%% The three QUIC packet-number spaces (RFC 9000 §12.3); a 1-RTT
+%% short-header packet belongs to the application space.
+-type level() :: initial | handshake | application.
+
+-type keys() :: roadrunner_quic_keys:keys().
+
+-type decoded() :: #{
+    level := level(),
+    pn := non_neg_integer(),
+    frames := [roadrunner_quic_frame:frame()],
+    %% Present only for application packets (the 1-RTT key-phase bit).
+    key_phase => 0 | 1
+}.
+
+-type outcome() ::
+    {ok, decoded()}
+    | {drop, atom()}
+    | {frame_error, level(), term()}.
+
+-doc """
+Decode every packet in a received datagram. `Keys` maps each available
+encryption level to its packet-protection keys, `Largest` maps each space
+to its largest received packet number (a level absent from `Largest` is
+treated as a fresh space). `DCIDLen` is the server's fixed connection-ID
+length, used to locate the packet number of short-header packets. Returns
+one outcome per packet, in datagram order.
+""".
+-spec datagram(binary(), non_neg_integer(), #{level() => keys()}, #{level() => non_neg_integer()}) ->
+    [outcome()].
+datagram(Datagram, DCIDLen, Keys, Largest) ->
+    case roadrunner_quic_packet:coalesced_split(Datagram) of
+        {ok, Packet, Rest} ->
+            [packet(Packet, DCIDLen, Keys, Largest) | datagram(Rest, DCIDLen, Keys, Largest)];
+        %% End of datagram, trailing padding, or a header whose boundary
+        %% can't be parsed: stop. Packets already decoded are returned.
+        done ->
+            [];
+        {error, _Reason} ->
+            []
+    end.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+-spec packet(binary(), non_neg_integer(), #{level() => keys()}, #{level() => non_neg_integer()}) ->
+    outcome().
+packet(Packet, DCIDLen, Keys, Largest) ->
+    maybe
+        {ok, Level} ?= classify(Packet),
+        {ok, #{key := Key, iv := IV, hp := HP}} ?= level_keys(Level, Keys),
+        {ok, PNOffset} ?= roadrunner_quic_packet:pn_offset(Packet, DCIDLen),
+        {ok, Header, PNLen, TruncPN, Ciphertext} ?=
+            roadrunner_quic_aead:unprotect_header(HP, Packet, PNOffset),
+        PN = reconstruct_pn(level_largest(Level, Largest), PNLen, TruncPN),
+        {ok, Plaintext} ?= open(Key, IV, PN, Header, Ciphertext),
+        decode_frames(Level, PN, Header, Plaintext)
+    else
+        {drop, _} = Drop -> Drop;
+        {error, Reason} -> {drop, Reason}
+    end.
+
+%% Encryption level from the (header-protection-independent) first byte:
+%% long-header type bits select Initial/Handshake; a short header is
+%% 1-RTT (application). 0-RTT and Retry are unsupported for a server-only
+%% v1 endpoint.
+-spec classify(binary()) -> {ok, level()} | {drop, unsupported_packet}.
+classify(<<1:1, 1:1, 0:2, _:4, _/binary>>) -> {ok, initial};
+classify(<<1:1, 1:1, 2:2, _:4, _/binary>>) -> {ok, handshake};
+classify(<<0:1, 1:1, _:6, _/binary>>) -> {ok, application};
+classify(_) -> {drop, unsupported_packet}.
+
+-spec level_keys(level(), #{level() => keys()}) -> {ok, keys()} | {drop, no_keys}.
+level_keys(Level, Keys) ->
+    case Keys of
+        #{Level := LevelKeys} -> {ok, LevelKeys};
+        #{} -> {drop, no_keys}
+    end.
+
+-spec level_largest(level(), #{level() => non_neg_integer()}) -> non_neg_integer() | undefined.
+level_largest(Level, Largest) ->
+    case Largest of
+        #{Level := N} -> N;
+        #{} -> undefined
+    end.
+
+%% Reconstruct the full packet number from the truncated wire value and
+%% the largest received in this space (RFC 9000 §A.3). A fresh space
+%% (`undefined`) uses the truncated value directly.
+-doc false.
+-spec reconstruct_pn(non_neg_integer() | undefined, 1..4, non_neg_integer()) -> non_neg_integer().
+reconstruct_pn(undefined, _PNLen, TruncPN) ->
+    TruncPN;
+reconstruct_pn(Largest, PNLen, TruncPN) ->
+    Win = 1 bsl (PNLen * 8),
+    HalfWin = Win bsr 1,
+    Expected = Largest + 1,
+    Candidate = (Expected band bnot (Win - 1)) bor TruncPN,
+    if
+        Candidate =< Expected - HalfWin andalso Candidate < (1 bsl 62) - Win -> Candidate + Win;
+        Candidate > Expected + HalfWin andalso Candidate >= Win -> Candidate - Win;
+        true -> Candidate
+    end.
+
+%% Normalise the AEAD open result (a bare `error`) to the tagged drop the
+%% packet/4 maybe expects.
+-spec open(binary(), binary(), non_neg_integer(), binary(), binary()) ->
+    {ok, binary()} | {error, decrypt_failed}.
+open(Key, IV, PN, AAD, Sealed) ->
+    case roadrunner_quic_aead:open(Key, IV, PN, AAD, Sealed) of
+        {ok, _} = Ok -> Ok;
+        error -> {error, decrypt_failed}
+    end.
+
+-spec decode_frames(level(), non_neg_integer(), binary(), binary()) ->
+    {ok, decoded()} | {frame_error, level(), term()}.
+decode_frames(Level, PN, Header, Plaintext) ->
+    case roadrunner_quic_frame:decode_all(Plaintext) of
+        {ok, Frames} -> {ok, decoded(Level, PN, Header, Frames)};
+        {error, Reason} -> {frame_error, Level, Reason}
+    end.
+
+-spec decoded(level(), non_neg_integer(), binary(), [roadrunner_quic_frame:frame()]) -> decoded().
+decoded(application, PN, <<FirstByte, _/binary>>, Frames) ->
+    #{
+        level => application,
+        pn => PN,
+        frames => Frames,
+        key_phase => roadrunner_quic_packet:key_phase(FirstByte)
+    };
+decoded(Level, PN, _Header, Frames) ->
+    #{level => Level, pn => PN, frames => Frames}.

--- a/test/roadrunner_quic_packet_tests.erl
+++ b/test/roadrunner_quic_packet_tests.erl
@@ -138,6 +138,47 @@ decode_coalesced_test() ->
     ?assertEqual(Second, Rest).
 
 %% =============================================================================
+%% coalesced_split/1 (works on a still-protected datagram).
+%% =============================================================================
+
+%% A long-header packet is bounded by its Length field, leaving the
+%% following coalesced packet as the remainder.
+coalesced_split_long_test() ->
+    First = enc(?M:encode_long(initial, ?V1, ?DCID, ?SCID, #{pn => 1, payload => <<"abc">>})),
+    Second = enc(?M:encode_short(?DCID, 2, <<"d">>, false)),
+    ?assertEqual(
+        {ok, First, Second}, ?M:coalesced_split(<<First/binary, Second/binary>>)
+    ).
+
+%% A short-header packet runs to the end of the datagram (no remainder).
+coalesced_split_short_test() ->
+    Short = enc(?M:encode_short(?DCID, 2, <<"body">>, false)),
+    ?assertEqual({ok, Short, <<>>}, ?M:coalesced_split(Short)).
+
+%% Empty input and trailing padding (a zero first byte / cleared fixed
+%% bit) end the coalesced run.
+coalesced_split_done_test() ->
+    ?assertEqual(done, ?M:coalesced_split(<<>>)),
+    ?assertEqual(done, ?M:coalesced_split(<<0, 0, 0>>)).
+
+%% A long header truncated before its connection IDs cannot be bounded.
+coalesced_split_truncated_test() ->
+    ?assertEqual({error, truncated}, ?M:coalesced_split(<<16#C0, ?V1:32, 8>>)).
+
+%% A long header whose Length field claims more bytes than the datagram
+%% holds cannot be sliced.
+coalesced_split_length_exceeds_test() ->
+    Full = enc(?M:encode_long(initial, ?V1, ?DCID, ?SCID, #{pn => 1, payload => <<"abcdefgh">>})),
+    Truncated = binary:part(Full, 0, byte_size(Full) - 4),
+    ?assertEqual({error, truncated}, ?M:coalesced_split(Truncated)).
+
+%% A long header whose DCID length exceeds the 20-byte maximum is invalid.
+coalesced_split_invalid_cid_test() ->
+    ?assertEqual(
+        {error, invalid_packet}, ?M:coalesced_split(<<16#C0, ?V1:32, 21>>)
+    ).
+
+%% =============================================================================
 %% dcid/2 routing (works on a still-protected packet).
 %% =============================================================================
 

--- a/test/roadrunner_quic_recv_tests.erl
+++ b/test/roadrunner_quic_recv_tests.erl
@@ -1,0 +1,231 @@
+-module(roadrunner_quic_recv_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_recv).
+
+%% Server fixed connection-ID length (only used to locate short-header PNs).
+-define(DCID_LEN, 8).
+-define(DCID, <<1, 2, 3, 4, 5, 6, 7, 8>>).
+-define(SCID, <<9, 10, 11, 12>>).
+
+%% =============================================================================
+%% RFC 9001 Appendix A.3 (Server Initial) — the authority. The published
+%% protected packet, decrypted with the vector's keys, yields the vector's
+%% frames at the Initial level with packet number 1.
+%% =============================================================================
+
+rfc9001_a3_server_initial_test() ->
+    Keys = #{
+        initial => #{
+            key => hex(~"cf3a5331653c364c88f0f379b6067e37"),
+            iv => hex(~"0ac1493ca1905853b0bba03e"),
+            hp => hex(~"c206b8d9b9f0f37644430b490eeaa314")
+        }
+    },
+    Packet = hex(
+        ~"cf000000010008f067a5502a4262b5004075c0d95a482cd0991cd25b0aac406a5816b6394100f37a1c69797554780bb38cc5a99f5ede4cf73c3ec2493a1839b3dbcba3f6ea46c5b7684df3548e7ddeb9c3bf9c73cc3f3bded74b562bfb19fb84022f8ef4cdd93795d77d06edbb7aaf2f58891850abbdca3d20398c276456cbc42158407dd074ee"
+    ),
+    Plaintext = hex(
+        ~"02000000000600405a020000560303eefce7f7b37ba1d1632e96677825ddf73988cfc79825df566dc5430b9a045a1200130100002e00330024001d00209d3c940d89690b84d08a60993c144eca684d1081287c834d5311bcf32bb9da1a002b00020304"
+    ),
+    {ok, Frames} = roadrunner_quic_frame:decode_all(Plaintext),
+    ?assertEqual(
+        [{ok, #{level => initial, pn => 1, frames => Frames}}],
+        ?M:datagram(Packet, ?DCID_LEN, Keys, #{})
+    ).
+
+%% =============================================================================
+%% Round trips per encryption level (seal+protect a packet, then decode).
+%% =============================================================================
+
+%% A Handshake packet, with the largest-received threaded in (the integer
+%% reconstruction clause), decodes its frames at the handshake level.
+handshake_round_trip_test() ->
+    {Plaintext, Frames} = frames_for([{crypto, 0, <<"handshake-crypto-data">>}]),
+    Wire = seal_long(handshake, 5, handshake_keys(), Plaintext),
+    ?assertEqual(
+        [{ok, #{level => handshake, pn => 5, frames => Frames}}],
+        ?M:datagram(Wire, ?DCID_LEN, #{handshake => handshake_keys()}, #{handshake => 4})
+    ).
+
+%% A 1-RTT short-header packet decodes at the application level and surfaces
+%% the key-phase bit.
+application_round_trip_test() ->
+    {Plaintext, Frames} = frames_for([{stream, 0, 0, <<"application-body">>, true}]),
+    Wire = seal_short(7, application_keys(), 1, Plaintext),
+    ?assertEqual(
+        [{ok, #{level => application, pn => 7, frames => Frames, key_phase => 1}}],
+        ?M:datagram(Wire, ?DCID_LEN, #{application => application_keys()}, #{})
+    ).
+
+%% A packet whose wire packet number is narrower than the full number
+%% forces real reconstruction: the truncated 0x05 plus a largest of
+%% 0x10004 must recover 0x10005 (used as the AEAD nonce, so a wrong
+%% reconstruction would fail to decrypt). Also pins key phase 0.
+reconstructed_pn_round_trip_test() ->
+    {Plaintext, Frames} = frames_for([{stream, 0, 0, <<"wrapped-pn-body">>, true}]),
+    FullPN = 16#10005,
+    Wire = seal_short_pn(FullPN, 1, application_keys(), 0, Plaintext),
+    ?assertEqual(
+        [{ok, #{level => application, pn => FullPN, frames => Frames, key_phase => 0}}],
+        ?M:datagram(Wire, ?DCID_LEN, #{application => application_keys()}, #{
+            application => 16#10004
+        })
+    ).
+
+%% A coalesced datagram (Initial then Handshake) decodes each packet with
+%% its own level keys, in order.
+coalesced_datagram_test() ->
+    {InitialPlain, InitialFrames} = frames_for([{crypto, 0, <<"initial-crypto-data">>}]),
+    {HandshakePlain, HandshakeFrames} = frames_for([{crypto, 0, <<"handshake-crypto-data">>}]),
+    Wire = <<
+        (seal_long(initial, 0, initial_keys(), InitialPlain))/binary,
+        (seal_long(handshake, 0, handshake_keys(), HandshakePlain))/binary
+    >>,
+    ?assertEqual(
+        [
+            {ok, #{level => initial, pn => 0, frames => InitialFrames}},
+            {ok, #{level => handshake, pn => 0, frames => HandshakeFrames}}
+        ],
+        ?M:datagram(
+            Wire, ?DCID_LEN, #{initial => initial_keys(), handshake => handshake_keys()}, #{}
+        )
+    ).
+
+%% Trailing zero padding after a packet ends the datagram cleanly (no extra
+%% outcome).
+trailing_padding_test() ->
+    {Plaintext, Frames} = frames_for([{crypto, 0, <<"handshake-crypto-data">>}]),
+    Wire = <<(seal_long(handshake, 1, handshake_keys(), Plaintext))/binary, 0, 0, 0, 0>>,
+    ?assertEqual(
+        [{ok, #{level => handshake, pn => 1, frames => Frames}}],
+        ?M:datagram(Wire, ?DCID_LEN, #{handshake => handshake_keys()}, #{})
+    ).
+
+%% =============================================================================
+%% Drops (per packet, never the whole datagram) and frame errors.
+%% =============================================================================
+
+%% No keys installed for the packet's level yet.
+no_keys_dropped_test() ->
+    {Plaintext, _} = frames_for([{crypto, 0, <<"handshake-crypto-data">>}]),
+    Wire = seal_long(handshake, 5, handshake_keys(), Plaintext),
+    ?assertEqual([{drop, no_keys}], ?M:datagram(Wire, ?DCID_LEN, #{}, #{})).
+
+%% A tampered tag fails authentication and drops only that packet.
+decrypt_failure_dropped_test() ->
+    {Plaintext, _} = frames_for([{crypto, 0, <<"handshake-crypto-data">>}]),
+    Wire0 = seal_long(handshake, 5, handshake_keys(), Plaintext),
+    Len = byte_size(Wire0) - 1,
+    <<Head:Len/binary, Last>> = Wire0,
+    Tampered = <<Head/binary, (Last bxor 1)>>,
+    ?assertEqual(
+        [{drop, decrypt_failed}],
+        ?M:datagram(Tampered, ?DCID_LEN, #{handshake => handshake_keys()}, #{})
+    ).
+
+%% A packet too small to hold the 16-byte header-protection sample.
+sample_too_short_dropped_test() ->
+    Tiny = <<16#C0, 0, 0, 0, 1, 0, 0, 0, 4, 16#AA, 16#BB, 16#CC, 16#DD>>,
+    ?assertEqual(
+        [{drop, sample_too_short}], ?M:datagram(Tiny, ?DCID_LEN, #{initial => initial_keys()}, #{})
+    ).
+
+%% A 0-RTT packet is unsupported for a server-only v1 endpoint.
+unsupported_packet_dropped_test() ->
+    Wire = enc(
+        roadrunner_quic_packet:encode_long(
+            zero_rtt, 1, ?DCID, ?SCID, #{payload => binary:copy(<<0>>, 24)}
+        )
+    ),
+    ?assertEqual([{drop, unsupported_packet}], ?M:datagram(Wire, ?DCID_LEN, #{}, #{})).
+
+%% A header truncated before its boundary can be found stops the datagram.
+malformed_header_stops_test() ->
+    ?assertEqual([], ?M:datagram(<<16#C0, 0, 0, 0, 1, 8>>, ?DCID_LEN, #{}, #{})).
+
+%% An authenticated payload that decodes to a malformed frame is a
+%% connection error, kept distinct from a silent drop.
+frame_error_reported_test() ->
+    %% CRYPTO frame claiming 8 bytes of data but carrying only 3.
+    BadPlaintext = <<16#06, 16#00, 16#08, 1, 2, 3>>,
+    ?assertMatch({error, _}, roadrunner_quic_frame:decode_all(BadPlaintext)),
+    Wire = seal_long(handshake, 5, handshake_keys(), BadPlaintext),
+    ?assertMatch(
+        [{frame_error, handshake, _}],
+        ?M:datagram(Wire, ?DCID_LEN, #{handshake => handshake_keys()}, #{})
+    ).
+
+%% =============================================================================
+%% Packet-number reconstruction (RFC 9000 §A.3) — direct, all windows.
+%% =============================================================================
+
+reconstruct_pn_fresh_space_test() ->
+    ?assertEqual(1234, ?M:reconstruct_pn(undefined, 4, 1234)).
+
+reconstruct_pn_rfc_example_test() ->
+    %% RFC 9000 §A.3: largest 0xa82f30ea, truncated 0x9b32 -> 0xa82f9b32.
+    ?assertEqual(16#a82f9b32, ?M:reconstruct_pn(16#a82f30ea, 2, 16#9b32)).
+
+reconstruct_pn_window_up_test() ->
+    %% Truncated value wrapped below the window: add a window.
+    ?assertEqual(1034, ?M:reconstruct_pn(1000, 1, 10)).
+
+reconstruct_pn_window_down_test() ->
+    %% Candidate (762) landed a window too high: subtract a window. The
+    %% result differs from both the truncated value and the candidate.
+    ?assertEqual(506, ?M:reconstruct_pn(600, 1, 250)).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+enc(Iolist) -> iolist_to_binary(Iolist).
+
+hex(H) -> binary:decode_hex(string:uppercase(H)).
+
+%% Distinct per-level keys; any valid AES-128 material round-trips.
+initial_keys() -> #{key => <<31:128>>, iv => <<32:96>>, hp => <<33:128>>}.
+handshake_keys() -> #{key => <<11:128>>, iv => <<12:96>>, hp => <<13:128>>}.
+application_keys() -> #{key => <<21:128>>, iv => <<22:96>>, hp => <<23:128>>}.
+
+%% Encode a frame list to a payload and the frames it decodes back to.
+frames_for(FrameList) ->
+    Plaintext = enc([roadrunner_quic_frame:encode(F) || F <- FrameList]),
+    {ok, Frames} = roadrunner_quic_frame:decode_all(Plaintext),
+    {Plaintext, Frames}.
+
+%% Build a protected long-header wire packet from level keys + plaintext,
+%% mirroring the send path: size the header for the sealed payload, seal
+%% with the header as AAD, then apply header protection.
+seal_long(Type, PN, #{key := Key, iv := IV, hp := HP}, Plaintext) ->
+    PNLen = roadrunner_quic_packet:pn_length(PN),
+    SealedSize = byte_size(Plaintext) + 16,
+    [Header, _] = roadrunner_quic_packet:encode_long(
+        Type, 1, ?DCID, ?SCID, #{pn => PN, payload => <<0:(SealedSize * 8)>>}
+    ),
+    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
+    <<Protected/binary, Sealed/binary>>.
+
+seal_short(PN, #{key := Key, iv := IV, hp := HP}, KeyPhase, Plaintext) ->
+    PNLen = roadrunner_quic_packet:pn_length(PN),
+    [Header, _] = roadrunner_quic_packet:encode_short(?DCID, PN, <<>>, false, KeyPhase),
+    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
+    <<Protected/binary, Sealed/binary>>.
+
+%% Build a short-header packet whose wire packet number is forced to
+%% `WirePNLen` bytes (the low bytes of `FullPN`), while the AEAD nonce uses
+%% the full number, the way a real sender truncates the PN against the
+%% largest acknowledged.
+seal_short_pn(FullPN, WirePNLen, #{key := Key, iv := IV, hp := HP}, KeyPhase, Plaintext) ->
+    FirstByte = 2#01000000 bor ((KeyPhase band 1) bsl 2) bor (WirePNLen - 1),
+    Header =
+        <<FirstByte, ?DCID/binary, (roadrunner_quic_packet:encode_pn(FullPN, WirePNLen))/binary>>,
+    Sealed = roadrunner_quic_aead:seal(Key, IV, FullPN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(
+        HP, Header, Sealed, byte_size(Header) - WirePNLen
+    ),
+    <<Protected/binary, Sealed/binary>>.


### PR DESCRIPTION
# Description

The pure receive path that turns one received UDP datagram into its decoded packets: it splits coalesced packets, classifies each header's encryption level, removes header protection, reconstructs the full packet number (RFC 9000 §A.3), AEAD-decrypts, and decodes the frames. Per-level keys and per-space largest-received packet number are inputs, so it stays pure and stateless; the connection loop owns the packet-number spaces and applies the frames. Each packet yields a decoded result, a silent per-packet drop, or a distinct frame error (an authenticated payload with a malformed frame, which the loop must close on). A new length-aware `coalesced_split/1` bounds each long-header packet before header protection is removed. Verified against the RFC 9001 Appendix A.3 published server Initial packet.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)