### PR TITLE
Add the native QUIC Version Negotiation response

### DIFF
--- a/src/roadrunner_quic_listener.erl
+++ b/src/roadrunner_quic_listener.erl
@@ -10,7 +10,9 @@
 %% Each datagram is routed by its Destination Connection ID
 %% (`roadrunner_quic_cid_registry`): a hit forwards `{quic_datagram, Peer,
 %% Bytes}` to the owning connection; a miss on a QUIC v1 Initial spawns a new
-%% connection. Spawning follows the strict ordering the handshake depends on
+%% connection; a miss on an unsupported-version long header answers with a
+%% Version Negotiation packet (RFC 9000 §5.2.2). Spawning follows the strict
+%% ordering the handshake depends on
 %% (RFC 9000 / the dep's contract): spawn the connection, monitor it (so a
 %% fast death is reaped before its connection ids are registered), register
 %% its CIDs (so a fast follow-up datagram already routes), run the
@@ -22,8 +24,8 @@
 %%
 %% A new server Source Connection ID is generated per connection at a fixed
 %% length, so short-header 1-RTT packets (which carry no CID-length field)
-%% demux by slicing that many leading bytes. The SO_REUSEPORT pool, the
-%% Version Negotiation trigger, and the supervisor are later slices.
+%% demux by slicing that many leading bytes. The SO_REUSEPORT pool and the
+%% supervisor are later slices.
 
 -export([start_link/1, get_port/1, stop/1]).
 -export([init/1]).
@@ -37,6 +39,9 @@
 -define(SCID_LEN, 8).
 %% QUIC version 1 (RFC 9000 §15); also defined in roadrunner_quic_send.
 -define(QUIC_V1, 16#00000001).
+%% The versions advertised in a Version Negotiation packet (RFC 9000 §17.2.1).
+%% A reserved 0x?a?a?a?a "grease" version (§6.3) is an optional addition.
+-define(SUPPORTED_VERSIONS, [?QUIC_V1]).
 %% RFC 9000 §14.1: a server MUST discard an Initial packet carried in a UDP
 %% datagram whose payload is smaller than 1200 bytes, so a too-small Initial
 %% never spawns a connection (clients pad Initial datagrams to this floor).
@@ -167,7 +172,7 @@ handle_message(Message, #listener{socket = Socket} = State) ->
 %% =============================================================================
 
 %% Execute a datagram's routing decision: forward to the owning connection,
-%% spawn one for a new client, or drop.
+%% spawn one for a new client, answer with Version Negotiation, or drop.
 -spec route(binary(), {inet:ip_address(), inet:port_number()}, #listener{}) -> #listener{}.
 route(Datagram, Peer, #listener{registry = Registry} = State) ->
     case classify(Datagram, Registry) of
@@ -176,40 +181,82 @@ route(Datagram, Peer, #listener{registry = Registry} = State) ->
             State;
         {spawn, ClientDCID} ->
             spawn_connection(Datagram, Peer, ClientDCID, State);
+        {version_negotiation, ClientDCID, ClientSCID} ->
+            send_version_negotiation(ClientDCID, ClientSCID, Peer, State);
         drop ->
             State
     end.
 
-%% Decide a datagram's fate from its Destination Connection ID and the routing
-%% table (a pure decision given the table): `{forward, Pid}` to the owning
-%% connection, `{spawn, DCID}` for a QUIC v1 Initial (in a datagram at the RFC
-%% 9000 §14.1 1200-byte floor) to an unknown id, or `drop` otherwise: a
-%% malformed header, a packet to an unknown id that is not a v1 Initial (a
-%% stray short-header packet; an unknown version is the Version Negotiation
-%% slice), or a v1 Initial below the §14.1 floor (a server MUST discard those,
-%% so we never spawn for one). The forward path is size-unconditional; the
-%% owning connection enforces §14.1 on its own received Initials.
+%% RFC 9000 §17.2.1: a Version Negotiation packet lists the versions the server
+%% supports and echoes the client's connection ids swapped (our destination id
+%% is the client's source id, our source id is the client's destination id) so
+%% the client accepts it. It consumes the whole datagram; exactly one is sent
+%% per received datagram.
+-spec send_version_negotiation(
+    binary(), binary(), {inet:ip_address(), inet:port_number()}, #listener{}
+) -> #listener{}.
+send_version_negotiation(ClientDCID, ClientSCID, {Ip, Port}, #listener{socket = Socket} = State) ->
+    Datagram = roadrunner_quic_packet:encode_version_negotiation(
+        ClientSCID, ClientDCID, ?SUPPORTED_VERSIONS
+    ),
+    _ = roadrunner_quic_socket:send(Socket, Ip, Port, Datagram),
+    State.
+
+%% Decide a datagram's fate from its connection ids and the routing table (a
+%% pure decision given the table): `{forward, Pid}` to the owning connection,
+%% `{spawn, DCID}` for a QUIC v1 Initial (at the RFC 9000 §14.1 1200-byte floor)
+%% to an unknown id, `{version_negotiation, DCID, SCID}` for an unsupported
+%% version at that floor (RFC 9000 §5.2.2), or `drop` otherwise: a malformed or
+%% short-header packet to an unknown id, a v1 Initial below the floor, or an
+%% unsupported-version packet below it (a server MUST discard those). The
+%% forward path is size-unconditional; the owning connection enforces §14.1 on
+%% its own received Initials.
 -doc false.
 -spec classify(binary(), roadrunner_quic_cid_registry:t()) ->
-    {forward, pid()} | {spawn, binary()} | drop.
+    {forward, pid()} | {spawn, binary()} | {version_negotiation, binary(), binary()} | drop.
 classify(Datagram, Registry) ->
     case roadrunner_quic_packet:dcid(Datagram, ?SCID_LEN) of
         {ok, DCID} ->
             case roadrunner_quic_cid_registry:lookup(Registry, DCID) of
-                {ok, ConnPid} ->
-                    {forward, ConnPid};
-                error ->
-                    case
-                        is_v1_initial(Datagram) andalso
-                            byte_size(Datagram) >= ?MIN_INITIAL_DATAGRAM
-                    of
-                        true -> {spawn, DCID};
-                        false -> drop
-                    end
+                {ok, ConnPid} -> {forward, ConnPid};
+                error -> classify_unrouted(Datagram, DCID)
             end;
         {error, _Reason} ->
-            drop
+            %% A datagram whose routable connection id could not be read: a
+            %% short header shorter than the fixed id length, or a long header
+            %% carrying a connection id longer than v1 allows. It is no known
+            %% connection and no v1 Initial, but an unsupported-version long
+            %% header still triggers Version Negotiation (connection-id length
+            %% must not gate that decision, RFC 9000 §17.2.1).
+            maybe_version_negotiation(Datagram)
     end.
+
+%% An unknown destination id at the §14.1 floor: a v1 Initial starts a
+%% connection; anything else falls through to the Version Negotiation check.
+-spec classify_unrouted(binary(), binary()) ->
+    {spawn, binary()} | {version_negotiation, binary(), binary()} | drop.
+classify_unrouted(Datagram, DCID) ->
+    case is_v1_initial(Datagram) andalso byte_size(Datagram) >= ?MIN_INITIAL_DATAGRAM of
+        true -> {spawn, DCID};
+        false -> maybe_version_negotiation(Datagram)
+    end.
+
+%% RFC 9000 §5.2.2: answer an unsupported-version long header (one we cannot
+%% serve, and which is not itself a Version Negotiation packet, version 0) with
+%% Version Negotiation, provided the datagram is at the 1200-byte floor; a
+%% server MUST drop smaller such packets, and short headers never negotiate.
+-spec maybe_version_negotiation(binary()) -> {version_negotiation, binary(), binary()} | drop.
+maybe_version_negotiation(Datagram) when byte_size(Datagram) >= ?MIN_INITIAL_DATAGRAM ->
+    case roadrunner_quic_packet:long_header_info(Datagram) of
+        {ok, #{version := Version, dcid := DCID, scid := SCID}} when
+            Version =/= 0, Version =/= ?QUIC_V1
+        ->
+            {version_negotiation, DCID, SCID};
+        _ ->
+            drop
+    end;
+maybe_version_negotiation(_Datagram) ->
+    drop.
 
 -spec is_v1_initial(binary()) -> boolean().
 is_v1_initial(<<1:1, _Fixed:1, 0:2, _TypeSpecific:4, Version:32, _/binary>>) ->

--- a/src/roadrunner_quic_packet.erl
+++ b/src/roadrunner_quic_packet.erl
@@ -31,6 +31,7 @@
     encode_version_negotiation/3,
     decode/2,
     dcid/2,
+    long_header_info/1,
     coalesced_split/1,
     pn_offset/2,
     encode_pn/2,
@@ -162,6 +163,27 @@ dcid(<<0:1, _:7, Rest/binary>>, DCIDLen) ->
     end;
 dcid(_, _) ->
     {error, invalid_packet}.
+
+-doc """
+Extract a long-header packet's version and connection ids: the
+version-independent invariant fields (RFC 8999 §5.1), readable for a packet
+whose version the server may not support. The connection-id lengths are read
+as the full 8-bit invariant lengths (not the v1 20-byte limit, `dcid/2`),
+because connection-id rules MUST NOT influence the Version Negotiation
+decision (RFC 9000 §17.2.1). Returns `{error, not_long_header}` for a short
+header and `{error, truncated}` for a clipped long header.
+""".
+-spec long_header_info(binary()) ->
+    {ok, #{version := non_neg_integer(), dcid := binary(), scid := binary()}}
+    | {error, not_long_header | truncated}.
+long_header_info(
+    <<1:1, _:7, Version:32, DCIDLen, DCID:DCIDLen/binary, SCIDLen, SCID:SCIDLen/binary, _/binary>>
+) ->
+    {ok, #{version => Version, dcid => DCID, scid => SCID}};
+long_header_info(<<1:1, _/bitstring>>) ->
+    {error, truncated};
+long_header_info(_) ->
+    {error, not_long_header}.
 
 -doc """
 Split the first packet of a (possibly coalesced) datagram (RFC 9000

--- a/test/roadrunner_quic_listener_SUITE.erl
+++ b/test/roadrunner_quic_listener_SUITE.erl
@@ -23,6 +23,7 @@ an outer guard. The pure routing decision (`classify/2`) is unit-tested in
     system_message_exposes_state/1,
     stray_message_is_ignored/1,
     malformed_datagram_is_dropped/1,
+    sends_version_negotiation_for_unsupported_version/1,
     conn_down_is_cleaned_up/1
 ]).
 
@@ -42,6 +43,7 @@ all() ->
         system_message_exposes_state,
         stray_message_is_ignored,
         malformed_datagram_is_dropped,
+        sends_version_negotiation_for_unsupported_version,
         conn_down_is_cleaned_up
     ].
 
@@ -174,6 +176,35 @@ malformed_datagram_is_dropped(_Config) ->
     ?assert(is_pid(ConnPid)),
     ?assertEqual(Port, roadrunner_quic_listener:get_port(Listener)),
     exit(ConnPid, kill),
+    ok = roadrunner_quic_socket:close(Client),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% RFC 9000 §5.2.2/§17.2.1: an unsupported-version Initial at the 1200-byte
+%% floor draws a Version Negotiation reply listing the supported versions, with
+%% the client's connection ids echoed swapped (the reply's destination id is the
+%% client's source id, its source id is the client's destination id). No
+%% connection is spawned.
+sends_version_negotiation_for_unsupported_version(_Config) ->
+    {Listener, Port} = start_listener(drain_handler()),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    SCID = <<9, 9, 9>>,
+    Header =
+        <<16#C0, 16#FF000001:32, (byte_size(DCID)), DCID/binary, (byte_size(SCID)), SCID/binary>>,
+    Initial = <<Header/binary, 0:((1200 - byte_size(Header)) * 8)>>,
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, Initial),
+    VN =
+        case roadrunner_quic_socket:recv(Client, 2000) of
+            {ok, _Peer, Datagram} -> Datagram;
+            Other -> ct:fail({no_version_negotiation, Other})
+        end,
+    <<FirstByte, 0:32, VNDcidLen, VNDcid:VNDcidLen/binary, VNScidLen, VNScid:VNScidLen/binary,
+        VersionsBin/binary>> = VN,
+    %% Long-header form bit and the RFC7983 fixed-bit position are both set.
+    ?assertEqual(16#C0, FirstByte band 16#C0),
+    ?assertEqual(SCID, VNDcid),
+    ?assertEqual(DCID, VNScid),
+    ?assertEqual([?QUIC_V1], [V || <<V:32>> <= VersionsBin]),
     ok = roadrunner_quic_socket:close(Client),
     ok = roadrunner_quic_listener:stop(Listener).
 

--- a/test/roadrunner_quic_listener_tests.erl
+++ b/test/roadrunner_quic_listener_tests.erl
@@ -5,61 +5,104 @@
 -define(M, roadrunner_quic_listener).
 -define(REG, roadrunner_quic_cid_registry).
 -define(QUIC_V1, 16#00000001).
+%% A version this server does not support (not v1, not the version-0 marker).
+-define(UNSUPPORTED, 16#FF000001).
+-define(DCID, <<1, 2, 3, 4, 5, 6, 7, 8>>).
+-define(SCID, <<5, 5, 5, 5>>).
 
 %% The routing decision is pure given the registry, so its branches are
-%% covered here with crafted headers; the side-effecting spawn + the process
-%% loop live in roadrunner_quic_listener_SUITE.
+%% covered here with crafted headers; the side-effecting spawn, the Version
+%% Negotiation send, and the process loop live in roadrunner_quic_listener_SUITE.
 
 classify_forwards_to_registered_connection_test() ->
     Registry = ?REG:new(),
-    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
-    ok = ?REG:register_pair(Registry, DCID, <<9, 9, 9, 9, 9, 9, 9, 9>>, self()),
-    ?assertEqual({forward, self()}, ?M:classify(v1_initial(DCID), Registry)).
+    ok = ?REG:register_pair(Registry, ?DCID, <<9, 9, 9, 9, 9, 9, 9, 9>>, self()),
+    ?assertEqual({forward, self()}, ?M:classify(v1_initial(?DCID), Registry)).
+
+%% A short-header (1-RTT) packet routes to its connection by the fixed-length
+%% destination id, the demux the established-connection hot path relies on.
+classify_forwards_short_header_to_registered_connection_test() ->
+    Registry = ?REG:new(),
+    ok = ?REG:register_pair(Registry, ?DCID, <<9, 9, 9, 9, 9, 9, 9, 9>>, self()),
+    ?assertEqual({forward, self()}, ?M:classify(short_header(?DCID), Registry)).
 
 classify_spawns_for_v1_initial_to_unknown_cid_test() ->
-    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
-    ?assertEqual({spawn, DCID}, ?M:classify(v1_initial_min(DCID), ?REG:new())).
+    ?assertEqual({spawn, ?DCID}, ?M:classify(v1_initial_min(?DCID), ?REG:new())).
 
 classify_drops_malformed_datagram_test() ->
     ?assertEqual(drop, ?M:classify(<<>>, ?REG:new())).
 
 classify_drops_short_header_to_unknown_cid_test() ->
-    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
-    ?assertEqual(drop, ?M:classify(short_header(DCID), ?REG:new())).
+    ?assertEqual(drop, ?M:classify(short_header(?DCID), ?REG:new())).
 
-classify_drops_unknown_version_initial_test() ->
-    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
-    ?assertEqual(drop, ?M:classify(unknown_version_initial(DCID), ?REG:new())).
+%% A short-header packet at the floor to an unknown id is dropped through the
+%% long-header check (a short header never negotiates a version), distinct from
+%% the sub-floor drop above.
+classify_drops_large_short_header_to_unknown_cid_test() ->
+    ?assertEqual(drop, ?M:classify(pad(short_header(?DCID)), ?REG:new())).
+
+%% RFC 9000 §5.2.2: a server MUST drop an unsupported-version packet below the
+%% 1200-byte floor rather than answer it with Version Negotiation.
+classify_drops_small_unsupported_version_test() ->
+    ?assertEqual(drop, ?M:classify(unsupported_version(?DCID, ?SCID), ?REG:new())).
 
 %% RFC 9000 §14.1: a v1 Initial below the 1200-byte datagram floor is discarded,
 %% so it never spawns even though its header is a well-formed v1 Initial.
 classify_drops_small_v1_initial_to_unknown_cid_test() ->
-    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
-    ?assertEqual(drop, ?M:classify(v1_initial(DCID), ?REG:new())).
+    ?assertEqual(drop, ?M:classify(v1_initial(?DCID), ?REG:new())).
 
-%% Only a long-header *Initial* (type 00) spawns; a v1 long-header of another
-%% type (here Handshake, type 10) to an unknown id is dropped even at the floor.
+%% Only a long-header *Initial* (type 00) spawns; a v1 long header of another
+%% type (here Handshake, type 10) to an unknown id is dropped even at the floor
+%% (a supported version is never answered with Version Negotiation).
 classify_drops_v1_handshake_to_unknown_cid_test() ->
-    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
-    ?assertEqual(drop, ?M:classify(pad(v1_handshake(DCID)), ?REG:new())).
+    ?assertEqual(drop, ?M:classify(pad(v1_handshake(?DCID)), ?REG:new())).
 
-%% A long-header Initial (first byte 0xC0 = long+fixed+type 00) for QUIC v1,
-%% carrying the DCID; enough bytes for dcid/2 + the version check, but below the
-%% §14.1 1200-byte floor.
+%% RFC 9000 §5.2.2/§17.2.1: an unsupported-version long header at the floor is
+%% answered with Version Negotiation, reporting the client's ids (the caller
+%% swaps them onto the wire).
+classify_triggers_version_negotiation_for_unsupported_version_test() ->
+    SCID = <<7, 7, 7>>,
+    ?assertEqual(
+        {version_negotiation, ?DCID, SCID},
+        ?M:classify(pad(unsupported_version(?DCID, SCID)), ?REG:new())
+    ).
+
+%% RFC 9000 §6.1: a received Version Negotiation packet (version 0) MUST NOT be
+%% answered with another Version Negotiation packet.
+classify_does_not_answer_a_version_negotiation_test() ->
+    ?assertEqual(drop, ?M:classify(pad(long_header(16#C0, 0, ?DCID, ?SCID)), ?REG:new())).
+
+%% RFC 9000 §17.2.1: connection-id length MUST NOT gate the Version Negotiation
+%% decision, so an unsupported version carried with an id longer than v1 allows
+%% (which dcid/2 cannot read) is still answered.
+classify_version_negotiation_ignores_connection_id_length_test() ->
+    BigDCID = binary:copy(<<3>>, 30),
+    SCID = <<7, 7, 7>>,
+    ?assertEqual(
+        {version_negotiation, BigDCID, SCID},
+        ?M:classify(pad(unsupported_version(BigDCID, SCID)), ?REG:new())
+    ).
+
+%% A well-formed long header (first byte, version, DCID, SCID); body-less, so
+%% below the §14.1 floor until padded.
+long_header(FirstByte, Version, DCID, SCID) ->
+    <<FirstByte, Version:32, (byte_size(DCID)), DCID/binary, (byte_size(SCID)), SCID/binary>>.
+
+%% A v1 Initial (first byte 0xC0 = long+fixed+type 00), below the floor.
 v1_initial(DCID) ->
-    <<16#C0, ?QUIC_V1:32, (byte_size(DCID)), DCID/binary>>.
+    long_header(16#C0, ?QUIC_V1, DCID, ?SCID).
 
 %% The same Initial padded to the §14.1 floor, so it is spawn-eligible.
 v1_initial_min(DCID) ->
     pad(v1_initial(DCID)).
 
-%% A v1 long header with packet type 10 (Handshake): first byte 0xE0 =
-%% long+fixed+type 10.
+%% A v1 long header of type 10 (Handshake): first byte 0xE0 = long+fixed+type 10.
 v1_handshake(DCID) ->
-    <<16#E0, ?QUIC_V1:32, (byte_size(DCID)), DCID/binary>>.
+    long_header(16#E0, ?QUIC_V1, DCID, ?SCID).
 
-unknown_version_initial(DCID) ->
-    <<16#C0, 16#FF000001:32, (byte_size(DCID)), DCID/binary>>.
+%% An unsupported-version long header, below the floor until padded.
+unsupported_version(DCID, SCID) ->
+    long_header(16#C0, ?UNSUPPORTED, DCID, SCID).
 
 %% A short-header (1-RTT) packet (first byte 0x40 = short+fixed); its DCID is
 %% the fixed server SCID length (8 bytes).

--- a/test/roadrunner_quic_packet_tests.erl
+++ b/test/roadrunner_quic_packet_tests.erl
@@ -286,6 +286,39 @@ pn_offset_errors_test() ->
     %% Initial whose Length varint is missing.
     ?assertEqual({error, truncated}, ?M:pn_offset(<<16#C0, ?V1:32, 0, 0, 0>>, 0)).
 
+long_header_info_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    SCID = <<9, 9, 9, 9>>,
+    Bin =
+        <<16#C0, 16#FF000001:32, (byte_size(DCID)), DCID/binary, (byte_size(SCID)), SCID/binary,
+            "payload">>,
+    ?assertEqual(
+        {ok, #{version => 16#FF000001, dcid => DCID, scid => SCID}},
+        ?M:long_header_info(Bin)
+    ).
+
+%% Connection ids longer than the v1 20-byte limit are still parsed (the
+%% invariant lengths are a full 8 bits), so an unsupported version carried with
+%% a long connection id can still elicit Version Negotiation (RFC 9000 §17.2.1).
+long_header_info_allows_oversized_cids_test() ->
+    DCID = binary:copy(<<7>>, 30),
+    SCID = binary:copy(<<8>>, 25),
+    Bin = <<16#C0, 16#FF000001:32, (byte_size(DCID)), DCID/binary, (byte_size(SCID)), SCID/binary>>,
+    ?assertEqual(
+        {ok, #{version => 16#FF000001, dcid => DCID, scid => SCID}},
+        ?M:long_header_info(Bin)
+    ).
+
+long_header_info_rejects_short_header_test() ->
+    ?assertEqual({error, not_long_header}, ?M:long_header_info(<<16#40, 1, 2, 3>>)),
+    ?assertEqual({error, not_long_header}, ?M:long_header_info(<<>>)).
+
+long_header_info_truncated_test() ->
+    %% Long header that ends inside the SCID (length 5, only 2 present).
+    ?assertEqual({error, truncated}, ?M:long_header_info(<<16#C0, ?V1:32, 0, 5, 1, 2>>)),
+    %% Long header missing its SCID length byte.
+    ?assertEqual({error, truncated}, ?M:long_header_info(<<16#C0, ?V1:32, 2, 1, 2>>)).
+
 %% =============================================================================
 %% Version Negotiation packet (no dep oracle: the dep randomises the first
 %% byte, so check the structure instead).


### PR DESCRIPTION
# Description

When the listener receives a long-header packet for a QUIC version it does not support, it replies with a Version Negotiation packet (RFC 9000 §5.2.2) advertising the supported versions, echoing the client's connection ids swapped. Packets below the 1200-byte floor and a received Version Negotiation (version 0) are dropped, and connection-id length never gates the decision (§17.2.1).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
