### PR TITLE
Serve the live HTTP/3 path on the native QUIC stack

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,6 +66,71 @@ only). Remaining work:
   registering them so packets using them route. A currently-unwired
   dep feature, a deliberate upstream effort if wanted
 
+## Native QUIC transport follow-ups
+
+The HTTP/3 path now runs on the native `roadrunner_quic_*` stack (the `quic`
+dep is a test-profile differential oracle + CT client only). The RFC MUSTs a
+browser depends on are implemented; the items below are conformance hardening
+and transport completeness that a real browser GET / POST does not need.
+
+### SHOULD/MAY conformance — harden against non-conformant peers
+
+A conformant browser / quiche / ngtcp2 never trips these; they tighten the
+advisory or malformed cases the server currently tolerates or omits.
+
+- Report a real ACK Delay (always 0 today) and advertise `ack_delay_exponent`
+  / `max_ack_delay` (RFC 9000 §13.2.5) — small-medium
+- Intersect the client's offered cipher / TLS version (`supported_versions`) /
+  group (`supported_groups`) against the hardcoded `TLS_AES_128_GCM_SHA256` /
+  TLS 1.3 / x25519, aborting on no overlap (RFC 8446 §4.1.1) — medium
+- Emit a reserved "GREASE" setting in the h3 SETTINGS frame (RFC 9114
+  §7.2.4.1) — small
+- Honor the peer's `SETTINGS_MAX_FIELD_SECTION_SIZE` when sizing response
+  headers (RFC 9114 §4.2.2) — small-medium
+- Reject non-zero packet reserved bits as PROTOCOL_VIOLATION after
+  header-protection removal (RFC 9000 §17.2 / §17.3.1) — small
+
+### Transport completeness — bites large transfers / advanced cases
+
+- Send-side flow control: seed send windows from the peer's advertised
+  transport params, process inbound `MAX_DATA` / `MAX_STREAM_DATA`, grant
+  outbound `MAX_DATA` / `MAX_STREAM_DATA`, and emit `DATA_BLOCKED` /
+  `STREAM_DATA_BLOCKED` (RFC 9000 §4). Each window is seeded from our own
+  advertised value and never raised, so a transfer past the initial grant
+  stalls; the suite max is 100 KB, well under it — medium
+- Respond to a peer-initiated key update (RFC 9001 §6). Security-sensitive:
+  trial-decrypt the next-phase keys and commit ONLY on success (not the dep's
+  commit-then-decrypt, which a single forged flipped-bit datagram desyncs),
+  keep the header-protection key fixed, enforce the AEAD integrity limit —
+  large
+- Draining state: linger ~3×PTO to absorb the peer's reordered packets before
+  close, and reject `send_data` on a draining connection (RFC 9000 §10.2) —
+  medium
+- Seed the idle timeout from the negotiated `max_idle_timeout` (a fixed 30s
+  today) (RFC 9000 §10.1) — small-medium
+- NewReno congestion control (RFC 9002 §7); needs the loss layer to surface
+  acked bytes + sent times. Sending is bounded only by the §8.1
+  anti-amplification limit and flow control today — large
+- A no-flatten / by-reference stream send buffer, so a large response body is
+  not flattened into one binary before sending — medium
+
+### Retire the dep
+
+- Build a native QUIC test client so the `quic` dep can leave the test profile
+  too; the h3 SUITE + bench drive the native server with the dep's client, its
+  last remaining use — large
+- Then move `quic` out of production `deps` into `profiles.test.deps` and drop
+  it from the dialyzer `plt_extra_apps`, so production deps become
+  `[telemetry]` — small
+
+### Known dep deviation (informational)
+
+The `quic` dep's QPACK static table has a `:age` typo at index 2 (RFC 9204
+Appendix A is `age`, no colon). The native stack is RFC-correct, so this entry
+is the one place the dep oracle cannot validate the native encode/decode; not a
+roadrunner bug, recorded so a future dep cross-check does not "correct" the
+native value back to the dep's.
+
 ## HttpArena profile gaps
 
 Remaining HttpArena profiles need roadrunner-side features.

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -8,10 +8,10 @@
 %%
 %% roadrunner owns this loop and applies its own rules (slot tracking,
 %% drain group, telemetry, dispatch, response shapes, crash isolation);
-%% the `quic` dependency provides the transport (`quic` / `quic_listener`
-%% drive the UDP socket + QUIC streams) and the codec helpers
-%% (`quic_h3_frame` for framing, `quic_qpack` for QPACK). The turnkey
-%% `quic_h3` server is deliberately not used.
+%% the native `roadrunner_quic` stack provides the transport
+%% (`roadrunner_quic_listener` drives the UDP socket, `roadrunner_quic` the
+%% per-connection control + streams) and the codecs
+%% (`roadrunner_quic_h3_frame` for framing, `roadrunner_qpack` for QPACK).
 %%
 %% The loop receives QUIC stream events as messages from the connection
 %% process:
@@ -161,7 +161,7 @@ start(ConnPid, ProtoOpts) ->
         false ->
             %% Over `max_clients` — refuse before ownership transfer.
             %% `try_acquire_slot/1` already rolled the counter back.
-            _ = quic:close(ConnPid, ?H3_NO_ERROR),
+            _ = roadrunner_quic:close(ConnPid, ?H3_NO_ERROR),
             {error, max_clients};
         true ->
             #{handler_spawn_opts := SpawnOpts} = ProtoOpts,
@@ -184,7 +184,7 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
     true = link(Conn),
     %% `remote_addr` is set at connection creation, so peername is
     %% available from the start (idle / handshaking states).
-    {ok, Peer} = quic:peername(Conn),
+    {ok, Peer} = roadrunner_quic:peername(Conn),
     StartMono = roadrunner_telemetry:listener_accept(#{
         listener_name => ListenerName, peer => Peer
     }),
@@ -243,9 +243,11 @@ recv_loop(#h3{conn = Conn} = State) ->
             %% let in-flight ones finish (the `loop/1` head closes the
             %% connection once they do). The listener force-exits us at
             %% the deadline if a request is still running then.
-            loop(start_drain(State));
-        _Other ->
-            loop(State)
+            loop(start_drain(State))
+        %% No catch-all: like the h2 connection loop, the owner uses a
+        %% selective receive. The native transport only ever sends it the
+        %% `{quic, Conn, Event}` notifications matched above, so an unmatched
+        %% message stays queued rather than being silently dropped.
     end.
 
 %% Open the server control stream and send SETTINGS on the `connected`
@@ -264,14 +266,14 @@ recv_loop(#h3{conn = Conn} = State) ->
 %% arrive, so it stays strictly matched.
 -spec send_control_stream(#h3{}) -> #h3{}.
 send_control_stream(#h3{conn = Conn, max_field_section_size = MaxFieldSection} = State) ->
-    {ok, CtrlStreamId} = quic:open_unidirectional_stream(Conn),
+    {ok, CtrlStreamId} = roadrunner_quic:open_unidirectional_stream(Conn),
     Prefix = roadrunner_quic_h3_frame:encode_stream_type(control),
     Settings = roadrunner_quic_h3_frame:encode_settings(#{
         qpack_max_table_capacity => 0,
         qpack_blocked_streams => 0,
         max_field_section_size => MaxFieldSection
     }),
-    _ = quic:send_data(Conn, CtrlStreamId, [Prefix, Settings], false),
+    _ = roadrunner_quic:send_data(Conn, CtrlStreamId, [Prefix, Settings], false),
     State#h3{control_stream_id = CtrlStreamId}.
 
 %% Begin a graceful drain (RFC 9114 §5.2): send a GOAWAY on the control
@@ -288,7 +290,9 @@ start_drain(#h3{conn = Conn, control_stream_id = CtrlId, last_request_id = LastI
     is_integer(CtrlId)
 ->
     GoawayId = LastId + 4,
-    _ = quic:send_data(Conn, CtrlId, roadrunner_quic_h3_frame:encode_goaway(GoawayId), false),
+    _ = roadrunner_quic:send_data(
+        Conn, CtrlId, roadrunner_quic_h3_frame:encode_goaway(GoawayId), false
+    ),
     State#h3{goaway_id = GoawayId}.
 
 %% A draining connection is done once no request is in flight — neither
@@ -364,7 +368,7 @@ handle_request_stream(State0, StreamId, Data, Fin) ->
                     %% Ask the client to stop and mark the stream
                     %% `discarding` so residual body is dropped rather
                     %% than mistaken for a new request.
-                    _ = quic:stop_sending(State#h3.conn, StreamId, ?H3_NO_ERROR),
+                    _ = roadrunner_quic:stop_sending(State#h3.conn, StreamId, ?H3_NO_ERROR),
                     State#h3{
                         streams = Streams#{
                             StreamId => Stream0#{
@@ -383,7 +387,7 @@ handle_request_stream(State0, StreamId, Data, Fin) ->
                         [{~"content-type", ~"text/plain"}],
                         ~"Request Header Fields Too Large"
                     ),
-                    _ = quic:stop_sending(State#h3.conn, StreamId, ?H3_NO_ERROR),
+                    _ = roadrunner_quic:stop_sending(State#h3.conn, StreamId, ?H3_NO_ERROR),
                     State#h3{
                         streams = Streams#{
                             StreamId => Stream0#{
@@ -806,7 +810,7 @@ handle_worker_down(#h3{worker_refs = WorkerRefs} = State, MonRef, Reason) ->
 
 -spec reset_and_drop(#h3{}, non_neg_integer(), non_neg_integer()) -> #h3{}.
 reset_and_drop(#h3{conn = Conn} = State, StreamId, ErrorCode) ->
-    _ = quic:reset_stream(Conn, StreamId, ErrorCode),
+    _ = roadrunner_quic:reset_stream(Conn, StreamId, ErrorCode),
     drop_stream(State, StreamId).
 
 %% Bump the cumulative throttled counter and emit the throttled telemetry
@@ -826,7 +830,7 @@ throttle_stream(#h3{proto_opts = #{throttled_counter := Counter}, listener_name 
 %% fires regardless.
 -spec close_connection(#h3{}, non_neg_integer(), binary()) -> ok.
 close_connection(#h3{conn = Conn} = State, ErrorCode, Reason) ->
-    _ = quic:close(Conn, ErrorCode, Reason),
+    _ = roadrunner_quic:close(Conn, ErrorCode, Reason),
     terminate(State).
 
 -spec drop_stream(#h3{}, non_neg_integer()) -> #h3{}.

--- a/src/roadrunner_http3_request.erl
+++ b/src/roadrunner_http3_request.erl
@@ -21,9 +21,14 @@
 %%   malformed request.
 %% - Pseudo-headers other than the four defined are rejected.
 %% - `:path` MUST NOT be empty.
-%% - Header field names are lowercase — `roadrunner_qpack:decode/1` returns
-%%   them as received, and an h3 client MUST send them lowercase.
+%% - Regular field names MUST be lowercase; an uppercase character makes the
+%%   request malformed (RFC 9114 §4.2).
 %% - Connection-specific headers MUST NOT appear (RFC 9114 §4.2).
+%% - The request MUST carry an `:authority` pseudo-header or a `host` header
+%%   (https has a mandatory authority component); if present neither is empty,
+%%   and if both appear they MUST match (RFC 9114 §4.3.1).
+%% - A `content-length` header MUST equal the received body length and MUST NOT
+%%   be repeated (RFC 9114 §4.1.2, RFC 9110 §8.6).
 
 -export([from_headers/3]).
 
@@ -35,7 +40,12 @@
     | unknown_pseudo_header
     | pseudo_after_regular
     | empty_path
-    | connection_specific_header.
+    | connection_specific_header
+    | uppercase_field_name
+    | content_length_mismatch
+    | missing_authority
+    | empty_authority
+    | authority_mismatch.
 
 -type request_context() :: #{
     peer := {inet:ip_address(), inet:port_number()} | undefined,
@@ -70,6 +80,8 @@ from_headers(Headers, Body, RequestContext) ->
         %% QUIC) since clients can lie about the pseudo-header value.
         {ok, Method, _Scheme, Path, Authority} ?= validate_pseudo(Pseudo),
         ok ?= check_banned(Regular),
+        ok ?= check_content_length(Regular, Body),
+        ok ?= check_authority(Authority, Regular),
         {ok, build(Method, Path, Authority, Regular, Body, RequestContext)}
     end.
 
@@ -143,16 +155,99 @@ validate_pseudo(Pseudo) ->
 %% the hot path branch-friendly: the BEAM compiles the literal-binary
 %% clauses to a hash/select, no `lists:member` call per header.
 -spec check_banned(roadrunner_http:headers()) ->
-    ok | {error, connection_specific_header}.
-check_banned([]) -> ok;
-check_banned([{~"connection", _} | _]) -> {error, connection_specific_header};
-check_banned([{~"keep-alive", _} | _]) -> {error, connection_specific_header};
-check_banned([{~"proxy-connection", _} | _]) -> {error, connection_specific_header};
-check_banned([{~"transfer-encoding", _} | _]) -> {error, connection_specific_header};
-check_banned([{~"upgrade", _} | _]) -> {error, connection_specific_header};
-check_banned([{~"te", ~"trailers"} | Rest]) -> check_banned(Rest);
-check_banned([{~"te", _} | _]) -> {error, connection_specific_header};
-check_banned([_ | Rest]) -> check_banned(Rest).
+    ok | {error, connection_specific_header | uppercase_field_name}.
+check_banned([]) ->
+    ok;
+check_banned([{~"connection", _} | _]) ->
+    {error, connection_specific_header};
+check_banned([{~"keep-alive", _} | _]) ->
+    {error, connection_specific_header};
+check_banned([{~"proxy-connection", _} | _]) ->
+    {error, connection_specific_header};
+check_banned([{~"transfer-encoding", _} | _]) ->
+    {error, connection_specific_header};
+check_banned([{~"upgrade", _} | _]) ->
+    {error, connection_specific_header};
+check_banned([{~"te", ~"trailers"} | Rest]) ->
+    check_banned(Rest);
+check_banned([{~"te", _} | _]) ->
+    {error, connection_specific_header};
+check_banned([{Name, _} | Rest]) ->
+    %% Any other name is not connection-specific, but RFC 9114 §4.2 makes a
+    %% request with an uppercase field name malformed; the banned literals
+    %% above are already lowercase, so only these unrecognised names need the
+    %% scan. Folding it here keeps one pass over the regular headers.
+    case lower_name(Name) of
+        ok -> check_banned(Rest);
+        {error, _} = Error -> Error
+    end.
+
+%% Reject any uppercase ASCII letter in a regular field name (RFC 9114 §4.2:
+%% uppercase field names MUST be treated as malformed). Mirrors
+%% roadrunner_http2_hpack:validate_lower/1.
+-spec lower_name(binary()) -> ok | {error, uppercase_field_name}.
+lower_name(<<>>) -> ok;
+lower_name(<<C, _/binary>>) when C >= $A, C =< $Z -> {error, uppercase_field_name};
+lower_name(<<_, Rest/binary>>) -> lower_name(Rest).
+
+%% RFC 9114 §4.1.2 / RFC 9110 §8.6: a `content-length` header whose value does
+%% not equal the bytes received in DATA frames (or a multi-valued or
+%% non-integer value) makes the request malformed; an absent header is always
+%% acceptable. Single-pass walk; the body size is taken only when a value is
+%% actually present. Mirrors roadrunner_conn_loop_http2:content_length_matches/2.
+-spec check_content_length(roadrunner_http:headers(), iodata()) ->
+    ok | {error, content_length_mismatch}.
+check_content_length(Headers, Body) ->
+    case find_content_length(Headers, undefined) of
+        none ->
+            ok;
+        multiple ->
+            {error, content_length_mismatch};
+        Value ->
+            BodyLen = iolist_size(Body),
+            try binary_to_integer(Value) of
+                BodyLen -> ok;
+                _ -> {error, content_length_mismatch}
+            catch
+                error:badarg -> {error, content_length_mismatch}
+            end
+    end.
+
+-spec find_content_length(roadrunner_http:headers(), binary() | undefined) ->
+    binary() | none | multiple.
+find_content_length([], undefined) ->
+    none;
+find_content_length([], Value) ->
+    Value;
+find_content_length([{~"content-length", _} | _], Value) when Value =/= undefined -> multiple;
+find_content_length([{~"content-length", Value} | Rest], undefined) ->
+    find_content_length(Rest, Value);
+find_content_length([_ | Rest], Value) ->
+    find_content_length(Rest, Value).
+
+%% RFC 9114 §4.3.1: over QUIC the scheme is always https (a mandatory authority
+%% component), so the request MUST carry an `:authority` pseudo-header or a
+%% `host` header; if present neither is empty, and if both appear they MUST
+%% match. The empty-value clauses precede the equality clause so an empty value
+%% loses even when both sides are equally empty.
+-spec check_authority(binary() | undefined, roadrunner_http:headers()) ->
+    ok | {error, missing_authority | empty_authority | authority_mismatch}.
+check_authority(Authority, Regular) ->
+    case {Authority, find_host(Regular)} of
+        {undefined, undefined} -> {error, missing_authority};
+        {~"", _} -> {error, empty_authority};
+        {_, ~""} -> {error, empty_authority};
+        {Same, Same} -> ok;
+        {_, undefined} -> ok;
+        {undefined, _} -> ok;
+        {_, _} -> {error, authority_mismatch}
+    end.
+
+%% The first `host` header value, or `undefined`.
+-spec find_host(roadrunner_http:headers()) -> binary() | undefined.
+find_host([]) -> undefined;
+find_host([{~"host", Value} | _]) -> Value;
+find_host([_ | Rest]) -> find_host(Rest).
 
 -spec build(
     binary(),
@@ -164,12 +259,14 @@ check_banned([_ | Rest]) -> check_banned(Rest).
 ) -> roadrunner_req:request().
 build(Method, Path, Authority, Regular, Body, RequestContext) ->
     %% Forward `:authority` as a `host` header so existing handler code
-    %% that reads `Host` still works (RFC 9114 §4.3.1 treats
-    %% `:authority` like `Host`).
+    %% that reads `Host` still works (RFC 9114 §4.3.1 treats `:authority`
+    %% like `Host`). When the client also sent a (validated equal) `host`
+    %% header, drop it first so a single canonical entry survives instead
+    %% of a duplicate.
     HeadersWithHost =
         case Authority of
             undefined -> Regular;
-            _ -> [{~"host", Authority} | Regular]
+            _ -> [{~"host", Authority} | lists:keydelete(~"host", 1, Regular)]
         end,
     %% The conn loop always builds `RequestContext` with all four
     %% fields populated, so pattern-matching wins vs. four `maps:get/3`.

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -13,9 +13,10 @@
 %%    sharing the exact dispatch path h1/h2 use
 %%    (`roadrunner_conn:resolve_handler/2` + the pre-composed pipeline).
 %% 3. Writes the response straight onto the QUIC stream via
-%%    `quic:send_data/4` — QUIC connections are gen_statem-backed, so a
-%%    non-owner process can send with the `Conn` handle (no h2-style
-%%    conn-mediated send protocol needed).
+%%    `roadrunner_quic:send_data/4` — a synchronous round-trip to the
+%%    connection (make_ref + reply) keyed by the `Conn` handle, so this
+%%    non-owner worker gets flow-control back-pressure without a separate
+%%    h2-style conn-mediated send module.
 %%
 %% Crash isolation: workers are spawn_monitored (NOT linked) by the
 %% conn loop. A handler crash is caught here and turned into a 500; any
@@ -248,7 +249,7 @@ emit_501(Conn, StreamId) ->
 
 %% Encode the response as a HEADERS frame (QPACK-encoded `:status` +
 %% the handler's headers) followed by a single DATA frame, and write
-%% both in one `quic:send_data/4` with the stream's FIN. A header-only
+%% both in one `roadrunner_quic:send_data/4` with the stream's FIN. A header-only
 %% response (empty body) sends just the HEADERS frame with FIN.
 -spec send_buffered(
     pid(), non_neg_integer(), roadrunner_http:status(), roadrunner_http:headers(), iodata()
@@ -265,7 +266,7 @@ send_buffered(Conn, StreamId, Status, Headers, Body) ->
     %% response, the connection is draining and the send returns an error.
     %% That is fine, the worker exits and the conn loop cleans up the stream
     %% (same rationale as the control-stream and GOAWAY sends).
-    _ = quic:send_data(Conn, StreamId, Frames, true),
+    _ = roadrunner_quic:send_data(Conn, StreamId, Frames, true),
     ok.
 
 %% `{stream, ...}` response: HEADERS (no FIN), then the handler's fun
@@ -284,7 +285,7 @@ send_buffered(Conn, StreamId, Status, Headers, Body) ->
     roadrunner_handler:stream_fun()
 ) -> ok.
 send_stream(Conn, StreamId, Status, Headers, Fun) ->
-    _ = quic:send_data(Conn, StreamId, header_frame(Status, Headers), false),
+    _ = roadrunner_quic:send_data(Conn, StreamId, header_frame(Status, Headers), false),
     erase(?FIN_KEY),
     Send = fun(Data, FinFlag) -> stream_send(Conn, StreamId, Data, FinFlag) end,
     _ = Fun(Send),
@@ -300,11 +301,11 @@ send_stream(Conn, StreamId, Status, Headers, Fun) ->
 stream_send(Conn, StreamId, Data, nofin) ->
     case iolist_size(Data) of
         0 -> ok;
-        Len -> quic:send_data(Conn, StreamId, data_frame(Data, Len), false)
+        Len -> roadrunner_quic:send_data(Conn, StreamId, data_frame(Data, Len), false)
     end;
 stream_send(Conn, StreamId, Data, fin) ->
     put(?FIN_KEY, true),
-    quic:send_data(Conn, StreamId, data_frame(Data, iolist_size(Data)), true);
+    roadrunner_quic:send_data(Conn, StreamId, data_frame(Data, iolist_size(Data)), true);
 stream_send(Conn, StreamId, Data, {fin, Trailers}) ->
     %% Trailers go out after the status + body, so an injected one cannot
     %% become a 500. One pass crashes on the RFC 9110 §5.5 check (so the conn
@@ -315,7 +316,9 @@ stream_send(Conn, StreamId, Data, {fin, Trailers}) ->
     Stripped = roadrunner_http:strip_connection_specific_fields_safe(Trailers),
     put(?FIN_KEY, true),
     TrailersFrame = roadrunner_quic_h3_frame:encode_headers(roadrunner_qpack:encode(Stripped)),
-    quic:send_data(Conn, StreamId, [data_frame(Data, iolist_size(Data)), TrailersFrame], true).
+    roadrunner_quic:send_data(
+        Conn, StreamId, [data_frame(Data, iolist_size(Data)), TrailersFrame], true
+    ).
 
 %% `{sendfile, ...}` response. There is no kernel sendfile over QUIC
 %% (the stream bytes are encrypted), so read the file in chunks and feed
@@ -372,7 +375,7 @@ sendfile_loop(IoDev, Remaining, Send) ->
     term()
 ) -> ok.
 send_loop(Conn, StreamId, Status, Headers, Handler, State) ->
-    _ = quic:send_data(Conn, StreamId, header_frame(Status, Headers), false),
+    _ = roadrunner_quic:send_data(Conn, StreamId, header_frame(Status, Headers), false),
     %% Stop looping if the connection dies — otherwise an idle loop
     %% worker (blocked in `info_loop` waiting for a message) leaks
     %% forever once the conn is gone. The monitor fires when the QUIC
@@ -407,7 +410,7 @@ info_loop(Conn, StreamId, Handler, Push, State) ->
                     info_loop(Conn, StreamId, Handler, Push, NewState);
                 {stop, _NewState} ->
                     %% Close the stream with an empty DATA frame + FIN.
-                    _ = quic:send_data(Conn, StreamId, data_frame(<<>>, 0), true),
+                    _ = roadrunner_quic:send_data(Conn, StreamId, data_frame(<<>>, 0), true),
                     ok
             end
     end.
@@ -418,7 +421,7 @@ info_loop(Conn, StreamId, Handler, Push, State) ->
 loop_push(Conn, StreamId, Data) ->
     case iolist_size(Data) of
         0 -> ok;
-        Len -> quic:send_data(Conn, StreamId, data_frame(Data, Len), false)
+        Len -> roadrunner_quic:send_data(Conn, StreamId, data_frame(Data, Len), false)
     end.
 
 %% HEADERS frame: QPACK-encoded `:status` + the handler's headers, with

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -660,18 +660,13 @@ start_tcp(Port, Opts, Protocols, ProtoOpts) ->
             end
     end.
 
-%% Start the QUIC listener roadrunner owns when `http3` is requested.
-%% Only the self-contained `quic_listener_sup` pool is started (via
-%% `start_quic_pool/2`), NOT the whole `quic` application. That app's
-%% supervisor tree backs the dep's own turnkey server (`server_registry`
-%% / `server_sup`), client (`token_cache`), and distribution
-%% (`dist_sup`) features — none of which roadrunner's owned listener
-%% uses — and `crypto` + `ssl` are already up as roadrunner's own deps.
-%% Keeping the `quic` app out of the boot path means a co-serving
-%% instance carries no idle supervisors it never uses. Each accepted
-%% QUIC connection is handed to a fresh `roadrunner_conn_loop_http3`
-%% owner via the arity-1 `connection_handler`; the QUIC listener then
-%% transfers ownership to the returned pid. `http3` having been
+%% Start the native QUIC listener pool roadrunner owns when `http3` is
+%% requested. `roadrunner_quic_listener_sup` is a self-contained supervisor
+%% (no OTP application to boot; `crypto` + `ssl` are already up as roadrunner's
+%% own deps), started directly by this gen_server via `start_quic_pool/2`.
+%% Each accepted QUIC connection is handed to a fresh
+%% `roadrunner_conn_loop_http3` owner via the arity-1 `connection_handler`; the
+%% listener then transfers ownership to the returned pid. `http3` having been
 %% validated to require `tls`, the `tls` opt is always present here.
 -spec start_quic(
     inet:port_number(), opts(), [http1 | http2 | http3, ...], roadrunner_conn:proto_opts()
@@ -684,11 +679,11 @@ start_quic(Port, Opts, Protocols, ProtoOpts) ->
             #{tls := UserTlsOpts} = Opts,
             {Cert, CertChain, Key} = quic_cert_key(UserTlsOpts),
             Handler = fun(ConnPid) -> roadrunner_conn_loop_http3:start(ConnPid, ProtoOpts) end,
-            %% Start a POOL of reuseport listeners (the dep enables
-            %% SO_REUSEPORT when pool_size > 0 and shares one connection
-            %% registry across them) so inbound demux parallelizes across
-            %% cores rather than funnelling through one listener process.
-            %% `quic_listener_sup:start_link` links the pool supervisor to
+            %% Start a POOL of reuseport listeners (the native pool sup enables
+            %% SO_REUSEPORT when there is more than one listener and shares one
+            %% connection registry across them) so inbound demux parallelizes
+            %% across cores rather than funnelling through one listener process.
+            %% `roadrunner_quic_listener_sup:start_link` links the pool supervisor to
             %% this gen_server for shared fate; an `init`-time bind failure
             %% comes back as `{error, _}` from the synchronous start (so
             %% `init/1` can still close the already-opened TCP socket).
@@ -724,7 +719,7 @@ start_quic(Port, Opts, Protocols, ProtoOpts) ->
 start_quic_pool(Port, PoolOpts) ->
     OldTrap = process_flag(trap_exit, true),
     try
-        quic_listener_sup:start_link(Port, PoolOpts)
+        roadrunner_quic_listener_sup:start_link(Port, PoolOpts)
     after
         _ = process_flag(trap_exit, OldTrap)
     end.
@@ -749,8 +744,8 @@ close_quic_probe(Probe) -> gen_udp:close(Probe).
 %% listener reads it back from the QUIC listener.
 -spec bound_port(roadrunner_transport:socket() | none, pid() | undefined) -> inet:port_number().
 bound_port(none, QuicPool) ->
-    [Listener | _] = quic_listener_sup:get_listeners(QuicPool),
-    quic_listener:get_port(Listener);
+    [Listener | _] = roadrunner_quic_listener_sup:get_listeners(QuicPool),
+    roadrunner_quic_listener:get_port(Listener);
 bound_port(LSocket, _QuicListener) ->
     {ok, BoundPort} = roadrunner_transport:port(LSocket),
     BoundPort.
@@ -1517,7 +1512,7 @@ do_drain(
     notify_conns(Group, Deadline),
     #{client_counter := Counter} = ProtoOpts,
     Reply = wait_for_drain(Counter, Deadline, Group),
-    %% Stop the QUIC listener LAST: `quic_listener:stop/1` kills the
+    %% Stop the QUIC listener LAST: `roadrunner_quic_listener:stop/1` kills the
     %% connections it `start_link`ed (and the h3 conn loops linked to
     %% them), so doing it before the notify/wait above would abruptly
     %% kill in-flight h3 conns instead of letting them drain. (New h3
@@ -1656,7 +1651,7 @@ stop_quic(QuicPool) ->
     %% Unlink first so stopping the pool (which `exit/2`s the supervisor)
     %% doesn't deliver a teardown EXIT back to this gen_server.
     true = unlink(QuicPool),
-    quic_listener_sup:stop(QuicPool).
+    roadrunner_quic_listener_sup:stop(QuicPool).
 
 -spec erase_routes(roadrunner_conn:proto_opts()) -> ok.
 erase_routes(#{dispatch := {router, Name}}) ->

--- a/src/roadrunner_qpack.erl
+++ b/src/roadrunner_qpack.erl
@@ -238,7 +238,7 @@ static_entry(0) ->
 static_entry(1) ->
     {~":path", ~"/"};
 static_entry(2) ->
-    {~":age", ~"0"};
+    {~"age", ~"0"};
 static_entry(3) ->
     {~"content-disposition", ~""};
 static_entry(4) ->
@@ -438,7 +438,7 @@ static_entry(_) ->
 -spec static_full_match(binary(), binary()) -> non_neg_integer() | none.
 static_full_match(~":path", ~"/") ->
     1;
-static_full_match(~":age", ~"0") ->
+static_full_match(~"age", ~"0") ->
     2;
 static_full_match(~"content-length", ~"0") ->
     4;
@@ -601,7 +601,7 @@ static_full_match(_, _) ->
 -spec static_name_match(binary()) -> non_neg_integer() | none.
 static_name_match(~":authority") -> 0;
 static_name_match(~":path") -> 1;
-static_name_match(~":age") -> 2;
+static_name_match(~"age") -> 2;
 static_name_match(~"content-disposition") -> 3;
 static_name_match(~"content-length") -> 4;
 static_name_match(~"cookie") -> 5;

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -74,8 +74,13 @@
 }).
 
 -record(state, {
+    %% The client's Initial Destination Connection ID: derives the Initial keys
+    %% and echoes as original_destination_connection_id. NOT the reply wire DCID.
     dcid :: binary(),
     scid :: binary(),
+    %% The client's Source Connection ID, which every server reply addresses as
+    %% its Destination Connection ID (RFC 9000 §7.2/§17.2).
+    peer_scid :: binary(),
     peer :: {inet:ip_address(), inet:port_number()},
     phase = handshaking :: phase(),
     tls :: roadrunner_quic_tls_server:t(),
@@ -125,6 +130,7 @@
 -type config() :: #{
     dcid := binary(),
     scid := binary(),
+    peer_scid := binary(),
     peer := {inet:ip_address(), inet:port_number()},
     cert_chain := [binary()],
     priv_key := public_key:private_key(),
@@ -168,16 +174,19 @@
 -doc """
 Build the connection state from the per-connection config and the birth time
 `Now` (ms). Bootstraps the Initial keys from the client's Destination
-Connection ID, the TLS server sequencer (the server transport parameters
-already carry the original/initial connection ids), the Initial and Handshake
-packet-number spaces (the Application space appears once 1-RTT keys arm), and
-the idle-timeout deadline anchored at `Now`.
+Connection ID (`dcid`), records the client's Source Connection ID (`peer_scid`)
+as the destination every reply is addressed to (RFC 9000 §7.2), the TLS server
+sequencer (the server transport parameters already carry the original/initial
+connection ids), the Initial and Handshake packet-number spaces (the Application
+space appears once 1-RTT keys arm), and the idle-timeout deadline anchored at
+`Now`.
 """.
 -spec new(config(), integer()) -> t().
 new(
     #{
         dcid := DCID,
         scid := SCID,
+        peer_scid := PeerSCID,
         peer := Peer,
         cert_chain := CertChain,
         priv_key := PrivKey,
@@ -201,6 +210,7 @@ new(
     #state{
         dcid = DCID,
         scid = SCID,
+        peer_scid = PeerSCID,
         peer = Peer,
         tls = Tls,
         recv_keys = #{initial => roadrunner_quic_keys:initial_client(DCID)},
@@ -362,7 +372,7 @@ owner_close(ErrorCode, Reason, #state{send_keys = SendKeys} = State) ->
 
 -spec send_owner_close(non_neg_integer(), binary(), roadrunner_quic_keys:keys(), t()) ->
     {t(), [effect()]}.
-send_owner_close(ErrorCode, Reason, Keys, #state{dcid = DCID, scid = SCID} = State) ->
+send_owner_close(ErrorCode, Reason, Keys, #state{peer_scid = DCID, scid = SCID} = State) ->
     Space = space(application, State),
     PN = Space#space.next_pn,
     Frame = {connection_close, application, ErrorCode, undefined, Reason},
@@ -734,7 +744,7 @@ close_code(_TlsReason) ->
 send_close(
     #state{
         pending_close = {Level, ErrorCode},
-        dcid = DCID,
+        peer_scid = DCID,
         scid = SCID,
         send_keys = SendKeys,
         amp = Amp
@@ -809,7 +819,7 @@ drain_send(Now, State, Acc) ->
         none ->
             {State, lists:reverse(Acc)};
         {Entries, Built} ->
-            #state{dcid = DCID, scid = SCID, amp = Amp} = State,
+            #state{peer_scid = DCID, scid = SCID, amp = Amp} = State,
             {Datagram, Sent} = roadrunner_quic_send:datagram(Entries, DCID, SCID),
             case roadrunner_quic_amp:can_send(byte_size(Datagram), Amp) of
                 false ->

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -205,7 +205,8 @@ new(
         transport_params => TransportParams,
         eph_pub => EphPub,
         eph_priv => EphPriv,
-        server_random => ServerRandom
+        server_random => ServerRandom,
+        peer_scid => PeerSCID
     }),
     %% Seed the connection receive window from the limit we advertise, so the
     %% window enforced (RFC 9000 §4.1) is exactly the one the peer was told it
@@ -729,9 +730,15 @@ close_code(Reason) when
     Reason =:= flow_control_error;
     Reason =:= final_size_error;
     Reason =:= stream_state_error;
-    Reason =:= protocol_violation
+    Reason =:= protocol_violation;
+    Reason =:= transport_parameter_error
 ->
     roadrunner_quic_error:code_int(Reason);
+close_code(missing_transport_params) ->
+    %% RFC 9001 §8.2: a ClientHello without the quic_transport_parameters
+    %% extension MUST close with 0x016d, a CRYPTO_ERROR carrying the TLS
+    %% missing_extension alert (109).
+    roadrunner_quic_error:code_int({crypto_error, 109});
 close_code(_TlsReason) ->
     %% Every other connection_fatal reason is a TLS handshake failure (a
     %% malformed or rejected ClientHello, a bad Finished, or an unexpected

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -207,6 +207,10 @@ new(
         eph_priv => EphPriv,
         server_random => ServerRandom
     }),
+    %% Seed the connection receive window from the limit we advertise, so the
+    %% window enforced (RFC 9000 §4.1) is exactly the one the peer was told it
+    %% may use, never a smaller hardcoded default it would trip early on.
+    #{initial_max_data := ConnMaxData} = TransportParams,
     #state{
         dcid = DCID,
         scid = SCID,
@@ -219,7 +223,7 @@ new(
         amp = roadrunner_quic_amp:new(),
         owner = undefined,
         info = #{alpn => Alpn, transport_params => TransportParams},
-        conn_flow = roadrunner_quic_flow:new(#{}),
+        conn_flow = roadrunner_quic_flow:new(#{initial_max_data => ConnMaxData}),
         idle_deadline = Now + ?IDLE_TIMEOUT
     }.
 
@@ -776,17 +780,29 @@ send_close(
 %% the stream, its flow, and the state carrying any queued event.
 -spec ensure_stream(non_neg_integer(), t()) ->
     {roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()}.
-ensure_stream(Sid, #state{streams = Streams} = State) ->
+ensure_stream(Sid, #state{streams = Streams, info = #{transport_params := TP}} = State) ->
     case Streams of
         #{Sid := {Stream, Flow}} ->
             {Stream, Flow, State};
         #{} ->
             {
                 roadrunner_quic_stream:new(),
-                roadrunner_quic_flow:new(#{}),
+                roadrunner_quic_flow:new(#{initial_max_data => stream_recv_window(Sid, TP)}),
                 emit({stream_opened, Sid}, State)
             }
     end.
+
+%% The receive window we advertised for a peer-initiated stream (RFC 9000
+%% §18.2): client-initiated bidirectional streams (Sid rem 4 == 0) get
+%% initial_max_stream_data_bidi_remote, client-initiated unidirectional streams
+%% (Sid rem 4 == 2) get initial_max_stream_data_uni. Server-initiated ids never
+%% reach here (process_stream/process_reset_stream reject them upstream).
+-spec stream_recv_window(non_neg_integer(), roadrunner_quic_transport_params:params()) ->
+    non_neg_integer().
+stream_recv_window(Sid, #{initial_max_stream_data_bidi_remote := Bidi}) when Sid rem 4 =:= 0 ->
+    Bidi;
+stream_recv_window(_Sid, #{initial_max_stream_data_uni := Uni}) ->
+    Uni.
 
 -spec put_stream(non_neg_integer(), roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()) ->
     t().

--- a/src/roadrunner_quic_listener.erl
+++ b/src/roadrunner_quic_listener.erl
@@ -13,14 +13,14 @@
 %% connection; a miss on an unsupported-version long header answers with a
 %% Version Negotiation packet (RFC 9000 §5.2.2). Spawning follows the strict
 %% ordering the handshake depends on
-%% (RFC 9000 / the dep's contract): spawn the connection, monitor it (so a
-%% fast death is reaped before its connection ids are registered), register
-%% its CIDs (so a fast follow-up datagram already routes), run the
-%% connection_handler to get the application owner, install the owner
-%% SYNCHRONOUSLY (so ownership transfers before the handshake can complete and
-%% race the `{connected, _}` event), and only then feed the first Initial. Slot
-%% limiting, telemetry, and drain stay in the owner the handler returns; the
-%% listener owns none of them.
+%% (RFC 9000 / the dep's contract): spawn the connection, link it (so the
+%% listener's own shutdown tears its connections down, and a connection's death
+%% reaps its routing rows), register its CIDs (so a fast follow-up datagram
+%% already routes), run the connection_handler to get the application owner,
+%% install the owner SYNCHRONOUSLY (so ownership transfers before the handshake
+%% can complete and race the `{connected, _}` event), and only then feed the
+%% first Initial. Slot limiting, telemetry, and drain stay in the owner the
+%% handler returns; the listener owns none of them.
 %%
 %% A new server Source Connection ID is generated per connection at a fixed
 %% length, so short-header 1-RTT packets (which carry no CID-length field)
@@ -65,6 +65,9 @@
 -record(listener, {
     socket :: roadrunner_quic_socket:socket(),
     port :: inet:port_number(),
+    %% The process that started (and is linked to) the listener — the pool
+    %% supervisor, or a standalone owner. Its `'EXIT'` is a shutdown request.
+    parent :: pid(),
     registry :: roadrunner_quic_cid_registry:t(),
     cert_chain :: [binary()],
     priv_key :: public_key:private_key(),
@@ -114,6 +117,13 @@ init(
         connection_handler := Handler
     } = Opts
 ) ->
+    %% Trap exits and link each spawned connection (in spawn_connection): a
+    %% connection's `'EXIT'` reaps its routing rows, and the listener's own
+    %% shutdown then tears its connections down (so their owners and stream
+    %% workers stop), matching the dep's listener-stop semantics the drain
+    %% relies on.
+    process_flag(trap_exit, true),
+    [Parent | _] = get('$ancestors'),
     ReusePort = maps:get(reuseport, Opts, false),
     case roadrunner_quic_socket:open(Port, #{active => once, reuseport => ReusePort}) of
         {ok, Socket} ->
@@ -127,6 +137,7 @@ init(
             loop(#listener{
                 socket = Socket,
                 port = BoundPort,
+                parent = Parent,
                 registry = Registry,
                 cert_chain = CertChain,
                 priv_key = PrivKey,
@@ -140,7 +151,7 @@ init(
     end.
 
 -spec loop(#listener{}) -> no_return().
-loop(#listener{socket = Socket} = State) ->
+loop(#listener{socket = Socket, parent = Parent} = State) ->
     receive
         {system, From, Req} ->
             roadrunner_loop_sys:handle_system(Req, From, State, fun loop/1);
@@ -156,7 +167,16 @@ loop(#listener{socket = Socket} = State) ->
             loop(State);
         {'$gen_cast', _Request} ->
             loop(State);
-        {'DOWN', _Ref, process, Pid, _Reason} ->
+        {'EXIT', Parent, Reason} ->
+            %% The (pool supervisor) parent is shutting us down: close the socket
+            %% and exit with its reason so our linked connections are torn down
+            %% with us (their owners and stream workers then stop on the loss).
+            ok = roadrunner_quic_socket:close(Socket),
+            exit(Reason);
+        {'EXIT', Pid, _Reason} ->
+            %% A linked connection ended (clean close, error, or our teardown
+            %% reaping it); drop its routing rows. delete_pid keys on the pid, so
+            %% it only reaps that connection's ids.
             ok = roadrunner_quic_cid_registry:delete_pid(State#listener.registry, Pid),
             loop(State);
         Message ->
@@ -188,8 +208,8 @@ route(Datagram, Peer, #listener{registry = Registry} = State) ->
         {forward, ConnPid} ->
             _ = ConnPid ! {quic_datagram, Peer, Datagram},
             State;
-        {spawn, ClientDCID} ->
-            spawn_connection(Datagram, Peer, ClientDCID, State);
+        {spawn, ClientDCID, ClientSCID} ->
+            spawn_connection(Datagram, Peer, ClientDCID, ClientSCID, State);
         {version_negotiation, ClientDCID, ClientSCID} ->
             send_version_negotiation(ClientDCID, ClientSCID, Peer, State);
         drop ->
@@ -213,8 +233,9 @@ send_version_negotiation(ClientDCID, ClientSCID, {Ip, Port}, #listener{socket = 
 
 %% Decide a datagram's fate from its connection ids and the routing table (a
 %% pure decision given the table): `{forward, Pid}` to the owning connection,
-%% `{spawn, DCID}` for a QUIC v1 Initial (at the RFC 9000 §14.1 1200-byte floor)
-%% to an unknown id, `{version_negotiation, DCID, SCID}` for an unsupported
+%% `{spawn, DCID, SCID}` for a QUIC v1 Initial (at the RFC 9000 §14.1 1200-byte
+%% floor) to an unknown id (carrying the client's source id, which the server's
+%% replies address per §7.2), `{version_negotiation, DCID, SCID}` for an unsupported
 %% version at that floor (RFC 9000 §5.2.2), or `drop` otherwise: a malformed or
 %% short-header packet to an unknown id, a v1 Initial below the floor, or an
 %% unsupported-version packet below it (a server MUST discard those). The
@@ -222,7 +243,10 @@ send_version_negotiation(ClientDCID, ClientSCID, {Ip, Port}, #listener{socket = 
 %% its own received Initials.
 -doc false.
 -spec classify(binary(), roadrunner_quic_cid_registry:t()) ->
-    {forward, pid()} | {spawn, binary()} | {version_negotiation, binary(), binary()} | drop.
+    {forward, pid()}
+    | {spawn, binary(), binary()}
+    | {version_negotiation, binary(), binary()}
+    | drop.
 classify(Datagram, Registry) ->
     case roadrunner_quic_packet:dcid(Datagram, ?SCID_LEN) of
         {ok, DCID} ->
@@ -241,13 +265,20 @@ classify(Datagram, Registry) ->
     end.
 
 %% An unknown destination id at the §14.1 floor: a v1 Initial starts a
-%% connection; anything else falls through to the Version Negotiation check.
+%% connection; anything else falls through to the Version Negotiation check. The
+%% client's source id is read alongside the routing id: the server addresses its
+%% replies with it (RFC 9000 §7.2), distinct from the client's destination id
+%% (which derives the Initial keys and echoes as original_destination_connection_id).
+%% A floor-sized v1 Initial always carries both ids, so long_header_info succeeds.
 -spec classify_unrouted(binary(), binary()) ->
-    {spawn, binary()} | {version_negotiation, binary(), binary()} | drop.
+    {spawn, binary(), binary()} | {version_negotiation, binary(), binary()} | drop.
 classify_unrouted(Datagram, DCID) ->
     case is_v1_initial(Datagram) andalso byte_size(Datagram) >= ?MIN_INITIAL_DATAGRAM of
-        true -> {spawn, DCID};
-        false -> maybe_version_negotiation(Datagram)
+        true ->
+            {ok, #{scid := SCID}} = roadrunner_quic_packet:long_header_info(Datagram),
+            {spawn, DCID, SCID};
+        false ->
+            maybe_version_negotiation(Datagram)
     end.
 
 %% RFC 9000 §5.2.2: answer an unsupported-version long header (one we cannot
@@ -274,22 +305,27 @@ is_v1_initial(_Datagram) ->
     false.
 
 %% Spawn a connection for a new client and feed it its first Initial, in the
-%% order the handshake depends on: spawn -> monitor -> register both connection
+%% order the handshake depends on: spawn -> link -> register both connection
 %% ids -> run the handler for the owner -> install the owner synchronously ->
-%% feed.
--spec spawn_connection(binary(), {inet:ip_address(), inet:port_number()}, binary(), #listener{}) ->
+%% feed. `ClientSCID` is the client's source id; the connection addresses its
+%% replies with it (RFC 9000 §7.2), while `ClientDCID` is the routing id (also
+%% the Initial-key and original_destination_connection_id anchor).
+-spec spawn_connection(
+    binary(), {inet:ip_address(), inet:port_number()}, binary(), binary(), #listener{}
+) ->
     #listener{}.
 spawn_connection(
     Datagram,
     Peer,
     ClientDCID,
+    ClientSCID,
     #listener{socket = Socket, registry = Registry, handler = Handler} = State
 ) ->
     ServerSCID = crypto:strong_rand_bytes(?SCID_LEN),
     {ok, ConnPid} = roadrunner_quic_connection:start(
-        Socket, conn_config(ClientDCID, ServerSCID, Peer, State)
+        Socket, conn_config(ClientDCID, ClientSCID, ServerSCID, Peer, State)
     ),
-    _Ref = monitor(process, ConnPid),
+    true = link(ConnPid),
     ok = roadrunner_quic_cid_registry:register_pair(Registry, ClientDCID, ServerSCID, ConnPid),
     ok = install_owner(ConnPid, Handler),
     _ = ConnPid ! {quic_datagram, Peer, Datagram},
@@ -330,15 +366,18 @@ set_owner_sync(ConnPid, Owner) ->
             ok
     end.
 
--spec conn_config(binary(), binary(), {inet:ip_address(), inet:port_number()}, #listener{}) ->
+-spec conn_config(
+    binary(), binary(), binary(), {inet:ip_address(), inet:port_number()}, #listener{}
+) ->
     roadrunner_quic_conn_state:config().
-conn_config(ClientDCID, ServerSCID, Peer, #listener{
+conn_config(ClientDCID, ClientSCID, ServerSCID, Peer, #listener{
     cert_chain = CertChain, priv_key = PrivKey, alpn = Alpn, transport_params = TransportParams
 }) ->
     {EphPub, EphPriv} = crypto:generate_key(ecdh, x25519),
     #{
         dcid => ClientDCID,
         scid => ServerSCID,
+        peer_scid => ClientSCID,
         peer => Peer,
         cert_chain => CertChain,
         priv_key => PrivKey,

--- a/src/roadrunner_quic_tls_server.erl
+++ b/src/roadrunner_quic_tls_server.erl
@@ -28,11 +28,15 @@
 %% shared secret (ECDHE over the client's key_share), the CertificateVerify
 %% signature scheme (the cert key's scheme intersected with the client's
 %% offer), and the ALPN protocol (the client must offer the configured one,
-%% RFC 7301 §3.2). Attacker-controlled inputs fail with a flat
-%% `{error, atom()}` (a malformed ClientHello, a missing x25519 key_share,
-%% no common signature scheme, no offered ALPN match, a client Finished
-%% mismatch); a cert/key whose type is unsupported is server config and
-%% legitimately crashes.
+%% RFC 7301 §3.2). The mandatory quic_transport_parameters extension
+%% (RFC 9001 §8.2) and the client's initial_source_connection_id binding
+%% (RFC 9000 §7.3, against the Initial Source Connection ID passed in as
+%% `peer_scid`) are also enforced here. Attacker-controlled inputs fail with a
+%% flat `{error, atom()}` (a malformed ClientHello, a missing x25519 key_share,
+%% no common signature scheme, no offered ALPN match, a missing transport-
+%% parameters extension, a connection-id mismatch, a client Finished mismatch);
+%% a cert/key whose type is unsupported is server config and legitimately
+%% crashes.
 %%
 %% The server's x25519 ephemeral key pair and ServerHello random are
 %% inputs (the connection loop generates them per connection), which keeps
@@ -61,6 +65,10 @@
     eph_pub :: binary(),
     eph_priv :: binary(),
     server_random :: binary(),
+    %% The Source Connection ID of the client's first Initial packet: the
+    %% client's initial_source_connection_id transport parameter must equal it
+    %% (RFC 9000 §7.3).
+    peer_scid :: binary(),
     %% Filled by process_client_hello/2, read by process_client_finished/2.
     client_hs_secret = <<>> :: binary(),
     client_finished_hash = <<>> :: binary()
@@ -75,7 +83,8 @@
     transport_params := roadrunner_quic_transport_params:params(),
     eph_pub := binary(),
     eph_priv := binary(),
-    server_random := binary()
+    server_random := binary(),
+    peer_scid := binary()
 }.
 
 -type flight() :: #{initial := iolist(), handshake := iolist()}.
@@ -88,8 +97,10 @@ Build the handshake state from the per-connection config: the server's DER
 certificate chain (leaf first) and private key, the selected ALPN
 protocol, the server transport parameters (already carrying the
 `original_destination_connection_id` and `initial_source_connection_id`
-the loop fills in), the server's x25519 ephemeral key pair, and the
-ServerHello random.
+the loop fills in), the server's x25519 ephemeral key pair, the ServerHello
+random, and the client's Initial Source Connection ID (`peer_scid`, the value
+the client's `initial_source_connection_id` transport parameter must match,
+RFC 9000 §7.3).
 """.
 -spec new(config()) -> t().
 new(#{
@@ -99,7 +110,8 @@ new(#{
     transport_params := TransportParams,
     eph_pub := EphPub,
     eph_priv := EphPriv,
-    server_random := ServerRandom
+    server_random := ServerRandom,
+    peer_scid := PeerSCID
 }) ->
     #server{
         cert_chain = CertChain,
@@ -108,7 +120,8 @@ new(#{
         transport_params = TransportParams,
         eph_pub = EphPub,
         eph_priv = EphPriv,
-        server_random = ServerRandom
+        server_random = ServerRandom,
+        peer_scid = PeerSCID
     }.
 
 -doc """
@@ -126,12 +139,19 @@ The returned `State` carries what `process_client_finished/2` needs.
 
 Fails with `{error, Reason}` on a malformed ClientHello, a missing x25519
 key_share (`missing_key_share`), no signature scheme shared between the
-cert key and the client's offer (`no_common_sig_alg`), or a client that
-did not offer the configured ALPN protocol (`no_application_protocol`).
+cert key and the client's offer (`no_common_sig_alg`), a client that did
+not offer the configured ALPN protocol (`no_application_protocol`), a
+ClientHello without the quic_transport_parameters extension
+(`missing_transport_params`, RFC 9001 §8.2), or a client
+`initial_source_connection_id` that does not equal (or is absent for) the
+Source Connection ID of its first Initial packet (`transport_parameter_error`,
+RFC 9000 §7.3).
 """.
 -spec process_client_hello(binary(), t()) ->
     {ok, flight(), [install()], t()} | {error, atom()}.
-process_client_hello(ClientHelloBody, #server{priv_key = PrivKey, alpn = Alpn} = State) ->
+process_client_hello(
+    ClientHelloBody, #server{priv_key = PrivKey, alpn = Alpn, peer_scid = PeerSCID} = State
+) ->
     maybe
         {ok,
             #{
@@ -143,6 +163,8 @@ process_client_hello(ClientHelloBody, #server{priv_key = PrivKey, alpn = Alpn} =
         {ok, ClientKeyShare} ?= client_key_share(ClientHello),
         {ok, Scheme} ?= negotiate_scheme(PrivKey, SigAlgs),
         ok ?= check_alpn(Alpn, ClientAlpns),
+        ok ?= check_transport_params(ClientHello),
+        ok ?= check_initial_scid(ClientHello, PeerSCID),
         build_flight(ClientHelloBody, SessionId, ClientKeyShare, Scheme, State)
     end.
 
@@ -175,6 +197,29 @@ process_client_finished(ClientFinishedBody, #server{
     {ok, binary()} | {error, missing_key_share}.
 client_key_share(#{key_share := ClientPub}) -> {ok, ClientPub};
 client_key_share(#{}) -> {error, missing_key_share}.
+
+%% RFC 9001 §8.2: a ClientHello MUST carry the quic_transport_parameters
+%% extension; its absence is a fatal missing_extension. The codec leaves an
+%% absent extension out of the parsed map, so presence is the key being set (a
+%% present-but-malformed extension already failed the parse with its own error).
+-spec check_transport_params(roadrunner_quic_tls_hello:client_hello()) ->
+    ok | {error, missing_transport_params}.
+check_transport_params(#{transport_params := _}) -> ok;
+check_transport_params(#{}) -> {error, missing_transport_params}.
+
+%% RFC 9000 §7.3: the client's initial_source_connection_id transport parameter
+%% MUST equal the Source Connection ID of its first Initial packet (the value
+%% the loop captured as peer_scid). The first clause binds PeerSCID twice (the
+%% function argument and the map value), so it matches ONLY when they are equal;
+%% a mismatch, a missing initial_source_connection_id, or (after
+%% check_transport_params) an absent extension all fall to the second clause as
+%% a transport_parameter_error.
+-spec check_initial_scid(roadrunner_quic_tls_hello:client_hello(), binary()) ->
+    ok | {error, transport_parameter_error}.
+check_initial_scid(#{transport_params := #{initial_source_connection_id := PeerSCID}}, PeerSCID) ->
+    ok;
+check_initial_scid(#{}, _PeerSCID) ->
+    {error, transport_parameter_error}.
 
 %% The CertificateVerify scheme for the cert key, if the client offered it
 %% in its signature_algorithms. The scheme is fixed by the key type (v1

--- a/test/roadrunner_http3_request_tests.erl
+++ b/test/roadrunner_http3_request_tests.erl
@@ -7,6 +7,9 @@ ctx() ->
 from(Headers) ->
     roadrunner_http3_request:from_headers(Headers, ~"", ctx()).
 
+from(Headers, Body) ->
+    roadrunner_http3_request:from_headers(Headers, Body, ctx()).
+
 base() ->
     [{~":method", ~"GET"}, {~":scheme", ~"https"}, {~":path", ~"/"}].
 
@@ -29,8 +32,11 @@ build_ok_test() ->
     ?assertEqual([{~"host", ~"example.com"}, {~"accept", ~"*/*"}], maps:get(headers, Req)).
 
 build_without_authority_test() ->
-    {ok, Req} = from(base()),
-    ?assertEqual([], maps:get(headers, Req)).
+    %% No :authority pseudo, but a Host header supplies the mandatory authority
+    %% component (RFC 9114 §4.3.1), so the request is valid and Host passes
+    %% through unchanged.
+    {ok, Req} = from(base() ++ [{~"host", ~"example.com"}]),
+    ?assertEqual([{~"host", ~"example.com"}], maps:get(headers, Req)).
 
 missing_pseudo_test() ->
     ?assertEqual(
@@ -75,12 +81,72 @@ banned_headers_test() ->
     ).
 
 te_trailers_allowed_test() ->
-    ?assertMatch({ok, _}, from(base() ++ [{~"te", ~"trailers"}])).
+    ?assertMatch({ok, _}, from(base() ++ [{~":authority", ~"h"}, {~"te", ~"trailers"}])).
 
 te_other_rejected_test() ->
     ?assertEqual({error, connection_specific_header}, from(base() ++ [{~"te", ~"gzip"}])).
 
 regular_header_passthrough_test() ->
-    %% Two regular headers exercise the body-recursion of partition_regular/1.
-    {ok, Req} = from(base() ++ [{~"x-a", ~"1"}, {~"x-b", ~"2"}]),
-    ?assertEqual([{~"x-a", ~"1"}, {~"x-b", ~"2"}], maps:get(headers, Req)).
+    %% Two regular headers exercise the body-recursion of partition_regular/1;
+    %% a Host header supplies the mandatory authority component.
+    {ok, Req} = from(base() ++ [{~"host", ~"h"}, {~"x-a", ~"1"}, {~"x-b", ~"2"}]),
+    ?assertEqual([{~"host", ~"h"}, {~"x-a", ~"1"}, {~"x-b", ~"2"}], maps:get(headers, Req)).
+
+%% =============================================================================
+%% RFC 9114 §4.3.1 authority, §4.1.2 content-length, §4.2 uppercase names
+%% =============================================================================
+
+missing_authority_test() ->
+    %% Neither :authority nor Host: malformed (https has a mandatory authority).
+    ?assertEqual({error, missing_authority}, from(base())).
+
+empty_authority_pseudo_test() ->
+    ?assertEqual({error, empty_authority}, from(base() ++ [{~":authority", ~""}])).
+
+empty_host_header_test() ->
+    ?assertEqual({error, empty_authority}, from(base() ++ [{~"host", ~""}])).
+
+authority_host_match_test() ->
+    %% Both present and equal is valid; the duplicate host header is collapsed
+    %% to a single canonical entry.
+    {ok, Req} = from(base() ++ [{~":authority", ~"example.com"}, {~"host", ~"example.com"}]),
+    ?assertEqual([{~"host", ~"example.com"}], maps:get(headers, Req)).
+
+authority_host_mismatch_test() ->
+    ?assertEqual(
+        {error, authority_mismatch},
+        from(base() ++ [{~":authority", ~"a.com"}, {~"host", ~"b.com"}])
+    ).
+
+uppercase_field_name_test() ->
+    %% RFC 9114 §4.2: an uppercase field name makes the request malformed (the
+    %% banned-header scan catches it before the authority check).
+    ?assertEqual({error, uppercase_field_name}, from(base() ++ [{~"X-Custom", ~"v"}])).
+
+mixedcase_value_allowed_test() ->
+    %% Only field NAMES are case-checked; an uppercase VALUE is fine.
+    ?assertMatch({ok, _}, from(base() ++ [{~"host", ~"h"}, {~"x-token", ~"AbC123"}])).
+
+content_length_match_test() ->
+    ?assertMatch(
+        {ok, _},
+        from(base() ++ [{~"host", ~"h"}, {~"content-length", ~"5"}], ~"abcde")
+    ).
+
+content_length_mismatch_test() ->
+    ?assertEqual(
+        {error, content_length_mismatch},
+        from(base() ++ [{~"content-length", ~"5"}], ~"abc")
+    ).
+
+content_length_non_integer_test() ->
+    ?assertEqual(
+        {error, content_length_mismatch},
+        from(base() ++ [{~"content-length", ~"banana"}], ~"")
+    ).
+
+content_length_multi_valued_test() ->
+    ?assertEqual(
+        {error, content_length_mismatch},
+        from(base() ++ [{~"content-length", ~"5"}, {~"content-length", ~"5"}], ~"abcde")
+    ).

--- a/test/roadrunner_qpack_tests.erl
+++ b/test/roadrunner_qpack_tests.erl
@@ -80,6 +80,13 @@ name_reference_every_static_name_test() ->
      || Name <- Names
     ].
 
+%% RFC 9204 Appendix A index 2 is `age: 0`. The dep's static table has a `:age`
+%% typo at this index, so it is pinned to the RFC directly, NOT cross-checked
+%% against the dep oracle (a full match must encode as the bare index-2 line).
+static_index_2_is_age_test() ->
+    ?assertEqual({ok, [{~"age", ~"0"}]}, ?M:decode(indexed_section(2))),
+    ?assertEqual(indexed_section(2), enc([{~"age", ~"0"}])).
+
 %% A name absent from the table encodes as a Literal with Literal Name.
 literal_literal_name_test() ->
     H = [{~"x-totally-unknown", ~"value"}],

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -24,6 +24,11 @@
 -define(NOW, 1000).
 %% Must match roadrunner_quic_conn_state's ?IDLE_TIMEOUT default.
 -define(IDLE_TIMEOUT, 30000).
+%% Advertised receive windows (RFC 9000 §4.1), deliberately small and distinct
+%% from roadrunner_quic_flow's 786432-byte default so a test can prove a window
+%% is seeded from the advertised value rather than that default.
+-define(CONN_RECV_WINDOW, 2000).
+-define(STREAM_RECV_WINDOW, 1000).
 
 %% =============================================================================
 %% Construction
@@ -484,24 +489,48 @@ reset_final_size_violation_closes_test() ->
     ?assertEqual(closed, ?M:phase(State2)),
     ?assertEqual([{emit, self(), {closed, {local, final_size_error}}}], emits(Effects)).
 
-stream_over_connection_flow_limit_closes_test() ->
-    %% A peer STREAM whose highest offset exceeds the connection's
-    %% 786432-byte receive window is an RFC 9000 §4.1 flow-control connection
-    %% error.
+stream_over_advertised_stream_flow_limit_closes_test() ->
+    %% A peer STREAM whose highest offset exceeds the per-stream receive window
+    %% we advertised (initial_max_stream_data_bidi_remote) is an RFC 9000 §4.1
+    %% flow-control connection error. The window is the advertised value (here
+    %% ?STREAM_RECV_WINDOW, well under the connection window so it is what
+    %% trips), not a larger hardcoded default that would let the overrun pass.
     {State, ApSecret} = connected_with_owner(),
-    Oversized = binary:copy(~"x", 786433),
+    Oversized = binary:copy(~"x", ?STREAM_RECV_WINDOW + 1),
     Bad = app_datagram([{stream, 0, 0, Oversized, false}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
     ?assertEqual(closed, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, flow_control_error}}}], emits(Effects)).
 
+data_over_advertised_connection_flow_limit_closes_test() ->
+    %% Data spread across streams, each within its per-stream window but
+    %% together exceeding the advertised connection window (initial_max_data),
+    %% is an RFC 9000 §4.1 flow-control connection error. Two full per-stream
+    %% windows fill the connection window exactly; one more byte on a third
+    %% stream overflows it, proving the window is the advertised value (it would
+    %% not trip this early under a larger default).
+    {State0, ApSecret} = connected_with_owner(),
+    Chunk = binary:copy(~"x", ?STREAM_RECV_WINDOW),
+    {State1, _} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 0, 0, Chunk, false}], 0, ApSecret), State0
+    ),
+    {State2, _} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 4, 0, Chunk, false}], 1, ApSecret), State1
+    ),
+    ?assertEqual(connected, ?M:phase(State2)),
+    {State3, Effects} = ?M:handle_datagram(
+        ?NOW, app_datagram([{stream, 8, 0, ~"x", false}], 2, ApSecret), State2
+    ),
+    ?assertEqual(closed, ?M:phase(State3)),
+    ?assertEqual([{emit, self(), {closed, {local, flow_control_error}}}], emits(Effects)).
+
 stream_retransmit_does_not_re_consume_flow_test() ->
     %% Flow control is charged by the increase in the highest received offset,
-    %% so resending bytes already received does not re-consume the connection
+    %% so resending bytes already received does not re-consume the receive
     %% window (RFC 9000 §4.1) even when the raw byte sum exceeds it; the
     %% duplicate also delivers no new stream_data.
     {State, ApSecret} = connected_with_owner(),
-    Chunk = binary:copy(~"x", 500000),
+    Chunk = binary:copy(~"x", ?STREAM_RECV_WINDOW - 200),
     {State1, _} = ?M:handle_datagram(
         ?NOW, app_datagram([{stream, 0, 0, Chunk, false}], 0, ApSecret), State
     ),
@@ -906,7 +935,13 @@ is_ack({ack, _Largest, _Delay, _First, _Ranges, _Ecn}) -> true;
 is_ack(_Frame) -> false.
 
 transport_params() ->
-    #{original_destination_connection_id => ?DCID, initial_source_connection_id => ?SCID}.
+    #{
+        original_destination_connection_id => ?DCID,
+        initial_source_connection_id => ?SCID,
+        initial_max_data => ?CONN_RECV_WINDOW,
+        initial_max_stream_data_bidi_remote => ?STREAM_RECV_WINDOW,
+        initial_max_stream_data_uni => ?STREAM_RECV_WINDOW
+    }.
 
 %% The connected payload conn_state caches at new/1 (alpn + advertised params).
 expected_info() ->

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -13,9 +13,13 @@
 -define(FINISHED, 20).
 
 %% A fixed client DCID (the server's routing id), an 8-byte server SCID to
-%% match the server's fixed ?SCID_LEN, the peer address, and a clock.
+%% match the server's fixed ?SCID_LEN, the client's source id (which the
+%% server's replies are addressed to, RFC 9000 §7.2: distinct from both the
+%% other two so a reply DCID can be attributed to exactly one of them), the
+%% peer address, and a clock.
 -define(DCID, <<1, 2, 3, 4, 5, 6, 7, 8>>).
 -define(SCID, <<8, 7, 6, 5, 4, 3, 2, 1>>).
+-define(CLIENT_SCID, <<11, 12, 13, 14, 15, 16, 17, 18>>).
 -define(PEER, {{127, 0, 0, 1}, 12345}).
 -define(NOW, 1000).
 %% Must match roadrunner_quic_conn_state's ?IDLE_TIMEOUT default.
@@ -32,6 +36,19 @@ new_starts_handshaking_test() ->
 peername_answers_in_handshaking_test() ->
     {State, _Ctx} = new_conn([~"leaf-cert-der"]),
     ?assertEqual({ok, ?PEER}, ?M:peername(State)).
+
+%% RFC 9000 §7.2/§17.2: a server addresses its replies with the client's source
+%% connection id, not the client's destination id (which only derives the
+%% Initial keys). A strict client matches inbound packets on its own source id,
+%% so a reply carrying anything else is dropped. The reply's wire DCID must be
+%% the configured peer_scid, distinct from both the routing dcid and the server
+%% scid.
+reply_addressed_to_client_source_cid_test() ->
+    #{effects1 := Effects1} = connect(),
+    [InitialReply | _] = sends(Effects1),
+    {ok, #{dcid := ReplyDCID}} = roadrunner_quic_packet:long_header_info(InitialReply),
+    ?assertEqual(?CLIENT_SCID, ReplyDCID),
+    ?assertNotEqual(?DCID, ReplyDCID).
 
 %% =============================================================================
 %% Full handshake: the in-test client completes a real handshake against the
@@ -854,6 +871,7 @@ new_conn(CertChain) ->
         #{
             dcid => ?DCID,
             scid => ?SCID,
+            peer_scid => ?CLIENT_SCID,
             peer => ?PEER,
             cert_chain => CertChain,
             priv_key => PrivKey,

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -214,6 +214,48 @@ malformed_client_hello_closes_test() ->
     ),
     ?assertMatch([{connection_close, transport, _Code, 0, <<>>}], Frames).
 
+initial_scid_mismatch_closes_test() ->
+    %% RFC 9000 §7.3: a client whose initial_source_connection_id does not equal
+    %% the conn's peer_scid (?CLIENT_SCID) closes with transport_parameter_error,
+    %% transmitted at the Initial level with wire code 0x08.
+    {State0, #{scheme := Scheme, client_pub := ClientPub}} = new_conn([~"leaf-cert-der"]),
+    Framed = ?TC:client_hello_framed(Scheme, ClientPub, ?DCID),
+    Datagram = ?TC:seal(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}], ?DCID, ?SCID
+    ),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State0)),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, transport_parameter_error}}}], emits(Effects)),
+    Frames = ?TC:frames(
+        sends(Effects),
+        initial,
+        #{initial => roadrunner_quic_keys:initial_server(?DCID)},
+        byte_size(?DCID)
+    ),
+    ExpectedCode = roadrunner_quic_error:code_int(transport_parameter_error),
+    ?assertMatch([{connection_close, transport, ExpectedCode, 0, <<>>}], Frames).
+
+missing_transport_params_closes_test() ->
+    %% RFC 9001 §8.2: a ClientHello without the quic_transport_parameters
+    %% extension closes with missing_transport_params, transmitted at the
+    %% Initial level with wire code 0x016d (CRYPTO_ERROR + missing_extension).
+    {State0, #{scheme := Scheme, client_pub := ClientPub}} = new_conn([~"leaf-cert-der"]),
+    Framed = ?TC:client_hello_framed(Scheme, ClientPub, none),
+    Datagram = ?TC:seal(
+        initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}], ?DCID, ?SCID
+    ),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State0)),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, missing_transport_params}}}], emits(Effects)),
+    Frames = ?TC:frames(
+        sends(Effects),
+        initial,
+        #{initial => roadrunner_quic_keys:initial_server(?DCID)},
+        byte_size(?DCID)
+    ),
+    ExpectedCode = roadrunner_quic_error:code_int({crypto_error, 109}),
+    ?assertMatch([{connection_close, transport, ExpectedCode, 0, <<>>}], Frames).
+
 unexpected_handshake_message_closes_test() ->
     %% An out-of-sequence handshake message type closes the connection.
     {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
@@ -922,7 +964,7 @@ new_conn(CertChain) ->
 %% The client Initial datagram and the framed ClientHello it carries (the
 %% first transcript element).
 client_hello_datagram(#{scheme := Scheme, client_pub := ClientPub}) ->
-    Framed = ?TC:client_hello_framed(Scheme, ClientPub),
+    Framed = ?TC:client_hello_framed(Scheme, ClientPub, ?CLIENT_SCID),
     Datagram = ?TC:seal(
         initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}], ?DCID, ?SCID
     ),

--- a/test/roadrunner_quic_connection_interop_SUITE.erl
+++ b/test/roadrunner_quic_connection_interop_SUITE.erl
@@ -89,17 +89,19 @@ pump_loop(Socket, Conns) ->
     end.
 
 %% Build the per-connection config from the first Initial and spawn (and
-%% link) the native shell. The reply DCID stays the client's chosen DCID,
-%% an RFC 9000 §17.2 deviation the key-routing dep client tolerates; a
-%% strict client would need the client's source CID echoed instead.
+%% link) the native shell. The reply DCID echoes the client's source CID
+%% (RFC 9000 §17.2/§7.2); the client's destination id is kept only as the
+%% routing / Initial-key / original_destination_connection_id anchor.
 start_shell(Socket, Peer, FirstDatagram) ->
     {ok, ClientDCID} = roadrunner_quic_packet:dcid(FirstDatagram, 8),
+    {ok, #{scid := ClientSCID}} = roadrunner_quic_packet:long_header_info(FirstDatagram),
     ServerSCID = crypto:strong_rand_bytes(8),
     {EphPub, EphPriv} = crypto:generate_key(ecdh, x25519),
     {CertChain, PrivKey} = cert_key(),
     Config = #{
         dcid => ClientDCID,
         scid => ServerSCID,
+        peer_scid => ClientSCID,
         peer => Peer,
         cert_chain => CertChain,
         priv_key => PrivKey,

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -224,7 +224,10 @@ config(Peer) ->
         alpn => ~"h3",
         transport_params => #{
             original_destination_connection_id => ?DCID,
-            initial_source_connection_id => ?SCID
+            initial_source_connection_id => ?SCID,
+            initial_max_data => 1048576,
+            initial_max_stream_data_bidi_remote => 262144,
+            initial_max_stream_data_uni => 262144
         },
         eph_pub => ServerPub,
         eph_priv => ServerPriv,

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -241,7 +241,7 @@ config(Peer) ->
     }}.
 
 client_hello(#{scheme := Scheme, client_pub := ClientPub}) ->
-    Framed = ?TC:client_hello_framed(Scheme, ClientPub),
+    Framed = ?TC:client_hello_framed(Scheme, ClientPub, ?SCID),
     Datagram = ?TC:seal(
         initial, 0, roadrunner_quic_keys:initial_client(?DCID), [{crypto, 0, Framed}], ?DCID, ?SCID
     ),

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -217,6 +217,7 @@ config(Peer) ->
     Config = #{
         dcid => ?DCID,
         scid => ?SCID,
+        peer_scid => ?SCID,
         peer => Peer,
         cert_chain => [~"leaf-cert-der"],
         priv_key => PrivKey,

--- a/test/roadrunner_quic_listener_tests.erl
+++ b/test/roadrunner_quic_listener_tests.erl
@@ -26,8 +26,11 @@ classify_forwards_short_header_to_registered_connection_test() ->
     ok = ?REG:register_pair(Registry, ?DCID, <<9, 9, 9, 9, 9, 9, 9, 9>>, self()),
     ?assertEqual({forward, self()}, ?M:classify(short_header(?DCID), Registry)).
 
+%% A v1 Initial to an unknown id spawns, capturing both the routing destination
+%% id and the client's source id (the latter is what the server's replies are
+%% addressed to, RFC 9000 §7.2): the two are distinct.
 classify_spawns_for_v1_initial_to_unknown_cid_test() ->
-    ?assertEqual({spawn, ?DCID}, ?M:classify(v1_initial_min(?DCID), ?REG:new())).
+    ?assertEqual({spawn, ?DCID, ?SCID}, ?M:classify(v1_initial_min(?DCID), ?REG:new())).
 
 classify_drops_malformed_datagram_test() ->
     ?assertEqual(drop, ?M:classify(<<>>, ?REG:new())).

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -13,7 +13,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -export([key_material/0, gen_keypair/0]).
--export([client_hello_framed/2]).
+-export([client_hello_framed/3]).
 -export([seal/6, seal_raw/6]).
 -export([crypto_bytes/4, frames/4]).
 -export([server_hello_key_share/1, deframe_all/1]).
@@ -29,6 +29,7 @@
 -define(EXT_SIGNATURE_ALGORITHMS, 16#000D).
 -define(EXT_ALPN, 16#0010).
 -define(EXT_KEY_SHARE, 16#0033).
+-define(EXT_QUIC_TRANSPORT_PARAMS, 16#0039).
 
 %% =============================================================================
 %% Key material
@@ -51,16 +52,24 @@ gen_keypair() ->
 
 -doc """
 A framed ClientHello (handshake-message bytes, RFC 8446 §4.1.2) offering
-the given signature scheme, the x25519 key share, and the `h3` ALPN. These
-bytes are both the CRYPTO-frame payload and the first transcript element.
+the given signature scheme, the x25519 key share, the `h3` ALPN, and a
+quic_transport_parameters extension carrying `ClientSCID` as the
+`initial_source_connection_id` (the server checks it against the client's
+Initial SCID, RFC 9000 §7.3, and requires the extension's presence, RFC 9001
+§8.2). `ClientSCID = none` omits the extension entirely, to exercise the §8.2
+missing-extension path. These bytes are both the CRYPTO-frame payload and the
+first transcript element.
 """.
--spec client_hello_framed(Scheme :: non_neg_integer(), ClientPub :: binary()) -> binary().
-client_hello_framed(Scheme, ClientPub) ->
+-spec client_hello_framed(
+    Scheme :: non_neg_integer(), ClientPub :: binary(), ClientSCID :: binary() | none
+) -> binary().
+client_hello_framed(Scheme, ClientPub, ClientSCID) ->
     Random = crypto:strong_rand_bytes(32),
     Extensions = iolist_to_binary([
         signature_algorithms_ext([Scheme]),
         alpn_ext(~"h3"),
-        key_share_ext(ClientPub)
+        key_share_ext(ClientPub),
+        transport_params_ext(ClientSCID)
     ]),
     CipherSuites = <<?CIPHER_AES_128_GCM_SHA256:16>>,
     Body =
@@ -79,6 +88,17 @@ alpn_ext(Protocol) ->
 key_share_ext(PubKey) ->
     Entry = <<?GROUP_X25519:16, (byte_size(PubKey)):16, PubKey/binary>>,
     extension(?EXT_KEY_SHARE, <<(byte_size(Entry)):16, Entry/binary>>).
+
+%% A quic_transport_parameters extension carrying just the client's
+%% initial_source_connection_id, encoded with the production codec so the wire
+%% bytes stay authoritative. `none` emits no extension at all.
+transport_params_ext(none) ->
+    <<>>;
+transport_params_ext(ClientSCID) ->
+    Body = iolist_to_binary(
+        roadrunner_quic_transport_params:encode(#{initial_source_connection_id => ClientSCID})
+    ),
+    extension(?EXT_QUIC_TRANSPORT_PARAMS, Body).
 
 extension(Type, Data) ->
     <<Type:16, (byte_size(Data)):16, Data/binary>>.

--- a/test/roadrunner_quic_tls_server_tests.erl
+++ b/test/roadrunner_quic_tls_server_tests.erl
@@ -46,12 +46,19 @@ assert_full_handshake(KeyType) ->
     {ClientPub, ClientPriv} = crypto:generate_key(ecdh, x25519),
     {ServerPub, ServerPriv} = crypto:generate_key(ecdh, x25519),
     ServerRandom = crypto:strong_rand_bytes(32),
+    %% The client's Initial SCID; its ClientHello advertises the same value as
+    %% initial_source_connection_id so the §7.3 check passes.
+    ClientSCID = <<10, 11, 12, 13>>,
     TransportParams = #{
         original_destination_connection_id => <<5, 6, 7, 8>>,
         initial_source_connection_id => <<1, 2, 3, 4>>
     },
     ClientHelloBody = client_hello_body(#{
-        key_share => ClientPub, sig_algs => [Scheme], alpn => ~"h3", session_id => <<>>
+        key_share => ClientPub,
+        sig_algs => [Scheme],
+        alpn => ~"h3",
+        session_id => <<>>,
+        transport_params => #{initial_source_connection_id => ClientSCID}
     }),
     State = ?M:new(#{
         cert_chain => [~"leaf-cert-der", ~"intermediate-cert-der"],
@@ -60,7 +67,8 @@ assert_full_handshake(KeyType) ->
         transport_params => TransportParams,
         eph_pub => ServerPub,
         eph_priv => ServerPriv,
-        server_random => ServerRandom
+        server_random => ServerRandom,
+        peer_scid => ClientSCID
     }),
 
     {ok, Flight, Installs, State1} = ?M:process_client_hello(ClientHelloBody, State),
@@ -192,6 +200,45 @@ malformed_client_hello_rejected_test() ->
         {error, malformed_client_hello}, ?M:process_client_hello(~"not a client hello", State)
     ).
 
+%% RFC 9001 §8.2: a ClientHello without the quic_transport_parameters extension
+%% MUST close the connection. The key_share/scheme/alpn gates pass, so the
+%% missing-extension gate is what fails.
+missing_transport_params_rejected_test() ->
+    State = rsa_state(),
+    {ClientPub, _} = crypto:generate_key(ecdh, x25519),
+    Body = client_hello_body(#{
+        key_share => ClientPub, sig_algs => [16#0804], alpn => ~"h3", session_id => <<>>
+    }),
+    ?assertEqual({error, missing_transport_params}, ?M:process_client_hello(Body, State)).
+
+%% RFC 9000 §7.3: the quic_transport_parameters extension is present but omits
+%% initial_source_connection_id, so the connection-id binding cannot be verified.
+missing_initial_scid_rejected_test() ->
+    State = rsa_state(),
+    {ClientPub, _} = crypto:generate_key(ecdh, x25519),
+    Body = client_hello_body(#{
+        key_share => ClientPub,
+        sig_algs => [16#0804],
+        alpn => ~"h3",
+        session_id => <<>>,
+        transport_params => #{initial_max_data => 4096}
+    }),
+    ?assertEqual({error, transport_parameter_error}, ?M:process_client_hello(Body, State)).
+
+%% RFC 9000 §7.3: the client's advertised initial_source_connection_id does not
+%% equal the Source Connection ID of its Initial (rsa_state's peer_scid).
+initial_scid_mismatch_rejected_test() ->
+    State = rsa_state(),
+    {ClientPub, _} = crypto:generate_key(ecdh, x25519),
+    Body = client_hello_body(#{
+        key_share => ClientPub,
+        sig_algs => [16#0804],
+        alpn => ~"h3",
+        session_id => <<>>,
+        transport_params => #{initial_source_connection_id => <<9, 9, 9, 9>>}
+    }),
+    ?assertEqual({error, transport_parameter_error}, ?M:process_client_hello(Body, State)).
+
 %% =============================================================================
 %% Helpers
 %% =============================================================================
@@ -206,7 +253,10 @@ rsa_state() ->
         transport_params => #{initial_source_connection_id => <<1, 2, 3, 4>>},
         eph_pub => ServerPub,
         eph_priv => ServerPriv,
-        server_random => crypto:strong_rand_bytes(32)
+        server_random => crypto:strong_rand_bytes(32),
+        %% The client Initial SCID the §7.3 check compares against; the
+        %% error-path tests fail at an earlier gate, so any binary serves.
+        peer_scid => <<1, 2, 3, 4>>
     }).
 
 %% A generated key pair per scheme, plus the crypto:verify inputs for its
@@ -233,7 +283,8 @@ client_hello_body(Opts) ->
     Extensions = iolist_to_binary([
         signature_algorithms_ext(SigAlgs),
         alpn_ext(Alpn),
-        key_share_ext(maps:get(key_share, Opts, undefined))
+        key_share_ext(maps:get(key_share, Opts, undefined)),
+        transport_params_ext(maps:get(transport_params, Opts, undefined))
     ]),
     CipherSuites = <<?CIPHER_AES_128_GCM_SHA256:16>>,
     <<?LEGACY_VERSION:16, Random/binary, (byte_size(SessionId)):8, SessionId/binary,
@@ -253,6 +304,17 @@ key_share_ext(undefined) ->
 key_share_ext(PubKey) ->
     Entry = <<?GROUP_X25519:16, (byte_size(PubKey)):16, PubKey/binary>>,
     extension(?EXT_KEY_SHARE, <<(byte_size(Entry)):16, Entry/binary>>).
+
+%% `undefined` emits no quic_transport_parameters extension (so a test can
+%% exercise the §8.2 missing-extension path); a params map is encoded with the
+%% production codec.
+transport_params_ext(undefined) ->
+    <<>>;
+transport_params_ext(Params) ->
+    extension(
+        ?EXT_QUIC_TRANSPORT_PARAMS,
+        iolist_to_binary(roadrunner_quic_transport_params:encode(Params))
+    ).
 
 extension(Type, Data) ->
     <<Type:16, (byte_size(Data)):16, Data/binary>>.


### PR DESCRIPTION
# Description

Cut the live HTTP/3 path over from the `quic` dependency to the native `roadrunner_quic_*` stack; the dep stays test-profile-only, as the differential oracle and CT client. The HTTP/3 owner, stream worker, and listener now drive the native transport, and the owner uses the same selective-receive loop as the HTTP/2 connection.

The cutover surfaced RFC deviations the key-routing dep client masked, fixed here so a strict client interops correctly: reply packets address the client's source connection id (RFC 9000 §7.2/§17.2), receive windows enforce the advertised `initial_max_data` and per-stream limits (§4.1), the handshake requires the client's `quic_transport_parameters` extension (RFC 9001 §8.2) and verifies its `initial_source_connection_id` (RFC 9000 §7.3), and HTTP/3 requests with a missing or empty authority, a mismatched content-length, or an uppercase field name are rejected as malformed (RFC 9114 §4.3.1, §4.1.2, §4.2). Deferred conformance and the test-client work that lets `quic` leave the test profile are tracked in `docs/roadmap.md`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)