### PR TITLE
Enforce the advertised QUIC stream-count limits per RFC 9000 §4.6

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -402,6 +402,43 @@ keyed on client IP all depend on it.
 listener opt), plus threading the parsed address into the request's peer
 field across h1, h2, and h3.
 
+### Decide handler 1xx response handling uniformly — small
+
+**What:** A handler that returns a status of 100..199 has it sent as the
+FINAL response (headers + end-of-stream) on h1, h2, and h3 alike, via three
+identical `Status >= 100, Status =< 599` guards (`roadrunner_http1:865`,
+`roadrunner_http2_stream_worker`, `roadrunner_http3_stream_worker`). A 1xx is
+interim (RFC 9110 §15.2): it cannot carry content or terminate the response,
+and a final response must follow. The single-response handler API cannot
+express "interim 1xx then final", so a returned 1xx is always a misuse. Pick
+ONE cross-protocol behavior: reject it (answer 500, log) or add a real
+interim-response mechanism.
+
+**Why deferred:** legitimate interim 1xx is already automatic where it matters
+(h1 `Expect: 100-continue` via `roadrunner_conn:maybe_send_continue`); a
+handler returning a 1xx is rare, and the current uniform behavior is at least
+consistent. It is a deliberate framework-wide decision, not an h3-only patch
+(which would diverge from h1/h2). Surfaced by the post-merge HTTP/3 review.
+
+**Scope:** small, but touches the three response paths together.
+
+### Cap outbound response header size — small
+
+**What:** h1/h2/h3 all cap INBOUND headers (the security-relevant direction,
+against untrusted clients: h3 answers 431, h1/h2 their own limits) but none
+bounds an OUTBOUND response header block, so a handler emitting a
+pathologically large header set produces an unbounded HEADERS frame. A
+self-cap (e.g. at the listener's `max_header_block`) answering 500 on overflow
+would bound it.
+
+**Why deferred:** outbound headers come from trusted handler code, not an
+untrusted peer, so the memory/abuse risk is low and the inbound caps already
+cover the attack surface. This is distinct from honoring the peer's advertised
+`SETTINGS_MAX_FIELD_SECTION_SIZE` (a separate SHOULD in the protocol sections).
+Surfaced by the post-merge HTTP/3 review.
+
+**Scope:** small, cross-protocol (the same response paths as the 1xx item).
+
 ## Per-route framework knobs the map shape unlocks
 
 The map-shape route entry (`#{path => ..., handler => ..., state =>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,6 +98,12 @@ advisory or malformed cases the server currently tolerates or omits.
   `STREAM_DATA_BLOCKED` (RFC 9000 §4). Each window is seeded from our own
   advertised value and never raised, so a transfer past the initial grant
   stalls; the suite max is 100 KB, well under it — medium
+- Stream-count grants and self-limiting (RFC 9000 §4.6): the server now rejects
+  a client stream id over the advertised `initial_max_streams_*`, but never
+  *sends* `MAX_STREAMS` to raise the limit, ignores an inbound `MAX_STREAMS`, and
+  does not check the peer's `initial_max_streams_uni` before opening its own
+  control / QPACK uni streams (it opens ~3, always within a sane client's
+  limit) — small
 - Respond to a peer-initiated key update (RFC 9001 §6). Security-sensitive:
   trial-decrypt the next-phase keys and commit ONLY on success (not the dep's
   commit-then-decrypt, which a single forged flipped-bit datagram desyncs),
@@ -111,6 +117,10 @@ advisory or malformed cases the server currently tolerates or omits.
 - NewReno congestion control (RFC 9002 §7); needs the loss layer to surface
   acked bytes + sent times. Sending is bounded only by the §8.1
   anti-amplification limit and flow control today — large
+- PTO explicit probe (RFC 9002 §6.2.4): a probe timeout only re-checks for
+  losses and backs off; it does not retransmit the oldest unacked ack-eliciting
+  frames as a probe. Bundle with NewReno (both need the loss layer to surface
+  the oldest-unacked) — medium
 - A no-flatten / by-reference stream send buffer, so a large response body is
   not flattened into one binary before sending — medium
 

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -105,6 +105,12 @@
     %% §2.1: server uni ids are 3, 7, 11, ...); the owner opens its h3
     %% control stream this way.
     next_uni = 3 :: non_neg_integer(),
+    %% The stream counts we advertised the peer may open
+    %% (initial_max_streams_bidi/uni, RFC 9000 §4.6): a client-initiated stream
+    %% whose ordinal (id div 4) is >= the limit for its type is a
+    %% STREAM_LIMIT_ERROR.
+    max_streams_bidi :: non_neg_integer(),
+    max_streams_uni :: non_neg_integer(),
     %% Connection-level flow control (RFC 9000 §4).
     conn_flow :: roadrunner_quic_flow:t(),
     %% Owner events accumulated while folding a datagram's frames, drained in
@@ -208,10 +214,14 @@ new(
         server_random => ServerRandom,
         peer_scid => PeerSCID
     }),
-    %% Seed the connection receive window from the limit we advertise, so the
-    %% window enforced (RFC 9000 §4.1) is exactly the one the peer was told it
-    %% may use, never a smaller hardcoded default it would trip early on.
-    #{initial_max_data := ConnMaxData} = TransportParams,
+    %% Seed the connection receive window and the stream-count limits from the
+    %% values we advertise, so what is enforced (RFC 9000 §4.1 / §4.6) is exactly
+    %% what the peer was told it may use, never a hardcoded default.
+    #{
+        initial_max_data := ConnMaxData,
+        initial_max_streams_bidi := MaxStreamsBidi,
+        initial_max_streams_uni := MaxStreamsUni
+    } = TransportParams,
     #state{
         dcid = DCID,
         scid = SCID,
@@ -224,6 +234,8 @@ new(
         amp = roadrunner_quic_amp:new(),
         owner = undefined,
         info = #{alpn => Alpn, transport_params => TransportParams},
+        max_streams_bidi = MaxStreamsBidi,
+        max_streams_uni = MaxStreamsUni,
         conn_flow = roadrunner_quic_flow:new(#{initial_max_data => ConnMaxData}),
         idle_deadline = Now + ?IDLE_TIMEOUT
     }.
@@ -671,6 +683,14 @@ process_ack(Now, Level, Ack, State) ->
 -spec process_stream(non_neg_integer(), non_neg_integer(), binary(), boolean(), t()) -> t().
 process_stream(Sid, _Offset, _Data, _Fin, State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
     connection_fatal(application, stream_state_error, State);
+process_stream(Sid, _Offset, _Data, _Fin, #state{max_streams_bidi = Max} = State) when
+    Sid rem 4 =:= 0, Sid div 4 >= Max
+->
+    connection_fatal(application, stream_limit_error, State);
+process_stream(Sid, _Offset, _Data, _Fin, #state{max_streams_uni = Max} = State) when
+    Sid rem 4 =:= 2, Sid div 4 >= Max
+->
+    connection_fatal(application, stream_limit_error, State);
 process_stream(Sid, Offset, Data, Fin, State) ->
     {Stream0, StreamFlow0, State1} = ensure_stream(Sid, State),
     #state{conn_flow = ConnFlow} = State1,
@@ -692,6 +712,14 @@ process_stream(Sid, Offset, Data, Fin, State) ->
 -spec process_reset_stream(non_neg_integer(), non_neg_integer(), non_neg_integer(), t()) -> t().
 process_reset_stream(Sid, _ErrorCode, _FinalSize, State) when Sid rem 4 =:= 1; Sid rem 4 =:= 3 ->
     connection_fatal(application, stream_state_error, State);
+process_reset_stream(Sid, _ErrorCode, _FinalSize, #state{max_streams_bidi = Max} = State) when
+    Sid rem 4 =:= 0, Sid div 4 >= Max
+->
+    connection_fatal(application, stream_limit_error, State);
+process_reset_stream(Sid, _ErrorCode, _FinalSize, #state{max_streams_uni = Max} = State) when
+    Sid rem 4 =:= 2, Sid div 4 >= Max
+->
+    connection_fatal(application, stream_limit_error, State);
 process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
     {Stream0, Flow, State1} = ensure_stream(Sid, State),
     case roadrunner_quic_stream:reset(FinalSize, Stream0) of
@@ -730,6 +758,7 @@ close_code(Reason) when
     Reason =:= flow_control_error;
     Reason =:= final_size_error;
     Reason =:= stream_state_error;
+    Reason =:= stream_limit_error;
     Reason =:= protocol_violation;
     Reason =:= transport_parameter_error
 ->

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -29,6 +29,11 @@
 %% is seeded from the advertised value rather than that default.
 -define(CONN_RECV_WINDOW, 2000).
 -define(STREAM_RECV_WINDOW, 1000).
+%% Advertised stream-count limits (RFC 9000 §4.6), small and distinct so a
+%% bidi/uni mix-up is caught. Existing tests open client-bidi ordinals 0..2
+%% (stream ids 0, 4, 8), so the bidi limit must leave those within range.
+-define(MAX_STREAMS_BIDI, 3).
+-define(MAX_STREAMS_UNI, 2).
 
 %% =============================================================================
 %% Construction
@@ -507,6 +512,52 @@ reset_stream_on_server_initiated_id_closes_test() ->
     ?assertEqual(closed, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, stream_state_error}}}], emits(Effects)).
 
+stream_over_advertised_bidi_count_closes_test() ->
+    %% RFC 9000 §4.6: a client bidi stream whose ordinal (id div 4) reaches the
+    %% advertised initial_max_streams_bidi is a STREAM_LIMIT_ERROR, transmitted
+    %% at the 1-RTT level with wire code 0x04 (not the larger no-limit default).
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    OverLimit = ?MAX_STREAMS_BIDI * 4,
+    Bad = app_datagram([{stream, OverLimit, 0, ~"x", true}], 0, ClientApSecret),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)),
+    ExpectedCode = roadrunner_quic_error:code_int(stream_limit_error),
+    ?assert(
+        lists:member(
+            {connection_close, transport, ExpectedCode, 0, <<>>},
+            sent_app_frames(Effects, ServerApSecret)
+        )
+    ).
+
+stream_over_advertised_uni_count_closes_test() ->
+    %% Same §4.6 limit on client unidirectional streams (rem 4 == 2), against the
+    %% distinct initial_max_streams_uni.
+    {State, ApSecret} = connected_with_owner(),
+    OverLimit = ?MAX_STREAMS_UNI * 4 + 2,
+    Bad = app_datagram([{stream, OverLimit, 0, ~"x", true}], 0, ApSecret),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)).
+
+reset_over_advertised_bidi_count_closes_test() ->
+    %% A RESET_STREAM on an over-limit client bidi id is the same §4.6 error.
+    {State, ApSecret} = connected_with_owner(),
+    OverLimit = ?MAX_STREAMS_BIDI * 4,
+    Bad = app_datagram([{reset_stream, OverLimit, 7, 0}], 0, ApSecret),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)).
+
+reset_over_advertised_uni_count_closes_test() ->
+    %% A RESET_STREAM on an over-limit client uni id, against initial_max_streams_uni.
+    {State, ApSecret} = connected_with_owner(),
+    OverLimit = ?MAX_STREAMS_UNI * 4 + 2,
+    Bad = app_datagram([{reset_stream, OverLimit, 7, 0}], 0, ApSecret),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)).
+
 stream_final_size_violation_closes_test() ->
     %% A FIN declaring a final size below the bytes already received is an
     %% RFC 9000 §4.5 connection error.
@@ -982,7 +1033,9 @@ transport_params() ->
         initial_source_connection_id => ?SCID,
         initial_max_data => ?CONN_RECV_WINDOW,
         initial_max_stream_data_bidi_remote => ?STREAM_RECV_WINDOW,
-        initial_max_stream_data_uni => ?STREAM_RECV_WINDOW
+        initial_max_stream_data_uni => ?STREAM_RECV_WINDOW,
+        initial_max_streams_bidi => ?MAX_STREAMS_BIDI,
+        initial_max_streams_uni => ?MAX_STREAMS_UNI
     }.
 
 %% The connected payload conn_state caches at new/1 (alpn + advertised params).

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -227,7 +227,9 @@ config(Peer) ->
             initial_source_connection_id => ?SCID,
             initial_max_data => 1048576,
             initial_max_stream_data_bidi_remote => 262144,
-            initial_max_stream_data_uni => 262144
+            initial_max_stream_data_uni => 262144,
+            initial_max_streams_bidi => 100,
+            initial_max_streams_uni => 100
         },
         eph_pub => ServerPub,
         eph_priv => ServerPriv,


### PR DESCRIPTION
# Description

The native QUIC stack now enforces the stream-count limits it advertises to the peer: opening or resetting a client-initiated stream past the advertised maximum is a `STREAM_LIMIT_ERROR` connection error, per RFC 9000 §4.6 ("An endpoint that receives a frame with a stream ID exceeding the limit it has sent MUST treat this as a connection error of type STREAM_LIMIT_ERROR"). The roadmap records the deferred follow-ups.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
