### PR TITLE
Add the native QUIC connection control API

### DIFF
--- a/src/roadrunner_quic.erl
+++ b/src/roadrunner_quic.erl
@@ -1,0 +1,95 @@
+-module(roadrunner_quic).
+-moduledoc false.
+
+%% The control API the HTTP/3 layer (`roadrunner_conn_loop_http3`,
+%% `roadrunner_http3_stream_worker`) calls on a native QUIC connection: the
+%% same surface the dep's `quic` module gave, so the h3 files change only the
+%% `quic:*` -> `roadrunner_quic:*` qualifier.
+%%
+%% The native connection is a hand-rolled `proc_lib` loop, not a gen_statem, so
+%% this module replicates `gen_statem:call` semantics itself: a `make_ref`
+%% tagged round-trip with a temporary monitor. A control request goes as
+%% `{quic_call, self(), Ref, Request}` and a stream write as `{quic_send,
+%% self(), Ref, Sid, IoData, Fin}`; both are answered by the connection with
+%% `{quic_reply, Ref, Result}`. The connection only ever sends to its owner
+%% asynchronously (`{quic, Conn, Event}`), so these synchronous calls never
+%% deadlock: the call tree is one-directional (owner/worker -> connection).
+%%
+%% A connection that dies before replying exits the caller with
+%% `{quic_conn_down, Reason}`, the same shape `gen_statem:call` gives for a
+%% dead callee (the owner is linked to the connection and tearing down anyway).
+
+-export([
+    peername/1,
+    open_unidirectional_stream/1,
+    send_data/4,
+    reset_stream/3,
+    stop_sending/3,
+    close/2,
+    close/3
+]).
+
+-doc "The connection's peer address. Answers in the handshaking phase, before connected.".
+-spec peername(pid()) -> {ok, {inet:ip_address(), inet:port_number()}}.
+peername(Conn) ->
+    call(Conn, peername).
+
+-doc "Allocate a server-initiated unidirectional stream id (the h3 control/encoder/decoder streams).".
+-spec open_unidirectional_stream(pid()) -> {ok, non_neg_integer()}.
+open_unidirectional_stream(Conn) ->
+    call(Conn, open_uni).
+
+-doc """
+Write stream data (an iolist of h3 frames), optionally finishing the stream.
+Returns once the connection has accepted it, the synchronous point that gives
+the stream worker flow-control back-pressure.
+""".
+-spec send_data(pid(), non_neg_integer(), iodata(), boolean()) -> ok | {error, term()}.
+send_data(Conn, StreamId, IoData, Fin) ->
+    Ref = make_ref(),
+    Mon = monitor(process, Conn),
+    _ = Conn ! {quic_send, self(), Ref, StreamId, IoData, Fin},
+    await(Conn, Ref, Mon).
+
+-doc "Abort the send side of a stream with a RESET_STREAM carrying the h3 error code.".
+-spec reset_stream(pid(), non_neg_integer(), non_neg_integer()) -> ok.
+reset_stream(Conn, StreamId, ErrorCode) ->
+    call(Conn, {reset_stream, StreamId, ErrorCode}).
+
+-doc "Ask the peer to stop sending on a stream with a STOP_SENDING carrying the h3 error code.".
+-spec stop_sending(pid(), non_neg_integer(), non_neg_integer()) -> ok.
+stop_sending(Conn, StreamId, ErrorCode) ->
+    call(Conn, {stop_sending, StreamId, ErrorCode}).
+
+-doc "Close the connection with an h3 error code (an application CONNECTION_CLOSE, no reason phrase).".
+-spec close(pid(), non_neg_integer()) -> ok.
+close(Conn, ErrorCode) ->
+    call(Conn, {close, ErrorCode}).
+
+-doc "Close the connection with an h3 error code and a reason phrase.".
+-spec close(pid(), non_neg_integer(), binary()) -> ok.
+close(Conn, ErrorCode, Reason) ->
+    call(Conn, {close, ErrorCode, Reason}).
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+-spec call(pid(), term()) -> term().
+call(Conn, Request) ->
+    Ref = make_ref(),
+    Mon = monitor(process, Conn),
+    _ = Conn ! {quic_call, self(), Ref, Request},
+    await(Conn, Ref, Mon).
+
+%% Wait for the connection's reply, or exit if it dies first (matching
+%% gen_statem:call against a dead callee).
+-spec await(pid(), reference(), reference()) -> term().
+await(Conn, Ref, Mon) ->
+    receive
+        {quic_reply, Ref, Result} ->
+            _ = demonitor(Mon, [flush]),
+            Result;
+        {'DOWN', Mon, process, Conn, Reason} ->
+            exit({quic_conn_down, Reason})
+    end.

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -313,7 +313,9 @@ with async `{emit, _, _}` effects, so it never blocks on the owner.
         | {set_owner, pid()}
         | open_uni
         | {reset_stream, non_neg_integer(), non_neg_integer()}
-        | {stop_sending, non_neg_integer(), non_neg_integer()}.
+        | {stop_sending, non_neg_integer(), non_neg_integer()}
+        | {close, non_neg_integer()}
+        | {close, non_neg_integer(), binary()}.
 handle_call(From, Ref, peername, _Now, #state{peer = Peer} = State) ->
     {State, [{reply, From, Ref, {ok, Peer}}]};
 handle_call(From, Ref, {set_owner, Owner}, _Now, State) ->
@@ -329,7 +331,47 @@ handle_call(From, Ref, {reset_stream, Sid, ErrorCode}, Now, State) ->
     {State1, [{reply, From, Ref, ok} | SendEffects]};
 handle_call(From, Ref, {stop_sending, Sid, ErrorCode}, Now, State) ->
     {State1, SendEffects} = do_stop_sending(Sid, ErrorCode, Now, State),
-    {State1, [{reply, From, Ref, ok} | SendEffects]}.
+    {State1, [{reply, From, Ref, ok} | SendEffects]};
+handle_call(From, Ref, {close, ErrorCode}, _Now, State) ->
+    {State1, CloseEffects} = owner_close(ErrorCode, <<>>, State),
+    {State1, [{reply, From, Ref, ok} | CloseEffects]};
+handle_call(From, Ref, {close, ErrorCode, Reason}, _Now, State) ->
+    {State1, CloseEffects} = owner_close(ErrorCode, Reason, State),
+    {State1, [{reply, From, Ref, ok} | CloseEffects]}.
+
+%% The owner closes the connection (RFC 9000 §10.2.2): send one application
+%% CONNECTION_CLOSE (0x1d, carrying the h3 error code and reason phrase) at the
+%% 1-RTT level and mark the connection closed so the shell exits. The owner
+%% triggered this, so no {closed, _} is emitted back; this runs only once the
+%% connection is established (1-RTT keys present), which is the only state the
+%% owner has a connection to close in. Distinct from connection_fatal/send_close
+%% (a locally-detected transport error during datagram processing): this is the
+%% application-variant close and never coalesces with other frames.
+-spec owner_close(non_neg_integer(), binary(), t()) -> {t(), [effect()]}.
+owner_close(ErrorCode, Reason, #state{send_keys = SendKeys} = State) ->
+    case SendKeys of
+        #{application := Keys} ->
+            send_owner_close(ErrorCode, Reason, Keys, State);
+        #{} ->
+            %% The owner closed before the handshake completed (e.g. the
+            %% connection_handler refusing on max_clients): there are no 1-RTT
+            %% keys to carry an application CONNECTION_CLOSE, so close silently
+            %% and let the client time out. The connection still ends.
+            {State#state{phase = closed}, []}
+    end.
+
+-spec send_owner_close(non_neg_integer(), binary(), roadrunner_quic_keys:keys(), t()) ->
+    {t(), [effect()]}.
+send_owner_close(ErrorCode, Reason, Keys, #state{dcid = DCID, scid = SCID} = State) ->
+    Space = space(application, State),
+    PN = Space#space.next_pn,
+    Frame = {connection_close, application, ErrorCode, undefined, Reason},
+    Entry = #{application => #{frames => [Frame], keys => Keys, pn => PN}},
+    {Datagram, _Sent} = roadrunner_quic_send:datagram(Entry, DCID, SCID),
+    State1 = put_space(
+        application, Space#space{next_pn = PN + 1}, State#state{phase = closed}
+    ),
+    {State1, [{send, Datagram}]}.
 
 %% Abandon the send side of a stream and tell the peer with a RESET_STREAM (RFC
 %% 9000 §19.4): discard the unsent buffer, record the bytes already sent as the

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -36,7 +36,7 @@
 %% / sent times / the oldest unacknowledged frames, a separate follow-up.
 
 -export([
-    new/2, handle_datagram/3, handle_timeout/3, handle_call/4, handle_send/7, peername/1, phase/1
+    new/2, handle_datagram/3, handle_timeout/3, handle_call/5, handle_send/7, peername/1, phase/1
 ]).
 
 -export_type([t/0, config/0, effect/0, event/0, info/0]).
@@ -307,18 +307,50 @@ Ref, Request}` here and performs the returned `{reply, From, Ref, Result}`
 connection are synchronous; the connection only ever notifies the owner
 with async `{emit, _, _}` effects, so it never blocks on the owner.
 """.
--spec handle_call(pid(), reference(), Request, t()) -> {t(), [effect()]} when
-    Request :: peername | {set_owner, pid()} | open_uni.
-handle_call(From, Ref, peername, #state{peer = Peer} = State) ->
+-spec handle_call(pid(), reference(), Request, integer(), t()) -> {t(), [effect()]} when
+    Request ::
+        peername
+        | {set_owner, pid()}
+        | open_uni
+        | {reset_stream, non_neg_integer(), non_neg_integer()}
+        | {stop_sending, non_neg_integer(), non_neg_integer()}.
+handle_call(From, Ref, peername, _Now, #state{peer = Peer} = State) ->
     {State, [{reply, From, Ref, {ok, Peer}}]};
-handle_call(From, Ref, {set_owner, Owner}, State) ->
+handle_call(From, Ref, {set_owner, Owner}, _Now, State) ->
     {State1, EmitEffects} = install_owner(Owner, State),
     {State1, [{reply, From, Ref, ok} | EmitEffects]};
-handle_call(From, Ref, open_uni, #state{next_uni = Id} = State) ->
+handle_call(From, Ref, open_uni, _Now, #state{next_uni = Id} = State) ->
     %% Allocate the next server-initiated unidirectional stream id. The stream
     %% itself is created lazily on the first send_data; the h3 layer writes the
     %% stream-type byte + SETTINGS, never this layer.
-    {State#state{next_uni = Id + 4}, [{reply, From, Ref, {ok, Id}}]}.
+    {State#state{next_uni = Id + 4}, [{reply, From, Ref, {ok, Id}}]};
+handle_call(From, Ref, {reset_stream, Sid, ErrorCode}, Now, State) ->
+    {State1, SendEffects} = do_reset_stream(Sid, ErrorCode, Now, State),
+    {State1, [{reply, From, Ref, ok} | SendEffects]};
+handle_call(From, Ref, {stop_sending, Sid, ErrorCode}, Now, State) ->
+    {State1, SendEffects} = do_stop_sending(Sid, ErrorCode, Now, State),
+    {State1, [{reply, From, Ref, ok} | SendEffects]}.
+
+%% Abandon the send side of a stream and tell the peer with a RESET_STREAM (RFC
+%% 9000 §19.4): discard the unsent buffer, record the bytes already sent as the
+%% Final Size, queue the frame at the application level, and flush it. The h3
+%% layer uses this to abort a response stream.
+-spec do_reset_stream(non_neg_integer(), non_neg_integer(), integer(), t()) -> {t(), [effect()]}.
+do_reset_stream(Sid, ErrorCode, Now, State) ->
+    {Stream, Flow, State1} = stream_for_send(Sid, State),
+    FinalSize = roadrunner_quic_stream:send_offset(Stream),
+    Stream1 = roadrunner_quic_stream:stop_sending(Stream),
+    State2 = put_stream(Sid, Stream1, Flow, State1),
+    State3 = queue_frame(application, {reset_stream, Sid, ErrorCode, FinalSize}, State2),
+    send_pass(Now, State3).
+
+%% Ask the peer to stop sending on a stream with a STOP_SENDING (RFC 9000
+%% §19.5): queue the frame at the application level and flush it. The h3 layer
+%% uses this to decline a request body it will not read.
+-spec do_stop_sending(non_neg_integer(), non_neg_integer(), integer(), t()) -> {t(), [effect()]}.
+do_stop_sending(Sid, ErrorCode, Now, State) ->
+    State1 = queue_frame(application, {stop_sending, Sid, ErrorCode}, State),
+    send_pass(Now, State1).
 
 %% Install the owner. When the handshake already completed before the owner
 %% was set (the deferred path), emit the once-only `{connected, Info}` now;

--- a/src/roadrunner_quic_connection.erl
+++ b/src/roadrunner_quic_connection.erl
@@ -77,7 +77,7 @@ loop(State) ->
         {quic_call, From, Ref, Request} ->
             Now = erlang:monotonic_time(millisecond),
             {Conn, Effects} = roadrunner_quic_conn_state:handle_call(
-                From, Ref, Request, State#shell.conn
+                From, Ref, Request, Now, State#shell.conn
             ),
             continue(perform(Effects, Now, State#shell{conn = Conn}));
         {quic_send, From, Ref, Sid, IoData, Fin} ->

--- a/src/roadrunner_quic_stream.erl
+++ b/src/roadrunner_quic_stream.erl
@@ -31,7 +31,7 @@
 %% the per-stream flow window.
 
 -export([new/0, receive_data/4, reset/2]).
--export([enqueue/2, finish/1, next_frame/2, stop_sending/1, send_pending/1]).
+-export([enqueue/2, finish/1, next_frame/2, stop_sending/1, send_pending/1, send_offset/1]).
 
 -export_type([t/0]).
 
@@ -181,6 +181,14 @@ stop_sending(#stream{} = Stream) ->
 send_pending(#stream{fin_sent = true}) -> false;
 send_pending(#stream{send_buf = <<>>, send_fin = false}) -> false;
 send_pending(#stream{}) -> true.
+
+-doc """
+The send offset: the number of stream bytes already put on the wire, which is
+the Final Size to carry in a RESET_STREAM (RFC 9000 §19.4) once the send side
+is abandoned.
+""".
+-spec send_offset(t()) -> non_neg_integer().
+send_offset(#stream{send_offset = Offset}) -> Offset.
 
 %% =============================================================================
 %% Internal

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -575,6 +575,44 @@ stop_sending_sends_stop_sending_frame_test() ->
     ?assertEqual({reply, self(), Ref, ok}, hd(Effects)),
     ?assert(lists:member({stop_sending, 0, 7}, sent_app_frames(Effects, ApSecret))).
 
+owner_close_sends_application_close_test() ->
+    %% An owner close sends one application-variant CONNECTION_CLOSE carrying the
+    %% h3 error code and reason phrase, marks the connection closed, and replies
+    %% ok (no {closed, _} back: the owner triggered it).
+    {State, ApSecret} = connected_for_send(),
+    Ref = make_ref(),
+    {State1, Effects} = ?M:handle_call(self(), Ref, {close, 16#0100, ~"bye"}, ?NOW, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual({reply, self(), Ref, ok}, hd(Effects)),
+    ?assertEqual([], emits(Effects)),
+    ?assert(
+        lists:member(
+            {connection_close, application, 16#0100, undefined, ~"bye"},
+            sent_app_frames(Effects, ApSecret)
+        )
+    ).
+
+owner_close_without_reason_sends_empty_phrase_test() ->
+    %% close/2 (no reason) carries an empty reason phrase.
+    {State, ApSecret} = connected_for_send(),
+    {State1, Effects} = ?M:handle_call(self(), make_ref(), {close, 16#0100}, ?NOW, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assert(
+        lists:member(
+            {connection_close, application, 16#0100, undefined, <<>>},
+            sent_app_frames(Effects, ApSecret)
+        )
+    ).
+
+owner_close_before_connected_closes_silently_test() ->
+    %% A close before the handshake completes (no 1-RTT keys, e.g. the
+    %% connection_handler refusing on max_clients) closes the connection without
+    %% sending a CONNECTION_CLOSE there are no application keys to seal one.
+    #{state0 := State0} = connect(),
+    {State1, Effects} = ?M:handle_call(self(), make_ref(), {close, 16#0100}, ?NOW, State0),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([], sends(Effects)).
+
 send_data_without_fin_leaves_stream_open_test() ->
     %% A non-final send carries Fin = false (used for the control stream's
     %% SETTINGS, which keeps the stream open).

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -314,7 +314,7 @@ peername_call_replies_test() ->
     Ref = make_ref(),
     ?assertEqual(
         {State, [{reply, self(), Ref, {ok, ?PEER}}]},
-        ?M:handle_call(self(), Ref, peername, State)
+        ?M:handle_call(self(), Ref, peername, 0, State)
     ).
 
 owner_set_in_handshaking_gets_connected_on_completion_test() ->
@@ -324,7 +324,7 @@ owner_set_in_handshaking_gets_connected_on_completion_test() ->
     #{state1 := State1, client_hs_secret := ClientHsSecret, cf_framed := ClientFinished} = connect(),
     Owner = self(),
     Ref = make_ref(),
-    {State1b, Installed} = ?M:handle_call(Owner, Ref, {set_owner, Owner}, State1),
+    {State1b, Installed} = ?M:handle_call(Owner, Ref, {set_owner, Owner}, 0, State1),
     ?assertEqual([{reply, Owner, Ref, ok}], Installed),
     Datagram = ?TC:seal(
         handshake,
@@ -344,7 +344,7 @@ owner_set_after_connection_gets_connected_now_test() ->
     #{state2 := State2} = connect(),
     Owner = self(),
     Ref = make_ref(),
-    {_State3, Effects} = ?M:handle_call(Owner, Ref, {set_owner, Owner}, State2),
+    {_State3, Effects} = ?M:handle_call(Owner, Ref, {set_owner, Owner}, 0, State2),
     ?assertEqual([{reply, Owner, Ref, ok}, {emit, Owner, {connected, expected_info()}}], Effects).
 
 connected_not_re_emitted_on_later_datagram_test() ->
@@ -359,7 +359,7 @@ connected_not_re_emitted_on_later_datagram_test() ->
         client_ap_secret := ClientApSecret
     } = connect(),
     Owner = self(),
-    {State1b, _} = ?M:handle_call(Owner, make_ref(), {set_owner, Owner}, State1),
+    {State1b, _} = ?M:handle_call(Owner, make_ref(), {set_owner, Owner}, 0, State1),
     Finished = ?TC:seal(
         handshake,
         0,
@@ -505,7 +505,7 @@ connected_precedes_stream_events_in_coalesced_datagram_test() ->
         client_ap_secret := ClientApSecret
     } = connect(),
     Owner = self(),
-    {State1b, _} = ?M:handle_call(Owner, make_ref(), {set_owner, Owner}, State1),
+    {State1b, _} = ?M:handle_call(Owner, make_ref(), {set_owner, Owner}, 0, State1),
     Finished = ?TC:seal(
         handshake,
         0,
@@ -542,10 +542,10 @@ open_uni_allocates_server_uni_ids_test() ->
     %% id (RFC 9000 §2.1: 3, 7, 11, ...) and replies with it.
     {State, _ApSecret} = connected_for_send(),
     Ref1 = make_ref(),
-    {State1, Effects1} = ?M:handle_call(self(), Ref1, open_uni, State),
+    {State1, Effects1} = ?M:handle_call(self(), Ref1, open_uni, 0, State),
     ?assertEqual([{reply, self(), Ref1, {ok, 3}}], Effects1),
     Ref2 = make_ref(),
-    {_State2, Effects2} = ?M:handle_call(self(), Ref2, open_uni, State1),
+    {_State2, Effects2} = ?M:handle_call(self(), Ref2, open_uni, 0, State1),
     ?assertEqual([{reply, self(), Ref2, {ok, 7}}], Effects2).
 
 send_data_emits_stream_frame_with_fin_test() ->
@@ -556,6 +556,24 @@ send_data_emits_stream_frame_with_fin_test() ->
     {_State1, Effects} = ?M:handle_send(self(), Ref, 0, ~"hello", true, ?NOW, State),
     ?assertEqual({reply, self(), Ref, ok}, hd(Effects)),
     ?assertEqual([{stream, 0, 0, ~"hello", true}], sent_stream_frames(Effects, ApSecret)).
+
+reset_stream_sends_reset_with_final_size_test() ->
+    %% reset_stream abandons the send side and emits a RESET_STREAM whose Final
+    %% Size is the bytes already sent (5 from the prior send), and replies ok.
+    {State, ApSecret} = connected_for_send(),
+    {State1, _} = ?M:handle_send(self(), make_ref(), 0, ~"hello", false, ?NOW, State),
+    Ref = make_ref(),
+    {_State2, Effects} = ?M:handle_call(self(), Ref, {reset_stream, 0, 7}, ?NOW, State1),
+    ?assertEqual({reply, self(), Ref, ok}, hd(Effects)),
+    ?assert(lists:member({reset_stream, 0, 7, 5}, sent_app_frames(Effects, ApSecret))).
+
+stop_sending_sends_stop_sending_frame_test() ->
+    %% stop_sending emits a STOP_SENDING frame for the stream and replies ok.
+    {State, ApSecret} = connected_for_send(),
+    Ref = make_ref(),
+    {_State1, Effects} = ?M:handle_call(self(), Ref, {stop_sending, 0, 7}, ?NOW, State),
+    ?assertEqual({reply, self(), Ref, ok}, hd(Effects)),
+    ?assert(lists:member({stop_sending, 0, 7}, sent_app_frames(Effects, ApSecret))).
 
 send_data_without_fin_leaves_stream_open_test() ->
     %% A non-final send carries Fin = false (used for the control stream's
@@ -841,7 +859,7 @@ expected_info() ->
 %% Install this process as the owner (no emit while handshaking) so a later
 %% close surfaces {closed, _} here.
 with_owner(State) ->
-    {State1, _} = ?M:handle_call(self(), make_ref(), {set_owner, self()}, State),
+    {State1, _} = ?M:handle_call(self(), make_ref(), {set_owner, self()}, 0, State),
     State1.
 
 %% Drive to connected with this process installed as owner (set during
@@ -856,7 +874,7 @@ connect_owned() ->
         client_ap_secret := ClientApSecret,
         server_ap_secret := ServerApSecret
     } = connect(),
-    {State1b, _} = ?M:handle_call(self(), make_ref(), {set_owner, self()}, State1),
+    {State1b, _} = ?M:handle_call(self(), make_ref(), {set_owner, self()}, 0, State1),
     Finished = ?TC:seal(
         handshake,
         0,
@@ -895,6 +913,16 @@ sent_stream_frames(Effects, ServerApSecret) ->
         byte_size(?DCID)
     ),
     [Frame || {stream, _Sid, _Off, _Data, _Fin} = Frame <- Frames].
+
+%% Every frame the server put on the wire at the application level (decoded with
+%% its 1-RTT keys), for asserting control frames like RESET_STREAM/STOP_SENDING.
+sent_app_frames(Effects, ServerApSecret) ->
+    ?TC:frames(
+        sends(Effects),
+        application,
+        #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+        byte_size(?DCID)
+    ).
 
 emits(Effects) ->
     [Emit || {emit, _Owner, _Event} = Emit <- Effects].

--- a/test/roadrunner_quic_tests.erl
+++ b/test/roadrunner_quic_tests.erl
@@ -1,0 +1,98 @@
+-module(roadrunner_quic_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic).
+
+%% The control API is a make_ref round-trip over the connection's
+%% {quic_call}/{quic_send} wire, so a fake connection that speaks that wire
+%% covers it without a full handshake (the real connection's replies are tested
+%% in roadrunner_quic_conn_state_tests).
+
+peername_round_trips_test() ->
+    Conn = replier({ok, {{127, 0, 0, 1}, 443}}),
+    ?assertEqual({ok, {{127, 0, 0, 1}, 443}}, ?M:peername(Conn)),
+    ?assertEqual(peername, recv_request()).
+
+open_unidirectional_stream_round_trips_test() ->
+    Conn = replier({ok, 3}),
+    ?assertEqual({ok, 3}, ?M:open_unidirectional_stream(Conn)),
+    ?assertEqual(open_uni, recv_request()).
+
+send_data_round_trips_test() ->
+    Conn = replier(ok),
+    ?assertEqual(ok, ?M:send_data(Conn, 4, ~"frames", true)),
+    ?assertEqual({send, 4, ~"frames", true}, recv_request()).
+
+%% send_data relays whatever the connection replies, including an error (a
+%% draining connection rejecting the write).
+send_data_relays_error_test() ->
+    Conn = replier({error, {invalid_state, draining}}),
+    ?assertEqual({error, {invalid_state, draining}}, ?M:send_data(Conn, 4, ~"x", false)),
+    %% Drain the request report so it does not bleed into the next test.
+    ?assertEqual({send, 4, ~"x", false}, recv_request()).
+
+reset_stream_round_trips_test() ->
+    Conn = replier(ok),
+    ?assertEqual(ok, ?M:reset_stream(Conn, 0, 16#0100)),
+    ?assertEqual({reset_stream, 0, 16#0100}, recv_request()).
+
+stop_sending_round_trips_test() ->
+    Conn = replier(ok),
+    ?assertEqual(ok, ?M:stop_sending(Conn, 0, 16#0100)),
+    ?assertEqual({stop_sending, 0, 16#0100}, recv_request()).
+
+close_round_trips_test() ->
+    Conn = replier(ok),
+    ?assertEqual(ok, ?M:close(Conn, 16#0100)),
+    ?assertEqual({close, 16#0100}, recv_request()).
+
+close_with_reason_round_trips_test() ->
+    Conn = replier(ok),
+    ?assertEqual(ok, ?M:close(Conn, 16#0100, ~"bye")),
+    ?assertEqual({close, 16#0100, ~"bye"}, recv_request()).
+
+%% A connection that dies before replying exits the caller with
+%% {quic_conn_down, _} (gen_statem:call semantics for a dead callee).
+conn_down_exits_caller_test() ->
+    Dead = dead_pid(),
+    {_Pid, Mon} = spawn_monitor(fun() -> ?M:peername(Dead) end),
+    receive
+        {'DOWN', Mon, process, _, Reason} ->
+            ?assertMatch({quic_conn_down, _}, Reason)
+    after 1000 ->
+        error(caller_did_not_exit)
+    end.
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+%% A one-shot fake connection: reports the request it received to the test, then
+%% answers with `Result`.
+replier(Result) ->
+    Test = self(),
+    spawn(fun() ->
+        receive
+            {quic_call, From, Ref, Request} ->
+                Test ! {request, Request},
+                From ! {quic_reply, Ref, Result};
+            {quic_send, From, Ref, StreamId, IoData, Fin} ->
+                Test ! {request, {send, StreamId, IoData, Fin}},
+                From ! {quic_reply, Ref, Result}
+        end
+    end).
+
+recv_request() ->
+    receive
+        {request, Request} -> Request
+    after 1000 ->
+        timeout
+    end.
+
+dead_pid() ->
+    {Pid, Mon} = spawn_monitor(fun() -> ok end),
+    receive
+        {'DOWN', Mon, process, Pid, _} -> ok
+    end,
+    Pid.


### PR DESCRIPTION
# Description

Add the native QUIC connection control API: a thin `roadrunner_quic` module (`peername`, `open_unidirectional_stream`, `send_data`, `reset_stream`, `stop_sending`, `close`) that replicates a `gen_statem:call` over the connection's `make_ref` round-trip with a conn-down monitor, plus the connection-state handlers it drives (owner-initiated stream reset and stop-sending, RFC 9000 §19.4/§19.5, and an application-level CONNECTION_CLOSE, §10.2.2). This is the seam the HTTP/3 owner and stream worker use to reach the native transport.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)