### PR TITLE
Add the native QUIC send pipeline

### DIFF
--- a/src/roadrunner_quic_send.erl
+++ b/src/roadrunner_quic_send.erl
@@ -1,0 +1,177 @@
+-module(roadrunner_quic_send).
+-moduledoc false.
+
+%% QUIC v1 send pipeline (RFC 9000 §12.2/§14.1, RFC 9001 §5), pure: the
+%% inverse of `roadrunner_quic_recv`.
+%%
+%% Given the frames to send per encryption level (each with its keys and
+%% packet number), it encodes the frames, AEAD-seals each packet (the
+%% unprotected header is the associated data), applies header protection,
+%% and coalesces the packets into ONE UDP datagram in increasing
+%% encryption-level order (Initial, then Handshake, then 1-RTT). It returns
+%% the datagram bytes plus a per-packet record (level, packet number,
+%% length, ack-eliciting?) the connection loop feeds into loss/ACK/CC
+%% tracking.
+%%
+%% Pure and stateless: the chosen frames, keys, and packet numbers are
+%% inputs. Frame selection, ACK generation, retransmission, packet-number
+%% assignment, and all anti-amplification/CC/loss state stay in the loop;
+%% this module assembles whatever it is handed. The loop gates the result
+%% against the §8.1 anti-amplification budget (it owns `roadrunner_quic_amp`)
+%% before sending, so this module never caps or defers.
+%%
+%% Two paddings, deliberately distinct: every packet's plaintext is padded
+%% to the RFC 9001 §5.4.2 header-protection-sample minimum before sealing,
+%% and a datagram that carries an Initial is padded once at the end to the
+%% RFC 9000 §14.1 minimum of 1200 bytes with trailing zero bytes
+%% (`roadrunner_quic_recv` stops at them). The trailing pad is valid only
+%% when the datagram's last packet is long-header, so coalescing an Initial
+%% with a 1-RTT (short-header) packet is rejected: a server never holds
+%% 1-RTT keys while still sending Initials, so it never arises.
+%%
+%% A sent-record's `length` is the bare per-packet wire size; the §14.1
+%% trailing pad belongs to the datagram, not any packet, so the loop
+%% accounts anti-amplification and congestion-control datagram bytes via
+%% the returned datagram's size. The record also carries the packet's
+%% frames so the loop can retransmit them if it is later declared lost.
+
+-export([datagram/3]).
+
+-export_type([level/0, entry/0, sent/0]).
+
+%% The QUIC v1 version number (RFC 9000 §15); this is a v1-only endpoint.
+-define(QUIC_V1, 16#00000001).
+%% RFC 9000 §14.1: a datagram carrying an Initial packet is >= 1200 bytes.
+-define(MIN_INITIAL_DATAGRAM, 1200).
+%% RFC 9001 §5.4.2: the header-protection sample is 16 bytes at 4 past the
+%% packet-number start, so the plaintext must seal to at least that; 4
+%% bytes of plaintext covers the worst case (a 1-byte packet number).
+-define(MIN_SAMPLE_PLAINTEXT, 4).
+%% AEAD authentication tag length (RFC 9001 §5.3).
+-define(TAG_LEN, 16).
+
+-type level() :: initial | handshake | application.
+
+-type entry() :: #{
+    frames := [roadrunner_quic_frame:frame()],
+    keys := roadrunner_quic_keys:keys(),
+    pn := non_neg_integer(),
+    %% 1-RTT key phase (application level only); defaults to 0.
+    key_phase => 0 | 1
+}.
+
+-type sent() :: #{
+    level := level(),
+    pn := non_neg_integer(),
+    length := non_neg_integer(),
+    ack_eliciting := boolean(),
+    frames := [roadrunner_quic_frame:frame()]
+}.
+
+-doc """
+Assemble one UDP datagram from the per-level send entries. `Entries` maps
+each encryption level to send to its `#{frames, keys, pn}` (plus an
+optional `key_phase` for the application level); packets are built in
+Initial, Handshake, 1-RTT order. `DCID` is the destination connection id
+(the peer's chosen source id) and `SCID` the server's source id (used by
+long headers only). Returns the datagram bytes and one sent-record per
+packet, in datagram order.
+""".
+-spec datagram(#{level() => entry()}, binary(), binary()) -> {binary(), [sent()]}.
+datagram(Entries, DCID, SCID) ->
+    {Packets, Sent} = build_levels([initial, handshake, application], Entries, DCID, SCID),
+    {pad_datagram(iolist_to_binary(Packets), Entries), Sent}.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% Build a packet for each present level in the given order; body recursion
+%% so the wires and records come out in datagram order.
+-spec build_levels([level()], #{level() => entry()}, binary(), binary()) ->
+    {[binary()], [sent()]}.
+build_levels([], _Entries, _DCID, _SCID) ->
+    {[], []};
+build_levels([Level | Rest], Entries, DCID, SCID) ->
+    case Entries of
+        #{Level := Entry} ->
+            {Wire, Record} = build_packet(Level, Entry, DCID, SCID),
+            {Wires, Records} = build_levels(Rest, Entries, DCID, SCID),
+            {[Wire | Wires], [Record | Records]};
+        #{} ->
+            build_levels(Rest, Entries, DCID, SCID)
+    end.
+
+%% Encode + seal + header-protect one packet, returning the wire bytes and
+%% its sent-record.
+-spec build_packet(level(), entry(), binary(), binary()) -> {binary(), sent()}.
+build_packet(Level, #{frames := Frames, keys := Keys, pn := PN} = Entry, DCID, SCID) ->
+    #{key := Key, iv := IV, hp := HP} = Keys,
+    Plaintext = pad_plaintext(iolist_to_binary([roadrunner_quic_frame:encode(F) || F <- Frames])),
+    PNLen = roadrunner_quic_packet:pn_length(PN),
+    Header = header(Level, DCID, SCID, PN, byte_size(Plaintext) + ?TAG_LEN, key_phase(Entry)),
+    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
+    Wire = <<Protected/binary, Sealed/binary>>,
+    Record = #{
+        level => Level,
+        pn => PN,
+        length => byte_size(Wire),
+        ack_eliciting => ack_eliciting(Frames),
+        frames => Frames
+    },
+    {Wire, Record}.
+
+%% The 1-RTT key phase (application level only); defaults to 0.
+-spec key_phase(entry()) -> 0 | 1.
+key_phase(#{key_phase := Phase}) -> Phase;
+key_phase(#{}) -> 0.
+
+%% The unprotected header through the packet number (the AEAD associated
+%% data). A long header's Length must count the sealed payload, so it is
+%% built with a placeholder of the sealed size; a short header has no
+%% Length field and carries the key phase.
+-spec header(level(), binary(), binary(), non_neg_integer(), non_neg_integer(), 0 | 1) ->
+    binary().
+header(application, DCID, _SCID, PN, _SealedSize, KeyPhase) ->
+    [Header, _] = roadrunner_quic_packet:encode_short(DCID, PN, <<>>, false, KeyPhase),
+    Header;
+header(Level, DCID, SCID, PN, SealedSize, _KeyPhase) ->
+    [Header, _] = roadrunner_quic_packet:encode_long(Level, ?QUIC_V1, DCID, SCID, #{
+        pn => PN, payload => <<0:(SealedSize * 8)>>
+    }),
+    Header.
+
+%% Pad a packet's plaintext to the header-protection-sample minimum with
+%% PADDING frames (zero bytes) before it is sealed (RFC 9001 §5.4.2).
+-spec pad_plaintext(binary()) -> binary().
+pad_plaintext(Plaintext) when byte_size(Plaintext) >= ?MIN_SAMPLE_PLAINTEXT ->
+    Plaintext;
+pad_plaintext(Plaintext) ->
+    <<Plaintext/binary, 0:((?MIN_SAMPLE_PLAINTEXT - byte_size(Plaintext)) * 8)>>.
+
+%% Pad a datagram that carries an Initial packet to the RFC 9000 §14.1
+%% minimum with trailing zero bytes. Coalescing an Initial with a 1-RTT
+%% packet is a contract violation: the 1-RTT short header has no Length, so
+%% the trailing pad would fold into its ciphertext and the peer could not
+%% decrypt it. A server never has 1-RTT keys while still sending Initials,
+%% so this never arises; reject it rather than emit a corrupt datagram.
+-spec pad_datagram(binary(), #{level() => entry()}) -> binary().
+pad_datagram(_Datagram, #{initial := _, application := _}) ->
+    error(initial_with_application_coalesced);
+pad_datagram(Datagram, #{initial := _}) when byte_size(Datagram) < ?MIN_INITIAL_DATAGRAM ->
+    <<Datagram/binary, 0:((?MIN_INITIAL_DATAGRAM - byte_size(Datagram)) * 8)>>;
+pad_datagram(Datagram, _Entries) ->
+    Datagram.
+
+%% A packet is ack-eliciting if it carries any frame other than PADDING,
+%% ACK, or CONNECTION_CLOSE (RFC 9002 §2).
+-spec ack_eliciting([roadrunner_quic_frame:frame()]) -> boolean().
+ack_eliciting(Frames) ->
+    lists:any(fun is_ack_eliciting/1, Frames).
+
+-spec is_ack_eliciting(roadrunner_quic_frame:frame()) -> boolean().
+is_ack_eliciting(padding) -> false;
+is_ack_eliciting({ack, _, _, _, _, _}) -> false;
+is_ack_eliciting({connection_close, _, _, _, _}) -> false;
+is_ack_eliciting(_) -> true.

--- a/test/roadrunner_quic_send_tests.erl
+++ b/test/roadrunner_quic_send_tests.erl
@@ -1,0 +1,173 @@
+-module(roadrunner_quic_send_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_send).
+
+-define(DCID, <<1, 2, 3, 4, 5, 6, 7, 8>>).
+-define(SCID, <<9, 10, 11, 12>>).
+
+%% =============================================================================
+%% Round trips: a sent datagram decodes back through roadrunner_quic_recv
+%% (the RFC-9001-A.3-validated inverse) to the same frames/level/pn.
+%% =============================================================================
+
+%% An Initial-bearing datagram is padded to 1200 and decodes to its frames
+%% (the trailing zero padding is ignored by the receiver).
+initial_round_trip_test() ->
+    Frames = [{crypto, 0, <<"server-hello-bytes">>}],
+    Entries = #{initial => #{frames => Frames, keys => initial_keys(), pn => 0}},
+    {Datagram, Sent} = ?M:datagram(Entries, ?DCID, ?SCID),
+    ?assertEqual(1200, byte_size(Datagram)),
+    ?assertEqual(
+        [{ok, #{level => initial, pn => 0, frames => Frames}}],
+        recv(Datagram, #{initial => initial_keys()})
+    ),
+    ?assertMatch([#{level := initial, pn := 0, ack_eliciting := true}], Sent).
+
+%% A Handshake-only datagram is not padded to 1200.
+handshake_round_trip_test() ->
+    Frames = [{crypto, 0, <<"encrypted-extensions-and-cert">>}],
+    Entries = #{handshake => #{frames => Frames, keys => handshake_keys(), pn => 5}},
+    {Datagram, Sent} = ?M:datagram(Entries, ?DCID, ?SCID),
+    ?assert(byte_size(Datagram) < 1200),
+    ?assertEqual(
+        [{ok, #{level => handshake, pn => 5, frames => Frames}}],
+        recv(Datagram, #{handshake => handshake_keys()})
+    ),
+    %% A single non-Initial packet is the whole (unpadded) datagram, so its
+    %% recorded length equals the datagram size; the record also carries the
+    %% frames for retransmission.
+    ?assertEqual(
+        [
+            #{
+                level => handshake,
+                pn => 5,
+                length => byte_size(Datagram),
+                ack_eliciting => true,
+                frames => Frames
+            }
+        ],
+        Sent
+    ).
+
+%% A multi-byte packet number is encoded at its minimal width and decodes
+%% back to the same value.
+multi_byte_pn_round_trip_test() ->
+    Frames = [{crypto, 0, <<"handshake-with-a-wide-packet-number">>}],
+    Entries = #{handshake => #{frames => Frames, keys => handshake_keys(), pn => 16#1234}},
+    {Datagram, Sent} = ?M:datagram(Entries, ?DCID, ?SCID),
+    ?assertEqual(
+        [{ok, #{level => handshake, pn => 16#1234, frames => Frames}}],
+        recv(Datagram, #{handshake => handshake_keys()})
+    ),
+    ?assertMatch([#{pn := 16#1234}], Sent).
+
+%% Version, DCID, and SCID are not header-protected, so a produced long
+%% packet's header fields can be read straight off the wire (pins the
+%% encode_long arguments independently of the receiver).
+header_fields_test() ->
+    Frames = [{crypto, 0, <<"handshake-crypto-payload">>}],
+    Entries = #{handshake => #{frames => Frames, keys => handshake_keys(), pn => 5}},
+    {Datagram, _} = ?M:datagram(Entries, ?DCID, ?SCID),
+    <<_FirstByte, Version:32, DCIDLen, AfterDCIDLen/binary>> = Datagram,
+    <<DCID:DCIDLen/binary, SCIDLen, SCID:SCIDLen/binary, _/binary>> = AfterDCIDLen,
+    ?assertEqual(16#00000001, Version),
+    ?assertEqual(?DCID, DCID),
+    ?assertEqual(?SCID, SCID).
+
+%% Coalescing an Initial with a 1-RTT packet is a contract violation (the
+%% trailing 1200 pad would corrupt the short-header packet).
+initial_with_application_rejected_test() ->
+    Entries = #{
+        initial => #{frames => [{crypto, 0, <<"server-hello">>}], keys => initial_keys(), pn => 0},
+        application => #{
+            frames => [{stream, 0, 0, <<"body">>, true}], keys => application_keys(), pn => 0
+        }
+    },
+    ?assertError(initial_with_application_coalesced, ?M:datagram(Entries, ?DCID, ?SCID)).
+
+%% A 1-RTT short-header datagram carries the explicit key phase.
+application_round_trip_test() ->
+    Frames = [{stream, 0, 0, <<"application-response-body">>, true}],
+    Entries = #{
+        application => #{frames => Frames, keys => application_keys(), pn => 9, key_phase => 1}
+    },
+    {Datagram, _Sent} = ?M:datagram(Entries, ?DCID, ?SCID),
+    ?assert(byte_size(Datagram) < 1200),
+    ?assertEqual(
+        [{ok, #{level => application, pn => 9, frames => Frames, key_phase => 1}}],
+        recv(Datagram, #{application => application_keys()})
+    ).
+
+%% Key phase defaults to 0 when omitted.
+application_default_key_phase_test() ->
+    Frames = [{stream, 0, 0, <<"more-body-data">>, false}],
+    Entries = #{application => #{frames => Frames, keys => application_keys(), pn => 1}},
+    {Datagram, _} = ?M:datagram(Entries, ?DCID, ?SCID),
+    ?assertEqual(
+        [{ok, #{level => application, pn => 1, frames => Frames, key_phase => 0}}],
+        recv(Datagram, #{application => application_keys()})
+    ).
+
+%% Initial and Handshake coalesce into one 1200-byte datagram, in order,
+%% and each decodes with its own level keys.
+coalesced_datagram_test() ->
+    InitialFrames = [{crypto, 0, <<"server-hello">>}],
+    HandshakeFrames = [{crypto, 0, <<"ee-cert-certverify-finished">>}],
+    Entries = #{
+        initial => #{frames => InitialFrames, keys => initial_keys(), pn => 0},
+        handshake => #{frames => HandshakeFrames, keys => handshake_keys(), pn => 0}
+    },
+    {Datagram, Sent} = ?M:datagram(Entries, ?DCID, ?SCID),
+    ?assertEqual(1200, byte_size(Datagram)),
+    ?assertEqual(
+        [
+            {ok, #{level => initial, pn => 0, frames => InitialFrames}},
+            {ok, #{level => handshake, pn => 0, frames => HandshakeFrames}}
+        ],
+        recv(Datagram, #{initial => initial_keys(), handshake => handshake_keys()})
+    ),
+    ?assertMatch([#{level := initial}, #{level := handshake}], Sent).
+
+%% A sub-4-byte payload (one PING) is padded for the header-protection
+%% sample; the PING survives and trailing PADDING frames fill the rest.
+small_packet_padded_test() ->
+    Entries = #{handshake => #{frames => [ping], keys => handshake_keys(), pn => 3}},
+    {Datagram, _} = ?M:datagram(Entries, ?DCID, ?SCID),
+    [{ok, #{frames := Frames}}] = recv(Datagram, #{handshake => handshake_keys()}),
+    ?assertEqual(ping, hd(Frames)),
+    ?assert(lists:all(fun(F) -> F =:= padding end, tl(Frames))).
+
+%% =============================================================================
+%% Sent records: ack-eliciting classification (RFC 9002 §2).
+%% =============================================================================
+
+ack_eliciting_classification_test() ->
+    Cases = [
+        {[{crypto, 0, <<"data">>}], true},
+        {[{ack, 0, 0, 0, [], undefined}], false},
+        {[{connection_close, transport, 0, 0, <<>>}], false},
+        {[padding, padding, padding, padding], false}
+    ],
+    [
+        begin
+            Entry = #{frames => Frames, keys => handshake_keys(), pn => 1},
+            {_, [#{ack_eliciting := AckEliciting}]} = ?M:datagram(
+                #{handshake => Entry}, ?DCID, ?SCID
+            ),
+            ?assertEqual(Expected, AckEliciting)
+        end
+     || {Frames, Expected} <- Cases
+    ].
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+recv(Datagram, Keys) ->
+    roadrunner_quic_recv:datagram(Datagram, byte_size(?DCID), Keys, #{}).
+
+initial_keys() -> #{key => <<31:128>>, iv => <<32:96>>, hp => <<33:128>>}.
+handshake_keys() -> #{key => <<11:128>>, iv => <<12:96>>, hp => <<13:128>>}.
+application_keys() -> #{key => <<21:128>>, iv => <<22:96>>, hp => <<23:128>>}.


### PR DESCRIPTION
# Description

The pure send path, inverse of the receive pipeline: given the frames to send per encryption level (each with its keys and packet number), it encodes the frames, AEAD-seals each packet, applies header protection, and coalesces the packets into one UDP datagram in Initial, Handshake, 1-RTT order. It pads each packet's plaintext to the header-protection-sample minimum and pads an Initial-bearing datagram to 1200 bytes. It returns the datagram bytes plus one sent-record per packet (level, packet number, length, ack-eliciting, frames) for the connection loop to feed into loss, ACK, and congestion-control tracking; anti-amplification gating stays with the loop. Verified by round-tripping every datagram shape back through the receive pipeline.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)