### PR TITLE
Add the native QUIC listener

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -88,6 +88,7 @@
         {"test/roadrunner_http3_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_connection_interop_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_quic_listener_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_tls_tests.erl", unnecessary_function_arguments},
         {"test/roadrunner_conn_tests.erl", unnecessary_function_arguments},

--- a/src/roadrunner_quic_cid_registry.erl
+++ b/src/roadrunner_quic_cid_registry.erl
@@ -1,0 +1,57 @@
+-module(roadrunner_quic_cid_registry).
+-moduledoc false.
+
+%% The connection-id -> connection-pid routing table for the native QUIC
+%% listener (an ETS set).
+%%
+%% A received datagram is routed to its owning connection by the Destination
+%% Connection ID in its header. A connection is registered under BOTH the
+%% client's original DCID (which the peer uses on its early Initials) and the
+%% server's issued SCID (which the peer echoes once it learns it, and which
+%% every fixed-length short-header 1-RTT packet carries), so either addressing
+%% finds the connection (RFC 9000 §5.1). The table is `public` so a
+%% SO_REUSEPORT pool can share one manager-held table across its listeners.
+%%
+%% Cleanup is the owner's contract: the listener monitors each connection and
+%% calls delete_pid/2 when it ends. Between a connection ending and that
+%% cleanup, lookup/2 may briefly return its now-dead pid; routing a datagram
+%% there is a harmless no-op (the message is dropped) and is the right outcome
+%% anyway (a datagram for a gone connection should be dropped). A registration
+%% for an id already held by another pid (a recycled or, astronomically,
+%% colliding client DCID) overwrites it; the previous pid's other ids are
+%% reaped by its own delete_pid/2.
+
+-export([new/0, register_pair/4, lookup/2, delete_pid/2]).
+
+-export_type([t/0]).
+
+-opaque t() :: ets:table().
+
+-doc "Create an empty routing table, owned by the calling process.".
+-spec new() -> t().
+new() ->
+    ets:new(?MODULE, [set, public, {read_concurrency, true}, {write_concurrency, auto}]).
+
+-doc """
+Route a connection's client DCID and server SCID to its pid (the dual
+registration of RFC 9000 §5.1), so a datagram addressed to either id reaches
+the connection.
+""".
+-spec register_pair(t(), binary(), binary(), pid()) -> ok.
+register_pair(Table, DCID, SCID, Pid) ->
+    true = ets:insert(Table, [{DCID, Pid}, {SCID, Pid}]),
+    ok.
+
+-doc "The connection owning a destination connection id, if one is registered.".
+-spec lookup(t(), binary()) -> {ok, pid()} | error.
+lookup(Table, CID) ->
+    case ets:lookup(Table, CID) of
+        [{_CID, Pid}] -> {ok, Pid};
+        [] -> error
+    end.
+
+-doc "Drop every connection id routing to `Pid` (its connection has ended).".
+-spec delete_pid(t(), pid()) -> ok.
+delete_pid(Table, Pid) ->
+    true = ets:match_delete(Table, {'_', Pid}),
+    ok.

--- a/src/roadrunner_quic_listener.erl
+++ b/src/roadrunner_quic_listener.erl
@@ -1,0 +1,287 @@
+-module(roadrunner_quic_listener).
+-moduledoc false.
+
+%% A single native QUIC listener: one UDP socket, a connection-id routing
+%% table, and the per-connection spawn ordering. A hand-rolled proc_lib
+%% receive loop (never a gen_server, mirroring the connection shell), driving
+%% the socket in `active => once` mode so datagrams interleave with monitor
+%% and system messages in one loop.
+%%
+%% Each datagram is routed by its Destination Connection ID
+%% (`roadrunner_quic_cid_registry`): a hit forwards `{quic_datagram, Peer,
+%% Bytes}` to the owning connection; a miss on a QUIC v1 Initial spawns a new
+%% connection. Spawning follows the strict ordering the handshake depends on
+%% (RFC 9000 / the dep's contract): spawn the connection, monitor it (so a
+%% fast death is reaped before its connection ids are registered), register
+%% its CIDs (so a fast follow-up datagram already routes), run the
+%% connection_handler to get the application owner, install the owner
+%% SYNCHRONOUSLY (so ownership transfers before the handshake can complete and
+%% race the `{connected, _}` event), and only then feed the first Initial. Slot
+%% limiting, telemetry, and drain stay in the owner the handler returns; the
+%% listener owns none of them.
+%%
+%% A new server Source Connection ID is generated per connection at a fixed
+%% length, so short-header 1-RTT packets (which carry no CID-length field)
+%% demux by slicing that many leading bytes. The SO_REUSEPORT pool, the
+%% Version Negotiation trigger, and the supervisor are later slices.
+
+-export([start_link/1, get_port/1, stop/1]).
+-export([init/1]).
+%% Exported for exhaustive eunit branch coverage of the pure routing decision.
+-export([classify/2]).
+
+-export_type([opts/0]).
+
+%% Must match roadrunner_quic_conn_state's ?SCID_LEN: the server issues SCIDs
+%% of this length so short-header packets demux by slicing it.
+-define(SCID_LEN, 8).
+%% QUIC version 1 (RFC 9000 §15); also defined in roadrunner_quic_send.
+-define(QUIC_V1, 16#00000001).
+%% RFC 9000 §14.1: a server MUST discard an Initial packet carried in a UDP
+%% datagram whose payload is smaller than 1200 bytes, so a too-small Initial
+%% never spawns a connection (clients pad Initial datagrams to this floor).
+-define(MIN_INITIAL_DATAGRAM, 1200).
+
+-type opts() :: #{
+    port := inet:port_number(),
+    cert_chain := [binary()],
+    priv_key := public_key:private_key(),
+    alpn := binary(),
+    transport_params := roadrunner_quic_transport_params:params(),
+    connection_handler := fun((pid()) -> {ok, pid()} | {error, term()}),
+    reuseport => boolean()
+}.
+
+-record(listener, {
+    socket :: roadrunner_quic_socket:socket(),
+    port :: inet:port_number(),
+    registry :: roadrunner_quic_cid_registry:t(),
+    cert_chain :: [binary()],
+    priv_key :: public_key:private_key(),
+    alpn :: binary(),
+    %% The base transport parameters (flow/stream/idle limits); the per-
+    %% connection original/initial connection ids are filled in at spawn.
+    transport_params :: roadrunner_quic_transport_params:params(),
+    handler :: fun((pid()) -> {ok, pid()} | {error, term()})
+}).
+
+%% =============================================================================
+%% API
+%% =============================================================================
+
+-doc """
+Start a listener bound to `port` (0 picks an ephemeral port, read back with
+get_port/1). Returns once the socket is bound, so a bind failure surfaces
+synchronously as `{error, _}`.
+""".
+-spec start_link(opts()) -> {ok, pid()} | {error, term()}.
+start_link(Opts) ->
+    proc_lib:start_link(?MODULE, init, [Opts]).
+
+-doc "The port the listener is bound to.".
+-spec get_port(pid()) -> inet:port_number().
+get_port(Pid) ->
+    gen_server:call(Pid, get_port).
+
+-doc "Stop the listener and close its socket.".
+-spec stop(pid()) -> ok.
+stop(Pid) ->
+    gen_server:call(Pid, stop).
+
+%% =============================================================================
+%% Loop
+%% =============================================================================
+
+-doc false.
+-spec init(opts()) -> no_return().
+init(
+    #{
+        port := Port,
+        cert_chain := CertChain,
+        priv_key := PrivKey,
+        alpn := Alpn,
+        transport_params := TransportParams,
+        connection_handler := Handler
+    } = Opts
+) ->
+    ReusePort = maps:get(reuseport, Opts, false),
+    case roadrunner_quic_socket:open(Port, #{active => once, reuseport => ReusePort}) of
+        {ok, Socket} ->
+            {ok, {_Ip, BoundPort}} = roadrunner_quic_socket:sockname(Socket),
+            proc_lib:set_label({?MODULE, BoundPort}),
+            proc_lib:init_ack({ok, self()}),
+            loop(#listener{
+                socket = Socket,
+                port = BoundPort,
+                registry = roadrunner_quic_cid_registry:new(),
+                cert_chain = CertChain,
+                priv_key = PrivKey,
+                alpn = Alpn,
+                transport_params = TransportParams,
+                handler = Handler
+            });
+        {error, Reason} ->
+            proc_lib:init_ack({error, Reason}),
+            exit(normal)
+    end.
+
+-spec loop(#listener{}) -> no_return().
+loop(#listener{socket = Socket} = State) ->
+    receive
+        {system, From, Req} ->
+            roadrunner_loop_sys:handle_system(Req, From, State, fun loop/1);
+        {'$gen_call', From, get_port} ->
+            ok = gen_server:reply(From, State#listener.port),
+            loop(State);
+        {'$gen_call', From, stop} ->
+            ok = gen_server:reply(From, ok),
+            ok = roadrunner_quic_socket:close(Socket),
+            exit(normal);
+        {'$gen_call', From, _Request} ->
+            ok = roadrunner_loop_sys:gen_call_unsupported(From),
+            loop(State);
+        {'$gen_cast', _Request} ->
+            loop(State);
+        {'DOWN', _Ref, process, Pid, _Reason} ->
+            ok = roadrunner_quic_cid_registry:delete_pid(State#listener.registry, Pid),
+            loop(State);
+        Message ->
+            loop(handle_message(Message, State))
+    end.
+
+%% A datagram from the active socket is routed (re-arming the socket first so
+%% the next datagram is already queued during the spawn round-trip); anything
+%% else is a stray message and dropped.
+-spec handle_message(term(), #listener{}) -> #listener{}.
+handle_message(Message, #listener{socket = Socket} = State) ->
+    case roadrunner_quic_socket:from_message(Socket, Message) of
+        {ok, Peer, Datagram} ->
+            ok = roadrunner_quic_socket:activate(Socket),
+            route(Datagram, Peer, State);
+        ignore ->
+            State
+    end.
+
+%% =============================================================================
+%% Routing
+%% =============================================================================
+
+%% Execute a datagram's routing decision: forward to the owning connection,
+%% spawn one for a new client, or drop.
+-spec route(binary(), {inet:ip_address(), inet:port_number()}, #listener{}) -> #listener{}.
+route(Datagram, Peer, #listener{registry = Registry} = State) ->
+    case classify(Datagram, Registry) of
+        {forward, ConnPid} ->
+            _ = ConnPid ! {quic_datagram, Peer, Datagram},
+            State;
+        {spawn, ClientDCID} ->
+            spawn_connection(Datagram, Peer, ClientDCID, State);
+        drop ->
+            State
+    end.
+
+%% Decide a datagram's fate from its Destination Connection ID and the routing
+%% table (a pure decision given the table): `{forward, Pid}` to the owning
+%% connection, `{spawn, DCID}` for a QUIC v1 Initial (in a datagram at the RFC
+%% 9000 §14.1 1200-byte floor) to an unknown id, or `drop` otherwise: a
+%% malformed header, a packet to an unknown id that is not a v1 Initial (a
+%% stray short-header packet; an unknown version is the Version Negotiation
+%% slice), or a v1 Initial below the §14.1 floor (a server MUST discard those,
+%% so we never spawn for one). The forward path is size-unconditional; the
+%% owning connection enforces §14.1 on its own received Initials.
+-doc false.
+-spec classify(binary(), roadrunner_quic_cid_registry:t()) ->
+    {forward, pid()} | {spawn, binary()} | drop.
+classify(Datagram, Registry) ->
+    case roadrunner_quic_packet:dcid(Datagram, ?SCID_LEN) of
+        {ok, DCID} ->
+            case roadrunner_quic_cid_registry:lookup(Registry, DCID) of
+                {ok, ConnPid} ->
+                    {forward, ConnPid};
+                error ->
+                    case
+                        is_v1_initial(Datagram) andalso
+                            byte_size(Datagram) >= ?MIN_INITIAL_DATAGRAM
+                    of
+                        true -> {spawn, DCID};
+                        false -> drop
+                    end
+            end;
+        {error, _Reason} ->
+            drop
+    end.
+
+-spec is_v1_initial(binary()) -> boolean().
+is_v1_initial(<<1:1, _Fixed:1, 0:2, _TypeSpecific:4, Version:32, _/binary>>) ->
+    Version =:= ?QUIC_V1;
+is_v1_initial(_Datagram) ->
+    false.
+
+%% Spawn a connection for a new client and feed it its first Initial, in the
+%% order the handshake depends on: spawn -> monitor -> register both connection
+%% ids -> run the handler for the owner -> install the owner synchronously ->
+%% feed.
+-spec spawn_connection(binary(), {inet:ip_address(), inet:port_number()}, binary(), #listener{}) ->
+    #listener{}.
+spawn_connection(
+    Datagram,
+    Peer,
+    ClientDCID,
+    #listener{socket = Socket, registry = Registry, handler = Handler} = State
+) ->
+    ServerSCID = crypto:strong_rand_bytes(?SCID_LEN),
+    {ok, ConnPid} = roadrunner_quic_connection:start(
+        Socket, conn_config(ClientDCID, ServerSCID, Peer, State)
+    ),
+    _Ref = monitor(process, ConnPid),
+    ok = roadrunner_quic_cid_registry:register_pair(Registry, ClientDCID, ServerSCID, ConnPid),
+    ok = install_owner(ConnPid, Handler),
+    _ = ConnPid ! {quic_datagram, Peer, Datagram},
+    State.
+
+%% Run the connection_handler to get the application owner and install it
+%% synchronously. On a refusal (e.g. {error, max_clients}) the owner is simply
+%% not installed; the connection will idle out (graceful refusal is a later
+%% slice).
+-spec install_owner(pid(), fun((pid()) -> {ok, pid()} | {error, term()})) -> ok.
+install_owner(ConnPid, Handler) ->
+    case Handler(ConnPid) of
+        {ok, Owner} when is_pid(Owner) ->
+            set_owner_sync(ConnPid, Owner);
+        {error, Reason} ->
+            logger:warning(#{what => quic_connection_handler_refused, reason => Reason}),
+            ok
+    end.
+
+%% The synchronous set_owner round-trip (mirrors the connection's control-call
+%% wire): the connection records the owner before any datagram drives the
+%% handshake, so the {connected, _} event cannot race ahead of ownership.
+-spec set_owner_sync(pid(), pid()) -> ok.
+set_owner_sync(ConnPid, Owner) ->
+    Ref = make_ref(),
+    _ = ConnPid ! {quic_call, self(), Ref, {set_owner, Owner}},
+    receive
+        {quic_reply, Ref, ok} -> ok
+    end.
+
+-spec conn_config(binary(), binary(), {inet:ip_address(), inet:port_number()}, #listener{}) ->
+    roadrunner_quic_conn_state:config().
+conn_config(ClientDCID, ServerSCID, Peer, #listener{
+    cert_chain = CertChain, priv_key = PrivKey, alpn = Alpn, transport_params = TransportParams
+}) ->
+    {EphPub, EphPriv} = crypto:generate_key(ecdh, x25519),
+    #{
+        dcid => ClientDCID,
+        scid => ServerSCID,
+        peer => Peer,
+        cert_chain => CertChain,
+        priv_key => PrivKey,
+        alpn => Alpn,
+        transport_params => TransportParams#{
+            original_destination_connection_id => ClientDCID,
+            initial_source_connection_id => ServerSCID
+        },
+        eph_pub => EphPub,
+        eph_priv => EphPriv,
+        server_random => crypto:strong_rand_bytes(32)
+    }.

--- a/src/roadrunner_quic_socket.erl
+++ b/src/roadrunner_quic_socket.erl
@@ -13,14 +13,17 @@
 %% send/receive pipeline, not the shared socket. The socket delivers each
 %% UDP datagram whole, with its source address.
 
--export([open/1, open/2, send/4, recv/2, close/1, sockname/1]).
+-export([open/1, open/2, send/4, recv/2, activate/1, from_message/2, close/1, sockname/1]).
 
 -export_type([socket/0, open_opts/0]).
 
 -opaque socket() :: {gen_udp, gen_udp:socket()}.
 
 -type open_opts() :: #{
-    recbuf => pos_integer(), sndbuf => pos_integer(), reuseport => boolean()
+    recbuf => pos_integer(),
+    sndbuf => pos_integer(),
+    reuseport => boolean(),
+    active => once | false
 }.
 
 %% Larger than the OS default, so a burst of datagrams is not dropped
@@ -34,21 +37,28 @@ open(Port) ->
     open(Port, #{}).
 
 -doc """
-Open a UDP socket on `Port`. The socket is binary and passive
-(`{active, false}`), with `reuseaddr` set; `recbuf` and `sndbuf` may be
-overridden via `Opts`. Port 0 picks an ephemeral port (read it back with
-`sockname/1`).
+Open a UDP socket on `Port`. The socket is binary, with `reuseaddr` set;
+`recbuf` and `sndbuf` may be overridden via `Opts`. Port 0 picks an ephemeral
+port (read it back with `sockname/1`).
 
-Set `reuseport` to `true` to enable `SO_REUSEPORT`, which lets a pool
-of sockets share one concrete port with kernel datagram fan-out (the
-shape the listener pool uses); it defaults to `false` for a lone socket.
+`active` defaults to `false` (passive: drain with `recv/2`). Set it to `once`
+for the listener: each datagram is then delivered to the controlling process
+as one message, parsed with `from_message/2` and re-armed with `activate/1`,
+so the listener can interleave datagrams with monitor/system messages in a
+single receive loop.
+
+Set `reuseport` to `true` to enable `SO_REUSEPORT`, which lets a pool of
+sockets share one concrete port with kernel datagram fan-out (the shape the
+listener pool uses); it defaults to `false` for a lone socket.
 """.
 -spec open(inet:port_number(), open_opts()) -> {ok, socket()} | {error, term()}.
 open(Port, Opts) ->
-    #{recbuf := RecBuf, sndbuf := SndBuf, reuseport := ReusePort} = validate_opts(Opts),
+    #{recbuf := RecBuf, sndbuf := SndBuf, reuseport := ReusePort, active := Active} = validate_opts(
+        Opts
+    ),
     SocketOpts = [
         binary,
-        {active, false},
+        {active, Active},
         {reuseaddr, true},
         {reuseport, ReusePort},
         {recbuf, RecBuf},
@@ -80,6 +90,28 @@ recv({gen_udp, Socket}, Timeout) ->
         {error, _} = Error -> Error
     end.
 
+-doc """
+Re-arm an `active => once` socket for the next datagram. Called after each
+message parsed with `from_message/2`, giving one-datagram-at-a-time
+back-pressure rather than an unbounded `{active, true}` flood.
+""".
+-spec activate(socket()) -> ok | {error, term()}.
+activate({gen_udp, Socket}) ->
+    inet:setopts(Socket, [{active, once}]).
+
+-doc """
+Parse a mailbox message from an `active => once` socket: returns the source
+address and datagram bytes for this socket's data message, or `ignore` for
+anything else (a different socket's data, a monitor `DOWN`, a system message),
+so the listener loop can dispatch the rest itself.
+""".
+-spec from_message(socket(), term()) ->
+    {ok, {inet:ip_address(), inet:port_number()}, binary()} | ignore.
+from_message({gen_udp, Socket}, {udp, Socket, Ip, Port, Data}) ->
+    {ok, {Ip, Port}, Data};
+from_message(_Socket, _Message) ->
+    ignore.
+
 -doc "Close the socket.".
 -spec close(socket()) -> ok.
 close({gen_udp, Socket}) ->
@@ -97,9 +129,19 @@ sockname({gen_udp, Socket}) ->
 %% Merge the caller's options over the defaults, rejecting unknown keys
 %% and out-of-range values (mirrors the listener-opt validation idiom).
 -spec validate_opts(open_opts()) ->
-    #{recbuf := pos_integer(), sndbuf := pos_integer(), reuseport := boolean()}.
+    #{
+        recbuf := pos_integer(),
+        sndbuf := pos_integer(),
+        reuseport := boolean(),
+        active := once | false
+    }.
 validate_opts(Opts) ->
-    Defaults = #{recbuf => ?DEFAULT_RECBUF, sndbuf => ?DEFAULT_SNDBUF, reuseport => false},
+    Defaults = #{
+        recbuf => ?DEFAULT_RECBUF,
+        sndbuf => ?DEFAULT_SNDBUF,
+        reuseport => false,
+        active => false
+    },
     maps:fold(fun validate_opt/3, Defaults, Opts).
 
 -spec validate_opt(atom(), term(), map()) -> map().
@@ -109,5 +151,7 @@ validate_opt(sndbuf, Value, Acc) when is_integer(Value), Value > 0 ->
     Acc#{sndbuf => Value};
 validate_opt(reuseport, Value, Acc) when is_boolean(Value) ->
     Acc#{reuseport => Value};
+validate_opt(active, Value, Acc) when Value =:= once; Value =:= false ->
+    Acc#{active => Value};
 validate_opt(Key, Value, _Acc) ->
     error({invalid_quic_socket_opt, Key, Value}).

--- a/test/roadrunner_quic_cid_registry_tests.erl
+++ b/test/roadrunner_quic_cid_registry_tests.erl
@@ -1,0 +1,31 @@
+-module(roadrunner_quic_cid_registry_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_cid_registry).
+
+register_pair_routes_both_ids_test() ->
+    %% Both the client DCID and the server SCID route to the connection pid.
+    Table = ?M:new(),
+    Pid = self(),
+    ok = ?M:register_pair(Table, ~"client-dcid", ~"server-scid", Pid),
+    ?assertEqual({ok, Pid}, ?M:lookup(Table, ~"client-dcid")),
+    ?assertEqual({ok, Pid}, ?M:lookup(Table, ~"server-scid")).
+
+lookup_unknown_cid_is_error_test() ->
+    Table = ?M:new(),
+    ?assertEqual(error, ?M:lookup(Table, ~"never-registered")).
+
+delete_pid_drops_all_its_ids_test() ->
+    %% Ending a connection removes every id that routed to it, leaving other
+    %% connections' ids intact.
+    Table = ?M:new(),
+    Gone = spawn(fun() -> ok end),
+    Kept = self(),
+    ok = ?M:register_pair(Table, ~"gone-dcid", ~"gone-scid", Gone),
+    ok = ?M:register_pair(Table, ~"kept-dcid", ~"kept-scid", Kept),
+    ok = ?M:delete_pid(Table, Gone),
+    ?assertEqual(error, ?M:lookup(Table, ~"gone-dcid")),
+    ?assertEqual(error, ?M:lookup(Table, ~"gone-scid")),
+    ?assertEqual({ok, Kept}, ?M:lookup(Table, ~"kept-dcid")),
+    ?assertEqual({ok, Kept}, ?M:lookup(Table, ~"kept-scid")).

--- a/test/roadrunner_quic_listener_SUITE.erl
+++ b/test/roadrunner_quic_listener_SUITE.erl
@@ -1,0 +1,310 @@
+-module(roadrunner_quic_listener_SUITE).
+-moduledoc """
+Integration tests for `roadrunner_quic_listener`.
+
+A CT suite rather than eunit: the load-bearing case drives the dep `quic`
+client through a real QUIC handshake against the native listener over
+loopback, and the process-loop edges (sys/gen messages, monitor cleanup,
+datagram routing) need a live listener process with the suite timetrap as
+an outer guard. The pure routing decision (`classify/2`) is unit-tested in
+`roadrunner_quic_listener_tests`.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    dep_client_handshakes_through_listener/1,
+    bind_failure_is_reported/1,
+    stop_closes_listener/1,
+    unsupported_gen_call_replies_error/1,
+    gen_cast_is_ignored/1,
+    system_message_exposes_state/1,
+    stray_message_is_ignored/1,
+    malformed_datagram_is_dropped/1,
+    conn_down_is_cleaned_up/1
+]).
+
+-define(LOOPBACK, {127, 0, 0, 1}).
+-define(QUIC_V1, 16#00000001).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [
+        dep_client_handshakes_through_listener,
+        bind_failure_is_reported,
+        stop_closes_listener,
+        unsupported_gen_call_replies_error,
+        gen_cast_is_ignored,
+        system_message_exposes_state,
+        stray_message_is_ignored,
+        malformed_datagram_is_dropped,
+        conn_down_is_cleaned_up
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(ssl),
+    %% The dep `quic` app backs the test CLIENT only; the native listener does
+    %% not depend on it. The default `pg` scope hosts the client's drain group,
+    %% started unlinked so it outlives this transient process.
+    {ok, _} = application:ensure_all_started(quic),
+    ok = ensure_pg_started(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% =============================================================================
+%% The dep `quic` client completes a real handshake routed through the native
+%% listener: this exercises the whole spawn ordering (spawn -> register CIDs ->
+%% run handler -> set_owner_sync -> feed first Initial), the active-socket read
+%% path, and datagram routing (the first Initial spawns, every follow-up
+%% datagram forwards to the registered connection by its server SCID).
+%% =============================================================================
+
+dep_client_handshakes_through_listener(_Config) ->
+    %% Report the spawned owner so it can be torn down with the case rather than
+    %% leaking an idle drain process for the rest of the suite run.
+    Test = self(),
+    Handler = fun(_ConnPid) ->
+        Owner = spawn(fun drain/0),
+        Test ! {owner, Owner},
+        {ok, Owner}
+    end,
+    {Listener, Port} = start_listener(Handler),
+
+    %% Drive the dep as a raw QUIC client. The QUIC `connected` event fires on
+    %% transport-handshake completion; the H3 SETTINGS exchange belongs to the
+    %% owner (a later slice), so the assertion is at the QUIC layer.
+    {ok, Conn} = quic:connect(
+        ~"127.0.0.1", Port, #{alpn => [~"h3"], verify => verify_none}, self()
+    ),
+    Result =
+        receive
+            {quic, Conn, {connected, _Info}} -> ok
+        after 5000 ->
+            timeout
+        end,
+
+    _ = quic:close(Conn),
+    receive
+        {owner, Owner} -> exit(Owner, kill)
+    after 0 -> ok
+    end,
+    ok = roadrunner_quic_listener:stop(Listener),
+    ?assertEqual(ok, Result).
+
+%% A bind onto a port already held without reuseport surfaces synchronously as
+%% {error, _} from start_link (init's error clause): a plain gen_udp blocker
+%% (no reuseaddr) refuses the second bind.
+bind_failure_is_reported(_Config) ->
+    {ok, Blocker} = gen_udp:open(0, [binary, {active, false}]),
+    {ok, {_Ip, Port}} = inet:sockname(Blocker),
+    ?assertMatch(
+        {error, _}, roadrunner_quic_listener:start_link(listener_opts(Port, drain_handler()))
+    ),
+    ok = gen_udp:close(Blocker).
+
+%% stop/1 replies ok, closes the socket, and exits normally.
+stop_closes_listener(_Config) ->
+    {Listener, _Port} = start_listener(drain_handler()),
+    Mon = monitor(process, Listener),
+    ?assertEqual(ok, roadrunner_quic_listener:stop(Listener)),
+    receive
+        {'DOWN', Mon, process, Listener, normal} -> ok
+    after 2000 ->
+        ct:fail(listener_did_not_stop)
+    end.
+
+%% A stray gen_server:call (anything but get_port/stop) is answered with
+%% {error, not_supported} so the caller fails fast instead of hanging.
+unsupported_gen_call_replies_error(_Config) ->
+    {Listener, _Port} = start_listener(drain_handler()),
+    ?assertEqual({error, not_supported}, gen_server:call(Listener, bogus_request)),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% A gen_server:cast is dropped; the loop survives (a later get_port answers).
+gen_cast_is_ignored(_Config) ->
+    {Listener, Port} = start_listener(drain_handler()),
+    ok = gen_server:cast(Listener, anything),
+    ?assertEqual(Port, roadrunner_quic_listener:get_port(Listener)),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% The OTP system protocol works via roadrunner_loop_sys: sys:get_state returns
+%% the listener's own state record.
+system_message_exposes_state(_Config) ->
+    {Listener, _Port} = start_listener(drain_handler()),
+    State = sys:get_state(Listener),
+    ?assertEqual(listener, element(1, State)),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% A message that is neither an OTP nor a socket message parses to `ignore`
+%% (handle_message's ignore clause) and is dropped; the loop survives.
+stray_message_is_ignored(_Config) ->
+    {Listener, Port} = start_listener(drain_handler()),
+    _ = Listener ! not_a_datagram,
+    ?assertEqual(Port, roadrunner_quic_listener:get_port(Listener)),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% A datagram whose header cannot be classified is dropped (route's drop
+%% clause), and a connection_handler that refuses (e.g. {error, max_clients})
+%% does not get an owner installed (install_owner's error clause). Both are
+%% driven from one ordered send: a malformed datagram, then a v1 Initial.
+%% Loopback delivers the two in order to the active socket, so the handler
+%% firing for the Initial proves the malformed datagram was already read and
+%% routed to drop. The refusing handler also keeps the spawned connection
+%% owner-less, so killing it for cleanup cannot race a set_owner_sync.
+malformed_datagram_is_dropped(_Config) ->
+    Test = self(),
+    Handler = fun(ConnPid) ->
+        Test ! {server_conn, ConnPid},
+        {error, max_clients}
+    end,
+    {Listener, Port} = start_listener(Handler),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    %% A short-header first byte with too few bytes for the fixed 8-byte SCID:
+    %% dcid/2 reports {error, truncated}, so classify -> drop.
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, <<16#40, 1, 2, 3>>),
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, crafted_initial()),
+    ConnPid = receive_server_conn(),
+    ?assert(is_pid(ConnPid)),
+    ?assertEqual(Port, roadrunner_quic_listener:get_port(Listener)),
+    exit(ConnPid, kill),
+    ok = roadrunner_quic_socket:close(Client),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% When a spawned connection dies, the listener's monitor fires and the CID
+%% registry row is dropped (delete_pid). This is proven, not merely
+%% line-covered: an Initial with the dead connection's DCID is forwarded to it
+%% while it lives, but once its row is gone the SAME DCID classifies as a new
+%% connection and spawns a fresh one. So a different connection answering the
+%% repeated Initial is direct evidence the row was removed. (delete_pid's own
+%% correctness is unit-tested in roadrunner_quic_cid_registry_tests.)
+%%
+%% A refusing handler is used so no owner is installed (no set_owner_sync to
+%% race the kill) while the connection is still spawned and registered.
+conn_down_is_cleaned_up(_Config) ->
+    Test = self(),
+    Handler = fun(ConnPid) ->
+        Test ! {server_conn, ConnPid},
+        {error, max_clients}
+    end,
+    {Listener, Port} = start_listener(Handler),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    DCID = <<9, 9, 9, 9, 9, 9, 9, 9>>,
+    Initial = crafted_initial(DCID),
+
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, Initial),
+    Conn1 = receive_server_conn(),
+
+    %% Kill the connection; the listener must drop its DCID row so the next
+    %% Initial with the same DCID spawns a *different* connection.
+    Mon = monitor(process, Conn1),
+    exit(Conn1, kill),
+    receive
+        {'DOWN', Mon, process, Conn1, killed} -> ok
+    after 2000 ->
+        ct:fail(conn_not_killed)
+    end,
+    Conn2 = await_respawn(Client, Port, Initial, Conn1, 25),
+    ?assertNotEqual(Conn1, Conn2),
+
+    exit(Conn2, kill),
+    ok = roadrunner_quic_socket:close(Client),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+start_listener(Handler) ->
+    {ok, Listener} = roadrunner_quic_listener:start_link(listener_opts(0, Handler)),
+    Port = roadrunner_quic_listener:get_port(Listener),
+    {Listener, Port}.
+
+%% The connection pid reported by a spawn-signalling connection_handler.
+receive_server_conn() ->
+    receive
+        {server_conn, Pid} -> Pid
+    after 2000 ->
+        ct:fail(handler_not_invoked)
+    end.
+
+%% Resend an Initial until a *different* connection answers it. While the dead
+%% connection's DCID row lingers the Initial forwards to it (no new spawn, no
+%% signal); once the row is dropped the same DCID spawns a fresh connection. So
+%% a different pid answering is direct proof the row was removed. Bounded, so a
+%% genuine cleanup failure fails the case rather than looping forever.
+await_respawn(_Client, _Port, _Initial, _Old, 0) ->
+    ct:fail(cid_row_not_cleaned_up);
+await_respawn(Client, Port, Initial, Old, Attempts) ->
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, Initial),
+    receive
+        {server_conn, New} when New =/= Old -> New
+    after 200 ->
+        await_respawn(Client, Port, Initial, Old, Attempts - 1)
+    end.
+
+listener_opts(Port, Handler) ->
+    {CertChain, PrivKey} = cert_key(),
+    #{
+        port => Port,
+        cert_chain => CertChain,
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => #{
+            initial_max_data => 1048576,
+            initial_max_stream_data_bidi_local => 262144,
+            initial_max_stream_data_bidi_remote => 262144,
+            initial_max_stream_data_uni => 262144,
+            initial_max_streams_bidi => 100,
+            initial_max_streams_uni => 100,
+            max_idle_timeout => 30000
+        },
+        connection_handler => Handler
+    }.
+
+%% A handler returning a process that swallows the connection's emitted events,
+%% so a real handshake can run to completion.
+drain_handler() ->
+    fun(_ConnPid) -> {ok, spawn(fun drain/0)} end.
+
+drain() ->
+    receive
+        _ -> drain()
+    end.
+
+%% A long-header QUIC v1 Initial (first byte 0xC0 = long+fixed+type 00) with a
+%% fresh 8-byte DCID, padded to the RFC 9000 §14.1 1200-byte floor so the
+%% listener spawns for it; the body is junk (the spawned connection drops the
+%% undecryptable packet and idles).
+crafted_initial() ->
+    crafted_initial(crypto:strong_rand_bytes(8)).
+
+crafted_initial(DCID) ->
+    Header = <<16#C0, ?QUIC_V1:32, (byte_size(DCID)), DCID/binary>>,
+    <<Header/binary, 0:((1200 - byte_size(Header)) * 8)>>.
+
+cert_key() ->
+    Opts = roadrunner_test_certs:server_opts(),
+    {cert, CertDer} = lists:keyfind(cert, 1, Opts),
+    {key, {KeyType, KeyDer}} = lists:keyfind(key, 1, Opts),
+    {[CertDer], public_key:der_decode(KeyType, KeyDer)}.
+
+ensure_pg_started() ->
+    case whereis(pg) of
+        undefined ->
+            case pg:start_link() of
+                {ok, Pid} ->
+                    _ = unlink(Pid),
+                    ok;
+                {error, {already_started, _}} ->
+                    ok
+            end;
+        _ ->
+            ok
+    end.

--- a/test/roadrunner_quic_listener_tests.erl
+++ b/test/roadrunner_quic_listener_tests.erl
@@ -1,0 +1,71 @@
+-module(roadrunner_quic_listener_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_listener).
+-define(REG, roadrunner_quic_cid_registry).
+-define(QUIC_V1, 16#00000001).
+
+%% The routing decision is pure given the registry, so its branches are
+%% covered here with crafted headers; the side-effecting spawn + the process
+%% loop live in roadrunner_quic_listener_SUITE.
+
+classify_forwards_to_registered_connection_test() ->
+    Registry = ?REG:new(),
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ok = ?REG:register_pair(Registry, DCID, <<9, 9, 9, 9, 9, 9, 9, 9>>, self()),
+    ?assertEqual({forward, self()}, ?M:classify(v1_initial(DCID), Registry)).
+
+classify_spawns_for_v1_initial_to_unknown_cid_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ?assertEqual({spawn, DCID}, ?M:classify(v1_initial_min(DCID), ?REG:new())).
+
+classify_drops_malformed_datagram_test() ->
+    ?assertEqual(drop, ?M:classify(<<>>, ?REG:new())).
+
+classify_drops_short_header_to_unknown_cid_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ?assertEqual(drop, ?M:classify(short_header(DCID), ?REG:new())).
+
+classify_drops_unknown_version_initial_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ?assertEqual(drop, ?M:classify(unknown_version_initial(DCID), ?REG:new())).
+
+%% RFC 9000 §14.1: a v1 Initial below the 1200-byte datagram floor is discarded,
+%% so it never spawns even though its header is a well-formed v1 Initial.
+classify_drops_small_v1_initial_to_unknown_cid_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ?assertEqual(drop, ?M:classify(v1_initial(DCID), ?REG:new())).
+
+%% Only a long-header *Initial* (type 00) spawns; a v1 long-header of another
+%% type (here Handshake, type 10) to an unknown id is dropped even at the floor.
+classify_drops_v1_handshake_to_unknown_cid_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ?assertEqual(drop, ?M:classify(pad(v1_handshake(DCID)), ?REG:new())).
+
+%% A long-header Initial (first byte 0xC0 = long+fixed+type 00) for QUIC v1,
+%% carrying the DCID; enough bytes for dcid/2 + the version check, but below the
+%% §14.1 1200-byte floor.
+v1_initial(DCID) ->
+    <<16#C0, ?QUIC_V1:32, (byte_size(DCID)), DCID/binary>>.
+
+%% The same Initial padded to the §14.1 floor, so it is spawn-eligible.
+v1_initial_min(DCID) ->
+    pad(v1_initial(DCID)).
+
+%% A v1 long header with packet type 10 (Handshake): first byte 0xE0 =
+%% long+fixed+type 10.
+v1_handshake(DCID) ->
+    <<16#E0, ?QUIC_V1:32, (byte_size(DCID)), DCID/binary>>.
+
+unknown_version_initial(DCID) ->
+    <<16#C0, 16#FF000001:32, (byte_size(DCID)), DCID/binary>>.
+
+%% A short-header (1-RTT) packet (first byte 0x40 = short+fixed); its DCID is
+%% the fixed server SCID length (8 bytes).
+short_header(DCID) ->
+    <<16#40, DCID/binary, 0>>.
+
+%% Pad a datagram up to the RFC 9000 §14.1 1200-byte floor.
+pad(Datagram) ->
+    <<Datagram/binary, 0:((1200 - byte_size(Datagram)) * 8)>>.

--- a/test/roadrunner_quic_socket_SUITE.erl
+++ b/test/roadrunner_quic_socket_SUITE.erl
@@ -18,7 +18,8 @@ clause is unit-tested in `roadrunner_quic_socket_tests`.
     recv_timeout/1,
     open_in_use_errors/1,
     open_with_custom_buffers/1,
-    reuseport_allows_shared_bind/1
+    reuseport_allows_shared_bind/1,
+    active_once_delivers_messages/1
 ]).
 
 -define(LOOPBACK, {127, 0, 0, 1}).
@@ -32,8 +33,48 @@ all() ->
         recv_timeout,
         open_in_use_errors,
         open_with_custom_buffers,
-        reuseport_allows_shared_bind
+        reuseport_allows_shared_bind,
+        active_once_delivers_messages
     ].
+
+%% An `active => once` socket delivers each datagram as one mailbox message,
+%% parsed with from_message/2 and re-armed with activate/1; before re-arming
+%% no further message arrives (one-at-a-time back-pressure).
+active_once_delivers_messages(_Config) ->
+    {ok, Server} = roadrunner_quic_socket:open(0, #{active => once}),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    {ok, {_, ServerPort}} = roadrunner_quic_socket:sockname(Server),
+    {ok, {_, ClientPort}} = roadrunner_quic_socket:sockname(Client),
+
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, ServerPort, ~"one"),
+    Msg1 =
+        receive
+            M1 -> M1
+        after 1000 -> ct:fail(no_active_message)
+        end,
+    ?assertEqual(
+        {ok, {?LOOPBACK, ClientPort}, ~"one"}, roadrunner_quic_socket:from_message(Server, Msg1)
+    ),
+
+    %% Not re-armed yet: a second datagram buffers but is not delivered.
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, ServerPort, ~"two"),
+    receive
+        Premature -> ct:fail({delivered_before_rearm, Premature})
+    after 200 -> ok
+    end,
+
+    ok = roadrunner_quic_socket:activate(Server),
+    Msg2 =
+        receive
+            M2 -> M2
+        after 1000 -> ct:fail(no_message_after_rearm)
+        end,
+    ?assertEqual(
+        {ok, {?LOOPBACK, ClientPort}, ~"two"}, roadrunner_quic_socket:from_message(Server, Msg2)
+    ),
+
+    ok = roadrunner_quic_socket:close(Server),
+    ok = roadrunner_quic_socket:close(Client).
 
 %% A datagram travels client -> server with its source address, then the
 %% server echoes back to that address. Exercises open/1 (default opts),

--- a/test/roadrunner_quic_socket_tests.erl
+++ b/test/roadrunner_quic_socket_tests.erl
@@ -20,3 +20,16 @@ open_rejects_negative_sndbuf_test() ->
 
 open_rejects_non_boolean_reuseport_test() ->
     ?assertError({invalid_quic_socket_opt, reuseport, yes}, ?M:open(0, #{reuseport => yes})).
+
+open_rejects_invalid_active_test() ->
+    ?assertError({invalid_quic_socket_opt, active, true}, ?M:open(0, #{active => true})).
+
+from_message_ignores_foreign_message_test() ->
+    %% A message that is not this socket's datagram (a different socket's data,
+    %% a DOWN, a system message) parses to `ignore` without opening any I/O.
+    {ok, Socket} = ?M:open(0),
+    ?assertEqual(
+        ignore, ?M:from_message(Socket, {udp, some_other_socket, {127, 0, 0, 1}, 1, ~"x"})
+    ),
+    ?assertEqual(ignore, ?M:from_message(Socket, {'DOWN', ref, process, self(), normal})),
+    ok = ?M:close(Socket).


### PR DESCRIPTION
# Description

The native QUIC UDP listener: a single `proc_lib` loop that reads the socket in `active => once` mode, routes each datagram to the owning connection by its connection id, and spawns a new connection for an unknown id's Initial. A `quic` dep client completes a full handshake routed through the listener over loopback.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
