### PR TITLE
Add the native QUIC listener pool

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -89,6 +89,7 @@
         {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_connection_interop_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_listener_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_quic_listener_sup_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_tls_tests.erl", unnecessary_function_arguments},
         {"test/roadrunner_conn_tests.erl", unnecessary_function_arguments},

--- a/src/roadrunner_quic_listener.erl
+++ b/src/roadrunner_quic_listener.erl
@@ -24,8 +24,8 @@
 %%
 %% A new server Source Connection ID is generated per connection at a fixed
 %% length, so short-header 1-RTT packets (which carry no CID-length field)
-%% demux by slicing that many leading bytes. The SO_REUSEPORT pool and the
-%% supervisor are later slices.
+%% demux by slicing that many leading bytes. `roadrunner_quic_listener_sup`
+%% runs a SO_REUSEPORT pool of these listeners sharing one injected registry.
 
 -export([start_link/1, get_port/1, stop/1]).
 -export([init/1]).
@@ -54,7 +54,12 @@
     alpn := binary(),
     transport_params := roadrunner_quic_transport_params:params(),
     connection_handler := fun((pid()) -> {ok, pid()} | {error, term()}),
-    reuseport => boolean()
+    reuseport => boolean(),
+    %% The connection-id routing table. A SO_REUSEPORT pool injects one shared
+    %% table (owned by the pool supervisor) so a datagram landing on any pool
+    %% socket routes to the owning connection; a standalone listener omits it
+    %% and creates (and owns) its own.
+    registry => roadrunner_quic_cid_registry:t()
 }.
 
 -record(listener, {
@@ -115,10 +120,14 @@ init(
             {ok, {_Ip, BoundPort}} = roadrunner_quic_socket:sockname(Socket),
             proc_lib:set_label({?MODULE, BoundPort}),
             proc_lib:init_ack({ok, self()}),
+            %% A pool injects one shared registry; a standalone listener owns its
+            %% own. Either way the listener never deletes the table on stop, so a
+            %% shared one outlives any single listener.
+            Registry = maps:get(registry, Opts, roadrunner_quic_cid_registry:new()),
             loop(#listener{
                 socket = Socket,
                 port = BoundPort,
-                registry = roadrunner_quic_cid_registry:new(),
+                registry = Registry,
                 cert_chain = CertChain,
                 priv_key = PrivKey,
                 alpn = Alpn,
@@ -302,13 +311,23 @@ install_owner(ConnPid, Handler) ->
 
 %% The synchronous set_owner round-trip (mirrors the connection's control-call
 %% wire): the connection records the owner before any datagram drives the
-%% handshake, so the {connected, _} event cannot race ahead of ownership.
+%% handshake, so the {connected, _} event cannot race ahead of ownership. A
+%% private monitor guards against the connection dying before it replies (e.g.
+%% a crash in its init): without it the loop would block here forever, which in
+%% a pool is a silent loss of one listener. The connection's id rows are reaped
+%% by the loop's own monitor (set in spawn_connection), so the abort here only
+%% skips the now-moot ownership install.
 -spec set_owner_sync(pid(), pid()) -> ok.
 set_owner_sync(ConnPid, Owner) ->
     Ref = make_ref(),
+    MonRef = monitor(process, ConnPid),
     _ = ConnPid ! {quic_call, self(), Ref, {set_owner, Owner}},
     receive
-        {quic_reply, Ref, ok} -> ok
+        {quic_reply, Ref, ok} ->
+            _ = demonitor(MonRef, [flush]),
+            ok;
+        {'DOWN', MonRef, process, ConnPid, _Reason} ->
+            ok
     end.
 
 -spec conn_config(binary(), binary(), {inet:ip_address(), inet:port_number()}, #listener{}) ->

--- a/src/roadrunner_quic_listener_sup.erl
+++ b/src/roadrunner_quic_listener_sup.erl
@@ -1,0 +1,174 @@
+-module(roadrunner_quic_listener_sup).
+-moduledoc false.
+
+%% A SO_REUSEPORT pool of `roadrunner_quic_listener`s sharing one connection-id
+%% registry. This is the drop-in for the dep's `quic_listener_sup`: the seam in
+%% `roadrunner_listener` starts it with `start_link/2`, reads a listener back
+%% with `get_listeners/1`, and tears it down with `stop/1`.
+%%
+%% `pool_size + 1` listeners (the `+1` is the primary, matching the dep) all
+%% bind the SAME concrete port with `SO_REUSEPORT`, so the kernel fans inbound
+%% datagrams across them and demux parallelizes across cores. The caller hands
+%% in a concrete port (`roadrunner_listener` pins a free one with a reuseport
+%% probe before calling, because binding port 0 on each listener would hand out
+%% a different ephemeral port); reuseport is enabled only when there is more
+%% than one listener.
+%%
+%% The shared registry is created here, so it is owned by this supervisor
+%% process and OUTLIVES any single listener: a crashed listener is restarted
+%% (one_for_one) with the same child spec, i.e. the same table, and a datagram
+%% that fans out to a different listener still routes to the owning connection.
+%% Each listener registers + monitors only the connections it spawns, so the
+%% per-listener cleanup stays correct over the shared table.
+%%
+%% Connections are owned (and linked) by the `roadrunner_conn_loop_http3` owner
+%% the `connection_handler` returns, not by the listeners, so `stop/1` brings
+%% the pool (and its sockets/port) down without abruptly killing in-flight
+%% connections; those drain through the owner protocol or idle out. The Version
+%% Negotiation trigger, anti-amplification, and the handshake all live in the
+%% listener and connection; this module is only the pool wiring.
+
+-behaviour(supervisor).
+
+-export([start_link/2, get_listeners/1, stop/1]).
+-export([init/1]).
+%% Exported for eunit coverage of the pure pool-options translation.
+-export([listener_opts/4]).
+
+-export_type([pool_opts/0]).
+
+%% Default transport parameters advertised to clients. Only initial_max_streams_
+%% bidi is carried in pool_opts today (from the listener's http3 opts); the rest
+%% are fixed defaults pending the flow-control opt wiring. They mirror the conn
+%% layer's own limits (the 30s idle matches the connection idle timeout).
+-define(DEFAULT_INITIAL_MAX_DATA, 1048576).
+-define(DEFAULT_INITIAL_MAX_STREAM_DATA, 262144).
+-define(DEFAULT_INITIAL_MAX_STREAMS_UNI, 100).
+-define(DEFAULT_MAX_IDLE_TIMEOUT, 30000).
+
+-type pool_opts() :: #{
+    cert := binary(),
+    key := public_key:private_key(),
+    cert_chain := [binary()],
+    alpn := [binary(), ...],
+    max_streams_bidi := non_neg_integer(),
+    connection_handler := fun((pid()) -> {ok, pid()} | {error, term()}),
+    pool_size := non_neg_integer()
+}.
+
+%% =============================================================================
+%% API
+%% =============================================================================
+
+-doc """
+Start a pool of reuseport listeners on `Port` (a concrete port; the caller
+resolves an ephemeral one first). Returns once every listener has bound, so a
+bind failure surfaces synchronously as `{error, _}`.
+""".
+-spec start_link(inet:port_number(), pool_opts()) -> {ok, pid()} | {error, term()}.
+start_link(Port, PoolOpts) ->
+    supervisor:start_link(?MODULE, {Port, PoolOpts}).
+
+-doc "The pool's listener pids (non-empty for a running pool, any answers get_port/1).".
+-spec get_listeners(pid()) -> [pid()].
+get_listeners(Sup) ->
+    [
+        Pid
+     || {{listener, _N}, Pid, _Type, _Modules} <- supervisor:which_children(Sup), is_pid(Pid)
+    ].
+
+-doc """
+Stop the pool, bringing the supervisor down (which terminates every listener,
+freeing the shared port). Called by the pool's owner, the process that
+`start_link`ed it: this unlinks first so the supervisor's shutdown exit does
+not fell the owner, and returns once the supervisor is gone.
+""".
+-spec stop(pid()) -> ok.
+stop(Sup) ->
+    Mon = monitor(process, Sup),
+    true = unlink(Sup),
+    _ = exit(Sup, shutdown),
+    receive
+        {'DOWN', Mon, process, Sup, _Reason} -> ok
+    end.
+
+%% =============================================================================
+%% Supervisor
+%% =============================================================================
+
+-doc false.
+-spec init({inet:port_number(), pool_opts()}) ->
+    {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init({Port, #{pool_size := PoolSize} = PoolOpts}) ->
+    %% The shared registry is created (and owned) here so it survives a listener
+    %% crash. A restarted listener gets the same child spec, hence the same
+    %% table.
+    Registry = roadrunner_quic_cid_registry:new(),
+    Count = PoolSize + 1,
+    ReusePort = Count > 1,
+    Specs = [listener_spec(N, Port, PoolOpts, Registry, ReusePort) || N <- lists:seq(1, Count)],
+    SupFlags = #{strategy => one_for_one, intensity => 10, period => 5},
+    {ok, {SupFlags, Specs}}.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+-spec listener_spec(
+    pos_integer(),
+    inet:port_number(),
+    pool_opts(),
+    roadrunner_quic_cid_registry:t(),
+    boolean()
+) -> supervisor:child_spec().
+listener_spec(N, Port, PoolOpts, Registry, ReusePort) ->
+    #{
+        id => {listener, N},
+        start =>
+            {roadrunner_quic_listener, start_link, [
+                listener_opts(Port, PoolOpts, Registry, ReusePort)
+            ]},
+        type => worker,
+        restart => permanent,
+        shutdown => 5000,
+        modules => [roadrunner_quic_listener]
+    }.
+
+-doc false.
+-spec listener_opts(
+    inet:port_number(), pool_opts(), roadrunner_quic_cid_registry:t(), boolean()
+) -> roadrunner_quic_listener:opts().
+listener_opts(Port, PoolOpts, Registry, ReusePort) ->
+    #{
+        cert := Cert,
+        key := Key,
+        cert_chain := CertChain,
+        alpn := [Alpn | _],
+        max_streams_bidi := MaxStreamsBidi,
+        connection_handler := Handler
+    } = PoolOpts,
+    #{
+        port => Port,
+        %% The native listener takes the full chain leaf-first; pool_opts keeps
+        %% the leaf and intermediates separate (the dep's split).
+        cert_chain => [Cert | CertChain],
+        priv_key => Key,
+        %% QUIC v1 negotiates a single ALPN; the listener carries the chosen one.
+        alpn => Alpn,
+        transport_params => transport_params(MaxStreamsBidi),
+        connection_handler => Handler,
+        reuseport => ReusePort,
+        registry => Registry
+    }.
+
+-spec transport_params(non_neg_integer()) -> roadrunner_quic_transport_params:params().
+transport_params(MaxStreamsBidi) ->
+    #{
+        initial_max_data => ?DEFAULT_INITIAL_MAX_DATA,
+        initial_max_stream_data_bidi_local => ?DEFAULT_INITIAL_MAX_STREAM_DATA,
+        initial_max_stream_data_bidi_remote => ?DEFAULT_INITIAL_MAX_STREAM_DATA,
+        initial_max_stream_data_uni => ?DEFAULT_INITIAL_MAX_STREAM_DATA,
+        initial_max_streams_bidi => MaxStreamsBidi,
+        initial_max_streams_uni => ?DEFAULT_INITIAL_MAX_STREAMS_UNI,
+        max_idle_timeout => ?DEFAULT_MAX_IDLE_TIMEOUT
+    }.

--- a/test/roadrunner_quic_listener_SUITE.erl
+++ b/test/roadrunner_quic_listener_SUITE.erl
@@ -24,6 +24,8 @@ an outer guard. The pure routing decision (`classify/2`) is unit-tested in
     stray_message_is_ignored/1,
     malformed_datagram_is_dropped/1,
     sends_version_negotiation_for_unsupported_version/1,
+    uses_injected_registry/1,
+    conn_death_before_set_owner_does_not_wedge/1,
     conn_down_is_cleaned_up/1
 ]).
 
@@ -44,6 +46,8 @@ all() ->
         stray_message_is_ignored,
         malformed_datagram_is_dropped,
         sends_version_negotiation_for_unsupported_version,
+        uses_injected_registry,
+        conn_death_before_set_owner_does_not_wedge,
         conn_down_is_cleaned_up
     ].
 
@@ -245,6 +249,56 @@ conn_down_is_cleaned_up(_Config) ->
     ?assertNotEqual(Conn1, Conn2),
 
     exit(Conn2, kill),
+    ok = roadrunner_quic_socket:close(Client),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% A connection that dies before accepting ownership does not wedge the listener
+%% in set_owner_sync: its private monitor sees the death and aborts, so the loop
+%% keeps serving. Without the guard the loop would block on the never-arriving
+%% reply forever, a silent loss of a pool listener (no crash, no restart).
+conn_death_before_set_owner_does_not_wedge(_Config) ->
+    Test = self(),
+    Handler = fun(ConnPid) ->
+        %% Kill the connection before returning, so set_owner_sync races a dead
+        %% conn (a stand-in for the connection crashing in its own init).
+        exit(ConnPid, kill),
+        Test ! {killed, ConnPid},
+        {ok, spawn(fun drain/0)}
+    end,
+    {Listener, Port} = start_listener(Handler),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, crafted_initial()),
+    receive
+        {killed, _ConnPid} -> ok
+    after 2000 ->
+        ct:fail(handler_not_invoked)
+    end,
+    %% The listener did not wedge: it still answers.
+    ?assertEqual(Port, roadrunner_quic_listener:get_port(Listener)),
+    ok = roadrunner_quic_socket:close(Client),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% A listener routes through an INJECTED registry (the pool's shared table), not
+%% a private one: a datagram for a connection id registered in the injected
+%% table is forwarded to that connection. This is what lets a SO_REUSEPORT pool
+%% route a datagram landing on any listener to the owning connection.
+uses_injected_registry(_Config) ->
+    Registry = roadrunner_quic_cid_registry:new(),
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ok = roadrunner_quic_cid_registry:register_pair(
+        Registry, DCID, <<9, 9, 9, 9, 9, 9, 9, 9>>, self()
+    ),
+    Opts = (listener_opts(0, drain_handler()))#{registry => Registry},
+    {ok, Listener} = roadrunner_quic_listener:start_link(Opts),
+    Port = roadrunner_quic_listener:get_port(Listener),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    %% A short-header (1-RTT) datagram whose destination id is the registered id.
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, <<16#40, DCID/binary, 0>>),
+    receive
+        {quic_datagram, _Peer, _Bytes} -> ok
+    after 2000 ->
+        ct:fail(not_forwarded_via_injected_registry)
+    end,
     ok = roadrunner_quic_socket:close(Client),
     ok = roadrunner_quic_listener:stop(Listener).
 

--- a/test/roadrunner_quic_listener_sup_SUITE.erl
+++ b/test/roadrunner_quic_listener_sup_SUITE.erl
@@ -1,0 +1,185 @@
+-module(roadrunner_quic_listener_sup_SUITE).
+-moduledoc """
+Integration tests for the native QUIC listener pool.
+
+A CT suite: the load-bearing case drives the dep `quic` client through a real
+handshake against a multi-listener SO_REUSEPORT pool, and the lifecycle cases
+(get_listeners, get_port, stop, bind failure) need live supervisor + listener
+processes. The pure pool-options translation is unit-tested in
+`roadrunner_quic_listener_sup_tests`.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    dep_client_handshakes_through_pool/1,
+    single_listener_pool_serves/1,
+    every_listener_answers_get_port/1,
+    bind_failure_is_reported/1,
+    stop_brings_the_pool_down/1
+]).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [
+        dep_client_handshakes_through_pool,
+        single_listener_pool_serves,
+        every_listener_answers_get_port,
+        bind_failure_is_reported,
+        stop_brings_the_pool_down
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(ssl),
+    %% The dep `quic` app backs the test CLIENT only; the native pool does not
+    %% depend on it. The default `pg` scope hosts the client's drain group.
+    {ok, _} = application:ensure_all_started(quic),
+    ok = ensure_pg_started(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% A dep client completes a real handshake through a multi-listener reuseport
+%% pool (pool_size 2 -> 3 listeners sharing one registry). The handler's owner
+%% is reported so it can be torn down with the case.
+dep_client_handshakes_through_pool(_Config) ->
+    Test = self(),
+    Handler = fun(_ConnPid) ->
+        Owner = spawn(fun drain/0),
+        Test ! {owner, Owner},
+        {ok, Owner}
+    end,
+    {Sup, Port} = start_pool(2, Handler),
+    ?assertEqual(3, length(roadrunner_quic_listener_sup:get_listeners(Sup))),
+    {ok, Conn} = quic:connect(
+        ~"127.0.0.1", Port, #{alpn => [~"h3"], verify => verify_none}, self()
+    ),
+    Result =
+        receive
+            {quic, Conn, {connected, _Info}} -> ok
+        after 5000 ->
+            timeout
+        end,
+    _ = quic:close(Conn),
+    receive
+        {owner, Owner} -> exit(Owner, kill)
+    after 0 -> ok
+    end,
+    stop_pool(Sup),
+    ?assertEqual(ok, Result).
+
+%% A single-listener pool (pool_size 0, no reuseport) binds an ephemeral port
+%% and answers get_port via its one listener.
+single_listener_pool_serves(_Config) ->
+    {Sup, Port} = start_single_pool(),
+    ?assertEqual(1, length(roadrunner_quic_listener_sup:get_listeners(Sup))),
+    [Listener] = roadrunner_quic_listener_sup:get_listeners(Sup),
+    ?assertEqual(Port, roadrunner_quic_listener:get_port(Listener)),
+    stop_pool(Sup).
+
+%% Every listener in the pool answers the same bound port (reuseport shares it),
+%% so taking the head of get_listeners for get_port is safe.
+every_listener_answers_get_port(_Config) ->
+    {Sup, Port} = start_pool(2, drain_handler()),
+    Listeners = roadrunner_quic_listener_sup:get_listeners(Sup),
+    [?assertEqual(Port, roadrunner_quic_listener:get_port(L)) || L <- Listeners],
+    stop_pool(Sup).
+
+%% A bind onto a port already held surfaces synchronously as {error, _} from
+%% start_link (a child's bind failure fails the supervisor start). start_link
+%% links the supervisor to the caller, so the failed-start exit must be trapped
+%% to surface as a return rather than felling the caller, exactly as
+%% roadrunner_listener:start_quic_pool does.
+bind_failure_is_reported(_Config) ->
+    {ok, Blocker} = gen_udp:open(0, [binary, {active, false}]),
+    {ok, {_Ip, Port}} = inet:sockname(Blocker),
+    Old = process_flag(trap_exit, true),
+    Result = roadrunner_quic_listener_sup:start_link(Port, pool_opts(0, drain_handler())),
+    receive
+        {'EXIT', _, _} -> ok
+    after 200 -> ok
+    end,
+    _ = process_flag(trap_exit, Old),
+    ?assertMatch({error, _}, Result),
+    ok = gen_udp:close(Blocker).
+
+%% stop/1 brings the (multi-listener) pool down synchronously, closing every
+%% reuseport socket: it returns with the supervisor gone, and a fresh plain
+%% (non-reuseport) bind on the shared port then succeeds, proving all of the
+%% pool's sockets were closed, not just one.
+stop_brings_the_pool_down(_Config) ->
+    {Sup, Port} = start_pool(2, drain_handler()),
+    ok = roadrunner_quic_listener_sup:stop(Sup),
+    ?assertNot(is_process_alive(Sup)),
+    {ok, Reclaim} = gen_udp:open(Port, [binary, {active, false}]),
+    ok = gen_udp:close(Reclaim).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+%% A multi-listener pool needs a concrete shared port: pin a free one with a
+%% reuseport probe, start the pool on it, then drop the probe (the listeners
+%% keep the port via reuseport).
+start_pool(PoolSize, Handler) ->
+    {ok, Probe} = gen_udp:open(0, [{reuseport, true}]),
+    {ok, Port} = inet:port(Probe),
+    {ok, Sup} = roadrunner_quic_listener_sup:start_link(Port, pool_opts(PoolSize, Handler)),
+    ok = gen_udp:close(Probe),
+    {Sup, Port}.
+
+%% A single-listener pool binds an ephemeral port directly (no reuseport).
+start_single_pool() ->
+    {ok, Sup} = roadrunner_quic_listener_sup:start_link(0, pool_opts(0, drain_handler())),
+    [Listener] = roadrunner_quic_listener_sup:get_listeners(Sup),
+    {Sup, roadrunner_quic_listener:get_port(Listener)}.
+
+%% stop/1 unlinks internally, so the owner just calls it.
+stop_pool(Sup) ->
+    ok = roadrunner_quic_listener_sup:stop(Sup).
+
+pool_opts(PoolSize, Handler) ->
+    {Cert, Chain, Key} = cert_key(),
+    #{
+        cert => Cert,
+        key => Key,
+        cert_chain => Chain,
+        alpn => [~"h3"],
+        max_streams_bidi => 100,
+        connection_handler => Handler,
+        pool_size => PoolSize
+    }.
+
+drain_handler() ->
+    fun(_ConnPid) -> {ok, spawn(fun drain/0)} end.
+
+drain() ->
+    receive
+        _ -> drain()
+    end.
+
+cert_key() ->
+    Opts = roadrunner_test_certs:server_opts(),
+    {cert, CertDer} = lists:keyfind(cert, 1, Opts),
+    {key, {KeyType, KeyDer}} = lists:keyfind(key, 1, Opts),
+    {CertDer, [], public_key:der_decode(KeyType, KeyDer)}.
+
+ensure_pg_started() ->
+    case whereis(pg) of
+        undefined ->
+            case pg:start_link() of
+                {ok, Pid} ->
+                    _ = unlink(Pid),
+                    ok;
+                {error, {already_started, _}} ->
+                    ok
+            end;
+        _ ->
+            ok
+    end.

--- a/test/roadrunner_quic_listener_sup_tests.erl
+++ b/test/roadrunner_quic_listener_sup_tests.erl
@@ -1,0 +1,93 @@
+-module(roadrunner_quic_listener_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_quic_listener_sup).
+-define(REG, roadrunner_quic_cid_registry).
+
+%% The pool-options -> per-listener-options translation and the child-spec build
+%% are pure (given a registry / the supervisor init), so they are covered here;
+%% the live pool (the reuseport bind, get_listeners, stop, a real handshake)
+%% lives in roadrunner_quic_listener_sup_SUITE.
+
+listener_opts_maps_pool_opts_test() ->
+    Registry = ?REG:new(),
+    Handler = fun(_ConnPid) -> {ok, self()} end,
+    PoolOpts = #{
+        cert => <<"leaf">>,
+        key => fake_key,
+        cert_chain => [<<"int1">>, <<"int2">>],
+        alpn => [~"h3"],
+        max_streams_bidi => 50,
+        connection_handler => Handler,
+        pool_size => 2
+    },
+    Opts = ?M:listener_opts(4433, PoolOpts, Registry, true),
+    ?assertEqual(4433, maps:get(port, Opts)),
+    %% The leaf is prepended to the intermediate chain (the listener takes the
+    %% full chain leaf-first; pool_opts keeps them split).
+    ?assertEqual([<<"leaf">>, <<"int1">>, <<"int2">>], maps:get(cert_chain, Opts)),
+    ?assertEqual(fake_key, maps:get(priv_key, Opts)),
+    %% The single negotiated ALPN is extracted from the list.
+    ?assertEqual(~"h3", maps:get(alpn, Opts)),
+    ?assertEqual(Handler, maps:get(connection_handler, Opts)),
+    ?assertEqual(true, maps:get(reuseport, Opts)),
+    ?assertEqual(Registry, maps:get(registry, Opts)),
+    TP = maps:get(transport_params, Opts),
+    ?assertEqual(50, maps:get(initial_max_streams_bidi, TP)),
+    %% The fixed defaults (pending the flow-control opt wiring).
+    ?assertEqual(1048576, maps:get(initial_max_data, TP)),
+    ?assertEqual(262144, maps:get(initial_max_stream_data_bidi_local, TP)),
+    ?assertEqual(262144, maps:get(initial_max_stream_data_bidi_remote, TP)),
+    ?assertEqual(262144, maps:get(initial_max_stream_data_uni, TP)),
+    ?assertEqual(100, maps:get(initial_max_streams_uni, TP)),
+    ?assertEqual(30000, maps:get(max_idle_timeout, TP)),
+    %% The base transport params carry no per-connection ids (filled at spawn).
+    ?assertNot(maps:is_key(original_destination_connection_id, TP)),
+    ?assertNot(maps:is_key(initial_source_connection_id, TP)).
+
+%% A single-listener pool passes reuseport => false, and an empty intermediate
+%% chain yields a one-element (leaf-only) chain.
+listener_opts_single_listener_test() ->
+    Registry = ?REG:new(),
+    Opts = ?M:listener_opts(0, pool_opts(0), Registry, false),
+    ?assertEqual(false, maps:get(reuseport, Opts)),
+    ?assertEqual([<<"leaf">>], maps:get(cert_chain, Opts)).
+
+%% init/1 builds `pool_size + 1` reuseport listeners that all share ONE registry
+%% handle: the property the pool exists for, so a datagram fanned out to any
+%% listener routes via the same table. A regression creating a fresh registry
+%% per listener fails the usort assertion.
+init_shares_one_registry_across_listeners_test() ->
+    {ok, {_SupFlags, Specs}} = ?M:init({4433, pool_opts(3)}),
+    ?assertEqual(4, length(Specs)),
+    ?assertEqual(1, length(lists:usort([registry_of(Spec) || Spec <- Specs]))),
+    ?assert(lists:all(fun(Spec) -> maps:get(reuseport, opts_of(Spec)) =:= true end, Specs)).
+
+%% A single-listener pool is one listener with reuseport off.
+init_single_listener_test() ->
+    {ok, {_SupFlags, Specs}} = ?M:init({0, pool_opts(0)}),
+    ?assertEqual(1, length(Specs)),
+    [Spec] = Specs,
+    ?assertEqual(false, maps:get(reuseport, opts_of(Spec))).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+registry_of(Spec) ->
+    maps:get(registry, opts_of(Spec)).
+
+opts_of(#{start := {roadrunner_quic_listener, start_link, [Opts]}}) ->
+    Opts.
+
+pool_opts(PoolSize) ->
+    #{
+        cert => <<"leaf">>,
+        key => fake_key,
+        cert_chain => [],
+        alpn => [~"h3"],
+        max_streams_bidi => 100,
+        connection_handler => fun(_ConnPid) -> {ok, self()} end,
+        pool_size => PoolSize
+    }.


### PR DESCRIPTION
# Description

Add the native QUIC listener pool: a thin `roadrunner_quic_listener_sup` supervisor that runs a SO_REUSEPORT pool of `roadrunner_quic_listener` processes sharing one connection-id registry, so a datagram landing on any pool socket routes to the owning connection. It exposes the `start_link/2` + `get_listeners/1` + `stop/1` seam the framework listener swaps onto.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)