### PR TITLE
Add the native QUIC stream receive reassembly

### DIFF
--- a/src/roadrunner_quic_stream.erl
+++ b/src/roadrunner_quic_stream.erl
@@ -1,0 +1,208 @@
+-module(roadrunner_quic_stream).
+-moduledoc false.
+
+%% QUIC stream receive-side reassembly (RFC 9000 §2.2/§4.5), pure.
+%%
+%% A per-stream state that turns out-of-order, overlapping, and
+%% retransmitted STREAM frame pieces into the in-order byte stream the
+%% application reads. The connection loop holds one of these per stream id
+%% (the peer of `roadrunner_quic_flow`, which it also holds per stream),
+%% feeds each received STREAM frame in with `receive_data/4`, and turns the
+%% result into a `{stream_data, StreamId, Bytes, Fin}` event, including the
+%% FIN-only `{<<>>, true}` case the HTTP/3 layer dispatches a request on.
+%% A RESET_STREAM aborts the receive side via `reset/2`.
+%%
+%% Pure and stateless about windows: flow control (the receive-window
+%% limit and MAX_STREAM_DATA grants) stays in the loop's
+%% `roadrunner_quic_flow`, which already returns `flow_control_error`. This
+%% module owns only ordering and the RFC 9000 §4.5 final-size rules, so it
+%% returns `final_size_error` and nothing else. The outbound send buffer is
+%% a separate concern, added in a follow-up.
+%%
+%% Buffered out-of-order data is kept as a sorted, non-overlapping list of
+%% `{Offset, Bytes}` segments (overlaps are trimmed on insert, since the
+%% bytes at an offset never change), so the contiguous prefix drains
+%% cleanly from the read cursor.
+
+-export([new/0, receive_data/4, reset/2]).
+
+-export_type([t/0]).
+
+-record(stream, {
+    %% Next byte to deliver: the length of the contiguous prefix already
+    %% handed to the application.
+    offset = 0 :: non_neg_integer(),
+    %% Buffered gaps: sorted ascending, non-overlapping, every offset
+    %% strictly above `offset`.
+    segments = [] :: [{non_neg_integer(), binary()}],
+    %% The stream's final size once a FIN (or RESET_STREAM) sets it.
+    final_size = undefined :: non_neg_integer() | undefined,
+    %% Whether the FIN has already been delivered (so a retransmit does
+    %% not deliver it twice).
+    fin_delivered = false :: boolean(),
+    %% Set by a RESET_STREAM: the receive side is aborted, so later STREAM
+    %% frames deliver nothing (RFC 9000 §3.2).
+    aborted = false :: boolean()
+}).
+
+-opaque t() :: #stream{}.
+
+-doc "A fresh receive stream, read cursor at offset 0.".
+-spec new() -> t().
+new() ->
+    #stream{}.
+
+-doc """
+Take a received STREAM frame piece (`Offset`, `Data`, end-of-stream `Fin`)
+and return the bytes that are now contiguous from the read cursor and
+whether the stream's end has been reached.
+
+`Deliverable` is the newly contiguous bytes (empty when the frame only
+filled a gap above the cursor, or was a pure duplicate). `FinReached` is
+true exactly once, when the contiguous data first reaches the final size;
+combined with an empty `Deliverable` that is the FIN-only end-of-stream.
+Returns `{error, final_size_error}` on an RFC 9000 §4.5 violation (data
+past the final size, a conflicting final size, or a final size below
+already-received data).
+""".
+-spec receive_data(non_neg_integer(), binary(), boolean(), t()) ->
+    {ok, binary(), boolean(), t()} | {error, final_size_error}.
+receive_data(_Offset, _Data, _Fin, #stream{aborted = true} = Stream) ->
+    %% RESET_STREAM aborted the receive side; ignore any late data.
+    {ok, <<>>, false, Stream};
+receive_data(Offset, Data, Fin, #stream{offset = Cursor} = Stream) ->
+    End = Offset + byte_size(Data),
+    case final_size(End, Fin, Stream) of
+        {error, _} = Error ->
+            Error;
+        {ok, FinalSize} ->
+            {KeepOffset, KeepData} = trim(Offset, Data, Cursor),
+            Segments = insert_segment(KeepOffset, KeepData, Stream#stream.segments),
+            {Deliverable, NewCursor, Rest} = drain(Cursor, Segments),
+            FinReached = FinalSize =/= undefined andalso NewCursor >= FinalSize,
+            DeliverFin = FinReached andalso not Stream#stream.fin_delivered,
+            {ok, Deliverable, DeliverFin, Stream#stream{
+                offset = NewCursor,
+                segments = Rest,
+                final_size = FinalSize,
+                fin_delivered = FinReached
+            }}
+    end.
+
+-doc """
+Abort the receive side on a RESET_STREAM, validating its final size
+against what was already received (RFC 9000 §4.5). On success the receive
+side is terminal: buffered data is discarded and later STREAM frames
+deliver nothing (RFC 9000 §3.2). Returns `{error, final_size_error}` on a
+conflicting or too-small final size.
+""".
+-spec reset(non_neg_integer(), t()) -> {ok, t()} | {error, final_size_error}.
+reset(FinalSize, #stream{final_size = Existing} = Stream) ->
+    case
+        (Existing =/= undefined andalso FinalSize =/= Existing) orelse
+            FinalSize < highest_received(Stream)
+    of
+        true -> {error, final_size_error};
+        false -> {ok, Stream#stream{final_size = FinalSize, segments = [], aborted = true}}
+    end.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% Validate the frame's end offset against the final size and, on a FIN,
+%% establish it (RFC 9000 §4.5).
+-spec final_size(non_neg_integer(), boolean(), t()) ->
+    {ok, non_neg_integer() | undefined} | {error, final_size_error}.
+final_size(End, Fin, #stream{final_size = Final} = Stream) ->
+    case Final of
+        %% A FIN sets the final size, but it cannot fall below data already
+        %% received.
+        undefined when Fin ->
+            case End < highest_received(Stream) of
+                true -> {error, final_size_error};
+                false -> {ok, End}
+            end;
+        undefined ->
+            {ok, undefined};
+        %% Data may not extend past an established final size.
+        _ when End > Final ->
+            {error, final_size_error};
+        %% A FIN may not contradict an established final size.
+        _ when Fin andalso End =/= Final ->
+            {error, final_size_error};
+        _ ->
+            {ok, Final}
+    end.
+
+%% The offset one past the highest byte received so far (delivered or
+%% buffered).
+-spec highest_received(t()) -> non_neg_integer().
+highest_received(#stream{offset = Cursor, segments = []}) ->
+    Cursor;
+highest_received(#stream{segments = Segments}) ->
+    {Offset, Data} = lists:last(Segments),
+    Offset + byte_size(Data).
+
+%% Drop the part of a piece that the read cursor has already delivered.
+-spec trim(non_neg_integer(), binary(), non_neg_integer()) -> {non_neg_integer(), binary()}.
+trim(Offset, Data, Cursor) when Offset >= Cursor ->
+    {Offset, Data};
+trim(Offset, Data, Cursor) ->
+    Drop = Cursor - Offset,
+    case Data of
+        <<_:Drop/binary, Tail/binary>> -> {Cursor, Tail};
+        _ -> {Cursor, <<>>}
+    end.
+
+%% Insert a piece into the sorted, non-overlapping segment list, keeping
+%% existing bytes where they overlap (the wire guarantees the bytes at an
+%% offset are identical, RFC 9000 §2.2). An empty piece is a no-op.
+-spec insert_segment(non_neg_integer(), binary(), [{non_neg_integer(), binary()}]) ->
+    [{non_neg_integer(), binary()}].
+insert_segment(_Offset, <<>>, Segments) ->
+    Segments;
+insert_segment(Offset, Data, []) ->
+    [{Offset, Data}];
+insert_segment(Offset, Data, [{SegOffset, SegData} = Segment | Rest]) ->
+    End = Offset + byte_size(Data),
+    SegEnd = SegOffset + byte_size(SegData),
+    if
+        End =< SegOffset ->
+            [{Offset, Data}, Segment | Rest];
+        Offset >= SegEnd ->
+            [Segment | insert_segment(Offset, Data, Rest)];
+        true ->
+            before_segment(Offset, Data, SegOffset) ++
+                [Segment | after_segment(Offset, Data, End, SegEnd, Rest)]
+    end.
+
+%% The part of an overlapping piece that falls before the segment it hit.
+-spec before_segment(non_neg_integer(), binary(), non_neg_integer()) ->
+    [{non_neg_integer(), binary()}].
+before_segment(Offset, Data, SegOffset) when Offset < SegOffset ->
+    [{Offset, binary:part(Data, 0, SegOffset - Offset)}];
+before_segment(_Offset, _Data, _SegOffset) ->
+    [].
+
+%% The part of an overlapping piece that falls after the segment it hit,
+%% re-inserted against the remaining segments.
+-spec after_segment(
+    non_neg_integer(), binary(), non_neg_integer(), non_neg_integer(), [
+        {non_neg_integer(), binary()}
+    ]
+) -> [{non_neg_integer(), binary()}].
+after_segment(Offset, Data, End, SegEnd, Rest) when End > SegEnd ->
+    insert_segment(SegEnd, binary:part(Data, SegEnd - Offset, End - SegEnd), Rest);
+after_segment(_Offset, _Data, _End, _SegEnd, Rest) ->
+    Rest.
+
+%% Pop the contiguous prefix starting at the cursor, advancing through
+%% adjacent segments; body recursion, consing the bytes on the way out.
+-spec drain(non_neg_integer(), [{non_neg_integer(), binary()}]) ->
+    {binary(), non_neg_integer(), [{non_neg_integer(), binary()}]}.
+drain(Cursor, [{Cursor, Data} | Rest]) ->
+    {More, NewCursor, Remaining} = drain(Cursor + byte_size(Data), Rest),
+    {<<Data/binary, More/binary>>, NewCursor, Remaining};
+drain(Cursor, Segments) ->
+    {<<>>, Cursor, Segments}.

--- a/test/property_test/roadrunner_quic_stream_props.erl
+++ b/test/property_test/roadrunner_quic_stream_props.erl
@@ -1,0 +1,62 @@
+-module(roadrunner_quic_stream_props).
+-moduledoc """
+Property-based test for `roadrunner_quic_stream` receive reassembly.
+
+Invariant: however a byte stream is fragmented into STREAM frame pieces,
+reordered, and partly retransmitted, feeding the pieces through
+`receive_data/4` reassembles exactly the original bytes and reports the
+stream's end. The fragmentation, duplication, and shuffle are derived
+deterministically from a generated seed (a pure function, easier to trust
+than nested generators), so the property varies them across runs.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+prop_reassembles_in_any_order() ->
+    ?FORALL(
+        {Bytes, Seed},
+        {non_empty(binary()), integer(1, 1_000_000)},
+        begin
+            Frames = fragment(Bytes, Seed),
+            {Delivered, FinReached} = reassemble(Frames),
+            Delivered =:= Bytes andalso FinReached
+        end
+    ).
+
+%% Feed every frame through receive_data/4, concatenating what is delivered
+%% and noting whether the FIN was reached.
+reassemble(Frames) ->
+    {_Stream, Delivered, FinReached} = lists:foldl(
+        fun({Offset, Data, Fin}, {Stream, Acc, Seen}) ->
+            {ok, Bin, Reached, Stream1} = roadrunner_quic_stream:receive_data(
+                Offset, Data, Fin, Stream
+            ),
+            {Stream1, <<Acc/binary, Bin/binary>>, Seen orelse Reached}
+        end,
+        {roadrunner_quic_stream:new(), <<>>, false},
+        Frames
+    ),
+    {Delivered, FinReached}.
+
+%% Fragment Bytes on two independent grids and shuffle the union. Two
+%% different cut grids over the same bytes guarantee partially overlapping
+%% and multi-segment-spanning pieces (the reassembler's core paths), while
+%% drawing both from the same bytes keeps overlapping bytes identical
+%% (RFC 9000 §2.2). A piece is a FIN iff it ends at the final size.
+fragment(Bytes, Seed) ->
+    Final = byte_size(Bytes),
+    Pieces = pieces(Bytes, 0, Seed) ++ pieces(Bytes, 0, Seed bxor 16#5555),
+    shuffle([{Offset, Data, Offset + byte_size(Data) =:= Final} || {Offset, Data} <- Pieces], Seed).
+
+pieces(<<>>, _Offset, _Seed) ->
+    [];
+pieces(Bin, Offset, Seed) ->
+    Take = min(1 + (erlang:phash2({Seed, Offset}) rem 4), byte_size(Bin)),
+    <<Chunk:Take/binary, Rest/binary>> = Bin,
+    [{Offset, Chunk} | pieces(Rest, Offset + Take, Seed)].
+
+shuffle(Frames, Seed) ->
+    [Frame || {_Key, Frame} <- lists:sort([{erlang:phash2({Seed, F}), F} || F <- Frames])].

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -47,7 +47,8 @@ Add a new property:
     quic_tls_handshake_matches_dep/1,
     quic_transport_params_matches_dep/1,
     quic_tls_hello_parse_never_crashes/1,
-    quic_tls_auth_certificate_verify_roundtrips/1
+    quic_tls_auth_certificate_verify_roundtrips/1,
+    quic_stream_reassembles/1
 ]).
 
 suite() ->
@@ -85,7 +86,8 @@ all() ->
         quic_tls_handshake_matches_dep,
         quic_transport_params_matches_dep,
         quic_tls_hello_parse_never_crashes,
-        quic_tls_auth_certificate_verify_roundtrips
+        quic_tls_auth_certificate_verify_roundtrips,
+        quic_stream_reassembles
     ].
 
 init_per_suite(Config) ->
@@ -277,5 +279,11 @@ quic_tls_hello_parse_never_crashes(Config) ->
 quic_tls_auth_certificate_verify_roundtrips(Config) ->
     ct_property_test:quickcheck(
         roadrunner_quic_tls_auth_props:prop_certificate_verify_roundtrips(),
+        Config
+    ).
+
+quic_stream_reassembles(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_quic_stream_props:prop_reassembles_in_any_order(),
         Config
     ).

--- a/test/roadrunner_quic_stream_tests.erl
+++ b/test/roadrunner_quic_stream_tests.erl
@@ -1,0 +1,160 @@
+-module(roadrunner_quic_stream_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_stream).
+
+%% =============================================================================
+%% In-order and out-of-order reassembly.
+%% =============================================================================
+
+in_order_delivery_test() ->
+    {ok, D1, false, S1} = ?M:receive_data(0, <<"hello ">>, false, ?M:new()),
+    {ok, D2, false, _} = ?M:receive_data(6, <<"world">>, false, S1),
+    ?assertEqual(<<"hello ">>, D1),
+    ?assertEqual(<<"world">>, D2).
+
+out_of_order_gap_fill_test() ->
+    %% The second piece arrives first (a gap), so nothing is delivered; the
+    %% first piece fills the gap and both drain in order.
+    {ok, D1, false, S1} = ?M:receive_data(6, <<"world">>, false, ?M:new()),
+    ?assertEqual(<<>>, D1),
+    {ok, D2, false, _} = ?M:receive_data(0, <<"hello ">>, false, S1),
+    ?assertEqual(<<"hello world">>, D2).
+
+multiple_gaps_test() ->
+    %% Three out-of-order gapped pieces buffer, then the first fills and the
+    %% whole prefix drains.
+    {ok, <<>>, false, S1} = ?M:receive_data(2, <<"cc">>, false, ?M:new()),
+    {ok, <<>>, false, S2} = ?M:receive_data(6, <<"gg">>, false, S1),
+    {ok, <<>>, false, S3} = ?M:receive_data(4, <<"ee">>, false, S2),
+    {ok, D, false, _} = ?M:receive_data(0, <<"aa">>, false, S3),
+    ?assertEqual(<<"aacceegg">>, D).
+
+%% =============================================================================
+%% Duplicates and overlap.
+%% =============================================================================
+
+duplicate_dropped_test() ->
+    {ok, <<"abc">>, false, S1} = ?M:receive_data(0, <<"abc">>, false, ?M:new()),
+    %% A full retransmit of already-delivered data yields nothing new.
+    {ok, D1, false, S2} = ?M:receive_data(0, <<"abc">>, false, S1),
+    ?assertEqual(<<>>, D1),
+    %% A frame overlapping the delivered prefix delivers only its new tail.
+    {ok, D2, false, _} = ?M:receive_data(1, <<"bcde">>, false, S2),
+    ?assertEqual(<<"de">>, D2).
+
+buffered_overlap_test() ->
+    %% A buffered gap piece, then a piece overlapping it on both sides;
+    %% existing bytes are kept and the new before/after parts are added.
+    {ok, <<>>, false, S1} = ?M:receive_data(6, <<"world">>, false, ?M:new()),
+    {ok, <<>>, false, S2} = ?M:receive_data(3, <<"lo worldXX">>, false, S1),
+    {ok, D, false, _} = ?M:receive_data(0, <<"hel">>, false, S2),
+    ?assertEqual(<<"hello worldXX">>, D).
+
+fully_covered_piece_dropped_test() ->
+    %% A piece entirely inside a buffered segment adds nothing.
+    {ok, <<>>, false, S1} = ?M:receive_data(6, <<"world">>, false, ?M:new()),
+    {ok, <<>>, false, S2} = ?M:receive_data(7, <<"or">>, false, S1),
+    {ok, D, false, _} = ?M:receive_data(0, <<"hello ">>, false, S2),
+    ?assertEqual(<<"hello world">>, D).
+
+multi_segment_span_test() ->
+    %% A piece that overlaps one buffered segment, fills the gap after it,
+    %% and overlaps a second buffered segment (the after_segment recursion
+    %% into a non-empty rest). Stream bytes: "01ccEEgg".
+    {ok, <<>>, false, S1} = ?M:receive_data(2, <<"cc">>, false, ?M:new()),
+    {ok, <<>>, false, S2} = ?M:receive_data(6, <<"gg">>, false, S1),
+    {ok, <<>>, false, S3} = ?M:receive_data(1, <<"1ccEEgg">>, false, S2),
+    {ok, D, false, _} = ?M:receive_data(0, <<"0">>, false, S3),
+    ?assertEqual(<<"01ccEEgg">>, D).
+
+%% =============================================================================
+%% FIN / end-of-stream.
+%% =============================================================================
+
+fin_with_data_test() ->
+    {ok, D, FinReached, _} = ?M:receive_data(0, <<"final">>, true, ?M:new()),
+    ?assertEqual(<<"final">>, D),
+    ?assert(FinReached).
+
+fin_only_delivery_test() ->
+    %% A stream that ends with no further data: an empty FIN frame at the
+    %% read cursor delivers {<<>>, true}.
+    {ok, <<"data">>, false, S1} = ?M:receive_data(0, <<"data">>, false, ?M:new()),
+    {ok, D, FinReached, _} = ?M:receive_data(4, <<>>, true, S1),
+    ?assertEqual(<<>>, D),
+    ?assert(FinReached).
+
+fin_rides_gap_fill_test() ->
+    %% The FIN arrives out of order and buffers; the gap-filling non-FIN
+    %% frame delivers everything and the FIN together.
+    {ok, <<>>, false, S1} = ?M:receive_data(5, <<"!!">>, true, ?M:new()),
+    {ok, D, FinReached, _} = ?M:receive_data(0, <<"hello">>, false, S1),
+    ?assertEqual(<<"hello!!">>, D),
+    ?assert(FinReached).
+
+fin_with_buffered_gaps_test() ->
+    %% A FIN whose final size is validated against buffered (not yet
+    %% delivered) data.
+    {ok, <<>>, false, S1} = ?M:receive_data(3, <<"de">>, false, ?M:new()),
+    {ok, <<>>, false, S2} = ?M:receive_data(5, <<>>, true, S1),
+    {ok, D, FinReached, _} = ?M:receive_data(0, <<"abc">>, false, S2),
+    ?assertEqual(<<"abcde">>, D),
+    ?assert(FinReached).
+
+duplicate_fin_not_redelivered_test() ->
+    {ok, <<"x">>, true, S1} = ?M:receive_data(0, <<"x">>, true, ?M:new()),
+    %% A retransmit of the final frame must not deliver the FIN again.
+    {ok, D, FinReached, _} = ?M:receive_data(0, <<"x">>, true, S1),
+    ?assertEqual(<<>>, D),
+    ?assertNot(FinReached).
+
+%% =============================================================================
+%% Final-size errors (RFC 9000 §4.5).
+%% =============================================================================
+
+data_beyond_final_size_test() ->
+    {ok, _, true, S1} = ?M:receive_data(0, <<"abc">>, true, ?M:new()),
+    ?assertEqual({error, final_size_error}, ?M:receive_data(3, <<"d">>, false, S1)).
+
+conflicting_final_size_test() ->
+    {ok, _, false, S1} = ?M:receive_data(0, <<"ab">>, false, ?M:new()),
+    {ok, <<>>, false, S2} = ?M:receive_data(5, <<"f">>, true, S1),
+    ?assertEqual({error, final_size_error}, ?M:receive_data(2, <<"cd">>, true, S2)).
+
+final_size_below_received_test() ->
+    {ok, _, false, S1} = ?M:receive_data(0, <<"abcde">>, false, ?M:new()),
+    ?assertEqual({error, final_size_error}, ?M:receive_data(3, <<>>, true, S1)).
+
+%% =============================================================================
+%% RESET_STREAM.
+%% =============================================================================
+
+reset_accepts_consistent_final_size_test() ->
+    {ok, _, false, S1} = ?M:receive_data(0, <<"abc">>, false, ?M:new()),
+    ?assertMatch({ok, _}, ?M:reset(3, S1)),
+    ?assertMatch({ok, _}, ?M:reset(10, S1)).
+
+reset_conflicting_final_size_test() ->
+    {ok, _, true, S1} = ?M:receive_data(0, <<"abc">>, true, ?M:new()),
+    ?assertEqual({error, final_size_error}, ?M:reset(5, S1)).
+
+reset_final_size_below_received_test() ->
+    {ok, _, false, S1} = ?M:receive_data(0, <<"abcde">>, false, ?M:new()),
+    ?assertEqual({error, final_size_error}, ?M:reset(3, S1)).
+
+reset_final_size_below_buffered_test() ->
+    %% A buffered (not yet delivered) gap counts as received data, so a
+    %% reset final size below it is rejected.
+    {ok, <<>>, false, S1} = ?M:receive_data(3, <<"de">>, false, ?M:new()),
+    ?assertEqual({error, final_size_error}, ?M:reset(4, S1)).
+
+reset_aborts_receive_test() ->
+    %% After a RESET_STREAM the receive side is terminal: buffered data is
+    %% discarded and a later STREAM frame delivers nothing.
+    {ok, <<>>, false, S1} = ?M:receive_data(2, <<"cc">>, false, ?M:new()),
+    {ok, S2} = ?M:reset(4, S1),
+    {ok, D, FinReached, _} = ?M:receive_data(0, <<"ab">>, false, S2),
+    ?assertEqual(<<>>, D),
+    ?assertNot(FinReached).


### PR DESCRIPTION
# Description

The receive side of the native QUIC stream layer (pure, per-stream): it turns out-of-order, overlapping, and retransmitted STREAM frame pieces into the in-order byte stream the application reads, including the FIN-only end-of-stream the HTTP/3 layer dispatches a request on, and aborts the receive side on a RESET_STREAM. Buffered gaps are kept as a sorted, non-overlapping list of segments so the contiguous prefix drains cleanly, and the RFC 9000 §4.5 final-size rules are enforced. Flow control stays in the connection loop's flow window; this module owns ordering and final size only. The outbound send buffer is a follow-up. A property fragments a byte stream on two independent grids and reassembles it in any order to verify overlap handling.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)