### PR TITLE
Drop the quic dependency from production into the test profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ A small, fast HTTP core you can trust on the hot path.
 - **Every HTTP version, one server**: HTTP/1.1, HTTP/2, HTTP/3 (experimental),
   and WebSocket served from one listener; browsers upgrade to h3 over the same
   port via `Alt-Svc`.
-- **Pure Erlang, almost no dependencies**: Two runtime deps (`telemetry` and
-  `quic`, the HTTP/3 transport), no C NIFs, and Roadrunner owns its own
-  h1/h2/h3 codecs: easy to read and audit. `quic` only starts for HTTP/3, so
-  h1/h2 deployments never load it.
+- **Pure Erlang, almost no dependencies**: One runtime dep (`telemetry`),
+  no C NIFs, and Roadrunner owns its own h1/h2/h3 codecs and its own QUIC
+  transport: easy to read and audit.
 - **Pleasant to build on**: Plain-Erlang request and response values, composable
   middleware, and opt-in helpers for cookies, query strings, multipart, SSE, and
   WebSocket.
@@ -68,9 +67,8 @@ Standards conformance:
   static-table compression. Enable per listener via
   `protocols => [http3]` (requires `tls`; QUIC mandates TLS 1.3); it
   co-serves with h1/h2 on the same port number (TCP for h1/h2, UDP for
-  h3) and advertises `Alt-Svc` so browsers upgrade. Built on the
-  pure-Erlang [`quic`](https://github.com/benoitc/erlang_quic) transport
-  (still 1.x), so treat HTTP/3 as experimental.
+  h3) and advertises `Alt-Svc` so browsers upgrade. Roadrunner ships its
+  own pure-Erlang QUIC transport; treat HTTP/3 as experimental.
 - **Content-Encoding (RFC 9110 §8.4.1)**: gzip + deflate with
   qvalue-aware `Accept-Encoding` negotiation (RFC 9110 §12.5.3),
   works unchanged over HTTP/2.
@@ -261,8 +259,8 @@ the `tls` opt.
 For HTTP/3 (experimental), add `http3` to a TLS listener's `protocols`
 (e.g. `protocols => [http1, http2, http3]`). It serves h3 over UDP on the
 same port number and advertises `Alt-Svc` so browsers upgrade from TCP;
-the `quic` transport starts on demand, so h1/h2-only listeners never load
-it.
+the QUIC transport starts on demand, so h1/h2-only listeners never open a
+UDP socket.
 
 For listeners that don't need routing, `routes => Mod` (or
 `{Mod, State}` to seed handler state) skips the router entirely and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,20 +51,20 @@ only). Remaining work:
 - WebSocket over h3 (`websocket` shape, still `501`) — RFC 9220
   Extended CONNECT; do WebSocket over h2 (RFC 8441) first, since it's
   the more common transport and h2 has no WebSocket either
-- QPACK dynamic table (non-zero capacity) — the `quic` dep has the full
-  RFC 9204 machinery; the work is wiring encoder/decoder streams +
-  section acks + blocked-stream buffering into the owned conn loop
+- QPACK dynamic table (non-zero capacity) — static-table compression ships
+  today; the work is wiring encoder/decoder streams + section acks +
+  blocked-stream buffering into the owned conn loop
 - HttpArena `baseline-h3` / `static-h3` profiles (the local
   `scripts/bench.escript` h3 path is wired and measured; these live in
   the separate `MDA2AV/HttpArena` repo)
 - WebTransport / Extended CONNECT (RFC 9220) and HTTP datagrams
-  (RFC 9297), both already provided by the dep
+  (RFC 9297)
 - A scheduler-scaled default for the reuseport pool size
   (`{http3, #{listeners => N}}`, validated `1..1024`, default 8,
   `1` = no pooling); currently unmeasured
 - Full RFC 9000 connection-ID rotation: issuing spare server CIDs and
-  registering them so packets using them route. A currently-unwired
-  dep feature, a deliberate upstream effort if wanted
+  registering them so packets using them route; currently unimplemented
+  in the native stack
 
 ## Native QUIC transport follow-ups
 
@@ -126,12 +126,12 @@ advisory or malformed cases the server currently tolerates or omits.
 
 ### Retire the dep
 
+`quic` is now production-free (test-profile-only; production deps are just
+`telemetry`). The last step to drop it entirely:
+
 - Build a native QUIC test client so the `quic` dep can leave the test profile
-  too; the h3 SUITE + bench drive the native server with the dep's client, its
-  last remaining use — large
-- Then move `quic` out of production `deps` into `profiles.test.deps` and drop
-  it from the dialyzer `plt_extra_apps`, so production deps become
-  `[telemetry]` — small
+  too; the differential-oracle tests, the h3 SUITE's CT client, and the bench
+  client are its only remaining users — large
 
 ### Known dep deviation (informational)
 

--- a/rebar.config
+++ b/rebar.config
@@ -10,13 +10,7 @@
 ]}.
 
 {deps, [
-    {telemetry, "1.4.2"},
-    %% Pure-Erlang QUIC + HTTP/3 (RFC 9000/9001/9114). Used as a
-    %% transport + codec helper layer only: roadrunner owns the
-    %% listener and the h3 connection loop, leaning on `quic` for the
-    %% QUIC transport (`quic`/`quic_listener`) and the h3/QPACK codecs
-    %% (`quic_h3_frame`/`quic_qpack`), not its turnkey `quic_h3` server.
-    {quic, "1.6.1"}
+    {telemetry, "1.4.2"}
 ]}.
 
 {project_plugins, [
@@ -47,7 +41,14 @@
             %% roadrunner against both. Test-profile-only to keep the
             %% production dep list at one entry (telemetry).
             {cowboy, "2.15.0"},
-            {elli, "3.3.0"}
+            {elli, "3.3.0"},
+            %% The native `roadrunner_quic_*` stack serves the live wire; this
+            %% dep is kept test-profile-only as the byte-for-byte differential
+            %% oracle for the codecs/crypto and the CT/bench client (`quic_h3`)
+            %% driving dep-client -> native-server interop. Production deps are
+            %% just telemetry. A native QUIC test client (roadmap) would let it
+            %% be dropped entirely.
+            {quic, "1.6.1"}
         ]}
     ]}
 ]}.
@@ -61,7 +62,7 @@
 {dialyzer, [
     {warnings, [unknown, unmatched_returns, error_handling]},
     {plt_apps, top_level_deps},
-    {plt_extra_apps, [ssl, public_key, crypto, quic]}
+    {plt_extra_apps, [ssl, public_key, crypto]}
 ]}.
 
 {xref_checks, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,8 @@
 {"1.2.0",
-[{<<"quic">>,{pkg,<<"quic">>,<<"1.6.1">>},0},
- {<<"telemetry">>,{pkg,<<"telemetry">>,<<"1.4.2">>},0}]}.
+[{<<"telemetry">>,{pkg,<<"telemetry">>,<<"1.4.2">>},0}]}.
 [
 {pkg_hash,[
- {<<"quic">>, <<"4CE7CE751900205ACBDE083E3766ED2DFF5942AA1ECC0F3FBDC21C5A0C811408">>},
  {<<"telemetry">>, <<"A0CB522801DFFB1C49FE6E30561BADFFC7B6D0E180DB1300DF759FAA22062855">>}]},
 {pkg_hash_ext,[
- {<<"quic">>, <<"6C9552F1B493D5B892332F64F24F1941611CB91372E7ECF61D7A39720EE40EA9">>},
  {<<"telemetry">>, <<"928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1">>}]}
 ].

--- a/src/roadrunner_quic.erl
+++ b/src/roadrunner_quic.erl
@@ -2,9 +2,7 @@
 -moduledoc false.
 
 %% The control API the HTTP/3 layer (`roadrunner_conn_loop_http3`,
-%% `roadrunner_http3_stream_worker`) calls on a native QUIC connection: the
-%% same surface the dep's `quic` module gave, so the h3 files change only the
-%% `quic:*` -> `roadrunner_quic:*` qualifier.
+%% `roadrunner_http3_stream_worker`) calls on a native QUIC connection.
 %%
 %% The native connection is a hand-rolled `proc_lib` loop, not a gen_statem, so
 %% this module replicates `gen_statem:call` semantics itself: a `make_ref`


### PR DESCRIPTION
# Description

A roadrunner release now ships with `telemetry` as its only production dependency. The native `roadrunner_quic` stack already serves the live HTTP/3 wire, so the hex `quic` dep moves to the test profile (the differential oracle and CT/bench client) and the docs no longer call it the production HTTP/3 transport.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
