### PR TITLE
Add the native QUIC connection loop

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -87,6 +87,7 @@
         {"test/roadrunner_http2_flow_control_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_http3_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_quic_connection_interop_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_tls_tests.erl", unnecessary_function_arguments},
         {"test/roadrunner_conn_tests.erl", unnecessary_function_arguments},

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -100,7 +100,11 @@
     conn_flow :: roadrunner_quic_flow:t(),
     %% Owner events accumulated while folding a datagram's frames, drained in
     %% order at the end of handle_datagram (newest-first, reversed on drain).
-    emits = [] :: [effect()]
+    emits = [] :: [effect()],
+    %% A locally-detected error to signal: {Level, WireErrorCode} for the one
+    %% CONNECTION_CLOSE to transmit at that encryption level. `undefined` for a
+    %% live connection or a peer-initiated close (which sends nothing back).
+    pending_close = undefined :: undefined | {level(), non_neg_integer()}
 }).
 
 -type stream() :: {roadrunner_quic_stream:t(), roadrunner_quic_flow:t()}.
@@ -230,15 +234,19 @@ handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys, phase = B
     State2 = lists:foldl(fun(O, S) -> process_outcome(Now, O, S) end, State1, Outcomes),
     finish_datagram(Now, Before, State2).
 
-%% After folding a datagram's frames: a peer CONNECTION_CLOSE during the fold
-%% closes the connection, so deliver the {closed, _} emit and send nothing
-%% further (RFC 9000 §10.2.2); otherwise run the send pass and drain owner
-%% events, with {connected, _} ordered ahead of any stream events from the
-%% same datagram so the owner opens its control stream before the first
-%% request.
+%% After folding a datagram's frames: if a close fired during the fold,
+%% transmit our CONNECTION_CLOSE for a locally-detected error (RFC 9000
+%% §10.2.3) or send nothing for a peer CONNECTION_CLOSE (§10.2.2), then deliver
+%% the {closed, _} emit. Otherwise run the send pass and drain owner events,
+%% with {connected, _} ordered ahead of any stream events from the same
+%% datagram so the owner opens its control stream before the first request.
 -spec finish_datagram(integer(), phase(), t()) -> {t(), [effect()]}.
-finish_datagram(_Now, _Before, #state{phase = closed} = State) ->
+finish_datagram(_Now, _Before, #state{phase = closed, pending_close = undefined} = State) ->
     drain_emits(State);
+finish_datagram(_Now, _Before, #state{phase = closed} = State) ->
+    {State1, CloseEffects} = send_close(State),
+    {State2, EmitEffects} = drain_emits(State1),
+    {State2, CloseEffects ++ EmitEffects};
 finish_datagram(Now, Before, State) ->
     {State3, SendEffects} = send_pass(Now, State),
     {State4, EmitEffects} = drain_emits(State3),
@@ -343,6 +351,11 @@ stream_for_send(Sid, #state{streams = Streams} = State) ->
     end.
 
 -spec process_outcome(integer(), roadrunner_quic_recv:outcome(), t()) -> t().
+process_outcome(_Now, _Outcome, #state{phase = closed} = State) ->
+    %% A close fired on an earlier packet in this datagram; skip the rest so we
+    %% neither act on their frames nor discard (via validate_on_handshake) the
+    %% space and keys a pending local close still needs to send its frame.
+    State;
 process_outcome(
     Now, {ok, #{level := Level, pn := PN, frames := Frames}}, #state{spaces = Spaces} = State
 ) ->
@@ -401,12 +414,12 @@ process_frame(
 process_frame(_Now, _Level, {connection_close, transport, ErrorCode, _FrameType, _Reason}, State) ->
     process_close(ErrorCode, State);
 process_frame(
-    _Now, _Level, {connection_close, application, _ErrorCode, _FrameType, _Reason}, State
+    _Now, Level, {connection_close, application, _ErrorCode, _FrameType, _Reason}, State
 ) ->
     %% The application CONNECTION_CLOSE (0x1d) is 0-RTT/1-RTT only (RFC 9000
     %% §19.19); one decoded from an Initial/Handshake packet is a protocol
     %% violation.
-    connection_fatal(protocol_violation, State);
+    connection_fatal(Level, protocol_violation, State);
 process_frame(_Now, Level, {crypto, Offset, Data}, State) ->
     process_crypto(Level, Offset, Data, State);
 process_frame(Now, Level, {ack, _, _, _, _, _} = Ack, State) ->
@@ -453,7 +466,7 @@ process_handshake(initial, {?CLIENT_HELLO, Body}, #state{tls = Tls} = State) ->
             State2 = queue_crypto(initial, InitialFlight, State1),
             queue_crypto(handshake, HandshakeFlight, State2);
         {error, Reason} ->
-            connection_fatal(Reason, State)
+            connection_fatal(initial, Reason, State)
     end;
 process_handshake(handshake, {?FINISHED, Body}, #state{tls = Tls} = State) ->
     case roadrunner_quic_tls_server:process_client_finished(Body, Tls) of
@@ -464,12 +477,12 @@ process_handshake(handshake, {?FINISHED, Body}, #state{tls = Tls} = State) ->
             State1 = discard_space(handshake, State#state{phase = connected}),
             queue_frame(application, handshake_done, State1);
         {error, Reason} ->
-            connection_fatal(Reason, State)
+            connection_fatal(handshake, Reason, State)
     end;
-process_handshake(_Level, {_Type, _Body}, State) ->
+process_handshake(Level, {_Type, _Body}, State) ->
     %% An out-of-sequence or unknown handshake message (RFC 8446 unexpected
     %% message); connection-fatal like the other handshake failures.
-    connection_fatal(unexpected_message, State).
+    connection_fatal(Level, unexpected_message, State).
 
 %% Arm the keys the TLS flight produced: server installs protect outgoing
 %% packets, client installs decrypt incoming ones; the Application space
@@ -549,7 +562,7 @@ process_ack(Now, Level, Ack, State) ->
 %% transport parameters are send-side follow-ups.
 -spec process_stream(non_neg_integer(), non_neg_integer(), binary(), boolean(), t()) -> t().
 process_stream(Sid, _Offset, _Data, _Fin, State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
-    connection_fatal(stream_state_error, State);
+    connection_fatal(application, stream_state_error, State);
 process_stream(Sid, Offset, Data, Fin, State) ->
     {Stream0, StreamFlow0, State1} = ensure_stream(Sid, State),
     #state{conn_flow = ConnFlow} = State1,
@@ -562,7 +575,7 @@ process_stream(Sid, Offset, Data, Fin, State) ->
         State2 = put_stream(Sid, Stream1, StreamFlow1, State1#state{conn_flow = ConnFlow1}),
         deliver_stream(Sid, Deliverable, FinReached, State2)
     else
-        {error, Reason} -> connection_fatal(Reason, State)
+        {error, Reason} -> connection_fatal(application, Reason, State)
     end.
 
 %% A RESET_STREAM aborts the peer's send side and surfaces the abort code. On
@@ -570,14 +583,14 @@ process_stream(Sid, Offset, Data, Fin, State) ->
 %% (RFC 9000 §19.4 STREAM_STATE_ERROR).
 -spec process_reset_stream(non_neg_integer(), non_neg_integer(), non_neg_integer(), t()) -> t().
 process_reset_stream(Sid, _ErrorCode, _FinalSize, State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
-    connection_fatal(stream_state_error, State);
+    connection_fatal(application, stream_state_error, State);
 process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
     {Stream0, Flow, State1} = ensure_stream(Sid, State),
     case roadrunner_quic_stream:reset(FinalSize, Stream0) of
         {ok, Stream1} ->
             emit({stream_reset, Sid, ErrorCode}, put_stream(Sid, Stream1, Flow, State1));
         {error, Reason} ->
-            connection_fatal(Reason, State)
+            connection_fatal(application, Reason, State)
     end.
 
 %% A well-placed peer CONNECTION_CLOSE (transport at any level, or application
@@ -591,16 +604,68 @@ process_close(ErrorCode, State) ->
 
 %% Close this single, isolated connection on a peer-reachable protocol error
 %% (flow control §4.1, final size §4.5, stream state §19.8, an out-of-place
-%% application CONNECTION_CLOSE §19.19, or a failed TLS handshake): surface a
-%% terminal {closed, {local, Reason}} to the owner and mark the connection
-%% closed so the fold short-circuits and the shell exits cleanly (no crash, no
-%% slot leak). Sending a CONNECTION_CLOSE to inform the peer of the error (at
-%% the triggering packet's encryption level) is a follow-up; a conformant peer
-%% never triggers these, and the listener drops a misbehaving peer's later
-%% packets to the gone pid.
--spec connection_fatal(atom(), t()) -> t().
-connection_fatal(Reason, State) ->
-    emit({closed, {local, Reason}}, State#state{phase = closed}).
+%% application CONNECTION_CLOSE §19.19, or a failed TLS handshake): record a
+%% CONNECTION_CLOSE to transmit at the triggering packet's level (Level), mark
+%% the connection closed so the fold short-circuits and the shell exits
+%% cleanly (no crash, no slot leak), and surface a terminal {closed, {local,
+%% Reason}} to the owner.
+-spec connection_fatal(level(), atom(), t()) -> t().
+connection_fatal(Level, Reason, State) ->
+    State1 = State#state{phase = closed, pending_close = {Level, close_code(Reason)}},
+    emit({closed, {local, Reason}}, State1).
+
+%% Map a connection-error reason to its CONNECTION_CLOSE wire error code: a TLS
+%% handshake failure becomes a CRYPTO_ERROR (RFC 9001 §4.8: 0x0100 + alert), a
+%% transport error maps directly (RFC 9000 §20).
+-spec close_code(atom()) -> non_neg_integer().
+close_code(Reason) when
+    Reason =:= flow_control_error;
+    Reason =:= final_size_error;
+    Reason =:= stream_state_error;
+    Reason =:= protocol_violation
+->
+    roadrunner_quic_error:code_int(Reason);
+close_code(_TlsReason) ->
+    %% Every other connection_fatal reason is a TLS handshake failure (a
+    %% malformed or rejected ClientHello, a bad Finished, or an unexpected
+    %% message); RFC 9001 §4.8 carries these as CRYPTO_ERROR (0x0100 + alert).
+    %% TLS alert 40 (handshake_failure); a per-alert mapping is a refinement.
+    roadrunner_quic_error:code_int({crypto_error, 40}).
+
+%% Build and send exactly one CONNECTION_CLOSE at the recorded level (the
+%% triggering packet's level, which the peer can decrypt), advancing that
+%% space's packet number. Only the close travels (RFC 9000 §10.2.3); no other
+%% queued frame is drained. The close always fits the §8.1 budget: it answers a
+%% received packet, so 3x bytes-received covers a <=1200-byte close.
+-spec send_close(t()) -> {t(), [effect()]}.
+send_close(
+    #state{
+        pending_close = {Level, ErrorCode},
+        dcid = DCID,
+        scid = SCID,
+        send_keys = SendKeys,
+        amp = Amp
+    } = State
+) ->
+    #{Level := Keys} = SendKeys,
+    Space = space(Level, State),
+    PN = Space#space.next_pn,
+    Frame = {connection_close, transport, ErrorCode, 0, <<>>},
+    Entry = #{Level => #{frames => [Frame], keys => Keys, pn => PN}},
+    {Datagram, _Sent} = roadrunner_quic_send:datagram(Entry, DCID, SCID),
+    case roadrunner_quic_amp:can_send(byte_size(Datagram), Amp) of
+        false ->
+            %% An Initial close is padded to 1200; for an undersized or spoofed
+            %% peer Initial that would exceed the §8.1 3x budget, so drop it
+            %% (no amplification reflector). The connection still closes and the
+            %% owner still learns via the {closed, _} emit, same as a silent
+            %% close.
+            {State, []};
+        true ->
+            Amp1 = roadrunner_quic_amp:sent(byte_size(Datagram), Amp),
+            State1 = put_space(Level, Space#space{next_pn = PN + 1}, State#state{amp = Amp1}),
+            {State1, [{send, Datagram}]}
+    end.
 
 %% Look up a stream, or create it. The first frame of a peer-initiated stream
 %% is announced with {stream_opened, Sid} (server-initiated ids never reach

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -80,8 +80,18 @@
     %% installed by the listener (via set_owner) during handshaking.
     owner :: pid() | undefined,
     %% The `connected` payload, built once at new/1.
-    info :: info()
+    info :: info(),
+    %% Application streams (peer-initiated, application space), each with its
+    %% own receive reassembly + flow window, keyed by stream id.
+    streams = #{} :: #{non_neg_integer() => stream()},
+    %% Connection-level flow control (RFC 9000 §4).
+    conn_flow :: roadrunner_quic_flow:t(),
+    %% Owner events accumulated while folding a datagram's frames, drained in
+    %% order at the end of handle_datagram (newest-first, reversed on drain).
+    emits = [] :: [effect()]
 }).
+
+-type stream() :: {roadrunner_quic_stream:t(), roadrunner_quic_flow:t()}.
 
 -opaque t() :: #state{}.
 
@@ -109,9 +119,13 @@
     | {emit, pid(), event()}
     | {reply, pid(), reference(), term()}.
 
-%% Async owner notifications (conn -> owner); extended with stream events
-%% in a later slice.
--type event() :: {connected, info()}.
+%% Async owner notifications (conn -> owner). `stream_data` carries the
+%% FIN-only end-of-stream as `{stream_data, Sid, <<>>, true}`.
+-type event() ::
+    {connected, info()}
+    | {stream_opened, non_neg_integer()}
+    | {stream_data, non_neg_integer(), binary(), boolean()}
+    | {stream_reset, non_neg_integer(), non_neg_integer()}.
 
 %% The `connected` payload. The h3 owner ignores it; it carries the
 %% negotiated ALPN and the advertised transport params for forward-compat.
@@ -160,7 +174,8 @@ new(#{
         spaces = #{initial => new_space(), handshake => new_space()},
         amp = roadrunner_quic_amp:new(),
         owner = undefined,
-        info = #{alpn => Alpn, transport_params => TransportParams}
+        info = #{alpn => Alpn, transport_params => TransportParams},
+        conn_flow = roadrunner_quic_flow:new(#{})
     }.
 
 -spec new_space() -> #space{}.
@@ -198,8 +213,25 @@ handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys, phase = B
         Datagram, ?SCID_LEN, RecvKeys, largest_map(State1)
     ),
     State2 = lists:foldl(fun(O, S) -> process_outcome(Now, O, S) end, State1, Outcomes),
-    {State3, Effects} = send_pass(Now, State2),
-    {State3, Effects ++ connected_effects(Before, State3)}.
+    {State3, SendEffects} = send_pass(Now, State2),
+    {State4, EmitEffects} = drain_emits(State3),
+    %% {connected, _} precedes any stream events drained from the same
+    %% datagram (a coalesced Handshake-Finished + 1-RTT STREAM), so the owner
+    %% opens its control stream before it sees the first request.
+    {State4, connected_effects(Before, State4) ++ EmitEffects ++ SendEffects}.
+
+%% Owner events accumulate (newest-first) in #state.emits while the
+%% datagram's frames are folded; hand them back in arrival order and clear.
+-spec drain_emits(t()) -> {t(), [effect()]}.
+drain_emits(#state{emits = Emits} = State) ->
+    {State#state{emits = []}, lists:reverse(Emits)}.
+
+%% Queue an owner event for the current datagram (dropped if no owner yet).
+-spec emit(event(), t()) -> t().
+emit(_Event, #state{owner = undefined} = State) ->
+    State;
+emit(Event, #state{owner = Owner, emits = Emits} = State) ->
+    State#state{emits = [{emit, Owner, Event} | Emits]}.
 
 %% Emit `{connected, Info}` exactly when this datagram drove the
 %% handshaking -> connected transition AND an owner is installed. With no
@@ -294,8 +326,12 @@ process_frame(_Now, Level, {crypto, Offset, Data}, State) ->
     process_crypto(Level, Offset, Data, State);
 process_frame(Now, Level, {ack, _, _, _, _, _} = Ack, State) ->
     process_ack(Now, Level, Ack, State);
+process_frame(_Now, application, {stream, Sid, Offset, Data, Fin}, State) ->
+    process_stream(Sid, Offset, Data, Fin, State);
+process_frame(_Now, application, {reset_stream, Sid, ErrorCode, FinalSize}, State) ->
+    process_reset_stream(Sid, ErrorCode, FinalSize, State);
 process_frame(_Now, _Level, _Frame, State) ->
-    %% ping / padding / (other frames arrive with the application phase).
+    %% ping / padding / peer flow-credit grants (handled with the send side).
     State.
 
 %% Reassemble CRYPTO, deframe complete handshake messages, and drive the
@@ -324,17 +360,29 @@ deframe(Buffer) ->
 
 -spec process_handshake(level(), {byte(), binary()}, t()) -> t().
 process_handshake(initial, {?CLIENT_HELLO, Body}, #state{tls = Tls} = State) ->
-    {ok, #{initial := InitialFlight, handshake := HandshakeFlight}, Installs, Tls1} =
-        roadrunner_quic_tls_server:process_client_hello(Body, Tls),
-    State1 = install_keys(Installs, State#state{tls = Tls1}),
-    State2 = queue_crypto(initial, InitialFlight, State1),
-    queue_crypto(handshake, HandshakeFlight, State2);
+    case roadrunner_quic_tls_server:process_client_hello(Body, Tls) of
+        {ok, #{initial := InitialFlight, handshake := HandshakeFlight}, Installs, Tls1} ->
+            State1 = install_keys(Installs, State#state{tls = Tls1}),
+            State2 = queue_crypto(initial, InitialFlight, State1),
+            queue_crypto(handshake, HandshakeFlight, State2);
+        {error, Reason} ->
+            connection_fatal(Reason)
+    end;
 process_handshake(handshake, {?FINISHED, Body}, #state{tls = Tls} = State) ->
-    ok = roadrunner_quic_tls_server:process_client_finished(Body, Tls),
-    %% Handshake confirmed: discard the Handshake space (RFC 9001 §4.9.2),
-    %% become connected, and send HANDSHAKE_DONE at the application level.
-    State1 = discard_space(handshake, State#state{phase = connected}),
-    queue_frame(application, handshake_done, State1).
+    case roadrunner_quic_tls_server:process_client_finished(Body, Tls) of
+        ok ->
+            %% Handshake confirmed: discard the Handshake space (RFC 9001
+            %% §4.9.2), become connected, and send HANDSHAKE_DONE at the
+            %% application level.
+            State1 = discard_space(handshake, State#state{phase = connected}),
+            queue_frame(application, handshake_done, State1);
+        {error, Reason} ->
+            connection_fatal(Reason)
+    end;
+process_handshake(_Level, {_Type, _Body}, _State) ->
+    %% An out-of-sequence or unknown handshake message (RFC 8446 unexpected
+    %% message); connection-fatal like the other handshake failures.
+    connection_fatal(unexpected_message).
 
 %% Arm the keys the TLS flight produced: server installs protect outgoing
 %% packets, client installs decrypt incoming ones; the Application space
@@ -394,6 +442,94 @@ process_ack(Now, Level, Ack, State) ->
                 State
             )
     end.
+
+%% =============================================================================
+%% Application streams (peer-initiated, receive side)
+%% =============================================================================
+
+%% Reassemble a peer STREAM frame, charging the increase in its highest
+%% received offset against the connection and per-stream receive windows
+%% (RFC 9000 §4.1), so retransmitted or overlapping bytes never re-consume
+%% the window. A STREAM frame on a server-initiated id is the peer writing to
+%% a stream it cannot send on (RFC 9000 §19.8). A flow-control overrun, a
+%% final-size violation, or that stream-state error is connection-fatal and
+%% let-it-crash here (graceful CONNECTION_CLOSE is a later slice). Emits
+%% {stream_opened, Sid} on a peer stream's first frame and {stream_data, Sid,
+%% Bin, Fin} (including the FIN-only {<<>>, true}). Granting more credit
+%% (MAX_DATA / MAX_STREAM_DATA) and seeding the windows from the advertised
+%% transport parameters are send-side follow-ups.
+-spec process_stream(non_neg_integer(), non_neg_integer(), binary(), boolean(), t()) -> t().
+process_stream(Sid, _Offset, _Data, _Fin, _State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
+    connection_fatal(stream_state_error);
+process_stream(Sid, Offset, Data, Fin, State) ->
+    {Stream0, StreamFlow0, State1} = ensure_stream(Sid, State),
+    #state{conn_flow = ConnFlow} = State1,
+    Delta = max(0, Offset + byte_size(Data) - roadrunner_quic_flow:bytes_received(StreamFlow0)),
+    maybe
+        {ok, ConnFlow1} ?= roadrunner_quic_flow:on_data_received(Delta, ConnFlow),
+        {ok, StreamFlow1} ?= roadrunner_quic_flow:on_data_received(Delta, StreamFlow0),
+        {ok, Deliverable, FinReached, Stream1} ?=
+            roadrunner_quic_stream:receive_data(Offset, Data, Fin, Stream0),
+        State2 = put_stream(Sid, Stream1, StreamFlow1, State1#state{conn_flow = ConnFlow1}),
+        deliver_stream(Sid, Deliverable, FinReached, State2)
+    else
+        {error, Reason} -> connection_fatal(Reason)
+    end.
+
+%% A RESET_STREAM aborts the peer's send side and surfaces the abort code. On
+%% a server-initiated id it is the peer resetting a stream it cannot send on
+%% (RFC 9000 §19.4 STREAM_STATE_ERROR).
+-spec process_reset_stream(non_neg_integer(), non_neg_integer(), non_neg_integer(), t()) -> t().
+process_reset_stream(Sid, _ErrorCode, _FinalSize, _State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
+    connection_fatal(stream_state_error);
+process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
+    {Stream0, Flow, State1} = ensure_stream(Sid, State),
+    case roadrunner_quic_stream:reset(FinalSize, Stream0) of
+        {ok, Stream1} ->
+            emit({stream_reset, Sid, ErrorCode}, put_stream(Sid, Stream1, Flow, State1));
+        {error, Reason} ->
+            connection_fatal(Reason)
+    end.
+
+%% Terminate this single, isolated connection on a peer-reachable protocol
+%% error (flow control §4.1, final size §4.5, stream state §19.8, or a failed
+%% TLS handshake), tagging it with a named reason. The graceful
+%% CONNECTION_CLOSE + draining response is the teardown slice that replaces
+%% this.
+-spec connection_fatal(atom()) -> no_return().
+connection_fatal(Reason) ->
+    error({quic_connection_error, Reason}).
+
+%% Look up a stream, or create it. The first frame of a peer-initiated stream
+%% is announced with {stream_opened, Sid} (server-initiated ids never reach
+%% here; process_stream/process_reset_stream reject them upstream). Returns
+%% the stream, its flow, and the state carrying any queued event.
+-spec ensure_stream(non_neg_integer(), t()) ->
+    {roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()}.
+ensure_stream(Sid, #state{streams = Streams} = State) ->
+    case Streams of
+        #{Sid := {Stream, Flow}} ->
+            {Stream, Flow, State};
+        #{} ->
+            {
+                roadrunner_quic_stream:new(),
+                roadrunner_quic_flow:new(#{}),
+                emit({stream_opened, Sid}, State)
+            }
+    end.
+
+-spec put_stream(non_neg_integer(), roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()) ->
+    t().
+put_stream(Sid, Stream, Flow, #state{streams = Streams} = State) ->
+    State#state{streams = Streams#{Sid => {Stream, Flow}}}.
+
+%% Emit {stream_data, ...} when there are newly-contiguous bytes OR the FIN
+%% was reached (the FIN-only {<<>>, true} end-of-stream the h3 layer needs).
+-spec deliver_stream(non_neg_integer(), binary(), boolean(), t()) -> t().
+deliver_stream(Sid, Deliverable, FinReached, State) when Deliverable =/= <<>>; FinReached ->
+    emit({stream_data, Sid, Deliverable, FinReached}, State);
+deliver_stream(_Sid, _Deliverable, _FinReached, State) ->
+    State.
 
 %% =============================================================================
 %% Outbound send pass

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -132,12 +132,15 @@
     | {reply, pid(), reference(), term()}.
 
 %% Async owner notifications (conn -> owner). `stream_data` carries the
-%% FIN-only end-of-stream as `{stream_data, Sid, <<>>, true}`.
+%% FIN-only end-of-stream as `{stream_data, Sid, <<>>, true}`. `closed` is the
+%% terminal event; `{peer, ErrorCode}` is a peer CONNECTION_CLOSE (local and
+%% idle-timeout close reasons join it in later teardown slices).
 -type event() ::
     {connected, info()}
     | {stream_opened, non_neg_integer()}
     | {stream_data, non_neg_integer(), binary(), boolean()}
-    | {stream_reset, non_neg_integer(), non_neg_integer()}.
+    | {stream_reset, non_neg_integer(), non_neg_integer()}
+    | {closed, {peer, non_neg_integer()}}.
 
 %% The `connected` payload. The h3 owner ignores it; it carries the
 %% negotiated ALPN and the advertised transport params for forward-compat.
@@ -225,11 +228,20 @@ handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys, phase = B
         Datagram, ?SCID_LEN, RecvKeys, largest_map(State1)
     ),
     State2 = lists:foldl(fun(O, S) -> process_outcome(Now, O, S) end, State1, Outcomes),
-    {State3, SendEffects} = send_pass(Now, State2),
+    finish_datagram(Now, Before, State2).
+
+%% After folding a datagram's frames: a peer CONNECTION_CLOSE during the fold
+%% closes the connection, so deliver the {closed, _} emit and send nothing
+%% further (RFC 9000 §10.2.2); otherwise run the send pass and drain owner
+%% events, with {connected, _} ordered ahead of any stream events from the
+%% same datagram so the owner opens its control stream before the first
+%% request.
+-spec finish_datagram(integer(), phase(), t()) -> {t(), [effect()]}.
+finish_datagram(_Now, _Before, #state{phase = closed} = State) ->
+    drain_emits(State);
+finish_datagram(Now, Before, State) ->
+    {State3, SendEffects} = send_pass(Now, State),
     {State4, EmitEffects} = drain_emits(State3),
-    %% {connected, _} precedes any stream events drained from the same
-    %% datagram (a coalesced Handshake-Finished + 1-RTT STREAM), so the owner
-    %% opens its control stream before it sees the first request.
     {State4, connected_effects(Before, State4) ++ EmitEffects ++ SendEffects}.
 
 %% Owner events accumulate (newest-first) in #state.emits while the
@@ -378,6 +390,12 @@ record_received(Level, PN, Frames, #state{spaces = Spaces} = State) ->
 %% =============================================================================
 
 -spec process_frame(integer(), level(), roadrunner_quic_frame:frame(), t()) -> t().
+process_frame(_Now, _Level, _Frame, #state{phase = closed} = State) ->
+    %% A CONNECTION_CLOSE earlier in this packet already closed the connection;
+    %% ignore the remaining frames (RFC 9000 §10.2.2).
+    State;
+process_frame(_Now, _Level, {connection_close, _Variant, ErrorCode, _FrameType, _Reason}, State) ->
+    process_close(ErrorCode, State);
 process_frame(_Now, Level, {crypto, Offset, Data}, State) ->
     process_crypto(Level, Offset, Data, State);
 process_frame(Now, Level, {ack, _, _, _, _, _} = Ack, State) ->
@@ -548,6 +566,18 @@ process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
         {error, Reason} ->
             connection_fatal(Reason)
     end.
+
+%% A peer CONNECTION_CLOSE ends the connection: surface it to the owner and
+%% mark the connection closed so the send pass is skipped and the shell exits.
+%% Both the transport (0x1c) and application (0x1d) variants are accepted at
+%% any level here (a clean terminate); rejecting a 0x1d before 1-RTT as a
+%% PROTOCOL_VIOLATION (RFC 9000 §19.19) waits for the graceful error-close
+%% path. Lingering in `draining` for 3x PTO to absorb the peer's reordered
+%% packets is a follow-up; for now the listener drops late packets to the
+%% gone pid.
+-spec process_close(non_neg_integer(), t()) -> t().
+process_close(ErrorCode, State) ->
+    emit({closed, {peer, ErrorCode}}, State#state{phase = closed}).
 
 %% Terminate this single, isolated connection on a peer-reachable protocol
 %% error (flow control §4.1, final size §4.5, stream state §19.8, or a failed

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -27,9 +27,11 @@
 %% anti-amplification budget, and records each sent packet for loss
 %% recovery.
 %%
-%% Congestion control is deferred (the connection sends within the
-%% anti-amplification and flow limits, the MUSTs); wiring NewReno needs the
-%% loss layer to surface acked bytes / sent times, a separate follow-up.
+%% Congestion control and probe transmission are deferred: the connection
+%% sends within the anti-amplification and flow limits (the MUSTs) and a
+%% probe timeout only re-checks for losses and backs off. Wiring NewReno and
+%% sending an explicit probe both need the loss layer to surface acked bytes
+%% / sent times / the oldest unacknowledged frames, a separate follow-up.
 
 -export([new/1, handle_datagram/3, handle_timeout/3, peername/1, phase/1]).
 
@@ -89,7 +91,9 @@
     server_random := binary()
 }.
 
--type effect() :: {send, binary()} | {arm_timer, atom(), non_neg_integer()}.
+%% A monotonic-clock millisecond, the same epoch `erlang:monotonic_time/1`
+%% returns (negative on the BEAM), so an `arm_timer` deadline is `integer()`.
+-type effect() :: {send, binary()} | {arm_timer, atom(), integer()}.
 
 %% =============================================================================
 %% Construction
@@ -163,7 +167,7 @@ amplification budget, decode and decrypt its packets, fold each packet's
 frames into the connection state, then run a send pass. Returns the new
 state and the effects to perform.
 """.
--spec handle_datagram(non_neg_integer(), binary(), t()) -> {t(), [effect()]}.
+-spec handle_datagram(integer(), binary(), t()) -> {t(), [effect()]}.
 handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys} = State0) ->
     State1 = State0#state{amp = roadrunner_quic_amp:received(byte_size(Datagram), Amp)},
     Outcomes = roadrunner_quic_recv:datagram(
@@ -172,7 +176,7 @@ handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys} = State0)
     State2 = lists:foldl(fun(O, S) -> process_outcome(Now, O, S) end, State1, Outcomes),
     send_pass(Now, State2).
 
--spec process_outcome(non_neg_integer(), roadrunner_quic_recv:outcome(), t()) -> t().
+-spec process_outcome(integer(), roadrunner_quic_recv:outcome(), t()) -> t().
 process_outcome(
     Now, {ok, #{level := Level, pn := PN, frames := Frames}}, #state{spaces = Spaces} = State
 ) ->
@@ -219,7 +223,7 @@ record_received(Level, PN, Frames, #state{spaces = Spaces} = State) ->
 %% Per-frame handlers
 %% =============================================================================
 
--spec process_frame(non_neg_integer(), level(), roadrunner_quic_frame:frame(), t()) -> t().
+-spec process_frame(integer(), level(), roadrunner_quic_frame:frame(), t()) -> t().
 process_frame(_Now, Level, {crypto, Offset, Data}, State) ->
     process_crypto(Level, Offset, Data, State);
 process_frame(Now, Level, {ack, _, _, _, _, _} = Ack, State) ->
@@ -311,7 +315,7 @@ queue_frame(Level, Frame, State) ->
     Space = space(Level, State),
     put_space(Level, Space#space{pending = Space#space.pending ++ [Frame]}, State).
 
--spec process_ack(non_neg_integer(), level(), tuple(), t()) -> t().
+-spec process_ack(integer(), level(), tuple(), t()) -> t().
 process_ack(Now, Level, Ack, State) ->
     Space = space(Level, State),
     case roadrunner_quic_loss:on_ack_received(Ack, Now, Space#space.loss) of
@@ -329,15 +333,15 @@ process_ack(Now, Level, Ack, State) ->
 %% Outbound send pass
 %% =============================================================================
 
--spec send_pass(non_neg_integer(), t()) -> {t(), [effect()]}.
+-spec send_pass(integer(), t()) -> {t(), [effect()]}.
 send_pass(Now, State) ->
     {State1, SendEffects} = drain_send(Now, State, []),
-    {State1, SendEffects ++ timer_effects(State1)}.
+    {State1, SendEffects ++ timer_effects(Now, State1)}.
 
 %% Build and send one datagram per iteration until nothing is pending or
 %% the anti-amplification budget blocks; roll back the built state if the
 %% datagram cannot be sent.
--spec drain_send(non_neg_integer(), t(), [effect()]) -> {t(), [effect()]}.
+-spec drain_send(integer(), t(), [effect()]) -> {t(), [effect()]}.
 drain_send(Now, State, Acc) ->
     case build_packets(State) of
         none ->
@@ -423,11 +427,11 @@ take_crypto(Crypto) ->
         {Offset, Data, _Fin, Crypto1} -> {[{crypto, Offset, Data}], Crypto1}
     end.
 
--spec record_sent(non_neg_integer(), [roadrunner_quic_send:sent()], t()) -> t().
+-spec record_sent(integer(), [roadrunner_quic_send:sent()], t()) -> t().
 record_sent(Now, Sent, State) ->
     lists:foldl(fun(S, Acc) -> record_one_sent(Now, S, Acc) end, State, Sent).
 
--spec record_one_sent(non_neg_integer(), roadrunner_quic_send:sent(), t()) -> t().
+-spec record_one_sent(integer(), roadrunner_quic_send:sent(), t()) -> t().
 record_one_sent(
     Now,
     #{level := Level, pn := PN, length := Len, ack_eliciting := AckEliciting, frames := Frames},
@@ -444,43 +448,52 @@ record_one_sent(
 %% =============================================================================
 
 -doc """
-Handle a fired loss/PTO timer: re-run loss detection on every space,
-queueing lost frames to retransmit, then run a send pass so a dropped
-handshake packet recovers.
+Handle a fired probe timer: re-run loss detection on every space (queueing
+any lost frames to retransmit), back off the probe timeout, then run a send
+pass. The backoff is what guarantees forward progress, so a probe that
+detects no loss re-arms strictly later rather than re-firing immediately.
 """.
--spec handle_timeout(non_neg_integer(), atom(), t()) -> {t(), [effect()]}.
+-spec handle_timeout(integer(), atom(), t()) -> {t(), [effect()]}.
 handle_timeout(Now, pto, State) ->
-    State1 = lists:foldl(
-        fun(Level, S) -> detect_loss(Now, Level, S) end, State, present_levels(State)
-    ),
+    State1 = lists:foldl(fun(Level, S) -> on_pto(Now, Level, S) end, State, present_levels(State)),
     send_pass(Now, State1).
 
--spec detect_loss(non_neg_integer(), level(), t()) -> t().
-detect_loss(Now, Level, State) ->
+%% On a probe timeout: queue any time-threshold losses to retransmit and
+%% increment the space's probe-timeout backoff (RFC 9002 §6.2.1), so the
+%% next deadline is strictly later. Sending an explicit probe when nothing
+%% is detected as lost is deferred with congestion control (it needs the
+%% loss layer to surface the oldest unacknowledged frames).
+-spec on_pto(integer(), level(), t()) -> t().
+on_pto(Now, Level, State) ->
     #space{loss = Loss0, pending = Pending} = Space = space(Level, State),
-    {Loss, Lost} = roadrunner_quic_loss:detect_lost(Now, Loss0),
-    put_space(
-        Level,
-        Space#space{loss = Loss, pending = Pending ++ retransmittable(Lost)},
-        State
-    ).
+    {Loss1, Lost} = roadrunner_quic_loss:detect_lost(Now, Loss0),
+    Loss2 = roadrunner_quic_loss:on_pto_expired(Loss1),
+    put_space(Level, Space#space{loss = Loss2, pending = Pending ++ retransmittable(Lost)}, State).
 
--spec timer_effects(t()) -> [effect()].
-timer_effects(State) ->
-    case earliest_loss_time(State) of
+%% Arm one probe timer at the earliest per-space deadline (now plus the
+%% space's probe timeout) across spaces that still hold ack-eliciting bytes
+%% in flight; nothing in flight means nothing to probe for, so no timer.
+-spec timer_effects(integer(), t()) -> [effect()].
+timer_effects(Now, State) ->
+    case earliest_pto(Now, State) of
         undefined -> [];
         AtMs -> [{arm_timer, pto, AtMs}]
     end.
 
--spec earliest_loss_time(t()) -> non_neg_integer() | undefined.
-earliest_loss_time(State) ->
+-spec earliest_pto(integer(), t()) -> integer() | undefined.
+earliest_pto(Now, State) ->
     lists:foldl(
-        fun(Level, Earliest) ->
-            min_defined(Earliest, roadrunner_quic_loss:loss_time((space(Level, State))#space.loss))
-        end,
+        fun(Level, Earliest) -> min_defined(Earliest, space_pto(Now, space(Level, State))) end,
         undefined,
         present_levels(State)
     ).
+
+-spec space_pto(integer(), #space{}) -> integer() | undefined.
+space_pto(Now, #space{loss = Loss}) ->
+    case roadrunner_quic_loss:bytes_in_flight(Loss) of
+        0 -> undefined;
+        _ -> Now + roadrunner_quic_loss:get_pto(Loss)
+    end.
 
 %% =============================================================================
 %% Internal
@@ -512,8 +525,7 @@ space(Level, #state{spaces = Spaces}) ->
 put_space(Level, Space, #state{spaces = Spaces} = State) ->
     State#state{spaces = Spaces#{Level => Space}}.
 
--spec min_defined(non_neg_integer() | undefined, non_neg_integer() | undefined) ->
-    non_neg_integer() | undefined.
+-spec min_defined(integer() | undefined, integer() | undefined) -> integer() | undefined.
 min_defined(undefined, B) -> B;
 min_defined(A, undefined) -> A;
 min_defined(A, B) -> min(A, B).

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -12,8 +12,9 @@
 %% gate; the shell only does the irreducible I/O.
 %%
 %% Effects: `{send, Datagram}` (hand to the socket), `{arm_timer, Kind,
-%% AtMs}` ((re)arm a timer). The owner events and control replies arrive
-%% with the application phase.
+%% AtMs}` ((re)arm a timer), `{emit, Owner, Event}` (async owner
+%% notification, e.g. `{connected, Info}`), and `{reply, To, Ref, Result}`
+%% (answer a synchronous control call).
 %%
 %% A connection keeps up to three packet-number spaces (Initial, Handshake,
 %% Application). The server reads with the peer's keys and writes with its
@@ -33,9 +34,9 @@
 %% sending an explicit probe both need the loss layer to surface acked bytes
 %% / sent times / the oldest unacknowledged frames, a separate follow-up.
 
--export([new/1, handle_datagram/3, handle_timeout/3, peername/1, phase/1]).
+-export([new/1, handle_datagram/3, handle_timeout/3, handle_call/4, peername/1, phase/1]).
 
--export_type([t/0, config/0, effect/0]).
+-export_type([t/0, config/0, effect/0, event/0, info/0]).
 
 %% RFC 9000 §17.2: the server uses a fixed-length SCID so short headers demux.
 -define(SCID_LEN, 8).
@@ -47,6 +48,7 @@
 -define(FINISHED, 20).
 
 -type level() :: initial | handshake | application.
+-type phase() :: handshaking | connected | draining | closed.
 
 -record(space, {
     ack :: roadrunner_quic_ack:t(),
@@ -64,7 +66,7 @@
     dcid :: binary(),
     scid :: binary(),
     peer :: {inet:ip_address(), inet:port_number()},
-    phase = handshaking :: handshaking | connected | draining | closed,
+    phase = handshaking :: phase(),
     tls :: roadrunner_quic_tls_server:t(),
     %% Keys to decrypt incoming packets (the peer's), by level.
     recv_keys :: #{level() => roadrunner_quic_keys:keys()},
@@ -73,7 +75,12 @@
     spaces :: #{level() => #space{}},
     amp :: roadrunner_quic_amp:t(),
     %% Cleared once a Handshake packet decrypts (address validated, §8.1).
-    validated = false :: boolean()
+    validated = false :: boolean(),
+    %% The application owner: the async sink for `{emit, _, _}` events,
+    %% installed by the listener (via set_owner) during handshaking.
+    owner :: pid() | undefined,
+    %% The `connected` payload, built once at new/1.
+    info :: info()
 }).
 
 -opaque t() :: #state{}.
@@ -93,7 +100,22 @@
 
 %% A monotonic-clock millisecond, the same epoch `erlang:monotonic_time/1`
 %% returns (negative on the BEAM), so an `arm_timer` deadline is `integer()`.
--type effect() :: {send, binary()} | {arm_timer, atom(), integer()}.
+%% `{emit, Owner, Event}` is an async owner notification (the shell does
+%% `Owner ! {quic, self(), Event}`); `{reply, To, Ref, Result}` answers a
+%% synchronous control call.
+-type effect() ::
+    {send, binary()}
+    | {arm_timer, atom(), integer()}
+    | {emit, pid(), event()}
+    | {reply, pid(), reference(), term()}.
+
+%% Async owner notifications (conn -> owner); extended with stream events
+%% in a later slice.
+-type event() :: {connected, info()}.
+
+%% The `connected` payload. The h3 owner ignores it; it carries the
+%% negotiated ALPN and the advertised transport params for forward-compat.
+-type info() :: #{alpn := binary(), transport_params := roadrunner_quic_transport_params:params()}.
 
 %% =============================================================================
 %% Construction
@@ -136,7 +158,9 @@ new(#{
         recv_keys = #{initial => roadrunner_quic_keys:initial_client(DCID)},
         send_keys = #{initial => roadrunner_quic_keys:initial_server(DCID)},
         spaces = #{initial => new_space(), handshake => new_space()},
-        amp = roadrunner_quic_amp:new()
+        amp = roadrunner_quic_amp:new(),
+        owner = undefined,
+        info = #{alpn => Alpn, transport_params => TransportParams}
     }.
 
 -spec new_space() -> #space{}.
@@ -153,7 +177,7 @@ peername(#state{peer = Peer}) ->
     {ok, Peer}.
 
 -doc "The connection's current phase.".
--spec phase(t()) -> handshaking | connected | draining | closed.
+-spec phase(t()) -> phase().
 phase(#state{phase = Phase}) ->
     Phase.
 
@@ -168,13 +192,55 @@ frames into the connection state, then run a send pass. Returns the new
 state and the effects to perform.
 """.
 -spec handle_datagram(integer(), binary(), t()) -> {t(), [effect()]}.
-handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys} = State0) ->
+handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys, phase = Before} = State0) ->
     State1 = State0#state{amp = roadrunner_quic_amp:received(byte_size(Datagram), Amp)},
     Outcomes = roadrunner_quic_recv:datagram(
         Datagram, ?SCID_LEN, RecvKeys, largest_map(State1)
     ),
     State2 = lists:foldl(fun(O, S) -> process_outcome(Now, O, S) end, State1, Outcomes),
-    send_pass(Now, State2).
+    {State3, Effects} = send_pass(Now, State2),
+    {State3, Effects ++ connected_effects(Before, State3)}.
+
+%% Emit `{connected, Info}` exactly when this datagram drove the
+%% handshaking -> connected transition AND an owner is installed. With no
+%% owner yet (the listener has not run set_owner), the emit is deferred to
+%% install_owner. The two sites are mutually exclusive, so it fires once.
+-spec connected_effects(phase(), t()) -> [effect()].
+connected_effects(handshaking, #state{phase = connected, owner = Owner, info = Info}) when
+    is_pid(Owner)
+->
+    [{emit, Owner, {connected, Info}}];
+connected_effects(_Before, _State) ->
+    [].
+
+%% =============================================================================
+%% Control calls (owner / listener -> conn, synchronous)
+%% =============================================================================
+
+-doc """
+Answer a synchronous control call: the shell forwards `{quic_call, From,
+Ref, Request}` here and performs the returned `{reply, From, Ref, Result}`
+(plus any deferred `{emit, _, _}`). Owner and listener calls into the
+connection are synchronous; the connection only ever notifies the owner
+with async `{emit, _, _}` effects, so it never blocks on the owner.
+""".
+-spec handle_call(pid(), reference(), Request, t()) -> {t(), [effect()]} when
+    Request :: peername | {set_owner, pid()}.
+handle_call(From, Ref, peername, #state{peer = Peer} = State) ->
+    {State, [{reply, From, Ref, {ok, Peer}}]};
+handle_call(From, Ref, {set_owner, Owner}, State) ->
+    {State1, EmitEffects} = install_owner(Owner, State),
+    {State1, [{reply, From, Ref, ok} | EmitEffects]}.
+
+%% Install the owner. When the handshake already completed before the owner
+%% was set (the deferred path), emit the once-only `{connected, Info}` now;
+%% normally the listener sets the owner during handshaking, so the emit
+%% instead rides out of handle_datagram at the transition.
+-spec install_owner(pid(), t()) -> {t(), [effect()]}.
+install_owner(Owner, #state{phase = connected, info = Info} = State) ->
+    {State#state{owner = Owner}, [{emit, Owner, {connected, Info}}]};
+install_owner(Owner, State) ->
+    {State#state{owner = Owner}, []}.
 
 -spec process_outcome(integer(), roadrunner_quic_recv:outcome(), t()) -> t().
 process_outcome(

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -133,14 +133,14 @@
 
 %% Async owner notifications (conn -> owner). `stream_data` carries the
 %% FIN-only end-of-stream as `{stream_data, Sid, <<>>, true}`. `closed` is the
-%% terminal event; `{peer, ErrorCode}` is a peer CONNECTION_CLOSE (local and
-%% idle-timeout close reasons join it in later teardown slices).
+%% terminal event: `{peer, ErrorCode}` is a peer CONNECTION_CLOSE, `{local,
+%% Reason}` a connection error we detected (idle-timeout joins them later).
 -type event() ::
     {connected, info()}
     | {stream_opened, non_neg_integer()}
     | {stream_data, non_neg_integer(), binary(), boolean()}
     | {stream_reset, non_neg_integer(), non_neg_integer()}
-    | {closed, {peer, non_neg_integer()}}.
+    | {closed, {peer, non_neg_integer()} | {local, atom()}}.
 
 %% The `connected` payload. The h3 owner ignores it; it carries the
 %% negotiated ALPN and the advertised transport params for forward-compat.
@@ -394,8 +394,19 @@ process_frame(_Now, _Level, _Frame, #state{phase = closed} = State) ->
     %% A CONNECTION_CLOSE earlier in this packet already closed the connection;
     %% ignore the remaining frames (RFC 9000 §10.2.2).
     State;
-process_frame(_Now, _Level, {connection_close, _Variant, ErrorCode, _FrameType, _Reason}, State) ->
+process_frame(
+    _Now, application, {connection_close, _Variant, ErrorCode, _FrameType, _Reason}, State
+) ->
     process_close(ErrorCode, State);
+process_frame(_Now, _Level, {connection_close, transport, ErrorCode, _FrameType, _Reason}, State) ->
+    process_close(ErrorCode, State);
+process_frame(
+    _Now, _Level, {connection_close, application, _ErrorCode, _FrameType, _Reason}, State
+) ->
+    %% The application CONNECTION_CLOSE (0x1d) is 0-RTT/1-RTT only (RFC 9000
+    %% §19.19); one decoded from an Initial/Handshake packet is a protocol
+    %% violation.
+    connection_fatal(protocol_violation, State);
 process_frame(_Now, Level, {crypto, Offset, Data}, State) ->
     process_crypto(Level, Offset, Data, State);
 process_frame(Now, Level, {ack, _, _, _, _, _} = Ack, State) ->
@@ -442,7 +453,7 @@ process_handshake(initial, {?CLIENT_HELLO, Body}, #state{tls = Tls} = State) ->
             State2 = queue_crypto(initial, InitialFlight, State1),
             queue_crypto(handshake, HandshakeFlight, State2);
         {error, Reason} ->
-            connection_fatal(Reason)
+            connection_fatal(Reason, State)
     end;
 process_handshake(handshake, {?FINISHED, Body}, #state{tls = Tls} = State) ->
     case roadrunner_quic_tls_server:process_client_finished(Body, Tls) of
@@ -453,12 +464,12 @@ process_handshake(handshake, {?FINISHED, Body}, #state{tls = Tls} = State) ->
             State1 = discard_space(handshake, State#state{phase = connected}),
             queue_frame(application, handshake_done, State1);
         {error, Reason} ->
-            connection_fatal(Reason)
+            connection_fatal(Reason, State)
     end;
-process_handshake(_Level, {_Type, _Body}, _State) ->
+process_handshake(_Level, {_Type, _Body}, State) ->
     %% An out-of-sequence or unknown handshake message (RFC 8446 unexpected
     %% message); connection-fatal like the other handshake failures.
-    connection_fatal(unexpected_message).
+    connection_fatal(unexpected_message, State).
 
 %% Arm the keys the TLS flight produced: server installs protect outgoing
 %% packets, client installs decrypt incoming ones; the Application space
@@ -528,15 +539,17 @@ process_ack(Now, Level, Ack, State) ->
 %% (RFC 9000 §4.1), so retransmitted or overlapping bytes never re-consume
 %% the window. A STREAM frame on a server-initiated id is the peer writing to
 %% a stream it cannot send on (RFC 9000 §19.8). A flow-control overrun, a
-%% final-size violation, or that stream-state error is connection-fatal and
-%% let-it-crash here (graceful CONNECTION_CLOSE is a later slice). Emits
-%% {stream_opened, Sid} on a peer stream's first frame and {stream_data, Sid,
+%% final-size violation, or that stream-state error is a peer-reachable
+%% connection error: it closes the connection gracefully via connection_fatal/2
+%% ({closed, {local, Reason}}), not a crash (transmitting a CONNECTION_CLOSE to
+%% the peer is a later slice). Emits {stream_opened, Sid} on a peer stream's
+%% first frame and {stream_data, Sid,
 %% Bin, Fin} (including the FIN-only {<<>>, true}). Granting more credit
 %% (MAX_DATA / MAX_STREAM_DATA) and seeding the windows from the advertised
 %% transport parameters are send-side follow-ups.
 -spec process_stream(non_neg_integer(), non_neg_integer(), binary(), boolean(), t()) -> t().
-process_stream(Sid, _Offset, _Data, _Fin, _State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
-    connection_fatal(stream_state_error);
+process_stream(Sid, _Offset, _Data, _Fin, State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
+    connection_fatal(stream_state_error, State);
 process_stream(Sid, Offset, Data, Fin, State) ->
     {Stream0, StreamFlow0, State1} = ensure_stream(Sid, State),
     #state{conn_flow = ConnFlow} = State1,
@@ -549,44 +562,45 @@ process_stream(Sid, Offset, Data, Fin, State) ->
         State2 = put_stream(Sid, Stream1, StreamFlow1, State1#state{conn_flow = ConnFlow1}),
         deliver_stream(Sid, Deliverable, FinReached, State2)
     else
-        {error, Reason} -> connection_fatal(Reason)
+        {error, Reason} -> connection_fatal(Reason, State)
     end.
 
 %% A RESET_STREAM aborts the peer's send side and surfaces the abort code. On
 %% a server-initiated id it is the peer resetting a stream it cannot send on
 %% (RFC 9000 §19.4 STREAM_STATE_ERROR).
 -spec process_reset_stream(non_neg_integer(), non_neg_integer(), non_neg_integer(), t()) -> t().
-process_reset_stream(Sid, _ErrorCode, _FinalSize, _State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
-    connection_fatal(stream_state_error);
+process_reset_stream(Sid, _ErrorCode, _FinalSize, State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
+    connection_fatal(stream_state_error, State);
 process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
     {Stream0, Flow, State1} = ensure_stream(Sid, State),
     case roadrunner_quic_stream:reset(FinalSize, Stream0) of
         {ok, Stream1} ->
             emit({stream_reset, Sid, ErrorCode}, put_stream(Sid, Stream1, Flow, State1));
         {error, Reason} ->
-            connection_fatal(Reason)
+            connection_fatal(Reason, State)
     end.
 
-%% A peer CONNECTION_CLOSE ends the connection: surface it to the owner and
-%% mark the connection closed so the send pass is skipped and the shell exits.
-%% Both the transport (0x1c) and application (0x1d) variants are accepted at
-%% any level here (a clean terminate); rejecting a 0x1d before 1-RTT as a
-%% PROTOCOL_VIOLATION (RFC 9000 §19.19) waits for the graceful error-close
-%% path. Lingering in `draining` for 3x PTO to absorb the peer's reordered
-%% packets is a follow-up; for now the listener drops late packets to the
-%% gone pid.
+%% A well-placed peer CONNECTION_CLOSE (transport at any level, or application
+%% at 1-RTT) ends the connection: surface it to the owner and mark the
+%% connection closed so the send pass is skipped and the shell exits. Lingering
+%% in `draining` for 3x PTO to absorb the peer's reordered packets is a
+%% follow-up; for now the listener drops late packets to the gone pid.
 -spec process_close(non_neg_integer(), t()) -> t().
 process_close(ErrorCode, State) ->
     emit({closed, {peer, ErrorCode}}, State#state{phase = closed}).
 
-%% Terminate this single, isolated connection on a peer-reachable protocol
-%% error (flow control §4.1, final size §4.5, stream state §19.8, or a failed
-%% TLS handshake), tagging it with a named reason. The graceful
-%% CONNECTION_CLOSE + draining response is the teardown slice that replaces
-%% this.
--spec connection_fatal(atom()) -> no_return().
-connection_fatal(Reason) ->
-    error({quic_connection_error, Reason}).
+%% Close this single, isolated connection on a peer-reachable protocol error
+%% (flow control §4.1, final size §4.5, stream state §19.8, an out-of-place
+%% application CONNECTION_CLOSE §19.19, or a failed TLS handshake): surface a
+%% terminal {closed, {local, Reason}} to the owner and mark the connection
+%% closed so the fold short-circuits and the shell exits cleanly (no crash, no
+%% slot leak). Sending a CONNECTION_CLOSE to inform the peer of the error (at
+%% the triggering packet's encryption level) is a follow-up; a conformant peer
+%% never triggers these, and the listener drops a misbehaving peer's later
+%% packets to the gone pid.
+-spec connection_fatal(atom(), t()) -> t().
+connection_fatal(Reason, State) ->
+    emit({closed, {local, Reason}}, State#state{phase = closed}).
 
 %% Look up a stream, or create it. The first frame of a peer-initiated stream
 %% is announced with {stream_opened, Sid} (server-initiated ids never reach

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -23,7 +23,8 @@
 %% Handshake state once the handshake is confirmed (RFC 9001 §4.9), which
 %% also keeps the send pass from ever coalescing an Initial with a 1-RTT
 %% packet. The send pass collects, per space in order, an ACK frame, the
-%% TLS flight / retransmits, and (at Application) HANDSHAKE_DONE, packs them
+%% TLS flight / retransmits, and (at the Application level) HANDSHAKE_DONE
+%% plus outbound STREAM data sliced within the send-flow windows, packs them
 %% with `roadrunner_quic_send`, gates the datagram against the §8.1
 %% anti-amplification budget, and records each sent packet for loss
 %% recovery.
@@ -34,7 +35,9 @@
 %% sending an explicit probe both need the loss layer to surface acked bytes
 %% / sent times / the oldest unacknowledged frames, a separate follow-up.
 
--export([new/1, handle_datagram/3, handle_timeout/3, handle_call/4, peername/1, phase/1]).
+-export([
+    new/1, handle_datagram/3, handle_timeout/3, handle_call/4, handle_send/7, peername/1, phase/1
+]).
 
 -export_type([t/0, config/0, effect/0, event/0, info/0]).
 
@@ -43,6 +46,10 @@
 %% A CRYPTO slice budget that leaves room for the packet header, an ACK
 %% frame, and the AEAD tag within the 1200-byte datagram (RFC 9000 §14).
 -define(CRYPTO_BUDGET, 1000).
+%% A STREAM data-slice budget, leaving room for the short header, an ACK
+%% frame, the STREAM frame header, and the AEAD tag within the 1200-byte
+%% datagram (RFC 9000 §14).
+-define(STREAM_BUDGET, 1000).
 %% TLS handshake message types carried in CRYPTO (RFC 8446 §4).
 -define(CLIENT_HELLO, 1).
 -define(FINISHED, 20).
@@ -81,9 +88,14 @@
     owner :: pid() | undefined,
     %% The `connected` payload, built once at new/1.
     info :: info(),
-    %% Application streams (peer-initiated, application space), each with its
-    %% own receive reassembly + flow window, keyed by stream id.
+    %% Application streams, each with its own reassembly + flow window, keyed
+    %% by stream id (peer-initiated on receive; server-initiated and client
+    %% request streams on send).
     streams = #{} :: #{non_neg_integer() => stream()},
+    %% Next server-initiated unidirectional stream id to hand out (RFC 9000
+    %% §2.1: server uni ids are 3, 7, 11, ...); the owner opens its h3
+    %% control stream this way.
+    next_uni = 3 :: non_neg_integer(),
     %% Connection-level flow control (RFC 9000 §4).
     conn_flow :: roadrunner_quic_flow:t(),
     %% Owner events accumulated while folding a datagram's frames, drained in
@@ -257,12 +269,17 @@ connection are synchronous; the connection only ever notifies the owner
 with async `{emit, _, _}` effects, so it never blocks on the owner.
 """.
 -spec handle_call(pid(), reference(), Request, t()) -> {t(), [effect()]} when
-    Request :: peername | {set_owner, pid()}.
+    Request :: peername | {set_owner, pid()} | open_uni.
 handle_call(From, Ref, peername, #state{peer = Peer} = State) ->
     {State, [{reply, From, Ref, {ok, Peer}}]};
 handle_call(From, Ref, {set_owner, Owner}, State) ->
     {State1, EmitEffects} = install_owner(Owner, State),
-    {State1, [{reply, From, Ref, ok} | EmitEffects]}.
+    {State1, [{reply, From, Ref, ok} | EmitEffects]};
+handle_call(From, Ref, open_uni, #state{next_uni = Id} = State) ->
+    %% Allocate the next server-initiated unidirectional stream id. The stream
+    %% itself is created lazily on the first send_data; the h3 layer writes the
+    %% stream-type byte + SETTINGS, never this layer.
+    {State#state{next_uni = Id + 4}, [{reply, From, Ref, {ok, Id}}]}.
 
 %% Install the owner. When the handshake already completed before the owner
 %% was set (the deferred path), emit the once-only `{connected, Info}` now;
@@ -273,6 +290,45 @@ install_owner(Owner, #state{phase = connected, info = Info} = State) ->
     {State#state{owner = Owner}, [{emit, Owner, {connected, Info}}]};
 install_owner(Owner, State) ->
     {State#state{owner = Owner}, []}.
+
+-doc """
+Buffer outbound stream data and run a send pass: the shell forwards
+`{quic_send, From, Ref, Sid, IoData, Fin}` here. The data is enqueued on the
+stream's send buffer (the stream is created on first reference), an optional
+FIN is flagged, then the queued bytes are flushed as STREAM frames within the
+connection and per-stream send-flow credit. Always replies `ok`; rejecting a
+send on a draining/closed connection is a teardown-slice follow-up.
+""".
+-spec handle_send(pid(), reference(), non_neg_integer(), iodata(), boolean(), integer(), t()) ->
+    {t(), [effect()]}.
+handle_send(From, Ref, Sid, IoData, Fin, Now, State) ->
+    State1 = enqueue_send(Sid, IoData, Fin, State),
+    {State2, SendEffects} = send_pass(Now, State1),
+    {State2, [{reply, From, Ref, ok} | SendEffects]}.
+
+%% Append outbound bytes to a stream's send buffer (creating the stream on
+%% first reference) and flag the FIN when this is the final write.
+-spec enqueue_send(non_neg_integer(), iodata(), boolean(), t()) -> t().
+enqueue_send(Sid, IoData, Fin, State) ->
+    {Stream0, Flow, State1} = stream_for_send(Sid, State),
+    Stream1 = roadrunner_quic_stream:enqueue(IoData, Stream0),
+    Stream2 =
+        case Fin of
+            true -> roadrunner_quic_stream:finish(Stream1);
+            false -> Stream1
+        end,
+    put_stream(Sid, Stream2, Flow, State1).
+
+%% Look up a stream for sending, or create it without announcing. Sends go to
+%% the server's own streams or to existing client request streams, never to a
+%% peer stream the owner has not already seen via {stream_opened, _}.
+-spec stream_for_send(non_neg_integer(), t()) ->
+    {roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()}.
+stream_for_send(Sid, #state{streams = Streams} = State) ->
+    case Streams of
+        #{Sid := {Stream, Flow}} -> {Stream, Flow, State};
+        #{} -> {roadrunner_quic_stream:new(), roadrunner_quic_flow:new(#{}), State}
+    end.
 
 -spec process_outcome(integer(), roadrunner_quic_recv:outcome(), t()) -> t().
 process_outcome(
@@ -331,7 +387,9 @@ process_frame(_Now, application, {stream, Sid, Offset, Data, Fin}, State) ->
 process_frame(_Now, application, {reset_stream, Sid, ErrorCode, FinalSize}, State) ->
     process_reset_stream(Sid, ErrorCode, FinalSize, State);
 process_frame(_Now, _Level, _Frame, State) ->
-    %% ping / padding / peer flow-credit grants (handled with the send side).
+    %% ping / padding are no-ops. Peer flow-credit grants (MAX_DATA /
+    %% MAX_STREAM_DATA) and MAX_STREAMS are accepted but not yet acted on, so
+    %% the send side keeps the default window until that follow-up lands.
     State.
 
 %% Reassemble CRYPTO, deframe complete handshake messages, and drive the
@@ -589,16 +647,60 @@ build_level(Level, State) ->
     {AckFrames, Ack} = take_ack(Space#space.ack),
     case Space#space.pending of
         [_ | _] = Pending ->
-            %% Retransmits travel in their own packet (no fresh CRYPTO
-            %% slice), so a replayed CRYPTO frame plus a new slice can
-            %% never overflow the datagram.
+            %% Retransmits travel in their own packet (no fresh CRYPTO or
+            %% STREAM slice), so a replayed frame plus a new slice can never
+            %% overflow the datagram.
             build_entry(Level, AckFrames ++ Pending, Space#space{ack = Ack, pending = []}, State);
         [] ->
-            {CryptoFrames, Crypto} = take_crypto(Space#space.crypto),
-            case AckFrames ++ CryptoFrames of
-                [] -> none;
-                Frames -> build_entry(Level, Frames, Space#space{ack = Ack, crypto = Crypto}, State)
-            end
+            build_data(Level, AckFrames, Space#space{ack = Ack}, State)
+    end.
+
+%% With nothing pending to retransmit, fill the packet after any ACK with
+%% fresh data: CRYPTO at the handshake levels, application STREAM frames at
+%% the application level (which never carries CRYPTO).
+-spec build_data(level(), [roadrunner_quic_frame:frame()], #space{}, t()) -> none | {map(), t()}.
+build_data(application, AckFrames, Space, State) ->
+    {StreamFrames, State1} = take_stream(State),
+    case AckFrames ++ StreamFrames of
+        [] -> none;
+        Frames -> build_entry(application, Frames, Space, State1)
+    end;
+build_data(Level, AckFrames, Space, State) ->
+    {CryptoFrames, Crypto} = take_crypto(Space#space.crypto),
+    case AckFrames ++ CryptoFrames of
+        [] -> none;
+        Frames -> build_entry(Level, Frames, Space#space{crypto = Crypto}, State)
+    end.
+
+%% Pull ONE outbound STREAM frame from the lowest-id stream that has data or a
+%% FIN to send and the credit to send it, skipping streams blocked by send
+%% flow control (a buffered-but-unsendable stream yields `nothing`; a pending
+%% FIN-only frame costs no credit and is always emitted). The slice is bounded
+%% by the connection and per-stream send windows and the per-packet budget,
+%% and the bytes are accounted against both windows.
+-spec take_stream(t()) -> {[roadrunner_quic_frame:frame()], t()}.
+take_stream(#state{streams = Streams} = State) ->
+    take_stream(lists:sort(maps:keys(Streams)), State).
+
+-spec take_stream([non_neg_integer()], t()) -> {[roadrunner_quic_frame:frame()], t()}.
+take_stream([], State) ->
+    {[], State};
+take_stream([Sid | Rest], #state{streams = Streams, conn_flow = ConnFlow} = State) ->
+    #{Sid := {Stream0, StreamFlow0}} = Streams,
+    Budget = lists:min([
+        ?STREAM_BUDGET,
+        roadrunner_quic_flow:send_window(ConnFlow),
+        roadrunner_quic_flow:send_window(StreamFlow0)
+    ]),
+    case roadrunner_quic_stream:next_frame(Budget, Stream0) of
+        nothing ->
+            take_stream(Rest, State);
+        {Offset, Data, Fin, Stream1} ->
+            Size = byte_size(Data),
+            {_, ConnFlow1} = roadrunner_quic_flow:on_data_sent(Size, ConnFlow),
+            {_, StreamFlow1} = roadrunner_quic_flow:on_data_sent(Size, StreamFlow0),
+            State1 = put_stream(Sid, Stream1, StreamFlow1, State#state{conn_flow = ConnFlow1}),
+            {[{stream, Sid, Offset, Data, Fin}], State1}
     end.
 
 -spec build_entry(level(), [roadrunner_quic_frame:frame()], #space{}, t()) -> {map(), t()}.

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -36,7 +36,7 @@
 %% / sent times / the oldest unacknowledged frames, a separate follow-up.
 
 -export([
-    new/1, handle_datagram/3, handle_timeout/3, handle_call/4, handle_send/7, peername/1, phase/1
+    new/2, handle_datagram/3, handle_timeout/3, handle_call/4, handle_send/7, peername/1, phase/1
 ]).
 
 -export_type([t/0, config/0, effect/0, event/0, info/0]).
@@ -50,6 +50,10 @@
 %% frame, the STREAM frame header, and the AEAD tag within the 1200-byte
 %% datagram (RFC 9000 §14).
 -define(STREAM_BUDGET, 1000).
+%% Default idle timeout (RFC 9000 §10.1): the connection silently closes after
+%% this many ms with no packet received. Seeding it from the advertised / peer
+%% max_idle_timeout is a follow-up.
+-define(IDLE_TIMEOUT, 30000).
 %% TLS handshake message types carried in CRYPTO (RFC 8446 §4).
 -define(CLIENT_HELLO, 1).
 -define(FINISHED, 20).
@@ -104,7 +108,14 @@
     %% A locally-detected error to signal: {Level, WireErrorCode} for the one
     %% CONNECTION_CLOSE to transmit at that encryption level. `undefined` for a
     %% live connection or a peer-initiated close (which sends nothing back).
-    pending_close = undefined :: undefined | {level(), non_neg_integer()}
+    pending_close = undefined :: undefined | {level(), non_neg_integer()},
+    %% Absolute time (ms) the connection idle-times-out; reset to Now +
+    %% ?IDLE_TIMEOUT on every received datagram (RFC 9000 §10.1). Always set
+    %% (from new/2's birth time), so it is the timer floor when nothing is in
+    %% flight. Also restarting it on the first ack-eliciting send since the
+    %% last receive (§10.1) is a follow-up; receive-only is conservative
+    %% (it closes no later than a strict implementation would).
+    idle_deadline :: integer()
 }).
 
 -type stream() :: {roadrunner_quic_stream:t(), roadrunner_quic_flow:t()}.
@@ -155,25 +166,29 @@
 %% =============================================================================
 
 -doc """
-Build the connection state from the per-connection config. Bootstraps the
-Initial keys from the client's Destination Connection ID, the TLS server
-sequencer (the server transport parameters already carry the
-original/initial connection ids), and the Initial and Handshake
-packet-number spaces (the Application space appears once 1-RTT keys arm).
+Build the connection state from the per-connection config and the birth time
+`Now` (ms). Bootstraps the Initial keys from the client's Destination
+Connection ID, the TLS server sequencer (the server transport parameters
+already carry the original/initial connection ids), the Initial and Handshake
+packet-number spaces (the Application space appears once 1-RTT keys arm), and
+the idle-timeout deadline anchored at `Now`.
 """.
--spec new(config()) -> t().
-new(#{
-    dcid := DCID,
-    scid := SCID,
-    peer := Peer,
-    cert_chain := CertChain,
-    priv_key := PrivKey,
-    alpn := Alpn,
-    transport_params := TransportParams,
-    eph_pub := EphPub,
-    eph_priv := EphPriv,
-    server_random := ServerRandom
-}) ->
+-spec new(config(), integer()) -> t().
+new(
+    #{
+        dcid := DCID,
+        scid := SCID,
+        peer := Peer,
+        cert_chain := CertChain,
+        priv_key := PrivKey,
+        alpn := Alpn,
+        transport_params := TransportParams,
+        eph_pub := EphPub,
+        eph_priv := EphPriv,
+        server_random := ServerRandom
+    },
+    Now
+) ->
     Tls = roadrunner_quic_tls_server:new(#{
         cert_chain => CertChain,
         priv_key => PrivKey,
@@ -194,7 +209,8 @@ new(#{
         amp = roadrunner_quic_amp:new(),
         owner = undefined,
         info = #{alpn => Alpn, transport_params => TransportParams},
-        conn_flow = roadrunner_quic_flow:new(#{})
+        conn_flow = roadrunner_quic_flow:new(#{}),
+        idle_deadline = Now + ?IDLE_TIMEOUT
     }.
 
 -spec new_space() -> #space{}.
@@ -227,7 +243,10 @@ state and the effects to perform.
 """.
 -spec handle_datagram(integer(), binary(), t()) -> {t(), [effect()]}.
 handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys, phase = Before} = State0) ->
-    State1 = State0#state{amp = roadrunner_quic_amp:received(byte_size(Datagram), Amp)},
+    State1 = State0#state{
+        amp = roadrunner_quic_amp:received(byte_size(Datagram), Amp),
+        idle_deadline = Now + ?IDLE_TIMEOUT
+    },
     Outcomes = roadrunner_quic_recv:datagram(
         Datagram, ?SCID_LEN, RecvKeys, largest_map(State1)
     ),
@@ -861,15 +880,19 @@ record_one_sent(
 %% =============================================================================
 
 -doc """
-Handle a fired probe timer: re-run loss detection on every space (queueing
-any lost frames to retransmit), back off the probe timeout, then run a send
-pass. The backoff is what guarantees forward progress, so a probe that
-detects no loss re-arms strictly later rather than re-firing immediately.
+Handle a fired timer. A probe timeout (`pto`) re-runs loss detection on every
+space (queueing any lost frames to retransmit), backs off the probe timeout
+(so a probe that detects no loss re-arms strictly later, guaranteeing forward
+progress), then runs a send pass. An idle timeout (`idle`) silently closes the
+connection (RFC 9000 §10.1, no CONNECTION_CLOSE) and surfaces the terminal
+`{closed, _}` event to the owner.
 """.
 -spec handle_timeout(integer(), atom(), t()) -> {t(), [effect()]}.
 handle_timeout(Now, pto, State) ->
     State1 = lists:foldl(fun(Level, S) -> on_pto(Now, Level, S) end, State, present_levels(State)),
-    send_pass(Now, State1).
+    send_pass(Now, State1);
+handle_timeout(_Now, idle, State) ->
+    drain_emits(emit({closed, {local, idle_timeout}}, State#state{phase = closed})).
 
 %% On a probe timeout: queue any time-threshold losses to retransmit and
 %% increment the space's probe-timeout backoff (RFC 9002 §6.2.1), so the
@@ -883,14 +906,22 @@ on_pto(Now, Level, State) ->
     Loss2 = roadrunner_quic_loss:on_pto_expired(Loss1),
     put_space(Level, Space#space{loss = Loss2, pending = Pending ++ retransmittable(Lost)}, State).
 
-%% Arm one probe timer at the earliest per-space deadline (now plus the
-%% space's probe timeout) across spaces that still hold ack-eliciting bytes
-%% in flight; nothing in flight means nothing to probe for, so no timer.
+%% Arm ONE timer at the nearest deadline: the earliest per-space probe timeout
+%% (across spaces with ack-eliciting bytes in flight) or the always-present
+%% idle deadline, whichever is sooner. A single nearest-deadline timer keeps
+%% the per-datagram re-arm to one timer operation; the loser is re-derived
+%% after the winner fires (RFC 9000 §10.1, RFC 9002 §6.2).
 -spec timer_effects(integer(), t()) -> [effect()].
 timer_effects(Now, State) ->
+    {Kind, AtMs} = earliest_deadline(Now, State),
+    [{arm_timer, Kind, AtMs}].
+
+-spec earliest_deadline(integer(), t()) -> {pto | idle, integer()}.
+earliest_deadline(Now, #state{idle_deadline = Idle} = State) ->
     case earliest_pto(Now, State) of
-        undefined -> [];
-        AtMs -> [{arm_timer, pto, AtMs}]
+        undefined -> {idle, Idle};
+        PtoAt when PtoAt =< Idle -> {pto, PtoAt};
+        _PtoAt -> {idle, Idle}
     end.
 
 -spec earliest_pto(integer(), t()) -> integer() | undefined.

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -1,0 +1,528 @@
+-module(roadrunner_quic_conn_state).
+-moduledoc false.
+
+%% The pure decision core of the native QUIC connection (RFC 9000/9001).
+%%
+%% `roadrunner_quic_connection` is the thin proc_lib shell that owns the
+%% socket, timers, and message loop; this module owns the whole `#state{}`
+%% and every decision. Each entry takes the wall-clock `Now` (ms) and a
+%% message and returns `{NewState, [effect()]}` for the shell to perform.
+%% Keeping the brain pure (recv/send/crypto all run here, since the leaves
+%% are pure) is what makes the connection eunit-reachable for the 100%
+%% gate; the shell only does the irreducible I/O.
+%%
+%% Effects: `{send, Datagram}` (hand to the socket), `{arm_timer, Kind,
+%% AtMs}` ((re)arm a timer). The owner events and control replies arrive
+%% with the application phase.
+%%
+%% A connection keeps up to three packet-number spaces (Initial, Handshake,
+%% Application). The server reads with the peer's keys and writes with its
+%% own; CRYPTO is reassembled per space (a `roadrunner_quic_stream` with no
+%% FIN). Initial state is discarded once a Handshake packet decrypts and
+%% Handshake state once the handshake is confirmed (RFC 9001 §4.9), which
+%% also keeps the send pass from ever coalescing an Initial with a 1-RTT
+%% packet. The send pass collects, per space in order, an ACK frame, the
+%% TLS flight / retransmits, and (at Application) HANDSHAKE_DONE, packs them
+%% with `roadrunner_quic_send`, gates the datagram against the §8.1
+%% anti-amplification budget, and records each sent packet for loss
+%% recovery.
+%%
+%% Congestion control is deferred (the connection sends within the
+%% anti-amplification and flow limits, the MUSTs); wiring NewReno needs the
+%% loss layer to surface acked bytes / sent times, a separate follow-up.
+
+-export([new/1, handle_datagram/3, handle_timeout/3, peername/1, phase/1]).
+
+-export_type([t/0, config/0, effect/0]).
+
+%% RFC 9000 §17.2: the server uses a fixed-length SCID so short headers demux.
+-define(SCID_LEN, 8).
+%% A CRYPTO slice budget that leaves room for the packet header, an ACK
+%% frame, and the AEAD tag within the 1200-byte datagram (RFC 9000 §14).
+-define(CRYPTO_BUDGET, 1000).
+%% TLS handshake message types carried in CRYPTO (RFC 8446 §4).
+-define(CLIENT_HELLO, 1).
+-define(FINISHED, 20).
+
+-type level() :: initial | handshake | application.
+
+-record(space, {
+    ack :: roadrunner_quic_ack:t(),
+    loss :: roadrunner_quic_loss:t(),
+    next_pn = 0 :: non_neg_integer(),
+    %% CRYPTO reassembly + send buffering for this space (FIN unused).
+    crypto :: roadrunner_quic_stream:t(),
+    %% Contiguous CRYPTO bytes received but not yet deframed.
+    crypto_in = <<>> :: binary(),
+    %% Frames to (re)send: losses to retransmit, plus queued control frames.
+    pending = [] :: [roadrunner_quic_frame:frame()]
+}).
+
+-record(state, {
+    dcid :: binary(),
+    scid :: binary(),
+    peer :: {inet:ip_address(), inet:port_number()},
+    phase = handshaking :: handshaking | connected | draining | closed,
+    tls :: roadrunner_quic_tls_server:t(),
+    %% Keys to decrypt incoming packets (the peer's), by level.
+    recv_keys :: #{level() => roadrunner_quic_keys:keys()},
+    %% Keys to protect outgoing packets (the server's), by level.
+    send_keys :: #{level() => roadrunner_quic_keys:keys()},
+    spaces :: #{level() => #space{}},
+    amp :: roadrunner_quic_amp:t(),
+    %% Cleared once a Handshake packet decrypts (address validated, §8.1).
+    validated = false :: boolean()
+}).
+
+-opaque t() :: #state{}.
+
+-type config() :: #{
+    dcid := binary(),
+    scid := binary(),
+    peer := {inet:ip_address(), inet:port_number()},
+    cert_chain := [binary()],
+    priv_key := public_key:private_key(),
+    alpn := binary(),
+    transport_params := roadrunner_quic_transport_params:params(),
+    eph_pub := binary(),
+    eph_priv := binary(),
+    server_random := binary()
+}.
+
+-type effect() :: {send, binary()} | {arm_timer, atom(), non_neg_integer()}.
+
+%% =============================================================================
+%% Construction
+%% =============================================================================
+
+-doc """
+Build the connection state from the per-connection config. Bootstraps the
+Initial keys from the client's Destination Connection ID, the TLS server
+sequencer (the server transport parameters already carry the
+original/initial connection ids), and the Initial and Handshake
+packet-number spaces (the Application space appears once 1-RTT keys arm).
+""".
+-spec new(config()) -> t().
+new(#{
+    dcid := DCID,
+    scid := SCID,
+    peer := Peer,
+    cert_chain := CertChain,
+    priv_key := PrivKey,
+    alpn := Alpn,
+    transport_params := TransportParams,
+    eph_pub := EphPub,
+    eph_priv := EphPriv,
+    server_random := ServerRandom
+}) ->
+    Tls = roadrunner_quic_tls_server:new(#{
+        cert_chain => CertChain,
+        priv_key => PrivKey,
+        alpn => Alpn,
+        transport_params => TransportParams,
+        eph_pub => EphPub,
+        eph_priv => EphPriv,
+        server_random => ServerRandom
+    }),
+    #state{
+        dcid = DCID,
+        scid = SCID,
+        peer = Peer,
+        tls = Tls,
+        recv_keys = #{initial => roadrunner_quic_keys:initial_client(DCID)},
+        send_keys = #{initial => roadrunner_quic_keys:initial_server(DCID)},
+        spaces = #{initial => new_space(), handshake => new_space()},
+        amp = roadrunner_quic_amp:new()
+    }.
+
+-spec new_space() -> #space{}.
+new_space() ->
+    #space{
+        ack = roadrunner_quic_ack:new(),
+        loss = roadrunner_quic_loss:new(#{}),
+        crypto = roadrunner_quic_stream:new()
+    }.
+
+-doc "The peer address, answerable from the handshaking phase onward.".
+-spec peername(t()) -> {ok, {inet:ip_address(), inet:port_number()}}.
+peername(#state{peer = Peer}) ->
+    {ok, Peer}.
+
+-doc "The connection's current phase.".
+-spec phase(t()) -> handshaking | connected | draining | closed.
+phase(#state{phase = Phase}) ->
+    Phase.
+
+%% =============================================================================
+%% Inbound datagram
+%% =============================================================================
+
+-doc """
+Process one received UDP datagram: account it against the anti-
+amplification budget, decode and decrypt its packets, fold each packet's
+frames into the connection state, then run a send pass. Returns the new
+state and the effects to perform.
+""".
+-spec handle_datagram(non_neg_integer(), binary(), t()) -> {t(), [effect()]}.
+handle_datagram(Now, Datagram, #state{amp = Amp, recv_keys = RecvKeys} = State0) ->
+    State1 = State0#state{amp = roadrunner_quic_amp:received(byte_size(Datagram), Amp)},
+    Outcomes = roadrunner_quic_recv:datagram(
+        Datagram, ?SCID_LEN, RecvKeys, largest_map(State1)
+    ),
+    State2 = lists:foldl(fun(O, S) -> process_outcome(Now, O, S) end, State1, Outcomes),
+    send_pass(Now, State2).
+
+-spec process_outcome(non_neg_integer(), roadrunner_quic_recv:outcome(), t()) -> t().
+process_outcome(
+    Now, {ok, #{level := Level, pn := PN, frames := Frames}}, #state{spaces = Spaces} = State
+) ->
+    case Spaces of
+        #{Level := _} ->
+            State1 = validate_on_handshake(Level, State),
+            State2 = lists:foldl(
+                fun(Frame, S) -> process_frame(Now, Level, Frame, S) end, State1, Frames
+            ),
+            record_received(Level, PN, Frames, State2);
+        #{} ->
+            %% A packet for a discarded space (e.g. a late Initial); ignore.
+            State
+    end;
+process_outcome(_Now, {drop, _Reason}, State) ->
+    State;
+process_outcome(_Now, {frame_error, _Level, _Reason}, State) ->
+    State.
+
+%% A decrypted Handshake packet proves the client received the server's
+%% Initial: lift the 3x anti-amplification limit (RFC 9000 §8.1) and
+%% discard the Initial space and keys (RFC 9001 §4.9.1).
+-spec validate_on_handshake(level(), t()) -> t().
+validate_on_handshake(handshake, #state{validated = false, amp = Amp} = State) ->
+    discard_space(initial, State#state{validated = true, amp = roadrunner_quic_amp:validate(Amp)});
+validate_on_handshake(_Level, State) ->
+    State.
+
+-spec record_received(level(), non_neg_integer(), [roadrunner_quic_frame:frame()], t()) -> t().
+record_received(Level, PN, Frames, #state{spaces = Spaces} = State) ->
+    case Spaces of
+        #{Level := Space} ->
+            Ack = roadrunner_quic_ack:record(
+                PN, roadrunner_quic_send:ack_eliciting(Frames), Space#space.ack
+            ),
+            put_space(Level, Space#space{ack = Ack}, State);
+        #{} ->
+            %% The space was discarded while folding this packet's frames
+            %% (the handshake just confirmed); there is nothing left to ack.
+            State
+    end.
+
+%% =============================================================================
+%% Per-frame handlers
+%% =============================================================================
+
+-spec process_frame(non_neg_integer(), level(), roadrunner_quic_frame:frame(), t()) -> t().
+process_frame(_Now, Level, {crypto, Offset, Data}, State) ->
+    process_crypto(Level, Offset, Data, State);
+process_frame(Now, Level, {ack, _, _, _, _, _} = Ack, State) ->
+    process_ack(Now, Level, Ack, State);
+process_frame(_Now, _Level, _Frame, State) ->
+    %% ping / padding / (other frames arrive with the application phase).
+    State.
+
+%% Reassemble CRYPTO, deframe complete handshake messages, and drive the
+%% TLS sequencer.
+-spec process_crypto(level(), non_neg_integer(), binary(), t()) -> t().
+process_crypto(Level, Offset, Data, State) ->
+    Space = space(Level, State),
+    {ok, NewBytes, _Fin, Crypto} = roadrunner_quic_stream:receive_data(
+        Offset, Data, false, Space#space.crypto
+    ),
+    Buffer = <<(Space#space.crypto_in)/binary, NewBytes/binary>>,
+    {Messages, Rest} = deframe(Buffer),
+    State1 = put_space(Level, Space#space{crypto = Crypto, crypto_in = Rest}, State),
+    lists:foldl(fun(Message, S) -> process_handshake(Level, Message, S) end, State1, Messages).
+
+%% Decode every complete handshake message, leaving trailing partial bytes.
+-spec deframe(binary()) -> {[{byte(), binary()}], binary()}.
+deframe(Buffer) ->
+    case roadrunner_quic_tls_handshake:decode(Buffer) of
+        {ok, {Type, Body}, Rest} ->
+            {More, Tail} = deframe(Rest),
+            {[{Type, Body} | More], Tail};
+        {more, _} ->
+            {[], Buffer}
+    end.
+
+-spec process_handshake(level(), {byte(), binary()}, t()) -> t().
+process_handshake(initial, {?CLIENT_HELLO, Body}, #state{tls = Tls} = State) ->
+    {ok, #{initial := InitialFlight, handshake := HandshakeFlight}, Installs, Tls1} =
+        roadrunner_quic_tls_server:process_client_hello(Body, Tls),
+    State1 = install_keys(Installs, State#state{tls = Tls1}),
+    State2 = queue_crypto(initial, InitialFlight, State1),
+    queue_crypto(handshake, HandshakeFlight, State2);
+process_handshake(handshake, {?FINISHED, Body}, #state{tls = Tls} = State) ->
+    ok = roadrunner_quic_tls_server:process_client_finished(Body, Tls),
+    %% Handshake confirmed: discard the Handshake space (RFC 9001 §4.9.2),
+    %% become connected, and send HANDSHAKE_DONE at the application level.
+    State1 = discard_space(handshake, State#state{phase = connected}),
+    queue_frame(application, handshake_done, State1).
+
+%% Arm the keys the TLS flight produced: server installs protect outgoing
+%% packets, client installs decrypt incoming ones; the Application space
+%% appears with its keys.
+-spec install_keys([roadrunner_quic_tls_server:install()], t()) -> t().
+install_keys(Installs, State) ->
+    lists:foldl(fun install_key/2, State, Installs).
+
+-spec install_key(roadrunner_quic_tls_server:install(), t()) -> t().
+install_key({Level, server, Keys}, #state{send_keys = SendKeys} = State) ->
+    ensure_space(Level, State#state{send_keys = SendKeys#{Level => Keys}});
+install_key({Level, client, Keys}, #state{recv_keys = RecvKeys} = State) ->
+    ensure_space(Level, State#state{recv_keys = RecvKeys#{Level => Keys}}).
+
+-spec ensure_space(level(), t()) -> t().
+ensure_space(Level, #state{spaces = Spaces} = State) ->
+    case Spaces of
+        #{Level := _} -> State;
+        #{} -> State#state{spaces = Spaces#{Level => new_space()}}
+    end.
+
+%% Forget a packet-number space and its keys (RFC 9001 §4.9).
+-spec discard_space(level(), t()) -> t().
+discard_space(Level, #state{spaces = Spaces, recv_keys = RK, send_keys = SK} = State) ->
+    State#state{
+        spaces = maps:remove(Level, Spaces),
+        recv_keys = maps:remove(Level, RK),
+        send_keys = maps:remove(Level, SK)
+    }.
+
+%% Buffer outbound CRYPTO bytes for a level (sent as CRYPTO frames).
+-spec queue_crypto(level(), iolist(), t()) -> t().
+queue_crypto(Level, Bytes, State) ->
+    Space = space(Level, State),
+    put_space(
+        Level,
+        Space#space{crypto = roadrunner_quic_stream:enqueue(Bytes, Space#space.crypto)},
+        State
+    ).
+
+%% Queue a control frame to send at a level.
+-spec queue_frame(level(), roadrunner_quic_frame:frame(), t()) -> t().
+queue_frame(Level, Frame, State) ->
+    Space = space(Level, State),
+    put_space(Level, Space#space{pending = Space#space.pending ++ [Frame]}, State).
+
+-spec process_ack(non_neg_integer(), level(), tuple(), t()) -> t().
+process_ack(Now, Level, Ack, State) ->
+    Space = space(Level, State),
+    case roadrunner_quic_loss:on_ack_received(Ack, Now, Space#space.loss) of
+        {error, _} ->
+            State;
+        {Loss, _Acked, Lost} ->
+            put_space(
+                Level,
+                Space#space{loss = Loss, pending = Space#space.pending ++ retransmittable(Lost)},
+                State
+            )
+    end.
+
+%% =============================================================================
+%% Outbound send pass
+%% =============================================================================
+
+-spec send_pass(non_neg_integer(), t()) -> {t(), [effect()]}.
+send_pass(Now, State) ->
+    {State1, SendEffects} = drain_send(Now, State, []),
+    {State1, SendEffects ++ timer_effects(State1)}.
+
+%% Build and send one datagram per iteration until nothing is pending or
+%% the anti-amplification budget blocks; roll back the built state if the
+%% datagram cannot be sent.
+-spec drain_send(non_neg_integer(), t(), [effect()]) -> {t(), [effect()]}.
+drain_send(Now, State, Acc) ->
+    case build_packets(State) of
+        none ->
+            {State, lists:reverse(Acc)};
+        {Entries, Built} ->
+            #state{dcid = DCID, scid = SCID, amp = Amp} = State,
+            {Datagram, Sent} = roadrunner_quic_send:datagram(Entries, DCID, SCID),
+            case roadrunner_quic_amp:can_send(byte_size(Datagram), Amp) of
+                false ->
+                    {State, lists:reverse(Acc)};
+                true ->
+                    Recorded = record_sent(Now, Sent, Built),
+                    Amp1 = roadrunner_quic_amp:sent(byte_size(Datagram), Amp),
+                    drain_send(Now, Recorded#state{amp = Amp1}, [{send, Datagram} | Acc])
+            end
+    end.
+
+%% Build ONE packet for the highest-priority present level that has
+%% something to send, returned as a single-level datagram plus the
+%% post-send state (CRYPTO popped, ACK marked sent, pending cleared,
+%% next-PN advanced). Sending one level per datagram instead of coalescing
+%% keeps every datagram within 1200 bytes: `roadrunner_quic_send` pads an
+%% Initial up to 1200 but never caps, so a coalesced Initial+Handshake
+%% flight would overflow. It also makes the forbidden Initial+1-RTT
+%% coalescing structurally impossible. Coalescing Initial+Handshake is a
+%% deferred optimization. Returns `none` when nothing is pending anywhere.
+-spec build_packets(t()) -> none | {#{level() => map()}, t()}.
+build_packets(State) ->
+    build_first(present_levels(State), State).
+
+-spec build_first([level()], t()) -> none | {#{level() => map()}, t()}.
+build_first([], _State) ->
+    none;
+build_first([Level | Rest], State) ->
+    case build_level(Level, State) of
+        none -> build_first(Rest, State);
+        {Entry, Built} -> {#{Level => Entry}, Built}
+    end.
+
+-spec build_level(level(), t()) -> none | {map(), t()}.
+build_level(Level, State) ->
+    Space = space(Level, State),
+    {AckFrames, Ack} = take_ack(Space#space.ack),
+    case Space#space.pending of
+        [_ | _] = Pending ->
+            %% Retransmits travel in their own packet (no fresh CRYPTO
+            %% slice), so a replayed CRYPTO frame plus a new slice can
+            %% never overflow the datagram.
+            build_entry(Level, AckFrames ++ Pending, Space#space{ack = Ack, pending = []}, State);
+        [] ->
+            {CryptoFrames, Crypto} = take_crypto(Space#space.crypto),
+            case AckFrames ++ CryptoFrames of
+                [] -> none;
+                Frames -> build_entry(Level, Frames, Space#space{ack = Ack, crypto = Crypto}, State)
+            end
+    end.
+
+-spec build_entry(level(), [roadrunner_quic_frame:frame()], #space{}, t()) -> {map(), t()}.
+build_entry(Level, Frames, #space{next_pn = PN} = Space, #state{send_keys = SendKeys} = State) ->
+    #{Level := Keys} = SendKeys,
+    Entry = #{frames => Frames, keys => Keys, pn => PN},
+    {Entry, put_space(Level, Space#space{next_pn = PN + 1}, State)}.
+
+-spec take_ack(roadrunner_quic_ack:t()) ->
+    {[roadrunner_quic_frame:frame()], roadrunner_quic_ack:t()}.
+take_ack(Ack) ->
+    case roadrunner_quic_ack:needs_ack(Ack) of
+        false ->
+            {[], Ack};
+        true ->
+            {Largest, FirstRange, Ranges} = roadrunner_quic_ack:to_ack(Ack),
+            {
+                [{ack, Largest, 0, FirstRange, Ranges, undefined}],
+                roadrunner_quic_ack:mark_ack_sent(Ack)
+            }
+    end.
+
+-spec take_crypto(roadrunner_quic_stream:t()) ->
+    {[roadrunner_quic_frame:frame()], roadrunner_quic_stream:t()}.
+take_crypto(Crypto) ->
+    case roadrunner_quic_stream:next_frame(?CRYPTO_BUDGET, Crypto) of
+        nothing -> {[], Crypto};
+        {Offset, Data, _Fin, Crypto1} -> {[{crypto, Offset, Data}], Crypto1}
+    end.
+
+-spec record_sent(non_neg_integer(), [roadrunner_quic_send:sent()], t()) -> t().
+record_sent(Now, Sent, State) ->
+    lists:foldl(fun(S, Acc) -> record_one_sent(Now, S, Acc) end, State, Sent).
+
+-spec record_one_sent(non_neg_integer(), roadrunner_quic_send:sent(), t()) -> t().
+record_one_sent(
+    Now,
+    #{level := Level, pn := PN, length := Len, ack_eliciting := AckEliciting, frames := Frames},
+    State
+) ->
+    Space = space(Level, State),
+    Loss = roadrunner_quic_loss:on_packet_sent(
+        PN, Len, AckEliciting, Frames, Now, Space#space.loss
+    ),
+    put_space(Level, Space#space{loss = Loss}, State).
+
+%% =============================================================================
+%% Timers
+%% =============================================================================
+
+-doc """
+Handle a fired loss/PTO timer: re-run loss detection on every space,
+queueing lost frames to retransmit, then run a send pass so a dropped
+handshake packet recovers.
+""".
+-spec handle_timeout(non_neg_integer(), atom(), t()) -> {t(), [effect()]}.
+handle_timeout(Now, pto, State) ->
+    State1 = lists:foldl(
+        fun(Level, S) -> detect_loss(Now, Level, S) end, State, present_levels(State)
+    ),
+    send_pass(Now, State1).
+
+-spec detect_loss(non_neg_integer(), level(), t()) -> t().
+detect_loss(Now, Level, State) ->
+    #space{loss = Loss0, pending = Pending} = Space = space(Level, State),
+    {Loss, Lost} = roadrunner_quic_loss:detect_lost(Now, Loss0),
+    put_space(
+        Level,
+        Space#space{loss = Loss, pending = Pending ++ retransmittable(Lost)},
+        State
+    ).
+
+-spec timer_effects(t()) -> [effect()].
+timer_effects(State) ->
+    case earliest_loss_time(State) of
+        undefined -> [];
+        AtMs -> [{arm_timer, pto, AtMs}]
+    end.
+
+-spec earliest_loss_time(t()) -> non_neg_integer() | undefined.
+earliest_loss_time(State) ->
+    lists:foldl(
+        fun(Level, Earliest) ->
+            min_defined(Earliest, roadrunner_quic_loss:loss_time((space(Level, State))#space.loss))
+        end,
+        undefined,
+        present_levels(State)
+    ).
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+-spec largest_map(t()) -> #{level() => non_neg_integer()}.
+largest_map(#state{spaces = Spaces}) ->
+    maps:fold(
+        fun(Level, #space{ack = Ack}, Acc) ->
+            case roadrunner_quic_ack:largest(Ack) of
+                undefined -> Acc;
+                Largest -> Acc#{Level => Largest}
+            end
+        end,
+        #{},
+        Spaces
+    ).
+
+-spec present_levels(t()) -> [level()].
+present_levels(#state{spaces = Spaces}) ->
+    [Level || Level <- [initial, handshake, application], is_map_key(Level, Spaces)].
+
+-spec space(level(), t()) -> #space{}.
+space(Level, #state{spaces = Spaces}) ->
+    #{Level := Space} = Spaces,
+    Space.
+
+-spec put_space(level(), #space{}, t()) -> t().
+put_space(Level, Space, #state{spaces = Spaces} = State) ->
+    State#state{spaces = Spaces#{Level => Space}}.
+
+-spec min_defined(non_neg_integer() | undefined, non_neg_integer() | undefined) ->
+    non_neg_integer() | undefined.
+min_defined(undefined, B) -> B;
+min_defined(A, undefined) -> A;
+min_defined(A, B) -> min(A, B).
+
+%% Flatten the per-packet frame lists a loss returns and keep only the
+%% frames worth resending: ACK / PADDING / CONNECTION_CLOSE are regenerated
+%% fresh or terminal, never replayed (RFC 9002 §13.3).
+%% `roadrunner_quic_send:ack_eliciting/1` is the single source of truth for
+%% which frames are ack-eliciting.
+-spec retransmittable([[roadrunner_quic_frame:frame()]]) -> [roadrunner_quic_frame:frame()].
+retransmittable(Lost) ->
+    [Frame || Frame <- lists:append(Lost), roadrunner_quic_send:is_ack_eliciting(Frame)].

--- a/src/roadrunner_quic_connection.erl
+++ b/src/roadrunner_quic_connection.erl
@@ -16,6 +16,12 @@
 %% `{send, Datagram}` goes out the socket to the peer, and `{arm_timer,
 %% Kind, AtMs}` (re)arms a self-tagged timer whose stale fires (from a timer
 %% that was re-armed before firing) are dropped by a reference match.
+%%
+%% Synchronous control calls from the owner or listener arrive as
+%% `{quic_call, From, Ref, Request}` and are answered with a `{reply, From,
+%% Ref, Result}` effect; owner notifications go out as async `{emit, Owner,
+%% Event}` effects (`Owner ! {quic, self(), Event}`). The connection only
+%% ever sends to the owner asynchronously, so it never blocks on it.
 
 -export([start/2]).
 -export([init/2]).
@@ -65,6 +71,12 @@ loop(State) ->
             loop(State);
         {'$gen_cast', _Request} ->
             loop(State);
+        {quic_call, From, Ref, Request} ->
+            Now = erlang:monotonic_time(millisecond),
+            {Conn, Effects} = roadrunner_quic_conn_state:handle_call(
+                From, Ref, Request, State#shell.conn
+            ),
+            loop(perform(Effects, Now, State#shell{conn = Conn}));
         {quic_datagram, _Peer, Datagram} ->
             Now = erlang:monotonic_time(millisecond),
             {Conn, Effects} = roadrunner_quic_conn_state:handle_datagram(
@@ -98,6 +110,12 @@ perform(Effects, Now, State) ->
 -spec perform_effect(roadrunner_quic_conn_state:effect(), integer(), #shell{}) -> #shell{}.
 perform_effect({send, Datagram}, _Now, #shell{socket = Socket, peer = {Ip, Port}} = State) ->
     _ = roadrunner_quic_socket:send(Socket, Ip, Port, Datagram),
+    State;
+perform_effect({emit, Owner, Event}, _Now, State) ->
+    _ = Owner ! {quic, self(), Event},
+    State;
+perform_effect({reply, To, Ref, Result}, _Now, State) ->
+    _ = To ! {quic_reply, Ref, Result},
     State;
 perform_effect({arm_timer, Kind, AtMs}, Now, #shell{timer = Prev} = State) ->
     _ = cancel(Prev),

--- a/src/roadrunner_quic_connection.erl
+++ b/src/roadrunner_quic_connection.erl
@@ -49,7 +49,8 @@ start(Socket, Config) ->
     {ok, proc_lib:spawn_opt(?MODULE, init, [Socket, Config], [])}.
 
 -doc false.
--spec init(roadrunner_quic_socket:socket(), roadrunner_quic_conn_state:config()) -> no_return().
+-spec init(roadrunner_quic_socket:socket(), roadrunner_quic_conn_state:config()) ->
+    ok | no_return().
 init(Socket, #{peer := Peer} = Config) ->
     proc_lib:set_label({?MODULE, Peer}),
     loop(#shell{
@@ -63,7 +64,7 @@ init(Socket, #{peer := Peer} = Config) ->
 %% Loop
 %% =============================================================================
 
--spec loop(#shell{}) -> no_return().
+-spec loop(#shell{}) -> ok | no_return().
 loop(State) ->
     receive
         {system, From, Req} ->
@@ -78,23 +79,34 @@ loop(State) ->
             {Conn, Effects} = roadrunner_quic_conn_state:handle_call(
                 From, Ref, Request, State#shell.conn
             ),
-            loop(perform(Effects, Now, State#shell{conn = Conn}));
+            continue(perform(Effects, Now, State#shell{conn = Conn}));
         {quic_send, From, Ref, Sid, IoData, Fin} ->
             Now = erlang:monotonic_time(millisecond),
             {Conn, Effects} = roadrunner_quic_conn_state:handle_send(
                 From, Ref, Sid, IoData, Fin, Now, State#shell.conn
             ),
-            loop(perform(Effects, Now, State#shell{conn = Conn}));
+            continue(perform(Effects, Now, State#shell{conn = Conn}));
         {quic_datagram, _Peer, Datagram} ->
             Now = erlang:monotonic_time(millisecond),
             {Conn, Effects} = roadrunner_quic_conn_state:handle_datagram(
                 Now, Datagram, State#shell.conn
             ),
-            loop(perform(Effects, Now, State#shell{conn = Conn}));
+            continue(perform(Effects, Now, State#shell{conn = Conn}));
         {?MODULE, timer, Kind, Ref} ->
-            loop(fire_timer(Ref, Kind, State));
+            continue(fire_timer(Ref, Kind, State));
         _Other ->
             loop(State)
+    end.
+
+%% Resume the loop, or exit normally once the pure core has moved to the
+%% `closed` phase. proc_lib treats a normal return as a clean process exit,
+%% and the owner already learned of the close via the {closed, _} emit, so
+%% there is no further teardown to do here.
+-spec continue(#shell{}) -> ok | no_return().
+continue(#shell{conn = Conn} = State) ->
+    case roadrunner_quic_conn_state:phase(Conn) of
+        closed -> ok;
+        _ -> loop(State)
     end.
 
 %% Run a fired timer only when its ref is still the armed one; a stale fire

--- a/src/roadrunner_quic_connection.erl
+++ b/src/roadrunner_quic_connection.erl
@@ -18,10 +18,12 @@
 %% that was re-armed before firing) are dropped by a reference match.
 %%
 %% Synchronous control calls from the owner or listener arrive as
-%% `{quic_call, From, Ref, Request}` and are answered with a `{reply, From,
-%% Ref, Result}` effect; owner notifications go out as async `{emit, Owner,
-%% Event}` effects (`Owner ! {quic, self(), Event}`). The connection only
-%% ever sends to the owner asynchronously, so it never blocks on it.
+%% `{quic_call, From, Ref, Request}` and stream writes as `{quic_send, From,
+%% Ref, Sid, IoData, Fin}`; both are answered with a `{reply, From, Ref,
+%% Result}` effect (delivered as `From ! {quic_reply, Ref, Result}`). Owner
+%% notifications go out as async `{emit, Owner, Event}` effects (`Owner !
+%% {quic, self(), Event}`). The connection only ever sends to the owner
+%% asynchronously, so it never blocks on it.
 
 -export([start/2]).
 -export([init/2]).
@@ -75,6 +77,12 @@ loop(State) ->
             Now = erlang:monotonic_time(millisecond),
             {Conn, Effects} = roadrunner_quic_conn_state:handle_call(
                 From, Ref, Request, State#shell.conn
+            ),
+            loop(perform(Effects, Now, State#shell{conn = Conn}));
+        {quic_send, From, Ref, Sid, IoData, Fin} ->
+            Now = erlang:monotonic_time(millisecond),
+            {Conn, Effects} = roadrunner_quic_conn_state:handle_send(
+                From, Ref, Sid, IoData, Fin, Now, State#shell.conn
             ),
             loop(perform(Effects, Now, State#shell{conn = Conn}));
         {quic_datagram, _Peer, Datagram} ->

--- a/src/roadrunner_quic_connection.erl
+++ b/src/roadrunner_quic_connection.erl
@@ -1,0 +1,113 @@
+-module(roadrunner_quic_connection).
+-moduledoc false.
+
+%% The thin proc_lib shell over the pure `roadrunner_quic_conn_state`
+%% decision core (a hand-rolled receive loop, never a gen_statem, mirroring
+%% `roadrunner_conn_loop_http2`). The core owns the whole connection state
+%% and every decision; this shell owns only the irreducible I/O: the shared
+%% UDP socket handle (for sending), the peer address, the conn_state value,
+%% and the single loss/PTO timer.
+%%
+%% The QUIC socket is passive and shared across connections (SO_REUSEPORT),
+%% so the shell never reads it. The listener reads the socket and routes
+%% each datagram to the owning connection as a `{quic_datagram, Peer,
+%% Bytes}` message; the shell only sends on the socket. Every message drives
+%% one conn_state entry point, and the returned effects are performed here:
+%% `{send, Datagram}` goes out the socket to the peer, and `{arm_timer,
+%% Kind, AtMs}` (re)arms a self-tagged timer whose stale fires (from a timer
+%% that was re-armed before firing) are dropped by a reference match.
+
+-export([start/2]).
+-export([init/2]).
+
+-record(shell, {
+    socket :: roadrunner_quic_socket:socket(),
+    peer :: {inet:ip_address(), inet:port_number()},
+    conn :: roadrunner_quic_conn_state:t(),
+    timer :: reference() | undefined
+}).
+
+%% =============================================================================
+%% Start
+%% =============================================================================
+
+-doc """
+Spawn a connection shell over the (shared) socket for the given
+per-connection config. The first Initial arrives later as a
+`{quic_datagram, _, _}` message, the same as every subsequent datagram.
+""".
+-spec start(roadrunner_quic_socket:socket(), roadrunner_quic_conn_state:config()) -> {ok, pid()}.
+start(Socket, Config) ->
+    {ok, proc_lib:spawn_opt(?MODULE, init, [Socket, Config], [])}.
+
+-doc false.
+-spec init(roadrunner_quic_socket:socket(), roadrunner_quic_conn_state:config()) -> no_return().
+init(Socket, #{peer := Peer} = Config) ->
+    proc_lib:set_label({?MODULE, Peer}),
+    loop(#shell{
+        socket = Socket,
+        peer = Peer,
+        conn = roadrunner_quic_conn_state:new(Config),
+        timer = undefined
+    }).
+
+%% =============================================================================
+%% Loop
+%% =============================================================================
+
+-spec loop(#shell{}) -> no_return().
+loop(State) ->
+    receive
+        {system, From, Req} ->
+            roadrunner_loop_sys:handle_system(Req, From, State, fun loop/1);
+        {'$gen_call', From, _Request} ->
+            ok = roadrunner_loop_sys:gen_call_unsupported(From),
+            loop(State);
+        {'$gen_cast', _Request} ->
+            loop(State);
+        {quic_datagram, _Peer, Datagram} ->
+            Now = erlang:monotonic_time(millisecond),
+            {Conn, Effects} = roadrunner_quic_conn_state:handle_datagram(
+                Now, Datagram, State#shell.conn
+            ),
+            loop(perform(Effects, Now, State#shell{conn = Conn}));
+        {?MODULE, timer, Kind, Ref} ->
+            loop(fire_timer(Ref, Kind, State));
+        _Other ->
+            loop(State)
+    end.
+
+%% Run a fired timer only when its ref is still the armed one; a stale fire
+%% (the timer was re-armed before this message was delivered) is dropped.
+-spec fire_timer(reference(), atom(), #shell{}) -> #shell{}.
+fire_timer(Ref, Kind, #shell{timer = Ref, conn = Conn} = State) ->
+    Now = erlang:monotonic_time(millisecond),
+    {Conn1, Effects} = roadrunner_quic_conn_state:handle_timeout(Now, Kind, Conn),
+    perform(Effects, Now, State#shell{conn = Conn1, timer = undefined});
+fire_timer(_Ref, _Kind, State) ->
+    State.
+
+%% =============================================================================
+%% Effects
+%% =============================================================================
+
+-spec perform([roadrunner_quic_conn_state:effect()], integer(), #shell{}) -> #shell{}.
+perform(Effects, Now, State) ->
+    lists:foldl(fun(Effect, Acc) -> perform_effect(Effect, Now, Acc) end, State, Effects).
+
+-spec perform_effect(roadrunner_quic_conn_state:effect(), integer(), #shell{}) -> #shell{}.
+perform_effect({send, Datagram}, _Now, #shell{socket = Socket, peer = {Ip, Port}} = State) ->
+    _ = roadrunner_quic_socket:send(Socket, Ip, Port, Datagram),
+    State;
+perform_effect({arm_timer, Kind, AtMs}, Now, #shell{timer = Prev} = State) ->
+    _ = cancel(Prev),
+    Ref = make_ref(),
+    _ = erlang:send_after(max(0, AtMs - Now), self(), {?MODULE, timer, Kind, Ref}),
+    State#shell{timer = Ref}.
+
+-spec cancel(reference() | undefined) -> ok.
+cancel(undefined) ->
+    ok;
+cancel(Ref) ->
+    _ = erlang:cancel_timer(Ref),
+    ok.

--- a/src/roadrunner_quic_connection.erl
+++ b/src/roadrunner_quic_connection.erl
@@ -56,7 +56,7 @@ init(Socket, #{peer := Peer} = Config) ->
     loop(#shell{
         socket = Socket,
         peer = Peer,
-        conn = roadrunner_quic_conn_state:new(Config),
+        conn = roadrunner_quic_conn_state:new(Config, erlang:monotonic_time(millisecond)),
         timer = undefined
     }).
 

--- a/src/roadrunner_quic_send.erl
+++ b/src/roadrunner_quic_send.erl
@@ -36,6 +36,9 @@
 %% frames so the loop can retransmit them if it is later declared lost.
 
 -export([datagram/3]).
+%% Exported for the connection loop's ack-tracking and loss-retransmit
+%% decisions: the single source of truth for which frames are ack-eliciting.
+-export([ack_eliciting/1, is_ack_eliciting/1]).
 
 -export_type([level/0, entry/0, sent/0]).
 
@@ -166,10 +169,14 @@ pad_datagram(Datagram, _Entries) ->
 
 %% A packet is ack-eliciting if it carries any frame other than PADDING,
 %% ACK, or CONNECTION_CLOSE (RFC 9002 §2).
+-doc false.
 -spec ack_eliciting([roadrunner_quic_frame:frame()]) -> boolean().
 ack_eliciting(Frames) ->
     lists:any(fun is_ack_eliciting/1, Frames).
 
+%% A single frame is ack-eliciting unless it is PADDING, ACK, or
+%% CONNECTION_CLOSE.
+-doc false.
 -spec is_ack_eliciting(roadrunner_quic_frame:frame()) -> boolean().
 is_ack_eliciting(padding) -> false;
 is_ack_eliciting({ack, _, _, _, _, _}) -> false;

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -18,6 +18,8 @@
 -define(SCID, <<8, 7, 6, 5, 4, 3, 2, 1>>).
 -define(PEER, {{127, 0, 0, 1}, 12345}).
 -define(NOW, 1000).
+%% Must match roadrunner_quic_conn_state's ?IDLE_TIMEOUT default.
+-define(IDLE_TIMEOUT, 30000).
 
 %% =============================================================================
 %% Construction
@@ -256,6 +258,52 @@ amplification_limit_caps_first_flight_test() ->
     {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State0),
     ?assertEqual(handshaking, ?M:phase(State1)),
     ?assert(lists:sum([byte_size(D) || D <- sends(Effects)]) =< 3 * 1200).
+
+idle_timeout_closes_test() ->
+    %% A fired idle timer silently closes the connection (RFC 9000 §10.1, no
+    %% CONNECTION_CLOSE) and surfaces {closed, {local, idle_timeout}}.
+    {State, _ApSecret} = connected_with_owner(),
+    {State1, Effects} = ?M:handle_timeout(?NOW, idle, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, idle_timeout}}}], emits(Effects)),
+    ?assertEqual([], sends(Effects)).
+
+idle_timer_armed_when_nothing_in_flight_test() ->
+    %% With no ack-eliciting bytes in flight (the peer just acknowledged the
+    %% server's HANDSHAKE_DONE), the idle deadline (Now + ?IDLE_TIMEOUT) is the
+    %% nearest, and only, timer armed.
+    {State, ApSecret} = connected_with_owner(),
+    Ack = app_datagram([{ack, 0, 0, 0, [], undefined}], 0, ApSecret),
+    {_State1, Effects} = ?M:handle_datagram(?NOW, Ack, State),
+    ?assertEqual([?NOW + ?IDLE_TIMEOUT], [At || {arm_timer, idle, At} <- Effects]).
+
+idle_deadline_reset_on_receive_test() ->
+    %% Each received datagram pushes the idle deadline to that datagram's Now +
+    %% ?IDLE_TIMEOUT (RFC 9000 §10.1 reset-on-receive), proving the reset moved
+    %% the deadline rather than leaving the birth anchor.
+    {State, ApSecret} = connected_with_owner(),
+    Later = ?NOW + 5000,
+    Ack = app_datagram([{ack, 0, 0, 0, [], undefined}], 0, ApSecret),
+    {_State1, Effects} = ?M:handle_datagram(Later, Ack, State),
+    ?assertEqual([Later + ?IDLE_TIMEOUT], [At || {arm_timer, idle, At} <- Effects]).
+
+idle_timer_armed_after_pto_backoff_test() ->
+    %% With data in flight the probe timer is nearer (armed FIRST); only once
+    %% repeated probe backoffs push the PTO deadline past the idle deadline is
+    %% the idle timer armed instead.
+    {State, _ApSecret} = connected_with_owner(),
+    {State1, Effects1} = ?M:handle_timeout(?NOW, pto, State),
+    ?assertNotEqual([], [At || {arm_timer, pto, At} <- Effects1]),
+    ?assertNotEqual([], drive_until_idle_armed(State1, 12)).
+
+drive_until_idle_armed(_State, 0) ->
+    [];
+drive_until_idle_armed(State, N) ->
+    {State1, Effects} = ?M:handle_timeout(?NOW, pto, State),
+    case [At || {arm_timer, idle, At} <- Effects] of
+        [] -> drive_until_idle_armed(State1, N - 1);
+        Idle -> Idle
+    end.
 
 %% =============================================================================
 %% Control calls + owner notification
@@ -746,18 +794,21 @@ new_conn(CertChain) ->
     {ClientPub, ClientPriv} = ?TC:gen_keypair(),
     {ServerPub, ServerPriv} = ?TC:gen_keypair(),
     TransportParams = transport_params(),
-    State = ?M:new(#{
-        dcid => ?DCID,
-        scid => ?SCID,
-        peer => ?PEER,
-        cert_chain => CertChain,
-        priv_key => PrivKey,
-        alpn => ~"h3",
-        transport_params => TransportParams,
-        eph_pub => ServerPub,
-        eph_priv => ServerPriv,
-        server_random => crypto:strong_rand_bytes(32)
-    }),
+    State = ?M:new(
+        #{
+            dcid => ?DCID,
+            scid => ?SCID,
+            peer => ?PEER,
+            cert_chain => CertChain,
+            priv_key => PrivKey,
+            alpn => ~"h3",
+            transport_params => TransportParams,
+            eph_pub => ServerPub,
+            eph_priv => ServerPriv,
+            server_random => crypto:strong_rand_bytes(32)
+        },
+        ?NOW
+    ),
     {State, #{
         scheme => Scheme,
         client_pub => ClientPub,

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -158,31 +158,31 @@ packet_for_discarded_space_ignored_test() ->
     {State2, _Effects} = ?M:handle_datagram(?NOW, <<Finished/binary, Trailing/binary>>, State1),
     ?assertEqual(connected, ?M:phase(State2)).
 
-tampered_client_finished_is_connection_fatal_test() ->
-    %% A forged Finished fails verification: a connection-fatal protocol
-    %% error (the graceful CONNECTION_CLOSE response is the teardown slice).
+tampered_client_finished_closes_test() ->
+    %% A forged Finished fails verification: the connection closes gracefully
+    %% with {closed, {local, handshake_failure}} rather than crashing.
     #{state1 := State1, client_hs_secret := ClientHsSecret, cf_framed := ClientFinished} = connect(),
     <<Type, Len:24, First, Rest/binary>> = ClientFinished,
     Tampered = <<Type, Len:24, (First bxor 1), Rest/binary>>,
     HsKeys = roadrunner_quic_keys:traffic_keys(ClientHsSecret),
     Datagram = ?TC:seal(handshake, 0, HsKeys, [{crypto, 0, Tampered}], ?DCID, ?SCID),
-    ?assertError(
-        {quic_connection_error, handshake_failure}, ?M:handle_datagram(?NOW, Datagram, State1)
-    ).
+    {State2, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State1)),
+    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual([{emit, self(), {closed, {local, handshake_failure}}}], emits(Effects)).
 
-malformed_client_hello_is_connection_fatal_test() ->
-    %% A ClientHello body the TLS layer cannot parse is connection-fatal.
+malformed_client_hello_closes_test() ->
+    %% A ClientHello body the TLS layer cannot parse closes the connection.
     {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
     Garbage = iolist_to_binary(roadrunner_quic_tls_handshake:encode(?CLIENT_HELLO, ~"not a hello")),
     Datagram = ?TC:seal(
         initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Garbage}], ?DCID, ?SCID
     ),
-    ?assertError(
-        {quic_connection_error, malformed_client_hello}, ?M:handle_datagram(?NOW, Datagram, State0)
-    ).
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State0)),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, malformed_client_hello}}}], emits(Effects)).
 
-unexpected_handshake_message_is_connection_fatal_test() ->
-    %% An out-of-sequence handshake message type is connection-fatal.
+unexpected_handshake_message_closes_test() ->
+    %% An out-of-sequence handshake message type closes the connection.
     {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
     Unexpected = iolist_to_binary(roadrunner_quic_tls_handshake:encode(?FINISHED, <<>>)),
     Datagram = ?TC:seal(
@@ -193,9 +193,35 @@ unexpected_handshake_message_is_connection_fatal_test() ->
         ?DCID,
         ?SCID
     ),
-    ?assertError(
-        {quic_connection_error, unexpected_message}, ?M:handle_datagram(?NOW, Datagram, State0)
-    ).
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State0)),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, unexpected_message}}}], emits(Effects)).
+
+application_close_at_initial_level_closes_test() ->
+    %% An application-variant CONNECTION_CLOSE (0x1d) decoded from an Initial
+    %% packet is a protocol violation (RFC 9000 §19.19, 0x1d is 1-RTT only):
+    %% the connection closes with {closed, {local, protocol_violation}}.
+    {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
+    Datagram = ?TC:seal(
+        initial,
+        0,
+        roadrunner_quic_keys:initial_client(?DCID),
+        [{connection_close, application, 7, undefined, <<>>}],
+        ?DCID,
+        ?SCID
+    ),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State0)),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, protocol_violation}}}], emits(Effects)).
+
+application_close_at_1rtt_closes_test() ->
+    %% An application-variant CONNECTION_CLOSE (0x1d) is legal at 1-RTT (an h3
+    %% client's graceful close) and surfaces {closed, {peer, ErrorCode}}.
+    {State, ApSecret} = connected_with_owner(),
+    Close = app_datagram([{connection_close, application, 9, undefined, <<>>}], 0, ApSecret),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Close, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {peer, 9}}}], emits(Effects)).
 
 %% =============================================================================
 %% Timers and anti-amplification
@@ -341,21 +367,26 @@ out_of_order_stream_not_delivered_test() ->
     {_State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State),
     ?assertEqual([{emit, self(), {stream_opened, 0}}], emits(Effects)).
 
-stream_on_server_initiated_id_is_connection_fatal_test() ->
+stream_on_server_initiated_id_closes_test() ->
     %% A peer STREAM on a server-initiated id (rem 4 == 3, a send-only stream
-    %% from the peer) is an RFC 9000 §19.8 STREAM_STATE_ERROR, not delivered.
+    %% from the peer) is an RFC 9000 §19.8 STREAM_STATE_ERROR: the connection
+    %% closes rather than delivering the data.
     {State, ApSecret} = connected_with_owner(),
     Bad = app_datagram([{stream, 3, 0, ~"x", true}], 0, ApSecret),
-    ?assertError({quic_connection_error, stream_state_error}, ?M:handle_datagram(?NOW, Bad, State)).
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, stream_state_error}}}], emits(Effects)).
 
-reset_stream_on_server_initiated_id_is_connection_fatal_test() ->
+reset_stream_on_server_initiated_id_closes_test() ->
     %% A RESET_STREAM on a server-initiated id (rem 4 == 1) is likewise an
     %% RFC 9000 §19.4 STREAM_STATE_ERROR.
     {State, ApSecret} = connected_with_owner(),
     Bad = app_datagram([{reset_stream, 1, 7, 0}], 0, ApSecret),
-    ?assertError({quic_connection_error, stream_state_error}, ?M:handle_datagram(?NOW, Bad, State)).
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, stream_state_error}}}], emits(Effects)).
 
-stream_final_size_violation_is_connection_fatal_test() ->
+stream_final_size_violation_closes_test() ->
     %% A FIN declaring a final size below the bytes already received is an
     %% RFC 9000 §4.5 connection error.
     {State, ApSecret} = connected_with_owner(),
@@ -363,9 +394,11 @@ stream_final_size_violation_is_connection_fatal_test() ->
         ?NOW, app_datagram([{stream, 0, 0, ~"hello", false}], 0, ApSecret), State
     ),
     Bad = app_datagram([{stream, 0, 0, <<>>, true}], 1, ApSecret),
-    ?assertError({quic_connection_error, final_size_error}, ?M:handle_datagram(?NOW, Bad, State1)).
+    {State2, Effects} = ?M:handle_datagram(?NOW, Bad, State1),
+    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual([{emit, self(), {closed, {local, final_size_error}}}], emits(Effects)).
 
-reset_final_size_violation_is_connection_fatal_test() ->
+reset_final_size_violation_closes_test() ->
     %% A RESET_STREAM final size below the bytes already received is likewise
     %% an RFC 9000 §4.5 connection error.
     {State, ApSecret} = connected_with_owner(),
@@ -373,16 +406,20 @@ reset_final_size_violation_is_connection_fatal_test() ->
         ?NOW, app_datagram([{stream, 0, 0, ~"hello", false}], 0, ApSecret), State
     ),
     Bad = app_datagram([{reset_stream, 0, 7, 2}], 1, ApSecret),
-    ?assertError({quic_connection_error, final_size_error}, ?M:handle_datagram(?NOW, Bad, State1)).
+    {State2, Effects} = ?M:handle_datagram(?NOW, Bad, State1),
+    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual([{emit, self(), {closed, {local, final_size_error}}}], emits(Effects)).
 
-stream_over_connection_flow_limit_is_connection_fatal_test() ->
+stream_over_connection_flow_limit_closes_test() ->
     %% A peer STREAM whose highest offset exceeds the connection's
     %% 786432-byte receive window is an RFC 9000 §4.1 flow-control connection
     %% error.
     {State, ApSecret} = connected_with_owner(),
     Oversized = binary:copy(~"x", 786433),
     Bad = app_datagram([{stream, 0, 0, Oversized, false}], 0, ApSecret),
-    ?assertError({quic_connection_error, flow_control_error}, ?M:handle_datagram(?NOW, Bad, State)).
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, flow_control_error}}}], emits(Effects)).
 
 stream_retransmit_does_not_re_consume_flow_test() ->
     %% Flow control is charged by the increase in the highest received offset,
@@ -535,6 +572,22 @@ frames_after_connection_close_are_ignored_test() ->
     ?assertEqual(closed, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {peer, 7}}}], emits(Effects)).
 
+peer_handshake_level_close_test() ->
+    %% A transport CONNECTION_CLOSE at the Handshake level (the peer aborting
+    %% mid-handshake) closes the connection just like a 1-RTT one.
+    #{state1 := State1, client_hs_secret := ClientHsSecret} = connect(),
+    Close = ?TC:seal(
+        handshake,
+        0,
+        roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+        [{connection_close, transport, 2, 0, <<>>}],
+        ?DCID,
+        ?SCID
+    ),
+    {State2, Effects} = ?M:handle_datagram(?NOW, Close, with_owner(State1)),
+    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual([{emit, self(), {closed, {peer, 2}}}], emits(Effects)).
+
 %% =============================================================================
 %% Handshake driver (plays the QUIC client with the shared test client)
 %% =============================================================================
@@ -665,6 +718,12 @@ transport_params() ->
 %% The connected payload conn_state caches at new/1 (alpn + advertised params).
 expected_info() ->
     #{alpn => ~"h3", transport_params => transport_params()}.
+
+%% Install this process as the owner (no emit while handshaking) so a later
+%% close surfaces {closed, _} here.
+with_owner(State) ->
+    {State1, _} = ?M:handle_call(self(), make_ref(), {set_owner, self()}, State),
+    State1.
 
 %% Drive to connected with this process installed as owner (set during
 %% handshaking, the normal ordering). Returns the state plus both application

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -6,6 +6,7 @@
 -define(TC, roadrunner_quic_test_client).
 
 %% TLS handshake message types asserted on (RFC 8446 §4).
+-define(CLIENT_HELLO, 1).
 -define(ENCRYPTED_EXTENSIONS, 8).
 -define(CERTIFICATE, 11).
 -define(CERTIFICATE_VERIFY, 15).
@@ -157,16 +158,44 @@ packet_for_discarded_space_ignored_test() ->
     {State2, _Effects} = ?M:handle_datagram(?NOW, <<Finished/binary, Trailing/binary>>, State1),
     ?assertEqual(connected, ?M:phase(State2)).
 
-tampered_client_finished_crashes_test() ->
-    %% A forged Finished fails verification; the decision core lets it crash
-    %% rather than reaching `connected` (no graceful handshake-failure path
-    %% in v1).
+tampered_client_finished_is_connection_fatal_test() ->
+    %% A forged Finished fails verification: a connection-fatal protocol
+    %% error (the graceful CONNECTION_CLOSE response is the teardown slice).
     #{state1 := State1, client_hs_secret := ClientHsSecret, cf_framed := ClientFinished} = connect(),
     <<Type, Len:24, First, Rest/binary>> = ClientFinished,
     Tampered = <<Type, Len:24, (First bxor 1), Rest/binary>>,
     HsKeys = roadrunner_quic_keys:traffic_keys(ClientHsSecret),
     Datagram = ?TC:seal(handshake, 0, HsKeys, [{crypto, 0, Tampered}], ?DCID, ?SCID),
-    ?assertError(_, ?M:handle_datagram(?NOW, Datagram, State1)).
+    ?assertError(
+        {quic_connection_error, handshake_failure}, ?M:handle_datagram(?NOW, Datagram, State1)
+    ).
+
+malformed_client_hello_is_connection_fatal_test() ->
+    %% A ClientHello body the TLS layer cannot parse is connection-fatal.
+    {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
+    Garbage = iolist_to_binary(roadrunner_quic_tls_handshake:encode(?CLIENT_HELLO, ~"not a hello")),
+    Datagram = ?TC:seal(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Garbage}], ?DCID, ?SCID
+    ),
+    ?assertError(
+        {quic_connection_error, malformed_client_hello}, ?M:handle_datagram(?NOW, Datagram, State0)
+    ).
+
+unexpected_handshake_message_is_connection_fatal_test() ->
+    %% An out-of-sequence handshake message type is connection-fatal.
+    {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
+    Unexpected = iolist_to_binary(roadrunner_quic_tls_handshake:encode(?FINISHED, <<>>)),
+    Datagram = ?TC:seal(
+        initial,
+        0,
+        roadrunner_quic_keys:initial_client(?DCID),
+        [{crypto, 0, Unexpected}],
+        ?DCID,
+        ?SCID
+    ),
+    ?assertError(
+        {quic_connection_error, unexpected_message}, ?M:handle_datagram(?NOW, Datagram, State0)
+    ).
 
 %% =============================================================================
 %% Timers and anti-amplification
@@ -264,6 +293,151 @@ connected_not_re_emitted_on_later_datagram_test() ->
     ),
     {_State3, LaterEffects} = ?M:handle_datagram(?NOW, AppPing, State2),
     ?assertEqual([], emits(LaterEffects)).
+
+%% =============================================================================
+%% Application streams (receive side)
+%% =============================================================================
+
+stream_data_emitted_test() ->
+    {State, ApSecret} = connected_with_owner(),
+    Datagram = app_datagram([{stream, 0, 0, ~"hello", true}], 0, ApSecret),
+    {_State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State),
+    ?assertEqual(
+        [{emit, self(), {stream_opened, 0}}, {emit, self(), {stream_data, 0, ~"hello", true}}],
+        emits(Effects)
+    ).
+
+stream_fin_only_emitted_test() ->
+    %% Data first (no FIN), then a FIN-only frame at the final offset yields
+    %% the {<<>>, true} end-of-stream the h3 layer dispatches on.
+    {State, ApSecret} = connected_with_owner(),
+    {State1, E1} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 0, ~"hi", false}], 0, ApSecret), State
+    ),
+    ?assertEqual(
+        [{emit, self(), {stream_opened, 0}}, {emit, self(), {stream_data, 0, ~"hi", false}}],
+        emits(E1)
+    ),
+    {_State2, E2} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 2, <<>>, true}], 1, ApSecret), State1
+    ),
+    ?assertEqual([{emit, self(), {stream_data, 0, <<>>, true}}], emits(E2)).
+
+stream_reset_emitted_test() ->
+    {State, ApSecret} = connected_with_owner(),
+    {State1, _} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 0, ~"hi", false}], 0, ApSecret), State
+    ),
+    {_State2, Effects} = ?M:handle_datagram(
+        ?NOW, app_datagram([{reset_stream, 0, 7, 2}], 1, ApSecret), State1
+    ),
+    ?assertEqual([{emit, self(), {stream_reset, 0, 7}}], emits(Effects)).
+
+out_of_order_stream_not_delivered_test() ->
+    %% A gap frame (offset ahead of the read cursor) buffers without
+    %% delivering, so only stream_opened is emitted.
+    {State, ApSecret} = connected_with_owner(),
+    Datagram = app_datagram([{stream, 0, 5, ~"x", false}], 0, ApSecret),
+    {_State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State),
+    ?assertEqual([{emit, self(), {stream_opened, 0}}], emits(Effects)).
+
+stream_on_server_initiated_id_is_connection_fatal_test() ->
+    %% A peer STREAM on a server-initiated id (rem 4 == 3, a send-only stream
+    %% from the peer) is an RFC 9000 §19.8 STREAM_STATE_ERROR, not delivered.
+    {State, ApSecret} = connected_with_owner(),
+    Bad = app_datagram([{stream, 3, 0, ~"x", true}], 0, ApSecret),
+    ?assertError({quic_connection_error, stream_state_error}, ?M:handle_datagram(?NOW, Bad, State)).
+
+reset_stream_on_server_initiated_id_is_connection_fatal_test() ->
+    %% A RESET_STREAM on a server-initiated id (rem 4 == 1) is likewise an
+    %% RFC 9000 §19.4 STREAM_STATE_ERROR.
+    {State, ApSecret} = connected_with_owner(),
+    Bad = app_datagram([{reset_stream, 1, 7, 0}], 0, ApSecret),
+    ?assertError({quic_connection_error, stream_state_error}, ?M:handle_datagram(?NOW, Bad, State)).
+
+stream_final_size_violation_is_connection_fatal_test() ->
+    %% A FIN declaring a final size below the bytes already received is an
+    %% RFC 9000 §4.5 connection error.
+    {State, ApSecret} = connected_with_owner(),
+    {State1, _} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 0, ~"hello", false}], 0, ApSecret), State
+    ),
+    Bad = app_datagram([{stream, 0, 0, <<>>, true}], 1, ApSecret),
+    ?assertError({quic_connection_error, final_size_error}, ?M:handle_datagram(?NOW, Bad, State1)).
+
+reset_final_size_violation_is_connection_fatal_test() ->
+    %% A RESET_STREAM final size below the bytes already received is likewise
+    %% an RFC 9000 §4.5 connection error.
+    {State, ApSecret} = connected_with_owner(),
+    {State1, _} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 0, ~"hello", false}], 0, ApSecret), State
+    ),
+    Bad = app_datagram([{reset_stream, 0, 7, 2}], 1, ApSecret),
+    ?assertError({quic_connection_error, final_size_error}, ?M:handle_datagram(?NOW, Bad, State1)).
+
+stream_over_connection_flow_limit_is_connection_fatal_test() ->
+    %% A peer STREAM whose highest offset exceeds the connection's
+    %% 786432-byte receive window is an RFC 9000 §4.1 flow-control connection
+    %% error.
+    {State, ApSecret} = connected_with_owner(),
+    Oversized = binary:copy(~"x", 786433),
+    Bad = app_datagram([{stream, 0, 0, Oversized, false}], 0, ApSecret),
+    ?assertError({quic_connection_error, flow_control_error}, ?M:handle_datagram(?NOW, Bad, State)).
+
+stream_retransmit_does_not_re_consume_flow_test() ->
+    %% Flow control is charged by the increase in the highest received offset,
+    %% so resending bytes already received does not re-consume the connection
+    %% window (RFC 9000 §4.1) even when the raw byte sum exceeds it; the
+    %% duplicate also delivers no new stream_data.
+    {State, ApSecret} = connected_with_owner(),
+    Chunk = binary:copy(~"x", 500000),
+    {State1, _} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 0, Chunk, false}], 0, ApSecret), State
+    ),
+    {State2, Effects} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 0, Chunk, false}], 1, ApSecret), State1
+    ),
+    ?assertEqual(connected, ?M:phase(State2)),
+    ?assertEqual([], emits(Effects)).
+
+connected_precedes_stream_events_in_coalesced_datagram_test() ->
+    %% A single datagram that coalesces the client Finished (completing the
+    %% handshake) with a 1-RTT STREAM must deliver {connected, _} before the
+    %% stream events, so the owner opens its control stream before the request.
+    #{
+        state1 := State1,
+        client_hs_secret := ClientHsSecret,
+        cf_framed := ClientFinished,
+        client_ap_secret := ClientApSecret
+    } = connect(),
+    Owner = self(),
+    {State1b, _} = ?M:handle_call(Owner, make_ref(), {set_owner, Owner}, State1),
+    Finished = ?TC:seal(
+        handshake,
+        0,
+        roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+        [{crypto, 0, ClientFinished}],
+        ?DCID,
+        ?SCID
+    ),
+    Request = app_datagram([{stream, 0, 0, ~"hi", true}], 0, ClientApSecret),
+    {_State2, Effects} = ?M:handle_datagram(?NOW, <<Finished/binary, Request/binary>>, State1b),
+    ?assertEqual(
+        [
+            {emit, Owner, {connected, expected_info()}},
+            {emit, Owner, {stream_opened, 0}},
+            {emit, Owner, {stream_data, 0, ~"hi", true}}
+        ],
+        emits(Effects)
+    ).
+
+stream_without_owner_not_emitted_test() ->
+    %% A connection that reached connected with no owner installed drops
+    %% stream events rather than crashing.
+    #{state2 := State, client_ap_secret := ApSecret} = connect(),
+    Datagram = app_datagram([{stream, 0, 0, ~"hi", true}], 0, ApSecret),
+    {_State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State),
+    ?assertEqual([], emits(Effects)).
 
 %% =============================================================================
 %% Handshake driver (plays the QUIC client with the shared test client)
@@ -395,6 +569,34 @@ transport_params() ->
 %% The connected payload conn_state caches at new/1 (alpn + advertised params).
 expected_info() ->
     #{alpn => ~"h3", transport_params => transport_params()}.
+
+%% A connected connection with this process installed as owner (set during
+%% handshaking, the normal ordering), plus the client application secret for
+%% sealing peer 1-RTT packets.
+connected_with_owner() ->
+    #{
+        state1 := State1,
+        client_hs_secret := ClientHsSecret,
+        cf_framed := ClientFinished,
+        client_ap_secret := ClientApSecret
+    } = connect(),
+    {State1b, _} = ?M:handle_call(self(), make_ref(), {set_owner, self()}, State1),
+    Finished = ?TC:seal(
+        handshake,
+        0,
+        roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+        [{crypto, 0, ClientFinished}],
+        ?DCID,
+        ?SCID
+    ),
+    {State2, _Effects} = ?M:handle_datagram(?NOW, Finished, State1b),
+    {State2, ClientApSecret}.
+
+%% Seal a peer 1-RTT (application) datagram carrying the given frames.
+app_datagram(Frames, PN, ClientApSecret) ->
+    ?TC:seal(
+        application, PN, roadrunner_quic_keys:traffic_keys(ClientApSecret), Frames, ?DCID, ?SCID
+    ).
 
 emits(Effects) ->
     [Emit || {emit, _Owner, _Event} = Emit <- Effects].

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -1,25 +1,15 @@
 -module(roadrunner_quic_conn_state_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include_lib("public_key/include/public_key.hrl").
 
 -define(M, roadrunner_quic_conn_state).
+-define(TC, roadrunner_quic_test_client).
 
-%% TLS handshake message types (RFC 8446 §4).
--define(CLIENT_HELLO, 1).
--define(SERVER_HELLO, 2).
+%% TLS handshake message types asserted on (RFC 8446 §4).
 -define(ENCRYPTED_EXTENSIONS, 8).
 -define(CERTIFICATE, 11).
 -define(CERTIFICATE_VERIFY, 15).
 -define(FINISHED, 20).
-
-%% ClientHello wire constants (RFC 8446 §4.1.2).
--define(LEGACY_VERSION, 16#0303).
--define(CIPHER_AES_128_GCM_SHA256, 16#1301).
--define(GROUP_X25519, 16#001D).
--define(EXT_SIGNATURE_ALGORITHMS, 16#000D).
--define(EXT_ALPN, 16#0010).
--define(EXT_KEY_SHARE, 16#0033).
 
 %% A fixed client DCID (the server's routing id), an 8-byte server SCID to
 %% match the server's fixed ?SCID_LEN, the peer address, and a clock.
@@ -52,28 +42,32 @@ handshake_reaches_connected_test() ->
 
 server_hello_carries_server_key_share_test() ->
     #{sh_framed := ServerHello, ctx := #{server_pub := ServerPub}} = connect(),
-    ?assertEqual(ServerPub, server_hello_key_share(ServerHello)).
+    ?assertEqual(ServerPub, ?TC:server_hello_key_share(ServerHello)).
 
 server_flight_carries_auth_messages_test() ->
     #{flight := Flight} = connect(),
     ?assertEqual(
         [?ENCRYPTED_EXTENSIONS, ?CERTIFICATE, ?CERTIFICATE_VERIFY, ?FINISHED],
-        [Type || {Type, _Body} <- deframe_all(Flight)]
+        [Type || {Type, _Body} <- ?TC:deframe_all(Flight)]
     ).
 
 initial_reply_acknowledges_client_test() ->
     #{effects1 := Effects1} = connect(),
-    Frames = server_frames(
-        sends(Effects1), initial, #{initial => roadrunner_quic_keys:initial_server(?DCID)}
+    Frames = ?TC:frames(
+        sends(Effects1),
+        initial,
+        #{initial => roadrunner_quic_keys:initial_server(?DCID)},
+        byte_size(?DCID)
     ),
     ?assert(lists:any(fun is_ack/1, Frames)).
 
 handshake_done_emitted_when_connected_test() ->
     #{effects2 := Effects2, server_ap_secret := ServerApSecret} = connect(),
-    Frames = server_frames(
+    Frames = ?TC:frames(
         sends(Effects2),
         application,
-        #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)}
+        #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+        byte_size(?DCID)
     ),
     ?assert(lists:member(handshake_done, Frames)).
 
@@ -85,9 +79,14 @@ client_ack_processed_test() ->
     %% A valid ACK of the server's ServerHello drives loss detection and is
     %% itself not acknowledged (an ACK is not ack-eliciting).
     #{state1 := State1} = connect(),
-    Datagram = seal(initial, 1, roadrunner_quic_keys:initial_client(?DCID), [
-        {ack, 0, 0, 0, [], undefined}
-    ]),
+    Datagram = ?TC:seal(
+        initial,
+        1,
+        roadrunner_quic_keys:initial_client(?DCID),
+        [{ack, 0, 0, 0, [], undefined}],
+        ?DCID,
+        ?SCID
+    ),
     {State2, _Effects} = ?M:handle_datagram(?NOW, Datagram, State1),
     ?assertEqual(handshaking, ?M:phase(State2)).
 
@@ -95,9 +94,14 @@ oversized_ack_range_ignored_test() ->
     %% An ACK claiming more packets than the loss layer accepts is dropped
     %% without disturbing the connection.
     #{state1 := State1} = connect(),
-    Datagram = seal(initial, 1, roadrunner_quic_keys:initial_client(?DCID), [
-        {ack, 70000, 0, 70000, [], undefined}
-    ]),
+    Datagram = ?TC:seal(
+        initial,
+        1,
+        roadrunner_quic_keys:initial_client(?DCID),
+        [{ack, 70000, 0, 70000, [], undefined}],
+        ?DCID,
+        ?SCID
+    ),
     {State2, _Effects} = ?M:handle_datagram(?NOW, Datagram, State1),
     ?assertEqual(handshaking, ?M:phase(State2)).
 
@@ -105,7 +109,9 @@ ping_and_padding_frames_handled_test() ->
     %% A PING (ack-eliciting) padded for the header-protection sample
     %% exercises the catch-all frame handler for both PING and PADDING.
     #{state1 := State1} = connect(),
-    Datagram = seal(initial, 1, roadrunner_quic_keys:initial_client(?DCID), [ping]),
+    Datagram = ?TC:seal(
+        initial, 1, roadrunner_quic_keys:initial_client(?DCID), [ping], ?DCID, ?SCID
+    ),
     {State2, _Effects} = ?M:handle_datagram(?NOW, Datagram, State1),
     ?assertEqual(handshaking, ?M:phase(State2)).
 
@@ -118,7 +124,7 @@ undecryptable_packet_dropped_test() ->
     %% §5.4.2); the connection neither advances nor replies.
     {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
     WrongKeys = #{key => <<0:128>>, iv => <<0:96>>, hp => <<0:128>>},
-    Datagram = seal(initial, 0, WrongKeys, [{crypto, 0, ~"hello"}]),
+    Datagram = ?TC:seal(initial, 0, WrongKeys, [{crypto, 0, ~"hello"}], ?DCID, ?SCID),
     {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State0),
     ?assertEqual(handshaking, ?M:phase(State1)),
     ?assertEqual([], sends(Effects)).
@@ -128,8 +134,13 @@ malformed_frame_ignored_test() ->
     %% connection error the decision core absorbs (a CRYPTO frame claiming
     %% eight bytes but carrying three).
     {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
-    Datagram = seal_raw(
-        initial, 0, roadrunner_quic_keys:initial_client(?DCID), <<16#06, 16#00, 16#08, 1, 2, 3>>
+    Datagram = ?TC:seal_raw(
+        initial,
+        0,
+        roadrunner_quic_keys:initial_client(?DCID),
+        <<16#06, 16#00, 16#08, 1, 2, 3>>,
+        ?DCID,
+        ?SCID
     ),
     {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State0),
     ?assertEqual(handshaking, ?M:phase(State1)),
@@ -141,8 +152,8 @@ packet_for_discarded_space_ignored_test() ->
     %% packet that then lands on the now-absent space.
     #{state1 := State1, client_hs_secret := ClientHsSecret, cf_framed := ClientFinished} = connect(),
     HsKeys = roadrunner_quic_keys:traffic_keys(ClientHsSecret),
-    Finished = seal(handshake, 0, HsKeys, [{crypto, 0, ClientFinished}]),
-    Trailing = seal(handshake, 1, HsKeys, [ping]),
+    Finished = ?TC:seal(handshake, 0, HsKeys, [{crypto, 0, ClientFinished}], ?DCID, ?SCID),
+    Trailing = ?TC:seal(handshake, 1, HsKeys, [ping], ?DCID, ?SCID),
     {State2, _Effects} = ?M:handle_datagram(?NOW, <<Finished/binary, Trailing/binary>>, State1),
     ?assertEqual(connected, ?M:phase(State2)).
 
@@ -154,27 +165,22 @@ tampered_client_finished_crashes_test() ->
     <<Type, Len:24, First, Rest/binary>> = ClientFinished,
     Tampered = <<Type, Len:24, (First bxor 1), Rest/binary>>,
     HsKeys = roadrunner_quic_keys:traffic_keys(ClientHsSecret),
-    Datagram = seal(handshake, 0, HsKeys, [{crypto, 0, Tampered}]),
+    Datagram = ?TC:seal(handshake, 0, HsKeys, [{crypto, 0, Tampered}], ?DCID, ?SCID),
     ?assertError(_, ?M:handle_datagram(?NOW, Datagram, State1)).
 
 %% =============================================================================
 %% Timers and anti-amplification
 %% =============================================================================
 
-pto_timeout_rearms_loss_timer_test() ->
-    %% A PTO fire re-runs loss detection across every live space and rearms
-    %% the loss timer from the oldest unacknowledged packet.
+pto_backoff_advances_deadline_test() ->
+    %% Each probe timeout that detects no loss must re-arm strictly later
+    %% (RFC 9002 §6.2.1 exponential backoff), never re-fire at the same past
+    %% deadline. Two fires at the same clock prove the deadline advances, so
+    %% the shell never busy-spins on send_after(0).
     #{state1 := State1} = connect(),
-    {_State2, Effects} = ?M:handle_timeout(?NOW + 100000, pto, State1),
-    ?assert(
-        lists:any(
-            fun
-                ({arm_timer, pto, _AtMs}) -> true;
-                (_) -> false
-            end,
-            Effects
-        )
-    ).
+    {State2, Effects1} = ?M:handle_timeout(?NOW, pto, State1),
+    {_State3, Effects2} = ?M:handle_timeout(?NOW, pto, State2),
+    ?assert(arm_deadline(Effects2) > arm_deadline(Effects1)).
 
 amplification_limit_caps_first_flight_test() ->
     %% A large certificate chain makes the server flight exceed 3x the
@@ -188,7 +194,7 @@ amplification_limit_caps_first_flight_test() ->
     ?assert(lists:sum([byte_size(D) || D <- sends(Effects)]) =< 3 * 1200).
 
 %% =============================================================================
-%% Handshake driver (plays the QUIC client with the merged leaves)
+%% Handshake driver (plays the QUIC client with the shared test client)
 %% =============================================================================
 
 %% Run a full RSA handshake against a fresh connection and return every
@@ -203,8 +209,8 @@ connect() ->
     Server1 = sends(Effects1),
 
     %% Recover the ServerHello and derive the handshake secrets.
-    ServerHello = server_crypto(
-        Server1, initial, #{initial => roadrunner_quic_keys:initial_server(?DCID)}
+    ServerHello = ?TC:crypto_bytes(
+        Server1, initial, #{initial => roadrunner_quic_keys:initial_server(?DCID)}, byte_size(?DCID)
     ),
     Shared = crypto:compute_key(ecdh, ServerPub, ClientPriv, x25519),
     HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
@@ -219,8 +225,11 @@ connect() ->
     ),
 
     %% Recover the server's authentication flight.
-    Flight = server_crypto(
-        Server1, handshake, #{handshake => roadrunner_quic_keys:traffic_keys(ServerHsSecret)}
+    Flight = ?TC:crypto_bytes(
+        Server1,
+        handshake,
+        #{handshake => roadrunner_quic_keys:traffic_keys(ServerHsSecret)},
+        byte_size(?DCID)
     ),
     FinishedHash = roadrunner_quic_tls_crypto:transcript_hash([
         ClientHelloFramed, ServerHello, Flight
@@ -233,11 +242,13 @@ connect() ->
     ClientFinishedFramed = iolist_to_binary(
         roadrunner_quic_tls_handshake:encode(?FINISHED, ClientFinishedBody)
     ),
-    HandshakeDatagram = seal(
+    HandshakeDatagram = ?TC:seal(
         handshake,
         0,
         roadrunner_quic_keys:traffic_keys(ClientHsSecret),
-        [{crypto, 0, ClientFinishedFramed}]
+        [{crypto, 0, ClientFinishedFramed}],
+        ?DCID,
+        ?SCID
     ),
     {State2, Effects2} = ?M:handle_datagram(?NOW, HandshakeDatagram, State1),
 
@@ -263,9 +274,9 @@ connect() ->
 
 %% A fresh server connection plus the client material the driver reuses.
 new_conn(CertChain) ->
-    {Scheme, PrivKey, _VerifyKey, _SigInputs} = key_material(rsa),
-    {ClientPub, ClientPriv} = crypto:generate_key(ecdh, x25519),
-    {ServerPub, ServerPriv} = crypto:generate_key(ecdh, x25519),
+    {Scheme, PrivKey} = ?TC:key_material(),
+    {ClientPub, ClientPriv} = ?TC:gen_keypair(),
+    {ServerPub, ServerPriv} = ?TC:gen_keypair(),
     TransportParams = #{
         original_destination_connection_id => ?DCID,
         initial_source_connection_id => ?SCID
@@ -292,119 +303,18 @@ new_conn(CertChain) ->
 %% The client Initial datagram and the framed ClientHello it carries (the
 %% first transcript element).
 client_hello_datagram(#{scheme := Scheme, client_pub := ClientPub}) ->
-    Body = client_hello_body(#{
-        key_share => ClientPub, sig_algs => [Scheme], alpn => ~"h3", session_id => <<>>
-    }),
-    Framed = iolist_to_binary(roadrunner_quic_tls_handshake:encode(?CLIENT_HELLO, Body)),
-    Datagram = seal(initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}]),
-    {Datagram, Framed}.
-
-%% Build a one-level client datagram through the send pipeline (an Initial
-%% is padded to 1200, so it satisfies the server's anti-amplification
-%% budget).
-seal(Level, PN, Keys, Frames) ->
-    Entries = #{Level => #{frames => Frames, keys => Keys, pn => PN}},
-    {Datagram, _Sent} = roadrunner_quic_send:datagram(Entries, ?DCID, ?SCID),
-    Datagram.
-
-%% Seal raw plaintext (bypassing frame encoding) so a packet can carry a
-%% deliberately malformed frame, mirroring the send path's header sizing.
-seal_raw(Level, PN, #{key := Key, iv := IV, hp := HP}, Plaintext) ->
-    PNLen = roadrunner_quic_packet:pn_length(PN),
-    SealedSize = byte_size(Plaintext) + 16,
-    [Header, _Payload] = roadrunner_quic_packet:encode_long(
-        Level, 1, ?DCID, ?SCID, #{pn => PN, payload => <<0:(SealedSize * 8)>>}
+    Framed = ?TC:client_hello_framed(Scheme, ClientPub),
+    Datagram = ?TC:seal(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}], ?DCID, ?SCID
     ),
-    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
-    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
-    <<Protected/binary, Sealed/binary>>.
+    {Datagram, Framed}.
 
 sends(Effects) ->
     [Datagram || {send, Datagram} <- Effects].
 
-%% Contiguous CRYPTO bytes for a level across the server's datagrams. The
-%% per-level keys map naturally filters out the other levels' packets (they
-%% decode to {drop, no_keys}); with no in-test loss a sorted concat
-%% reassembles the flight.
-server_crypto(Datagrams, Level, Keys) ->
-    Slices = [{Offset, Data} || {crypto, Offset, Data} <- server_frames(Datagrams, Level, Keys)],
-    iolist_to_binary([Data || {_Offset, Data} <- lists:sort(Slices)]).
-
-server_frames(Datagrams, Level, Keys) ->
-    lists:append([level_frames(Datagram, Level, Keys) || Datagram <- Datagrams]).
-
-level_frames(Datagram, Level, Keys) ->
-    Outcomes = roadrunner_quic_recv:datagram(Datagram, byte_size(?DCID), Keys, #{}),
-    lists:append([Frames || {ok, #{level := L, frames := Frames}} <- Outcomes, L =:= Level]).
-
 is_ack({ack, _Largest, _Delay, _First, _Ranges, _Ecn}) -> true;
 is_ack(_Frame) -> false.
 
-%% A generated key pair per scheme plus the crypto:verify inputs for its
-%% public half (mirrors roadrunner_quic_tls_server_tests:key_material/1).
-key_material(rsa) ->
-    #'RSAPrivateKey'{publicExponent = E, modulus = N} =
-        PrivKey = public_key:generate_key({rsa, 2048, 65537}),
-    {16#0804, PrivKey, [E, N],
-        {rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]}}.
-
-%% Build a ClientHello body (RFC 8446 §4.1.2) carrying the requested
-%% extensions; the x25519 key_share is omitted when no key is given.
-client_hello_body(Opts) ->
-    Random = maps:get(random, Opts, crypto:strong_rand_bytes(32)),
-    SessionId = maps:get(session_id, Opts, <<>>),
-    SigAlgs = maps:get(sig_algs, Opts, [16#0804]),
-    Alpn = maps:get(alpn, Opts, ~"h3"),
-    Extensions = iolist_to_binary([
-        signature_algorithms_ext(SigAlgs),
-        alpn_ext(Alpn),
-        key_share_ext(maps:get(key_share, Opts, undefined))
-    ]),
-    CipherSuites = <<?CIPHER_AES_128_GCM_SHA256:16>>,
-    <<?LEGACY_VERSION:16, Random/binary, (byte_size(SessionId)):8, SessionId/binary,
-        (byte_size(CipherSuites)):16, CipherSuites/binary, 1:8, 0:8, (byte_size(Extensions)):16,
-        Extensions/binary>>.
-
-signature_algorithms_ext(Schemes) ->
-    List = <<<<S:16>> || S <- Schemes>>,
-    extension(?EXT_SIGNATURE_ALGORITHMS, <<(byte_size(List)):16, List/binary>>).
-
-alpn_ext(Protocol) ->
-    Entry = <<(byte_size(Protocol)):8, Protocol/binary>>,
-    extension(?EXT_ALPN, <<(byte_size(Entry)):16, Entry/binary>>).
-
-key_share_ext(undefined) ->
-    <<>>;
-key_share_ext(PubKey) ->
-    Entry = <<?GROUP_X25519:16, (byte_size(PubKey)):16, PubKey/binary>>,
-    extension(?EXT_KEY_SHARE, <<(byte_size(Entry)):16, Entry/binary>>).
-
-extension(Type, Data) ->
-    <<Type:16, (byte_size(Data)):16, Data/binary>>.
-
-%% The server's x25519 public key from a ServerHello's key_share extension.
-server_hello_key_share(ServerHello) ->
-    {?SERVER_HELLO, Body} = deframe(ServerHello),
-    <<_LegacyVersion:16, _Random:32/binary, SessionLen:8, _Session:SessionLen/binary, _Cipher:16,
-        _Compression:8, _ExtsLen:16, Extensions/binary>> = Body,
-    <<?GROUP_X25519:16, KeyLen:16, PubKey:KeyLen/binary>> =
-        extract_extension(?EXT_KEY_SHARE, Extensions),
-    PubKey.
-
-extract_extension(Type, <<Type:16, Len:16, Data:Len/binary, _Rest/binary>>) ->
-    Data;
-extract_extension(Type, <<_OtherType:16, Len:16, _Data:Len/binary, Rest/binary>>) ->
-    extract_extension(Type, Rest).
-
-deframe(Iolist) ->
-    {ok, {Type, Body}, <<>>} = roadrunner_quic_tls_handshake:decode(iolist_to_binary(Iolist)),
-    {Type, Body}.
-
-deframe_all(Iolist) ->
-    deframe_all_bin(iolist_to_binary(Iolist)).
-
-deframe_all_bin(<<>>) ->
-    [];
-deframe_all_bin(Bin) ->
-    {ok, {Type, Body}, Rest} = roadrunner_quic_tls_handshake:decode(Bin),
-    [{Type, Body} | deframe_all_bin(Rest)].
+arm_deadline(Effects) ->
+    [AtMs] = [At || {arm_timer, pto, At} <- Effects],
+    AtMs.

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -1,0 +1,410 @@
+-module(roadrunner_quic_conn_state_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
+
+-define(M, roadrunner_quic_conn_state).
+
+%% TLS handshake message types (RFC 8446 §4).
+-define(CLIENT_HELLO, 1).
+-define(SERVER_HELLO, 2).
+-define(ENCRYPTED_EXTENSIONS, 8).
+-define(CERTIFICATE, 11).
+-define(CERTIFICATE_VERIFY, 15).
+-define(FINISHED, 20).
+
+%% ClientHello wire constants (RFC 8446 §4.1.2).
+-define(LEGACY_VERSION, 16#0303).
+-define(CIPHER_AES_128_GCM_SHA256, 16#1301).
+-define(GROUP_X25519, 16#001D).
+-define(EXT_SIGNATURE_ALGORITHMS, 16#000D).
+-define(EXT_ALPN, 16#0010).
+-define(EXT_KEY_SHARE, 16#0033).
+
+%% A fixed client DCID (the server's routing id), an 8-byte server SCID to
+%% match the server's fixed ?SCID_LEN, the peer address, and a clock.
+-define(DCID, <<1, 2, 3, 4, 5, 6, 7, 8>>).
+-define(SCID, <<8, 7, 6, 5, 4, 3, 2, 1>>).
+-define(PEER, {{127, 0, 0, 1}, 12345}).
+-define(NOW, 1000).
+
+%% =============================================================================
+%% Construction
+%% =============================================================================
+
+new_starts_handshaking_test() ->
+    {State, _Ctx} = new_conn([~"leaf-cert-der"]),
+    ?assertEqual(handshaking, ?M:phase(State)).
+
+peername_answers_in_handshaking_test() ->
+    {State, _Ctx} = new_conn([~"leaf-cert-der"]),
+    ?assertEqual({ok, ?PEER}, ?M:peername(State)).
+
+%% =============================================================================
+%% Full handshake: the in-test client completes a real handshake against the
+%% decision core, end to end through the packet/crypto leaves.
+%% =============================================================================
+
+handshake_reaches_connected_test() ->
+    #{state1 := State1, state2 := State2} = connect(),
+    ?assertEqual(handshaking, ?M:phase(State1)),
+    ?assertEqual(connected, ?M:phase(State2)).
+
+server_hello_carries_server_key_share_test() ->
+    #{sh_framed := ServerHello, ctx := #{server_pub := ServerPub}} = connect(),
+    ?assertEqual(ServerPub, server_hello_key_share(ServerHello)).
+
+server_flight_carries_auth_messages_test() ->
+    #{flight := Flight} = connect(),
+    ?assertEqual(
+        [?ENCRYPTED_EXTENSIONS, ?CERTIFICATE, ?CERTIFICATE_VERIFY, ?FINISHED],
+        [Type || {Type, _Body} <- deframe_all(Flight)]
+    ).
+
+initial_reply_acknowledges_client_test() ->
+    #{effects1 := Effects1} = connect(),
+    Frames = server_frames(
+        sends(Effects1), initial, #{initial => roadrunner_quic_keys:initial_server(?DCID)}
+    ),
+    ?assert(lists:any(fun is_ack/1, Frames)).
+
+handshake_done_emitted_when_connected_test() ->
+    #{effects2 := Effects2, server_ap_secret := ServerApSecret} = connect(),
+    Frames = server_frames(
+        sends(Effects2),
+        application,
+        #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)}
+    ),
+    ?assert(lists:member(handshake_done, Frames)).
+
+%% =============================================================================
+%% Frame handling
+%% =============================================================================
+
+client_ack_processed_test() ->
+    %% A valid ACK of the server's ServerHello drives loss detection and is
+    %% itself not acknowledged (an ACK is not ack-eliciting).
+    #{state1 := State1} = connect(),
+    Datagram = seal(initial, 1, roadrunner_quic_keys:initial_client(?DCID), [
+        {ack, 0, 0, 0, [], undefined}
+    ]),
+    {State2, _Effects} = ?M:handle_datagram(?NOW, Datagram, State1),
+    ?assertEqual(handshaking, ?M:phase(State2)).
+
+oversized_ack_range_ignored_test() ->
+    %% An ACK claiming more packets than the loss layer accepts is dropped
+    %% without disturbing the connection.
+    #{state1 := State1} = connect(),
+    Datagram = seal(initial, 1, roadrunner_quic_keys:initial_client(?DCID), [
+        {ack, 70000, 0, 70000, [], undefined}
+    ]),
+    {State2, _Effects} = ?M:handle_datagram(?NOW, Datagram, State1),
+    ?assertEqual(handshaking, ?M:phase(State2)).
+
+ping_and_padding_frames_handled_test() ->
+    %% A PING (ack-eliciting) padded for the header-protection sample
+    %% exercises the catch-all frame handler for both PING and PADDING.
+    #{state1 := State1} = connect(),
+    Datagram = seal(initial, 1, roadrunner_quic_keys:initial_client(?DCID), [ping]),
+    {State2, _Effects} = ?M:handle_datagram(?NOW, Datagram, State1),
+    ?assertEqual(handshaking, ?M:phase(State2)).
+
+%% =============================================================================
+%% Drop / error paths
+%% =============================================================================
+
+undecryptable_packet_dropped_test() ->
+    %% A packet sealed with the wrong keys is silently dropped (RFC 9001
+    %% §5.4.2); the connection neither advances nor replies.
+    {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
+    WrongKeys = #{key => <<0:128>>, iv => <<0:96>>, hp => <<0:128>>},
+    Datagram = seal(initial, 0, WrongKeys, [{crypto, 0, ~"hello"}]),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State0),
+    ?assertEqual(handshaking, ?M:phase(State1)),
+    ?assertEqual([], sends(Effects)).
+
+malformed_frame_ignored_test() ->
+    %% An authenticated payload that decodes to a malformed frame is a
+    %% connection error the decision core absorbs (a CRYPTO frame claiming
+    %% eight bytes but carrying three).
+    {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
+    Datagram = seal_raw(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), <<16#06, 16#00, 16#08, 1, 2, 3>>
+    ),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State0),
+    ?assertEqual(handshaking, ?M:phase(State1)),
+    ?assertEqual([], sends(Effects)).
+
+packet_for_discarded_space_ignored_test() ->
+    %% One datagram coalescing the client Finished (which confirms the
+    %% handshake and discards the Handshake space) with a trailing handshake
+    %% packet that then lands on the now-absent space.
+    #{state1 := State1, client_hs_secret := ClientHsSecret, cf_framed := ClientFinished} = connect(),
+    HsKeys = roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+    Finished = seal(handshake, 0, HsKeys, [{crypto, 0, ClientFinished}]),
+    Trailing = seal(handshake, 1, HsKeys, [ping]),
+    {State2, _Effects} = ?M:handle_datagram(?NOW, <<Finished/binary, Trailing/binary>>, State1),
+    ?assertEqual(connected, ?M:phase(State2)).
+
+tampered_client_finished_crashes_test() ->
+    %% A forged Finished fails verification; the decision core lets it crash
+    %% rather than reaching `connected` (no graceful handshake-failure path
+    %% in v1).
+    #{state1 := State1, client_hs_secret := ClientHsSecret, cf_framed := ClientFinished} = connect(),
+    <<Type, Len:24, First, Rest/binary>> = ClientFinished,
+    Tampered = <<Type, Len:24, (First bxor 1), Rest/binary>>,
+    HsKeys = roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+    Datagram = seal(handshake, 0, HsKeys, [{crypto, 0, Tampered}]),
+    ?assertError(_, ?M:handle_datagram(?NOW, Datagram, State1)).
+
+%% =============================================================================
+%% Timers and anti-amplification
+%% =============================================================================
+
+pto_timeout_rearms_loss_timer_test() ->
+    %% A PTO fire re-runs loss detection across every live space and rearms
+    %% the loss timer from the oldest unacknowledged packet.
+    #{state1 := State1} = connect(),
+    {_State2, Effects} = ?M:handle_timeout(?NOW + 100000, pto, State1),
+    ?assert(
+        lists:any(
+            fun
+                ({arm_timer, pto, _AtMs}) -> true;
+                (_) -> false
+            end,
+            Effects
+        )
+    ).
+
+amplification_limit_caps_first_flight_test() ->
+    %% A large certificate chain makes the server flight exceed 3x the
+    %% client's 1200-byte Initial, so the send pass stops before sending it
+    %% all (the connection stays handshaking until more client bytes lift
+    %% the limit).
+    {State0, Ctx} = new_conn([binary:copy(<<0>>, 6000)]),
+    {Datagram, _CHFramed} = client_hello_datagram(Ctx),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, State0),
+    ?assertEqual(handshaking, ?M:phase(State1)),
+    ?assert(lists:sum([byte_size(D) || D <- sends(Effects)]) =< 3 * 1200).
+
+%% =============================================================================
+%% Handshake driver (plays the QUIC client with the merged leaves)
+%% =============================================================================
+
+%% Run a full RSA handshake against a fresh connection and return every
+%% intermediate the assertions need.
+connect() ->
+    {State0, Ctx} = new_conn([~"leaf-cert-der"]),
+    #{client_priv := ClientPriv, server_pub := ServerPub} = Ctx,
+
+    %% Client Initial carrying the ClientHello.
+    {InitialDatagram, ClientHelloFramed} = client_hello_datagram(Ctx),
+    {State1, Effects1} = ?M:handle_datagram(?NOW, InitialDatagram, State0),
+    Server1 = sends(Effects1),
+
+    %% Recover the ServerHello and derive the handshake secrets.
+    ServerHello = server_crypto(
+        Server1, initial, #{initial => roadrunner_quic_keys:initial_server(?DCID)}
+    ),
+    Shared = crypto:compute_key(ecdh, ServerPub, ClientPriv, x25519),
+    HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
+        roadrunner_quic_tls_crypto:early_secret(), Shared
+    ),
+    HelloHash = roadrunner_quic_tls_crypto:transcript_hash([ClientHelloFramed, ServerHello]),
+    ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, handshake, HandshakeSecret, HelloHash
+    ),
+    ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, handshake, HandshakeSecret, HelloHash
+    ),
+
+    %% Recover the server's authentication flight.
+    Flight = server_crypto(
+        Server1, handshake, #{handshake => roadrunner_quic_keys:traffic_keys(ServerHsSecret)}
+    ),
+    FinishedHash = roadrunner_quic_tls_crypto:transcript_hash([
+        ClientHelloFramed, ServerHello, Flight
+    ]),
+
+    %% Build and send the client Finished at the handshake level.
+    ClientFinishedBody = roadrunner_quic_tls_crypto:verify_data(
+        roadrunner_quic_tls_crypto:finished_key(ClientHsSecret), FinishedHash
+    ),
+    ClientFinishedFramed = iolist_to_binary(
+        roadrunner_quic_tls_handshake:encode(?FINISHED, ClientFinishedBody)
+    ),
+    HandshakeDatagram = seal(
+        handshake,
+        0,
+        roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+        [{crypto, 0, ClientFinishedFramed}]
+    ),
+    {State2, Effects2} = ?M:handle_datagram(?NOW, HandshakeDatagram, State1),
+
+    %% Application keys, for reading the HANDSHAKE_DONE.
+    MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
+    ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, application, MasterSecret, FinishedHash
+    ),
+
+    #{
+        state0 => State0,
+        state1 => State1,
+        state2 => State2,
+        effects1 => Effects1,
+        effects2 => Effects2,
+        sh_framed => ServerHello,
+        flight => Flight,
+        cf_framed => ClientFinishedFramed,
+        client_hs_secret => ClientHsSecret,
+        server_ap_secret => ServerApSecret,
+        ctx => Ctx
+    }.
+
+%% A fresh server connection plus the client material the driver reuses.
+new_conn(CertChain) ->
+    {Scheme, PrivKey, _VerifyKey, _SigInputs} = key_material(rsa),
+    {ClientPub, ClientPriv} = crypto:generate_key(ecdh, x25519),
+    {ServerPub, ServerPriv} = crypto:generate_key(ecdh, x25519),
+    TransportParams = #{
+        original_destination_connection_id => ?DCID,
+        initial_source_connection_id => ?SCID
+    },
+    State = ?M:new(#{
+        dcid => ?DCID,
+        scid => ?SCID,
+        peer => ?PEER,
+        cert_chain => CertChain,
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => TransportParams,
+        eph_pub => ServerPub,
+        eph_priv => ServerPriv,
+        server_random => crypto:strong_rand_bytes(32)
+    }),
+    {State, #{
+        scheme => Scheme,
+        client_pub => ClientPub,
+        client_priv => ClientPriv,
+        server_pub => ServerPub
+    }}.
+
+%% The client Initial datagram and the framed ClientHello it carries (the
+%% first transcript element).
+client_hello_datagram(#{scheme := Scheme, client_pub := ClientPub}) ->
+    Body = client_hello_body(#{
+        key_share => ClientPub, sig_algs => [Scheme], alpn => ~"h3", session_id => <<>>
+    }),
+    Framed = iolist_to_binary(roadrunner_quic_tls_handshake:encode(?CLIENT_HELLO, Body)),
+    Datagram = seal(initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}]),
+    {Datagram, Framed}.
+
+%% Build a one-level client datagram through the send pipeline (an Initial
+%% is padded to 1200, so it satisfies the server's anti-amplification
+%% budget).
+seal(Level, PN, Keys, Frames) ->
+    Entries = #{Level => #{frames => Frames, keys => Keys, pn => PN}},
+    {Datagram, _Sent} = roadrunner_quic_send:datagram(Entries, ?DCID, ?SCID),
+    Datagram.
+
+%% Seal raw plaintext (bypassing frame encoding) so a packet can carry a
+%% deliberately malformed frame, mirroring the send path's header sizing.
+seal_raw(Level, PN, #{key := Key, iv := IV, hp := HP}, Plaintext) ->
+    PNLen = roadrunner_quic_packet:pn_length(PN),
+    SealedSize = byte_size(Plaintext) + 16,
+    [Header, _Payload] = roadrunner_quic_packet:encode_long(
+        Level, 1, ?DCID, ?SCID, #{pn => PN, payload => <<0:(SealedSize * 8)>>}
+    ),
+    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
+    <<Protected/binary, Sealed/binary>>.
+
+sends(Effects) ->
+    [Datagram || {send, Datagram} <- Effects].
+
+%% Contiguous CRYPTO bytes for a level across the server's datagrams. The
+%% per-level keys map naturally filters out the other levels' packets (they
+%% decode to {drop, no_keys}); with no in-test loss a sorted concat
+%% reassembles the flight.
+server_crypto(Datagrams, Level, Keys) ->
+    Slices = [{Offset, Data} || {crypto, Offset, Data} <- server_frames(Datagrams, Level, Keys)],
+    iolist_to_binary([Data || {_Offset, Data} <- lists:sort(Slices)]).
+
+server_frames(Datagrams, Level, Keys) ->
+    lists:append([level_frames(Datagram, Level, Keys) || Datagram <- Datagrams]).
+
+level_frames(Datagram, Level, Keys) ->
+    Outcomes = roadrunner_quic_recv:datagram(Datagram, byte_size(?DCID), Keys, #{}),
+    lists:append([Frames || {ok, #{level := L, frames := Frames}} <- Outcomes, L =:= Level]).
+
+is_ack({ack, _Largest, _Delay, _First, _Ranges, _Ecn}) -> true;
+is_ack(_Frame) -> false.
+
+%% A generated key pair per scheme plus the crypto:verify inputs for its
+%% public half (mirrors roadrunner_quic_tls_server_tests:key_material/1).
+key_material(rsa) ->
+    #'RSAPrivateKey'{publicExponent = E, modulus = N} =
+        PrivKey = public_key:generate_key({rsa, 2048, 65537}),
+    {16#0804, PrivKey, [E, N],
+        {rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]}}.
+
+%% Build a ClientHello body (RFC 8446 §4.1.2) carrying the requested
+%% extensions; the x25519 key_share is omitted when no key is given.
+client_hello_body(Opts) ->
+    Random = maps:get(random, Opts, crypto:strong_rand_bytes(32)),
+    SessionId = maps:get(session_id, Opts, <<>>),
+    SigAlgs = maps:get(sig_algs, Opts, [16#0804]),
+    Alpn = maps:get(alpn, Opts, ~"h3"),
+    Extensions = iolist_to_binary([
+        signature_algorithms_ext(SigAlgs),
+        alpn_ext(Alpn),
+        key_share_ext(maps:get(key_share, Opts, undefined))
+    ]),
+    CipherSuites = <<?CIPHER_AES_128_GCM_SHA256:16>>,
+    <<?LEGACY_VERSION:16, Random/binary, (byte_size(SessionId)):8, SessionId/binary,
+        (byte_size(CipherSuites)):16, CipherSuites/binary, 1:8, 0:8, (byte_size(Extensions)):16,
+        Extensions/binary>>.
+
+signature_algorithms_ext(Schemes) ->
+    List = <<<<S:16>> || S <- Schemes>>,
+    extension(?EXT_SIGNATURE_ALGORITHMS, <<(byte_size(List)):16, List/binary>>).
+
+alpn_ext(Protocol) ->
+    Entry = <<(byte_size(Protocol)):8, Protocol/binary>>,
+    extension(?EXT_ALPN, <<(byte_size(Entry)):16, Entry/binary>>).
+
+key_share_ext(undefined) ->
+    <<>>;
+key_share_ext(PubKey) ->
+    Entry = <<?GROUP_X25519:16, (byte_size(PubKey)):16, PubKey/binary>>,
+    extension(?EXT_KEY_SHARE, <<(byte_size(Entry)):16, Entry/binary>>).
+
+extension(Type, Data) ->
+    <<Type:16, (byte_size(Data)):16, Data/binary>>.
+
+%% The server's x25519 public key from a ServerHello's key_share extension.
+server_hello_key_share(ServerHello) ->
+    {?SERVER_HELLO, Body} = deframe(ServerHello),
+    <<_LegacyVersion:16, _Random:32/binary, SessionLen:8, _Session:SessionLen/binary, _Cipher:16,
+        _Compression:8, _ExtsLen:16, Extensions/binary>> = Body,
+    <<?GROUP_X25519:16, KeyLen:16, PubKey:KeyLen/binary>> =
+        extract_extension(?EXT_KEY_SHARE, Extensions),
+    PubKey.
+
+extract_extension(Type, <<Type:16, Len:16, Data:Len/binary, _Rest/binary>>) ->
+    Data;
+extract_extension(Type, <<_OtherType:16, Len:16, _Data:Len/binary, Rest/binary>>) ->
+    extract_extension(Type, Rest).
+
+deframe(Iolist) ->
+    {ok, {Type, Body}, <<>>} = roadrunner_quic_tls_handshake:decode(iolist_to_binary(Iolist)),
+    {Type, Body}.
+
+deframe_all(Iolist) ->
+    deframe_all_bin(iolist_to_binary(Iolist)).
+
+deframe_all_bin(<<>>) ->
+    [];
+deframe_all_bin(Bin) ->
+    {ok, {Type, Body}, Rest} = roadrunner_quic_tls_handshake:decode(Bin),
+    [{Type, Body} | deframe_all_bin(Rest)].

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -194,6 +194,78 @@ amplification_limit_caps_first_flight_test() ->
     ?assert(lists:sum([byte_size(D) || D <- sends(Effects)]) =< 3 * 1200).
 
 %% =============================================================================
+%% Control calls + owner notification
+%% =============================================================================
+
+peername_call_replies_test() ->
+    {State, _Ctx} = new_conn([~"leaf-cert-der"]),
+    Ref = make_ref(),
+    ?assertEqual(
+        {State, [{reply, self(), Ref, {ok, ?PEER}}]},
+        ?M:handle_call(self(), Ref, peername, State)
+    ).
+
+owner_set_in_handshaking_gets_connected_on_completion_test() ->
+    %% The normal listener ordering: the owner is installed while still
+    %% handshaking (no emit yet), then the confirming datagram emits
+    %% {connected, _} to it exactly once.
+    #{state1 := State1, client_hs_secret := ClientHsSecret, cf_framed := ClientFinished} = connect(),
+    Owner = self(),
+    Ref = make_ref(),
+    {State1b, Installed} = ?M:handle_call(Owner, Ref, {set_owner, Owner}, State1),
+    ?assertEqual([{reply, Owner, Ref, ok}], Installed),
+    Datagram = ?TC:seal(
+        handshake,
+        0,
+        roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+        [{crypto, 0, ClientFinished}],
+        ?DCID,
+        ?SCID
+    ),
+    {State2, Effects} = ?M:handle_datagram(?NOW, Datagram, State1b),
+    ?assertEqual(connected, ?M:phase(State2)),
+    ?assertEqual([{emit, Owner, {connected, expected_info()}}], emits(Effects)).
+
+owner_set_after_connection_gets_connected_now_test() ->
+    %% The deferred ordering: if the handshake confirms before the owner is
+    %% installed, set_owner emits {connected, _} immediately.
+    #{state2 := State2} = connect(),
+    Owner = self(),
+    Ref = make_ref(),
+    {_State3, Effects} = ?M:handle_call(Owner, Ref, {set_owner, Owner}, State2),
+    ?assertEqual([{reply, Owner, Ref, ok}, {emit, Owner, {connected, expected_info()}}], Effects).
+
+connected_not_re_emitted_on_later_datagram_test() ->
+    %% The once-only guard: with an owner installed, a datagram AFTER the
+    %% connection completes must NOT re-emit {connected, _}. There is no
+    %% emitted-flag; this pins that the emit rides the handshaking -> connected
+    %% transition only, so dropping that guard would be caught here.
+    #{
+        state1 := State1,
+        client_hs_secret := ClientHsSecret,
+        cf_framed := ClientFinished,
+        client_ap_secret := ClientApSecret
+    } = connect(),
+    Owner = self(),
+    {State1b, _} = ?M:handle_call(Owner, make_ref(), {set_owner, Owner}, State1),
+    Finished = ?TC:seal(
+        handshake,
+        0,
+        roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+        [{crypto, 0, ClientFinished}],
+        ?DCID,
+        ?SCID
+    ),
+    {State2, FirstEffects} = ?M:handle_datagram(?NOW, Finished, State1b),
+    ?assertEqual([{emit, Owner, {connected, expected_info()}}], emits(FirstEffects)),
+    %% A processed 1-RTT packet once connected: still exactly zero re-emits.
+    AppPing = ?TC:seal(
+        application, 0, roadrunner_quic_keys:traffic_keys(ClientApSecret), [ping], ?DCID, ?SCID
+    ),
+    {_State3, LaterEffects} = ?M:handle_datagram(?NOW, AppPing, State2),
+    ?assertEqual([], emits(LaterEffects)).
+
+%% =============================================================================
 %% Handshake driver (plays the QUIC client with the shared test client)
 %% =============================================================================
 
@@ -252,10 +324,14 @@ connect() ->
     ),
     {State2, Effects2} = ?M:handle_datagram(?NOW, HandshakeDatagram, State1),
 
-    %% Application keys, for reading the HANDSHAKE_DONE.
+    %% Application keys, for reading the HANDSHAKE_DONE and sealing a
+    %% post-connected client 1-RTT packet.
     MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
     ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
         server, application, MasterSecret, FinishedHash
+    ),
+    ClientApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, application, MasterSecret, FinishedHash
     ),
 
     #{
@@ -269,6 +345,7 @@ connect() ->
         cf_framed => ClientFinishedFramed,
         client_hs_secret => ClientHsSecret,
         server_ap_secret => ServerApSecret,
+        client_ap_secret => ClientApSecret,
         ctx => Ctx
     }.
 
@@ -277,10 +354,7 @@ new_conn(CertChain) ->
     {Scheme, PrivKey} = ?TC:key_material(),
     {ClientPub, ClientPriv} = ?TC:gen_keypair(),
     {ServerPub, ServerPriv} = ?TC:gen_keypair(),
-    TransportParams = #{
-        original_destination_connection_id => ?DCID,
-        initial_source_connection_id => ?SCID
-    },
+    TransportParams = transport_params(),
     State = ?M:new(#{
         dcid => ?DCID,
         scid => ?SCID,
@@ -314,6 +388,16 @@ sends(Effects) ->
 
 is_ack({ack, _Largest, _Delay, _First, _Ranges, _Ecn}) -> true;
 is_ack(_Frame) -> false.
+
+transport_params() ->
+    #{original_destination_connection_id => ?DCID, initial_source_connection_id => ?SCID}.
+
+%% The connected payload conn_state caches at new/1 (alpn + advertised params).
+expected_info() ->
+    #{alpn => ~"h3", transport_params => transport_params()}.
+
+emits(Effects) ->
+    [Emit || {emit, _Owner, _Event} = Emit <- Effects].
 
 arm_deadline(Effects) ->
     [AtMs] = [At || {arm_timer, pto, At} <- Effects],

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -511,6 +511,31 @@ fully_sent_stream_is_skipped_on_later_pass_test() ->
     ?assertEqual([], sent_stream_frames(Effects, ServerApSecret)).
 
 %% =============================================================================
+%% Connection close (peer-initiated)
+%% =============================================================================
+
+peer_connection_close_emits_closed_and_sends_nothing_test() ->
+    %% A peer CONNECTION_CLOSE moves the connection to `closed`, surfaces
+    %% {closed, {peer, ErrorCode}} to the owner, and sends nothing back.
+    {State, ApSecret} = connected_with_owner(),
+    Close = app_datagram([{connection_close, transport, 0, 0, <<>>}], 0, ApSecret),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Close, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {peer, 0}}}], emits(Effects)),
+    ?assertEqual([], sends(Effects)).
+
+frames_after_connection_close_are_ignored_test() ->
+    %% Once a CONNECTION_CLOSE is seen, the rest of the packet is dropped: a
+    %% trailing STREAM frame produces no stream events.
+    {State, ApSecret} = connected_with_owner(),
+    Close = app_datagram(
+        [{connection_close, transport, 7, 0, <<>>}, {stream, 0, 0, ~"x", true}], 0, ApSecret
+    ),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Close, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {peer, 7}}}], emits(Effects)).
+
+%% =============================================================================
 %% Handshake driver (plays the QUIC client with the shared test client)
 %% =============================================================================
 

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -179,7 +179,16 @@ malformed_client_hello_closes_test() ->
     ),
     {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State0)),
     ?assertEqual(closed, ?M:phase(State1)),
-    ?assertEqual([{emit, self(), {closed, {local, malformed_client_hello}}}], emits(Effects)).
+    ?assertEqual([{emit, self(), {closed, {local, malformed_client_hello}}}], emits(Effects)),
+    %% The CONNECTION_CLOSE is transmitted at the Initial level (a TLS error
+    %% the client can still read with Initial keys).
+    Frames = ?TC:frames(
+        sends(Effects),
+        initial,
+        #{initial => roadrunner_quic_keys:initial_server(?DCID)},
+        byte_size(?DCID)
+    ),
+    ?assertMatch([{connection_close, transport, _Code, 0, <<>>}], Frames).
 
 unexpected_handshake_message_closes_test() ->
     %% An out-of-sequence handshake message type closes the connection.
@@ -587,6 +596,65 @@ peer_handshake_level_close_test() ->
     {State2, Effects} = ?M:handle_datagram(?NOW, Close, with_owner(State1)),
     ?assertEqual(closed, ?M:phase(State2)),
     ?assertEqual([{emit, self(), {closed, {peer, 2}}}], emits(Effects)).
+
+local_error_transmits_connection_close_test() ->
+    %% A locally-detected error transmits one CONNECTION_CLOSE at the
+    %% triggering packet's level (here application), carrying the mapped wire
+    %% error code; a peer-initiated close, by contrast, sends nothing back.
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Bad = app_datagram([{stream, 3, 0, ~"x", true}], 0, ClientApSecret),
+    {_State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    Frames = ?TC:frames(
+        sends(Effects),
+        application,
+        #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+        byte_size(?DCID)
+    ),
+    ?assertEqual(
+        [
+            {connection_close, transport, roadrunner_quic_error:code_int(stream_state_error), 0,
+                <<>>}
+        ],
+        Frames
+    ).
+
+undersized_initial_close_is_suppressed_test() ->
+    %% A close that would breach the §8.1 3x budget for an undersized (spoofed
+    %% or non-conformant) peer Initial is dropped, so the server is never an
+    %% amplification reflector. The connection still closes and the owner still
+    %% learns via {closed, _}, but nothing is sent back.
+    {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
+    CloseFrame = iolist_to_binary(
+        roadrunner_quic_frame:encode({connection_close, application, 7, undefined, <<>>})
+    ),
+    Tiny = ?TC:seal_raw(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), CloseFrame, ?DCID, ?SCID
+    ),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Tiny, with_owner(State0)),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, protocol_violation}}}], emits(Effects)),
+    ?assertEqual([], sends(Effects)).
+
+coalesced_initial_error_then_handshake_does_not_crash_test() ->
+    %% A datagram coalescing an Initial-level error (a 0x1d at Initial) with a
+    %% Handshake packet must not let the Handshake packet's space-discard run
+    %% after the close; the connection closes cleanly without crashing on the
+    %% Initial keys the pending close still needs.
+    #{state1 := State1, client_hs_secret := ClientHsSecret} = connect(),
+    CloseFrame = iolist_to_binary(
+        roadrunner_quic_frame:encode({connection_close, application, 7, undefined, <<>>})
+    ),
+    BadInitial = ?TC:seal_raw(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), CloseFrame, ?DCID, ?SCID
+    ),
+    HandshakePing = ?TC:seal(
+        handshake, 1, roadrunner_quic_keys:traffic_keys(ClientHsSecret), [ping], ?DCID, ?SCID
+    ),
+    {State2, Effects} = ?M:handle_datagram(
+        ?NOW, <<BadInitial/binary, HandshakePing/binary>>, with_owner(State1)
+    ),
+    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual([{emit, self(), {closed, {local, protocol_violation}}}], emits(Effects)).
 
 %% =============================================================================
 %% Handshake driver (plays the QUIC client with the shared test client)

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -440,6 +440,77 @@ stream_without_owner_not_emitted_test() ->
     ?assertEqual([], emits(Effects)).
 
 %% =============================================================================
+%% Application streams (send side)
+%% =============================================================================
+
+open_uni_allocates_server_uni_ids_test() ->
+    %% Each open_unidirectional_stream hands out the next server-initiated uni
+    %% id (RFC 9000 §2.1: 3, 7, 11, ...) and replies with it.
+    {State, _ApSecret} = connected_for_send(),
+    Ref1 = make_ref(),
+    {State1, Effects1} = ?M:handle_call(self(), Ref1, open_uni, State),
+    ?assertEqual([{reply, self(), Ref1, {ok, 3}}], Effects1),
+    Ref2 = make_ref(),
+    {_State2, Effects2} = ?M:handle_call(self(), Ref2, open_uni, State1),
+    ?assertEqual([{reply, self(), Ref2, {ok, 7}}], Effects2).
+
+send_data_emits_stream_frame_with_fin_test() ->
+    %% A finished send becomes a single STREAM frame carrying the data and FIN,
+    %% and the call is acknowledged with ok.
+    {State, ApSecret} = connected_for_send(),
+    Ref = make_ref(),
+    {_State1, Effects} = ?M:handle_send(self(), Ref, 0, ~"hello", true, ?NOW, State),
+    ?assertEqual({reply, self(), Ref, ok}, hd(Effects)),
+    ?assertEqual([{stream, 0, 0, ~"hello", true}], sent_stream_frames(Effects, ApSecret)).
+
+send_data_without_fin_leaves_stream_open_test() ->
+    %% A non-final send carries Fin = false (used for the control stream's
+    %% SETTINGS, which keeps the stream open).
+    {State, ApSecret} = connected_for_send(),
+    {_State1, Effects} = ?M:handle_send(self(), make_ref(), 3, ~"settings", false, ?NOW, State),
+    ?assertEqual([{stream, 3, 0, ~"settings", false}], sent_stream_frames(Effects, ApSecret)).
+
+send_data_multi_call_advances_offset_test() ->
+    %% Successive sends on one stream advance the stream offset; the FIN rides
+    %% the final write.
+    {State, ApSecret} = connected_for_send(),
+    {State1, E1} = ?M:handle_send(self(), make_ref(), 0, ~"foo", false, ?NOW, State),
+    ?assertEqual([{stream, 0, 0, ~"foo", false}], sent_stream_frames(E1, ApSecret)),
+    {_State2, E2} = ?M:handle_send(self(), make_ref(), 0, ~"bar", true, ?NOW, State1),
+    ?assertEqual([{stream, 0, 3, ~"bar", true}], sent_stream_frames(E2, ApSecret)).
+
+send_data_slices_large_payload_test() ->
+    %% A payload larger than the per-packet budget is sliced across datagrams
+    %% (one STREAM frame each), offsets contiguous, FIN on the last slice, and
+    %% the bytes reassemble to the original.
+    {State, ApSecret} = connected_for_send(),
+    Payload = binary:copy(~"x", 2500),
+    {_State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, true, ?NOW, State),
+    Frames = sent_stream_frames(Effects, ApSecret),
+    ?assertEqual([0, 1000, 2000], [Off || {stream, 0, Off, _, _} <- Frames]),
+    ?assertEqual([false, false, true], [Fin || {stream, 0, _, _, Fin} <- Frames]),
+    ?assertEqual(Payload, iolist_to_binary([D || {stream, 0, _, D, _} <- Frames])).
+
+send_data_on_control_then_request_stream_test() ->
+    %% The two load-bearing GET writes: SETTINGS on the server control stream
+    %% (id 3) then a response on the client request stream (id 0), each on its
+    %% own stream.
+    {State, ApSecret} = connected_for_send(),
+    {State1, E1} = ?M:handle_send(self(), make_ref(), 3, ~"settings", false, ?NOW, State),
+    ?assertEqual([{stream, 3, 0, ~"settings", false}], sent_stream_frames(E1, ApSecret)),
+    {_State2, E2} = ?M:handle_send(self(), make_ref(), 0, ~"response", true, ?NOW, State1),
+    ?assertEqual([{stream, 0, 0, ~"response", true}], sent_stream_frames(E2, ApSecret)).
+
+fully_sent_stream_is_skipped_on_later_pass_test() ->
+    %% Once a stream is finished and drained, a later send pass (here driven by
+    %% a peer PING that elicits an ACK) emits no STREAM frame for it.
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    {State1, _} = ?M:handle_send(self(), make_ref(), 0, ~"done", true, ?NOW, State),
+    Ping = app_datagram([ping], 0, ClientApSecret),
+    {_State2, Effects} = ?M:handle_datagram(?NOW, Ping, State1),
+    ?assertEqual([], sent_stream_frames(Effects, ServerApSecret)).
+
+%% =============================================================================
 %% Handshake driver (plays the QUIC client with the shared test client)
 %% =============================================================================
 
@@ -570,15 +641,17 @@ transport_params() ->
 expected_info() ->
     #{alpn => ~"h3", transport_params => transport_params()}.
 
-%% A connected connection with this process installed as owner (set during
-%% handshaking, the normal ordering), plus the client application secret for
-%% sealing peer 1-RTT packets.
-connected_with_owner() ->
+%% Drive to connected with this process installed as owner (set during
+%% handshaking, the normal ordering). Returns the state plus both application
+%% secrets: the client secret seals peer 1-RTT packets (receive-side tests),
+%% the server secret decodes the connection's own 1-RTT (send-side tests).
+connect_owned() ->
     #{
         state1 := State1,
         client_hs_secret := ClientHsSecret,
         cf_framed := ClientFinished,
-        client_ap_secret := ClientApSecret
+        client_ap_secret := ClientApSecret,
+        server_ap_secret := ServerApSecret
     } = connect(),
     {State1b, _} = ?M:handle_call(self(), make_ref(), {set_owner, self()}, State1),
     Finished = ?TC:seal(
@@ -590,13 +663,35 @@ connected_with_owner() ->
         ?SCID
     ),
     {State2, _Effects} = ?M:handle_datagram(?NOW, Finished, State1b),
+    {State2, ClientApSecret, ServerApSecret}.
+
+%% Connected, owner installed, with the client secret for sealing peer 1-RTT.
+connected_with_owner() ->
+    {State2, ClientApSecret, _ServerApSecret} = connect_owned(),
     {State2, ClientApSecret}.
+
+%% Connected, owner installed, with the server secret for decoding the
+%% connection's own outbound 1-RTT.
+connected_for_send() ->
+    {State2, _ClientApSecret, ServerApSecret} = connect_owned(),
+    {State2, ServerApSecret}.
 
 %% Seal a peer 1-RTT (application) datagram carrying the given frames.
 app_datagram(Frames, PN, ClientApSecret) ->
     ?TC:seal(
         application, PN, roadrunner_quic_keys:traffic_keys(ClientApSecret), Frames, ?DCID, ?SCID
     ).
+
+%% Decode the application (1-RTT) frames the connection sent, then keep just
+%% the STREAM frames.
+sent_stream_frames(Effects, ServerApSecret) ->
+    Frames = ?TC:frames(
+        sends(Effects),
+        application,
+        #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+        byte_size(?DCID)
+    ),
+    [Frame || {stream, _Sid, _Off, _Data, _Fin} = Frame <- Frames].
 
 emits(Effects) ->
     [Emit || {emit, _Owner, _Event} = Emit <- Effects].

--- a/test/roadrunner_quic_connection_interop_SUITE.erl
+++ b/test/roadrunner_quic_connection_interop_SUITE.erl
@@ -1,0 +1,144 @@
+-module(roadrunner_quic_connection_interop_SUITE).
+-moduledoc false.
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0, init_per_suite/1, end_per_suite/1]).
+-export([dep_client_completes_handshake/1]).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [dep_client_completes_handshake].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(ssl),
+    %% The dep `quic` app backs the test CLIENT; the native server shell
+    %% does not need it. The default `pg` scope hosts the client's drain
+    %% group, started unlinked so it outlives this transient process.
+    {ok, _} = application:ensure_all_started(quic),
+    ok = ensure_pg_started(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% =============================================================================
+%% The dep `quic` client completes a real QUIC handshake against the native
+%% connection shell over loopback.
+%% =============================================================================
+
+dep_client_completes_handshake(_Config) ->
+    %% A minimal in-test listener: the pump owns one UDP socket, reads it,
+    %% and routes each datagram to a per-peer native shell that sends its
+    %% replies back on the same socket. Linking the pump (and its shells)
+    %% to this process makes a handshake crash surface as a test failure
+    %% rather than a silent timeout.
+    Test = self(),
+    Pump = spawn_link(fun() ->
+        {ok, Socket} = roadrunner_quic_socket:open(0),
+        {ok, {_Ip, Port}} = roadrunner_quic_socket:sockname(Socket),
+        Test ! {pump_port, self(), Port},
+        pump_loop(Socket, #{})
+    end),
+    Port =
+        receive
+            {pump_port, Pump, P} -> P
+        after 2000 ->
+            exit(pump_no_port)
+        end,
+
+    %% Drive the dep as a raw QUIC client. The QUIC `connected` event fires
+    %% on transport-handshake completion; the H3 SETTINGS exchange (needed
+    %% by quic_h3:wait_connected) belongs to the owner, a later slice, so we
+    %% assert at the QUIC layer.
+    {ok, Conn} = quic:connect(
+        ~"127.0.0.1", Port, #{alpn => [~"h3"], verify => verify_none}, self()
+    ),
+    Result =
+        receive
+            {quic, Conn, {connected, _Info}} -> ok
+        after 5000 ->
+            timeout
+        end,
+
+    _ = quic:close(Conn),
+    unlink(Pump),
+    exit(Pump, shutdown),
+    ?assertEqual(ok, Result).
+
+%% =============================================================================
+%% Listener pump + per-connection shell wiring
+%% =============================================================================
+
+pump_loop(Socket, Conns) ->
+    case roadrunner_quic_socket:recv(Socket, 500) of
+        {ok, Peer, Datagram} ->
+            Shell =
+                case Conns of
+                    #{Peer := Existing} -> Existing;
+                    #{} -> start_shell(Socket, Peer, Datagram)
+                end,
+            Shell ! {quic_datagram, Peer, Datagram},
+            pump_loop(Socket, Conns#{Peer => Shell});
+        {error, timeout} ->
+            pump_loop(Socket, Conns)
+    end.
+
+%% Build the per-connection config from the first Initial and spawn (and
+%% link) the native shell. The reply DCID stays the client's chosen DCID,
+%% an RFC 9000 §17.2 deviation the key-routing dep client tolerates; a
+%% strict client would need the client's source CID echoed instead.
+start_shell(Socket, Peer, FirstDatagram) ->
+    {ok, ClientDCID} = roadrunner_quic_packet:dcid(FirstDatagram, 8),
+    ServerSCID = crypto:strong_rand_bytes(8),
+    {EphPub, EphPriv} = crypto:generate_key(ecdh, x25519),
+    {CertChain, PrivKey} = cert_key(),
+    Config = #{
+        dcid => ClientDCID,
+        scid => ServerSCID,
+        peer => Peer,
+        cert_chain => CertChain,
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => #{
+            original_destination_connection_id => ClientDCID,
+            initial_source_connection_id => ServerSCID,
+            initial_max_data => 1048576,
+            initial_max_stream_data_bidi_local => 262144,
+            initial_max_stream_data_bidi_remote => 262144,
+            initial_max_stream_data_uni => 262144,
+            initial_max_streams_bidi => 100,
+            initial_max_streams_uni => 100,
+            max_idle_timeout => 30000
+        },
+        eph_pub => EphPub,
+        eph_priv => EphPriv,
+        server_random => crypto:strong_rand_bytes(32)
+    },
+    {ok, Shell} = roadrunner_quic_connection:start(Socket, Config),
+    true = link(Shell),
+    Shell.
+
+cert_key() ->
+    Opts = roadrunner_test_certs:server_opts(),
+    {cert, CertDer} = lists:keyfind(cert, 1, Opts),
+    {key, {KeyType, KeyDer}} = lists:keyfind(key, 1, Opts),
+    {[CertDer], public_key:der_decode(KeyType, KeyDer)}.
+
+ensure_pg_started() ->
+    case whereis(pg) of
+        undefined ->
+            case pg:start_link() of
+                {ok, Pid} ->
+                    _ = unlink(Pid),
+                    ok;
+                {error, {already_started, _}} ->
+                    ok
+            end;
+        _ ->
+            ok
+    end.

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -17,6 +17,8 @@
 shell_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun handshake_completes/1,
+        fun peername_round_trip/1,
+        fun set_owner_emits_connected/1,
         fun system_message_handled/1,
         fun unsupported_call_replies/1,
         fun cast_ignored/1,
@@ -45,70 +47,48 @@ cleanup(#{shell := Shell, client := ClientSocket, server := ServerSocket}) ->
 
 handshake_completes(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
     fun() ->
-        #{client_priv := ClientPriv, server_pub := ServerPub} = Ctx,
-
-        %% Client Initial -> the shell answers with its first flight.
-        {InitialDatagram, ClientHelloFramed} = client_hello(Ctx),
-        Shell ! {quic_datagram, Peer, InitialDatagram},
-        Flight1 = recv_all(ClientSocket),
-
-        ServerHello = ?TC:crypto_bytes(
-            Flight1,
-            initial,
-            #{initial => roadrunner_quic_keys:initial_server(?DCID)},
-            byte_size(?DCID)
-        ),
-        ?assertNotEqual(<<>>, ServerHello),
-        Shared = crypto:compute_key(ecdh, ServerPub, ClientPriv, x25519),
-        HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
-            roadrunner_quic_tls_crypto:early_secret(), Shared
-        ),
-        HelloHash = roadrunner_quic_tls_crypto:transcript_hash([ClientHelloFramed, ServerHello]),
-        ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
-            client, handshake, HandshakeSecret, HelloHash
-        ),
-        ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
-            server, handshake, HandshakeSecret, HelloHash
-        ),
-        Flight = ?TC:crypto_bytes(
-            Flight1,
-            handshake,
-            #{handshake => roadrunner_quic_keys:traffic_keys(ServerHsSecret)},
-            byte_size(?DCID)
-        ),
-        FinishedHash = roadrunner_quic_tls_crypto:transcript_hash([
-            ClientHelloFramed, ServerHello, Flight
-        ]),
-
-        %% Client Finished -> the shell becomes connected and sends HANDSHAKE_DONE.
-        ClientFinishedBody = roadrunner_quic_tls_crypto:verify_data(
-            roadrunner_quic_tls_crypto:finished_key(ClientHsSecret), FinishedHash
-        ),
-        ClientFinishedFramed = iolist_to_binary(
-            roadrunner_quic_tls_handshake:encode(?FINISHED, ClientFinishedBody)
-        ),
-        FinishedDatagram = ?TC:seal(
-            handshake,
-            0,
-            roadrunner_quic_keys:traffic_keys(ClientHsSecret),
-            [{crypto, 0, ClientFinishedFramed}],
-            ?DCID,
-            ?SCID
-        ),
-        Shell ! {quic_datagram, Peer, FinishedDatagram},
-        Flight2 = recv_all(ClientSocket),
-
-        MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
-        ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
-            server, application, MasterSecret, FinishedHash
-        ),
+        ServerApSecret = do_handshake(Shell, Peer, ClientSocket, Ctx),
         AppFrames = ?TC:frames(
-            Flight2,
+            recv_all(ClientSocket),
             application,
             #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
             byte_size(?DCID)
         ),
         ?assert(lists:member(handshake_done, AppFrames))
+    end.
+
+%% A synchronous peername control call round-trips through the shell.
+peername_round_trip(#{shell := Shell, peer := Peer}) ->
+    fun() ->
+        Ref = make_ref(),
+        Shell ! {quic_call, self(), Ref, peername},
+        receive
+            {quic_reply, Ref, Result} -> ?assertEqual({ok, Peer}, Result)
+        after 1000 ->
+            erlang:error(no_reply)
+        end
+    end.
+
+%% Installing this process as owner on a connected shell emits the once-only
+%% {connected, _} event back to it.
+set_owner_emits_connected(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
+    fun() ->
+        _ServerApSecret = do_handshake(Shell, Peer, ClientSocket, Ctx),
+        %% do_handshake sent the client Finished before this set_owner, so by
+        %% mailbox FIFO the shell is already connected when set_owner runs and
+        %% the {connected, _} emit takes the deferred (install_owner) path.
+        Ref = make_ref(),
+        Shell ! {quic_call, self(), Ref, {set_owner, self()}},
+        receive
+            {quic_reply, Ref, ok} -> ok
+        after 1000 ->
+            erlang:error(no_reply)
+        end,
+        receive
+            {quic, Shell, {connected, Info}} -> ?assertMatch(#{alpn := _}, Info)
+        after 1000 ->
+            erlang:error(no_connected_event)
+        end
     end.
 
 %% =============================================================================
@@ -203,6 +183,57 @@ client_hello(#{scheme := Scheme, client_pub := ClientPub}) ->
         initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}], ?DCID, ?SCID
     ),
     {Datagram, Framed}.
+
+%% Drive the shell to `connected`: feed the ClientHello, derive the schedule
+%% from the server's flight, then feed the client Finished. The shell sends
+%% HANDSHAKE_DONE (left on the socket for the caller). Returns the server
+%% application secret for decoding the 1-RTT reply.
+do_handshake(Shell, Peer, ClientSocket, Ctx) ->
+    #{client_priv := ClientPriv, server_pub := ServerPub} = Ctx,
+    {InitialDatagram, ClientHelloFramed} = client_hello(Ctx),
+    Shell ! {quic_datagram, Peer, InitialDatagram},
+    Flight1 = recv_all(ClientSocket),
+    ServerHello = ?TC:crypto_bytes(
+        Flight1, initial, #{initial => roadrunner_quic_keys:initial_server(?DCID)}, byte_size(?DCID)
+    ),
+    ?assertNotEqual(<<>>, ServerHello),
+    Shared = crypto:compute_key(ecdh, ServerPub, ClientPriv, x25519),
+    HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
+        roadrunner_quic_tls_crypto:early_secret(), Shared
+    ),
+    HelloHash = roadrunner_quic_tls_crypto:transcript_hash([ClientHelloFramed, ServerHello]),
+    ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, handshake, HandshakeSecret, HelloHash
+    ),
+    ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, handshake, HandshakeSecret, HelloHash
+    ),
+    Flight = ?TC:crypto_bytes(
+        Flight1,
+        handshake,
+        #{handshake => roadrunner_quic_keys:traffic_keys(ServerHsSecret)},
+        byte_size(?DCID)
+    ),
+    FinishedHash = roadrunner_quic_tls_crypto:transcript_hash([
+        ClientHelloFramed, ServerHello, Flight
+    ]),
+    ClientFinishedBody = roadrunner_quic_tls_crypto:verify_data(
+        roadrunner_quic_tls_crypto:finished_key(ClientHsSecret), FinishedHash
+    ),
+    ClientFinishedFramed = iolist_to_binary(
+        roadrunner_quic_tls_handshake:encode(?FINISHED, ClientFinishedBody)
+    ),
+    FinishedDatagram = ?TC:seal(
+        handshake,
+        0,
+        roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+        [{crypto, 0, ClientFinishedFramed}],
+        ?DCID,
+        ?SCID
+    ),
+    Shell ! {quic_datagram, Peer, FinishedDatagram},
+    MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
+    roadrunner_quic_tls_crypto:traffic_secret(server, application, MasterSecret, FinishedHash).
 
 %% Collect datagrams the shell sent until a quiet gap (no in-test loss, so
 %% the whole flight arrives back to back).

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -1,0 +1,219 @@
+-module(roadrunner_quic_connection_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CONN, roadrunner_quic_connection).
+-define(TC, roadrunner_quic_test_client).
+-define(FINISHED, 20).
+
+%% A fixed client DCID (the server's routing id) and an 8-byte server SCID
+%% (matching the server's fixed ?SCID_LEN).
+-define(DCID, <<1, 2, 3, 4, 5, 6, 7, 8>>).
+-define(SCID, <<8, 7, 6, 5, 4, 3, 2, 1>>).
+
+%% Each case spawns a fresh shell over a pair of loopback sockets: the
+%% server socket the shell sends on, and a client socket bound so the
+%% shell's datagrams land where the test can read them.
+shell_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun handshake_completes/1,
+        fun system_message_handled/1,
+        fun unsupported_call_replies/1,
+        fun cast_ignored/1,
+        fun stray_message_ignored/1,
+        fun stale_timer_fire_ignored/1,
+        fun loss_timer_fires/1
+    ]}.
+
+setup() ->
+    {ok, ServerSocket} = roadrunner_quic_socket:open(0),
+    {ok, ClientSocket} = roadrunner_quic_socket:open(0),
+    {ok, {_Ip, ClientPort}} = roadrunner_quic_socket:sockname(ClientSocket),
+    Peer = {{127, 0, 0, 1}, ClientPort},
+    {Config, Ctx} = config(Peer),
+    {ok, Shell} = ?CONN:start(ServerSocket, Config),
+    #{shell => Shell, peer => Peer, client => ClientSocket, server => ServerSocket, ctx => Ctx}.
+
+cleanup(#{shell := Shell, client := ClientSocket, server := ServerSocket}) ->
+    exit(Shell, kill),
+    ok = roadrunner_quic_socket:close(ClientSocket),
+    ok = roadrunner_quic_socket:close(ServerSocket).
+
+%% =============================================================================
+%% A full handshake driven over real sockets reaches HANDSHAKE_DONE.
+%% =============================================================================
+
+handshake_completes(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
+    fun() ->
+        #{client_priv := ClientPriv, server_pub := ServerPub} = Ctx,
+
+        %% Client Initial -> the shell answers with its first flight.
+        {InitialDatagram, ClientHelloFramed} = client_hello(Ctx),
+        Shell ! {quic_datagram, Peer, InitialDatagram},
+        Flight1 = recv_all(ClientSocket),
+
+        ServerHello = ?TC:crypto_bytes(
+            Flight1,
+            initial,
+            #{initial => roadrunner_quic_keys:initial_server(?DCID)},
+            byte_size(?DCID)
+        ),
+        ?assertNotEqual(<<>>, ServerHello),
+        Shared = crypto:compute_key(ecdh, ServerPub, ClientPriv, x25519),
+        HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
+            roadrunner_quic_tls_crypto:early_secret(), Shared
+        ),
+        HelloHash = roadrunner_quic_tls_crypto:transcript_hash([ClientHelloFramed, ServerHello]),
+        ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+            client, handshake, HandshakeSecret, HelloHash
+        ),
+        ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+            server, handshake, HandshakeSecret, HelloHash
+        ),
+        Flight = ?TC:crypto_bytes(
+            Flight1,
+            handshake,
+            #{handshake => roadrunner_quic_keys:traffic_keys(ServerHsSecret)},
+            byte_size(?DCID)
+        ),
+        FinishedHash = roadrunner_quic_tls_crypto:transcript_hash([
+            ClientHelloFramed, ServerHello, Flight
+        ]),
+
+        %% Client Finished -> the shell becomes connected and sends HANDSHAKE_DONE.
+        ClientFinishedBody = roadrunner_quic_tls_crypto:verify_data(
+            roadrunner_quic_tls_crypto:finished_key(ClientHsSecret), FinishedHash
+        ),
+        ClientFinishedFramed = iolist_to_binary(
+            roadrunner_quic_tls_handshake:encode(?FINISHED, ClientFinishedBody)
+        ),
+        FinishedDatagram = ?TC:seal(
+            handshake,
+            0,
+            roadrunner_quic_keys:traffic_keys(ClientHsSecret),
+            [{crypto, 0, ClientFinishedFramed}],
+            ?DCID,
+            ?SCID
+        ),
+        Shell ! {quic_datagram, Peer, FinishedDatagram},
+        Flight2 = recv_all(ClientSocket),
+
+        MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
+        ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+            server, application, MasterSecret, FinishedHash
+        ),
+        AppFrames = ?TC:frames(
+            Flight2,
+            application,
+            #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+            byte_size(?DCID)
+        ),
+        ?assert(lists:member(handshake_done, AppFrames))
+    end.
+
+%% =============================================================================
+%% OTP / stray messages keep the long-lived loop alive.
+%% =============================================================================
+
+system_message_handled(#{shell := Shell}) ->
+    fun() ->
+        %% sys:get_state drives the {system, _, _} clause; the handler state
+        %% is opaque, so the assertion is only that the loop resumed.
+        _State = sys:get_state(Shell),
+        ?assert(is_process_alive(Shell))
+    end.
+
+unsupported_call_replies(#{shell := Shell}) ->
+    fun() ->
+        ?assertEqual({error, not_supported}, gen_server:call(Shell, ping))
+    end.
+
+cast_ignored(#{shell := Shell}) ->
+    fun() ->
+        ok = gen_server:cast(Shell, anything),
+        ?assert(still_running(Shell))
+    end.
+
+stray_message_ignored(#{shell := Shell}) ->
+    fun() ->
+        Shell ! some_stray_message,
+        ?assert(still_running(Shell))
+    end.
+
+%% =============================================================================
+%% Timers.
+%% =============================================================================
+
+stale_timer_fire_ignored(#{shell := Shell}) ->
+    fun() ->
+        %% A timer fire whose ref is not the armed one is dropped.
+        Shell ! {?CONN, timer, pto, make_ref()},
+        ?assert(still_running(Shell))
+    end.
+
+loss_timer_fires(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
+    {timeout, 10, fun() ->
+        %% Feed only the ClientHello so the handshake stalls; the shell sends
+        %% its flight and arms a probe timer that fires with no peer response,
+        %% driving the armed-ref timer path. The probe timeout is ~1s (initial
+        %% RTT 333ms), so wait past it. That the re-arm backs off rather than
+        %% busy-spinning is proven in roadrunner_quic_conn_state_tests
+        %% (pto_backoff_advances_deadline_test); here we only confirm the shell
+        %% handled the fire and stayed alive.
+        {InitialDatagram, _ClientHelloFramed} = client_hello(Ctx),
+        Shell ! {quic_datagram, Peer, InitialDatagram},
+        _Flight = recv_all(ClientSocket),
+        timer:sleep(1500),
+        ?assert(still_running(Shell))
+    end}.
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+config(Peer) ->
+    {Scheme, PrivKey} = ?TC:key_material(),
+    {ClientPub, ClientPriv} = ?TC:gen_keypair(),
+    {ServerPub, ServerPriv} = ?TC:gen_keypair(),
+    Config = #{
+        dcid => ?DCID,
+        scid => ?SCID,
+        peer => Peer,
+        cert_chain => [~"leaf-cert-der"],
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => #{
+            original_destination_connection_id => ?DCID,
+            initial_source_connection_id => ?SCID
+        },
+        eph_pub => ServerPub,
+        eph_priv => ServerPriv,
+        server_random => crypto:strong_rand_bytes(32)
+    },
+    {Config, #{
+        scheme => Scheme,
+        client_pub => ClientPub,
+        client_priv => ClientPriv,
+        server_pub => ServerPub
+    }}.
+
+client_hello(#{scheme := Scheme, client_pub := ClientPub}) ->
+    Framed = ?TC:client_hello_framed(Scheme, ClientPub),
+    Datagram = ?TC:seal(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}], ?DCID, ?SCID
+    ),
+    {Datagram, Framed}.
+
+%% Collect datagrams the shell sent until a quiet gap (no in-test loss, so
+%% the whole flight arrives back to back).
+recv_all(Socket) ->
+    case roadrunner_quic_socket:recv(Socket, 200) of
+        {ok, _Peer, Data} -> [Data | recv_all(Socket)];
+        {error, timeout} -> []
+    end.
+
+%% A synchronous round-trip after an async message proves the loop consumed
+%% that message (mailbox order) and is still looping.
+still_running(Shell) ->
+    _State = sys:get_state(Shell),
+    is_process_alive(Shell).

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -18,6 +18,7 @@ shell_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun handshake_completes/1,
         fun send_data_round_trip/1,
+        fun peer_close_terminates_shell/1,
         fun peername_round_trip/1,
         fun set_owner_emits_connected/1,
         fun system_message_handled/1,
@@ -48,7 +49,7 @@ cleanup(#{shell := Shell, client := ClientSocket, server := ServerSocket}) ->
 
 handshake_completes(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
     fun() ->
-        ServerApSecret = do_handshake(Shell, Peer, ClientSocket, Ctx),
+        {_ClientApSecret, ServerApSecret} = do_handshake(Shell, Peer, ClientSocket, Ctx),
         AppFrames = ?TC:frames(
             recv_all(ClientSocket),
             application,
@@ -62,7 +63,7 @@ handshake_completes(#{shell := Shell, peer := Peer, client := ClientSocket, ctx 
 %% with {quic_reply, Ref, ok} and the data goes out as a 1-RTT STREAM frame.
 send_data_round_trip(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
     fun() ->
-        ServerApSecret = do_handshake(Shell, Peer, ClientSocket, Ctx),
+        {_ClientApSecret, ServerApSecret} = do_handshake(Shell, Peer, ClientSocket, Ctx),
         Ref = make_ref(),
         Shell ! {quic_send, self(), Ref, 0, ~"hello", true},
         receive
@@ -78,6 +79,42 @@ send_data_round_trip(#{shell := Shell, peer := Peer, client := ClientSocket, ctx
         ),
         ?assert(lists:member({stream, 0, 0, ~"hello", true}, Frames))
     end.
+
+%% A peer CONNECTION_CLOSE emits {closed, _} to the owner and terminates the
+%% shell process cleanly (a normal proc_lib exit, not a crash).
+peer_close_terminates_shell(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
+    {timeout, 10, fun() ->
+        {ClientApSecret, _ServerApSecret} = do_handshake(Shell, Peer, ClientSocket, Ctx),
+        %% Install self as owner (handshake already done, so {connected, _}
+        %% comes back immediately) to receive the {closed, _} event.
+        Ref = make_ref(),
+        Shell ! {quic_call, self(), Ref, {set_owner, self()}},
+        receive
+            {quic_reply, Ref, ok} -> ok
+        after 1000 ->
+            erlang:error(no_reply)
+        end,
+        receive
+            {quic, Shell, {connected, _}} -> ok
+        after 1000 ->
+            erlang:error(no_connected_event)
+        end,
+        Close = ?TC:seal(
+            application,
+            0,
+            roadrunner_quic_keys:traffic_keys(ClientApSecret),
+            [{connection_close, transport, 0, 0, <<>>}],
+            ?DCID,
+            ?SCID
+        ),
+        Shell ! {quic_datagram, Peer, Close},
+        receive
+            {quic, Shell, {closed, {peer, 0}}} -> ok
+        after 1000 ->
+            erlang:error(no_closed_event)
+        end,
+        wait_dead(Shell, 50)
+    end}.
 
 %% A synchronous peername control call round-trips through the shell.
 peername_round_trip(#{shell := Shell, peer := Peer}) ->
@@ -95,7 +132,7 @@ peername_round_trip(#{shell := Shell, peer := Peer}) ->
 %% {connected, _} event back to it.
 set_owner_emits_connected(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
     fun() ->
-        _ServerApSecret = do_handshake(Shell, Peer, ClientSocket, Ctx),
+        _Secrets = do_handshake(Shell, Peer, ClientSocket, Ctx),
         %% do_handshake sent the client Finished before this set_owner, so by
         %% mailbox FIFO the shell is already connected when set_owner runs and
         %% the {connected, _} emit takes the deferred (install_owner) path.
@@ -255,7 +292,13 @@ do_handshake(Shell, Peer, ClientSocket, Ctx) ->
     ),
     Shell ! {quic_datagram, Peer, FinishedDatagram},
     MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
-    roadrunner_quic_tls_crypto:traffic_secret(server, application, MasterSecret, FinishedHash).
+    ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, application, MasterSecret, FinishedHash
+    ),
+    ClientApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, application, MasterSecret, FinishedHash
+    ),
+    {ClientApSecret, ServerApSecret}.
 
 %% Collect datagrams the shell sent until a quiet gap (no in-test loss, so
 %% the whole flight arrives back to back).
@@ -270,3 +313,16 @@ recv_all(Socket) ->
 still_running(Shell) ->
     _State = sys:get_state(Shell),
     is_process_alive(Shell).
+
+%% Poll until the shell process has exited (a clean teardown), failing if it
+%% is still alive after the budget of ~20ms ticks.
+wait_dead(_Shell, 0) ->
+    erlang:error(still_alive);
+wait_dead(Shell, N) ->
+    case is_process_alive(Shell) of
+        false ->
+            ok;
+        true ->
+            timer:sleep(20),
+            wait_dead(Shell, N - 1)
+    end.

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -17,6 +17,7 @@
 shell_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun handshake_completes/1,
+        fun send_data_round_trip/1,
         fun peername_round_trip/1,
         fun set_owner_emits_connected/1,
         fun system_message_handled/1,
@@ -55,6 +56,27 @@ handshake_completes(#{shell := Shell, peer := Peer, client := ClientSocket, ctx 
             byte_size(?DCID)
         ),
         ?assert(lists:member(handshake_done, AppFrames))
+    end.
+
+%% A stream write round-trips through the shell: {quic_send, ...} is answered
+%% with {quic_reply, Ref, ok} and the data goes out as a 1-RTT STREAM frame.
+send_data_round_trip(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
+    fun() ->
+        ServerApSecret = do_handshake(Shell, Peer, ClientSocket, Ctx),
+        Ref = make_ref(),
+        Shell ! {quic_send, self(), Ref, 0, ~"hello", true},
+        receive
+            {quic_reply, Ref, ok} -> ok
+        after 1000 ->
+            erlang:error(no_reply)
+        end,
+        Frames = ?TC:frames(
+            recv_all(ClientSocket),
+            application,
+            #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+            byte_size(?DCID)
+        ),
+        ?assert(lists:member({stream, 0, 0, ~"hello", true}, Frames))
     end.
 
 %% A synchronous peername control call round-trips through the shell.

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -1,0 +1,191 @@
+-module(roadrunner_quic_test_client).
+-moduledoc false.
+
+%% Shared in-test QUIC client driver: the crypto/codec primitives a test
+%% needs to play the QUIC client against the native server modules, used by
+%% both the pure-value `roadrunner_quic_conn_state` tests and the
+%% `roadrunner_quic_connection` process tests. The TLS 1.3 key schedule
+%% itself is a handful of `roadrunner_quic_tls_crypto` calls each test makes
+%% inline (the explicit client derivation is part of what the test asserts);
+%% this module supplies the ClientHello codec, the packet sealing, and the
+%% server-reply decoding so neither is duplicated.
+
+-include_lib("public_key/include/public_key.hrl").
+
+-export([key_material/0, gen_keypair/0]).
+-export([client_hello_framed/2]).
+-export([seal/6, seal_raw/6]).
+-export([crypto_bytes/4, frames/4]).
+-export([server_hello_key_share/1, deframe_all/1]).
+
+%% TLS handshake message types (RFC 8446 §4).
+-define(CLIENT_HELLO, 1).
+-define(SERVER_HELLO, 2).
+
+%% ClientHello wire constants (RFC 8446 §4.1.2).
+-define(LEGACY_VERSION, 16#0303).
+-define(CIPHER_AES_128_GCM_SHA256, 16#1301).
+-define(GROUP_X25519, 16#001D).
+-define(EXT_SIGNATURE_ALGORITHMS, 16#000D).
+-define(EXT_ALPN, 16#0010).
+-define(EXT_KEY_SHARE, 16#0033).
+
+%% =============================================================================
+%% Key material
+%% =============================================================================
+
+-doc "A fresh RSA key pair and its signature scheme (rsa_pss_rsae_sha256).".
+-spec key_material() -> {Scheme :: 16#0804, public_key:private_key()}.
+key_material() ->
+    PrivKey = public_key:generate_key({rsa, 2048, 65537}),
+    {16#0804, PrivKey}.
+
+-doc "A fresh x25519 ephemeral key pair.".
+-spec gen_keypair() -> {Pub :: binary(), Priv :: binary()}.
+gen_keypair() ->
+    crypto:generate_key(ecdh, x25519).
+
+%% =============================================================================
+%% ClientHello
+%% =============================================================================
+
+-doc """
+A framed ClientHello (handshake-message bytes, RFC 8446 §4.1.2) offering
+the given signature scheme, the x25519 key share, and the `h3` ALPN. These
+bytes are both the CRYPTO-frame payload and the first transcript element.
+""".
+-spec client_hello_framed(Scheme :: non_neg_integer(), ClientPub :: binary()) -> binary().
+client_hello_framed(Scheme, ClientPub) ->
+    Random = crypto:strong_rand_bytes(32),
+    Extensions = iolist_to_binary([
+        signature_algorithms_ext([Scheme]),
+        alpn_ext(~"h3"),
+        key_share_ext(ClientPub)
+    ]),
+    CipherSuites = <<?CIPHER_AES_128_GCM_SHA256:16>>,
+    Body =
+        <<?LEGACY_VERSION:16, Random/binary, 0:8, (byte_size(CipherSuites)):16, CipherSuites/binary,
+            1:8, 0:8, (byte_size(Extensions)):16, Extensions/binary>>,
+    iolist_to_binary(roadrunner_quic_tls_handshake:encode(?CLIENT_HELLO, Body)).
+
+signature_algorithms_ext(Schemes) ->
+    List = <<<<S:16>> || S <- Schemes>>,
+    extension(?EXT_SIGNATURE_ALGORITHMS, <<(byte_size(List)):16, List/binary>>).
+
+alpn_ext(Protocol) ->
+    Entry = <<(byte_size(Protocol)):8, Protocol/binary>>,
+    extension(?EXT_ALPN, <<(byte_size(Entry)):16, Entry/binary>>).
+
+key_share_ext(PubKey) ->
+    Entry = <<?GROUP_X25519:16, (byte_size(PubKey)):16, PubKey/binary>>,
+    extension(?EXT_KEY_SHARE, <<(byte_size(Entry)):16, Entry/binary>>).
+
+extension(Type, Data) ->
+    <<Type:16, (byte_size(Data)):16, Data/binary>>.
+
+%% =============================================================================
+%% Packet sealing (build client datagrams)
+%% =============================================================================
+
+-doc """
+Build a one-level client datagram through the send pipeline. An Initial is
+padded to 1200, satisfying the server's anti-amplification budget.
+""".
+-spec seal(
+    roadrunner_quic_send:level(),
+    non_neg_integer(),
+    roadrunner_quic_keys:keys(),
+    [roadrunner_quic_frame:frame()],
+    binary(),
+    binary()
+) -> binary().
+seal(Level, PN, Keys, Frames, DCID, SCID) ->
+    Entries = #{Level => #{frames => Frames, keys => Keys, pn => PN}},
+    {Datagram, _Sent} = roadrunner_quic_send:datagram(Entries, DCID, SCID),
+    Datagram.
+
+-doc """
+Seal raw plaintext (bypassing frame encoding) so a packet can carry a
+deliberately malformed frame, mirroring the send path's header sizing.
+""".
+-spec seal_raw(
+    roadrunner_quic_packet:long_type(),
+    non_neg_integer(),
+    roadrunner_quic_keys:keys(),
+    binary(),
+    binary(),
+    binary()
+) -> binary().
+seal_raw(Level, PN, #{key := Key, iv := IV, hp := HP}, Plaintext, DCID, SCID) ->
+    PNLen = roadrunner_quic_packet:pn_length(PN),
+    SealedSize = byte_size(Plaintext) + 16,
+    [Header, _Payload] = roadrunner_quic_packet:encode_long(
+        Level, 1, DCID, SCID, #{pn => PN, payload => <<0:(SealedSize * 8)>>}
+    ),
+    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
+    <<Protected/binary, Sealed/binary>>.
+
+%% =============================================================================
+%% Decode server datagrams
+%% =============================================================================
+
+-doc """
+Contiguous CRYPTO bytes for a level across the server's datagrams. The
+per-level keys map filters out the other levels' packets (they decode to
+`{drop, no_keys}`); with no in-test loss a sorted concat reassembles the
+flight.
+""".
+-spec crypto_bytes(
+    [binary()],
+    roadrunner_quic_recv:level(),
+    #{roadrunner_quic_recv:level() => map()},
+    non_neg_integer()
+) -> binary().
+crypto_bytes(Datagrams, Level, Keys, DCIDLen) ->
+    Slices = [{Offset, Data} || {crypto, Offset, Data} <- frames(Datagrams, Level, Keys, DCIDLen)],
+    iolist_to_binary([Data || {_Offset, Data} <- lists:sort(Slices)]).
+
+-doc "Every frame decoded at a level across the server's datagrams.".
+-spec frames(
+    [binary()],
+    roadrunner_quic_recv:level(),
+    #{roadrunner_quic_recv:level() => map()},
+    non_neg_integer()
+) -> [roadrunner_quic_frame:frame()].
+frames(Datagrams, Level, Keys, DCIDLen) ->
+    lists:append([level_frames(Datagram, Level, Keys, DCIDLen) || Datagram <- Datagrams]).
+
+level_frames(Datagram, Level, Keys, DCIDLen) ->
+    Outcomes = roadrunner_quic_recv:datagram(Datagram, DCIDLen, Keys, #{}),
+    lists:append([Fs || {ok, #{level := L, frames := Fs}} <- Outcomes, L =:= Level]).
+
+%% =============================================================================
+%% Handshake-message decoding
+%% =============================================================================
+
+-doc "The server's x25519 public key from a ServerHello's key_share extension.".
+-spec server_hello_key_share(binary()) -> binary().
+server_hello_key_share(ServerHello) ->
+    [{?SERVER_HELLO, Body} | _] = deframe_all(ServerHello),
+    <<_LegacyVersion:16, _Random:32/binary, SessionLen:8, _Session:SessionLen/binary, _Cipher:16,
+        _Compression:8, _ExtsLen:16, Extensions/binary>> = Body,
+    <<?GROUP_X25519:16, KeyLen:16, PubKey:KeyLen/binary>> =
+        extract_extension(?EXT_KEY_SHARE, Extensions),
+    PubKey.
+
+extract_extension(Type, <<Type:16, Len:16, Data:Len/binary, _Rest/binary>>) ->
+    Data;
+extract_extension(Type, <<_OtherType:16, Len:16, _Data:Len/binary, Rest/binary>>) ->
+    extract_extension(Type, Rest).
+
+-doc "Decode all framed handshake messages into `{Type, Body}` pairs.".
+-spec deframe_all(iodata()) -> [{byte(), binary()}].
+deframe_all(Iolist) ->
+    deframe_all_bin(iolist_to_binary(Iolist)).
+
+deframe_all_bin(<<>>) ->
+    [];
+deframe_all_bin(Bin) ->
+    {ok, {Type, Body}, Rest} = roadrunner_quic_tls_handshake:decode(Bin),
+    [{Type, Body} | deframe_all_bin(Rest)].


### PR DESCRIPTION
# Description

The native QUIC server connection: a pure decision core plus a `proc_lib` loop that drives it through the TLS 1.3 handshake, stream send and receive with flow control, owner events and control calls, and connection close (peer, error, and idle). A `quic` dep client completes a full handshake against it over loopback.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
