### PR TITLE
Add a native QUIC and HTTP/3 client for the test profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -90,6 +90,7 @@
         {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_connection_interop_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_test_conn_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_quic_test_h3_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_listener_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_listener_sup_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},

--- a/rebar.config
+++ b/rebar.config
@@ -89,6 +89,7 @@
         {"test/roadrunner_http3_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_connection_interop_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_quic_test_conn_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_listener_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_listener_sup_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_property_SUITE.erl", unnecessary_function_arguments},

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -244,11 +244,15 @@ parse_server_hello(Body) ->
         extract_extension(?EXT_KEY_SHARE, Exts),
     #{random => Random, session_id => SessionId, cipher => Cipher, key_share => KeyShare}.
 
--doc "EncryptedExtensions body: the selected ALPN protocol and decoded QUIC transport parameters, each present when the server sent it.".
--spec parse_encrypted_extensions(binary()) ->
-    #{
-        alpn => binary(), transport_params => roadrunner_quic_transport_params:params()
-    }.
+-doc """
+EncryptedExtensions body: the selected ALPN protocol and the server's raw
+QUIC transport-parameters bytes, each present when the server sent it. The
+parameters are kept as raw bytes rather than decoded: the production decoder
+is the server's (it rejects the server-only parameters a server legitimately
+sends, e.g. original_destination_connection_id), and the test client does
+not need to interpret them (it sends within the generous default windows).
+""".
+-spec parse_encrypted_extensions(binary()) -> #{alpn => binary(), transport_params => binary()}.
 parse_encrypted_extensions(<<ExtsLen:16, Exts:ExtsLen/binary>>) ->
     ExtMap = extension_map(Exts),
     add_transport_params(ExtMap, add_alpn(ExtMap, #{})).
@@ -259,8 +263,7 @@ add_alpn(#{}, Acc) ->
     Acc.
 
 add_transport_params(#{?EXT_QUIC_TRANSPORT_PARAMS := Data}, Acc) ->
-    {ok, Params} = roadrunner_quic_transport_params:decode(Data),
-    Acc#{transport_params => Params};
+    Acc#{transport_params => Data};
 add_transport_params(#{}, Acc) ->
     Acc.
 

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -17,6 +17,13 @@
 -export([seal/6, seal_raw/6]).
 -export([crypto_bytes/4, frames/4]).
 -export([server_hello_key_share/1, deframe_all/1]).
+-export([
+    parse_server_hello/1,
+    parse_encrypted_extensions/1,
+    parse_certificate/1,
+    parse_certificate_verify/1,
+    parse_finished/1
+]).
 
 %% TLS handshake message types (RFC 8446 §4).
 -define(CLIENT_HELLO, 1).
@@ -184,15 +191,11 @@ level_frames(Datagram, Level, Keys, DCIDLen) ->
 %% Handshake-message decoding
 %% =============================================================================
 
--doc "The server's x25519 public key from a ServerHello's key_share extension.".
+-doc "The server's x25519 public key from a (framed) ServerHello's key_share extension.".
 -spec server_hello_key_share(binary()) -> binary().
 server_hello_key_share(ServerHello) ->
     [{?SERVER_HELLO, Body} | _] = deframe_all(ServerHello),
-    <<_LegacyVersion:16, _Random:32/binary, SessionLen:8, _Session:SessionLen/binary, _Cipher:16,
-        _Compression:8, _ExtsLen:16, Extensions/binary>> = Body,
-    <<?GROUP_X25519:16, KeyLen:16, PubKey:KeyLen/binary>> =
-        extract_extension(?EXT_KEY_SHARE, Extensions),
-    PubKey.
+    maps:get(key_share, parse_server_hello(Body)).
 
 extract_extension(Type, <<Type:16, Len:16, Data:Len/binary, _Rest/binary>>) ->
     Data;
@@ -209,3 +212,72 @@ deframe_all_bin(<<>>) ->
 deframe_all_bin(Bin) ->
     {ok, {Type, Body}, Rest} = roadrunner_quic_tls_handshake:decode(Bin),
     [{Type, Body} | deframe_all_bin(Rest)].
+
+%% =============================================================================
+%% Server-flight parsing (the client mirror of the server-side build,
+%% RFC 8446 §4.1.3/§4.3.1/§4.4). Each takes a deframed handshake-message body.
+%% These parse trusted server output in tests, so they pattern-match strictly
+%% and let it crash on a malformed buffer rather than returning `{error, _}`.
+%% =============================================================================
+
+-doc "ServerHello body: the server random, echoed session id, selected cipher, and x25519 key share.".
+-spec parse_server_hello(binary()) ->
+    #{
+        random := binary(),
+        session_id := binary(),
+        cipher := non_neg_integer(),
+        key_share := binary()
+    }.
+parse_server_hello(Body) ->
+    <<?LEGACY_VERSION:16, Random:32/binary, SidLen:8, SessionId:SidLen/binary, Cipher:16, 0:8,
+        ExtsLen:16, Exts:ExtsLen/binary>> = Body,
+    <<?GROUP_X25519:16, KeyLen:16, KeyShare:KeyLen/binary>> =
+        extract_extension(?EXT_KEY_SHARE, Exts),
+    #{random => Random, session_id => SessionId, cipher => Cipher, key_share => KeyShare}.
+
+-doc "EncryptedExtensions body: the selected ALPN protocol and decoded QUIC transport parameters, each present when the server sent it.".
+-spec parse_encrypted_extensions(binary()) ->
+    #{
+        alpn => binary(), transport_params => roadrunner_quic_transport_params:params()
+    }.
+parse_encrypted_extensions(<<ExtsLen:16, Exts:ExtsLen/binary>>) ->
+    ExtMap = extension_map(Exts),
+    add_transport_params(ExtMap, add_alpn(ExtMap, #{})).
+
+add_alpn(#{?EXT_ALPN := <<_ListLen:16, NameLen:8, Proto:NameLen/binary>>}, Acc) ->
+    Acc#{alpn => Proto};
+add_alpn(#{}, Acc) ->
+    Acc.
+
+add_transport_params(#{?EXT_QUIC_TRANSPORT_PARAMS := Data}, Acc) ->
+    {ok, Params} = roadrunner_quic_transport_params:decode(Data),
+    Acc#{transport_params => Params};
+add_transport_params(#{}, Acc) ->
+    Acc.
+
+-doc "Certificate body: the DER certificate chain, leaf first (RFC 8446 §4.4.2).".
+-spec parse_certificate(binary()) -> [binary()].
+parse_certificate(<<CtxLen:8, _Ctx:CtxLen/binary, ListLen:24, List:ListLen/binary>>) ->
+    cert_entries(List).
+
+cert_entries(<<>>) ->
+    [];
+cert_entries(<<CertLen:24, Cert:CertLen/binary, ExtLen:16, _Exts:ExtLen/binary, Rest/binary>>) ->
+    [Cert | cert_entries(Rest)].
+
+-doc "CertificateVerify body: the signature scheme and signature bytes (RFC 8446 §4.4.3).".
+-spec parse_certificate_verify(binary()) -> {non_neg_integer(), binary()}.
+parse_certificate_verify(<<Scheme:16, SigLen:16, Signature:SigLen/binary>>) ->
+    {Scheme, Signature}.
+
+-doc "Finished body: the verify_data MAC itself (RFC 8446 §4.4.4).".
+-spec parse_finished(binary()) -> binary().
+parse_finished(VerifyData) ->
+    VerifyData.
+
+%% A lenient type => data map of an extension vector, for the optional
+%% EncryptedExtensions extensions.
+extension_map(<<>>) ->
+    #{};
+extension_map(<<Type:16, Len:16, Data:Len/binary, Rest/binary>>) ->
+    (extension_map(Rest))#{Type => Data}.

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -24,6 +24,7 @@
     parse_certificate_verify/1,
     parse_finished/1
 ]).
+-export([verify_server_certificate_verify/4]).
 
 %% TLS handshake message types (RFC 8446 §4).
 -define(CLIENT_HELLO, 1).
@@ -37,6 +38,14 @@
 -define(EXT_ALPN, 16#0010).
 -define(EXT_KEY_SHARE, 16#0033).
 -define(EXT_QUIC_TRANSPORT_PARAMS, 16#0039).
+
+%% Signature schemes (RFC 8446 §4.2.3) the server may sign with.
+-define(SIG_RSA_PSS_RSAE_SHA256, 16#0804).
+-define(SIG_ECDSA_SECP256R1_SHA256, 16#0403).
+-define(SIG_ED25519, 16#0807).
+
+%% The server CertificateVerify signature context (RFC 8446 §4.4.3).
+-define(CERT_VERIFY_CONTEXT, ~"TLS 1.3, server CertificateVerify").
 
 %% =============================================================================
 %% Key material
@@ -281,3 +290,40 @@ extension_map(<<>>) ->
     #{};
 extension_map(<<Type:16, Len:16, Data:Len/binary, Rest/binary>>) ->
     (extension_map(Rest))#{Type => Data}.
+
+%% =============================================================================
+%% Server CertificateVerify verification (RFC 8446 §4.4.3) - the client side
+%% of the server's signing. Reconstructs the signed content (64 spaces, the
+%% context string, a 0 separator, then the transcript hash through the
+%% Certificate message) and verifies `Signature` under `Scheme` with the
+%% server's public key.
+%% =============================================================================
+
+-doc "Verify a server CertificateVerify signature over `TranscriptHash` with the server's `PublicKey`.".
+-spec verify_server_certificate_verify(
+    non_neg_integer(), binary(), public_key:public_key(), binary()
+) -> boolean().
+verify_server_certificate_verify(Scheme, Signature, PublicKey, TranscriptHash) ->
+    Content = iolist_to_binary([
+        binary:copy(<<16#20>>, 64), ?CERT_VERIFY_CONTEXT, 0, TranscriptHash
+    ]),
+    {SigAlg, HashAlg, Options} = verify_params(Scheme),
+    crypto:verify(SigAlg, HashAlg, Content, Signature, crypto_pubkey(Scheme, PublicKey), Options).
+
+-spec verify_params(non_neg_integer()) -> {atom(), atom(), [{atom(), atom() | integer()}]}.
+verify_params(?SIG_RSA_PSS_RSAE_SHA256) ->
+    {rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]};
+verify_params(?SIG_ECDSA_SECP256R1_SHA256) ->
+    {ecdsa, sha256, []};
+verify_params(?SIG_ED25519) ->
+    {eddsa, none, []}.
+
+%% Convert the public_key public-key term into the key form crypto:verify
+%% expects for the scheme (mirror of the server-side crypto_key/2).
+-spec crypto_pubkey(non_neg_integer(), public_key:public_key()) -> [integer() | binary() | atom()].
+crypto_pubkey(?SIG_RSA_PSS_RSAE_SHA256, #'RSAPublicKey'{publicExponent = E, modulus = N}) ->
+    [E, N];
+crypto_pubkey(?SIG_ECDSA_SECP256R1_SHA256, {#'ECPoint'{point = Point}, _Params}) ->
+    [Point, secp256r1];
+crypto_pubkey(?SIG_ED25519, {#'ECPoint'{point = Point}, _Params}) ->
+    [Point, ed25519].

--- a/test/roadrunner_quic_test_client_tests.erl
+++ b/test/roadrunner_quic_test_client_tests.erl
@@ -1,6 +1,7 @@
 -module(roadrunner_quic_test_client_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
 
 -define(C, roadrunner_quic_test_client).
 
@@ -61,3 +62,19 @@ finished_round_trip_test() ->
     FinishedKey = roadrunner_quic_tls_crypto:finished_key(TrafficSecret),
     Expected = roadrunner_quic_tls_crypto:verify_data(FinishedKey, Hash),
     ?assertEqual(Expected, ?C:parse_finished(Body)).
+
+certificate_verify_signature_verifies_test() ->
+    {Scheme, Priv} = ?C:key_material(),
+    Pub = #'RSAPublicKey'{
+        modulus = Priv#'RSAPrivateKey'.modulus,
+        publicExponent = Priv#'RSAPrivateKey'.publicExponent
+    },
+    Hash = crypto:strong_rand_bytes(32),
+    Framed = roadrunner_quic_tls_auth:build_certificate_verify(Scheme, Priv, Hash),
+    [{15, Body}] = ?C:deframe_all(Framed),
+    {Scheme, Signature} = ?C:parse_certificate_verify(Body),
+    ?assert(?C:verify_server_certificate_verify(Scheme, Signature, Pub, Hash)),
+    %% A signature over a different transcript hash must not verify.
+    ?assertNot(
+        ?C:verify_server_certificate_verify(Scheme, Signature, Pub, crypto:strong_rand_bytes(32))
+    ).

--- a/test/roadrunner_quic_test_client_tests.erl
+++ b/test/roadrunner_quic_test_client_tests.erl
@@ -1,0 +1,63 @@
+-module(roadrunner_quic_test_client_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(C, roadrunner_quic_test_client).
+
+%% Each server-flight parser is proven by round-tripping the native server
+%% builder: server build_X -> deframe -> client parse_X recovers the fields.
+%% No dep oracle is involved; the native server modules are the reference.
+
+server_hello_round_trip_test() ->
+    Random = crypto:strong_rand_bytes(32),
+    SessionId = crypto:strong_rand_bytes(8),
+    {Pub, _Priv} = ?C:gen_keypair(),
+    Framed = roadrunner_quic_tls_hello:build_server_hello(#{
+        random => Random, session_id => SessionId, key_share => Pub
+    }),
+    [{2, Body}] = ?C:deframe_all(Framed),
+    Parsed = ?C:parse_server_hello(Body),
+    ?assertEqual(Random, maps:get(random, Parsed)),
+    ?assertEqual(SessionId, maps:get(session_id, Parsed)),
+    ?assertEqual(16#1301, maps:get(cipher, Parsed)),
+    ?assertEqual(Pub, maps:get(key_share, Parsed)).
+
+encrypted_extensions_round_trip_test() ->
+    Params = #{initial_max_data => 65536},
+    Framed = roadrunner_quic_tls_hello:build_encrypted_extensions(#{
+        alpn => ~"h3", transport_params => Params
+    }),
+    [{8, Body}] = ?C:deframe_all(Framed),
+    Parsed = ?C:parse_encrypted_extensions(Body),
+    ?assertEqual(~"h3", maps:get(alpn, Parsed)),
+    ?assertEqual(Params, maps:get(transport_params, Parsed)).
+
+encrypted_extensions_absent_extensions_test() ->
+    %% No ALPN, no transport params: both keys are simply absent.
+    Framed = roadrunner_quic_tls_hello:build_encrypted_extensions(#{}),
+    [{8, Body}] = ?C:deframe_all(Framed),
+    ?assertEqual(#{}, ?C:parse_encrypted_extensions(Body)).
+
+certificate_round_trip_test() ->
+    Chain = [<<"leaf-der">>, <<"intermediate-der">>],
+    Framed = roadrunner_quic_tls_auth:build_certificate(Chain),
+    [{11, Body}] = ?C:deframe_all(Framed),
+    ?assertEqual(Chain, ?C:parse_certificate(Body)).
+
+certificate_verify_round_trip_test() ->
+    {Scheme, PrivKey} = ?C:key_material(),
+    Hash = crypto:strong_rand_bytes(32),
+    Framed = roadrunner_quic_tls_auth:build_certificate_verify(Scheme, PrivKey, Hash),
+    [{15, Body}] = ?C:deframe_all(Framed),
+    {ParsedScheme, Signature} = ?C:parse_certificate_verify(Body),
+    ?assertEqual(Scheme, ParsedScheme),
+    ?assert(byte_size(Signature) > 0).
+
+finished_round_trip_test() ->
+    TrafficSecret = crypto:strong_rand_bytes(32),
+    Hash = crypto:strong_rand_bytes(32),
+    Framed = roadrunner_quic_tls_auth:build_finished(TrafficSecret, Hash),
+    [{20, Body}] = ?C:deframe_all(Framed),
+    FinishedKey = roadrunner_quic_tls_crypto:finished_key(TrafficSecret),
+    Expected = roadrunner_quic_tls_crypto:verify_data(FinishedKey, Hash),
+    ?assertEqual(Expected, ?C:parse_finished(Body)).

--- a/test/roadrunner_quic_test_client_tests.erl
+++ b/test/roadrunner_quic_test_client_tests.erl
@@ -31,7 +31,12 @@ encrypted_extensions_round_trip_test() ->
     [{8, Body}] = ?C:deframe_all(Framed),
     Parsed = ?C:parse_encrypted_extensions(Body),
     ?assertEqual(~"h3", maps:get(alpn, Parsed)),
-    ?assertEqual(Params, maps:get(transport_params, Parsed)).
+    %% The transport parameters are captured as raw bytes (the client does not
+    %% decode them); they equal the server's encoding.
+    ?assertEqual(
+        iolist_to_binary(roadrunner_quic_transport_params:encode(Params)),
+        maps:get(transport_params, Parsed)
+    ).
 
 encrypted_extensions_absent_extensions_test() ->
     %% No ALPN, no transport params: both keys are simply absent.

--- a/test/roadrunner_quic_test_conn.erl
+++ b/test/roadrunner_quic_test_conn.erl
@@ -2,14 +2,20 @@
 -moduledoc false.
 
 %% In-test native QUIC CLIENT connection: a proc_lib process that connects to
-%% the native server over UDP and completes the QUIC + TLS 1.3 handshake, the
-%% client counterpart to roadrunner_quic_connection. Scope: the handshake to
-%% "connected" (the server's HANDSHAKE_DONE received). It owns its own UDP
-%% socket and reads it directly (unlike the server shell, which the listener
-%% feeds). The packet/frame/key pipeline is the production roadrunner_quic_*
-%% modules (role-agnostic); the TLS handshake is driven by
+%% the native server over UDP, completes the QUIC + TLS 1.3 handshake, and
+%% then carries 1-RTT application streams. The client counterpart to
+%% roadrunner_quic_connection. It owns its own UDP socket and reads it
+%% directly (unlike the server shell, which the listener feeds). The
+%% packet/frame/key pipeline is the production roadrunner_quic_* modules
+%% (role-agnostic); the TLS handshake is driven by
 %% roadrunner_quic_test_handshake over the client primitives in
 %% roadrunner_quic_test_client.
+%%
+%% Once connected, the owner opens streams (open_bidi/open_uni) and writes
+%% with send/4; the loop sends each as a STREAM frame in a 1-RTT packet and
+%% delivers received stream data back to the owner as
+%% {quic_test_stream, Conn, StreamId, Data, Fin}. The h3 framing on top is
+%% roadrunner_quic_test_h3.
 %%
 %% The CID flow (RFC 9000 §17.2/§7.2): the client picks a random Initial DCID
 %% (the server's Initial-key + original_destination_connection_id anchor) and
@@ -25,7 +31,7 @@
 
 -include_lib("public_key/include/public_key.hrl").
 
--export([connect/2, close/1]).
+-export([connect/2, close/1, open_bidi/1, open_uni/1, send/4]).
 
 %% v1 connection-id length and signature scheme (the test cert is RSA).
 -define(CID_LEN, 8).
@@ -50,8 +56,16 @@
         #{server := roadrunner_quic_keys:keys(), client := roadrunner_quic_keys:keys()}
         | undefined,
     app_server_keys :: roadrunner_quic_keys:keys() | undefined,
+    app_client_keys :: roadrunner_quic_keys:keys() | undefined,
+    owner :: pid() | undefined,
     finished_sent = false :: boolean(),
-    datagrams = [] :: [binary()]
+    datagrams = [] :: [binary()],
+    %% 1-RTT stream state (RFC 9000 §2.1 client-initiated stream ids).
+    next_bidi = 0 :: non_neg_integer(),
+    next_uni = 2 :: non_neg_integer(),
+    send_pn = 0 :: non_neg_integer(),
+    send_offsets = #{} :: #{non_neg_integer() => non_neg_integer()},
+    recv_streams = #{} :: #{non_neg_integer() => roadrunner_quic_stream:t()}
 }).
 
 %% =============================================================================
@@ -90,6 +104,40 @@ close(Pid) ->
     Pid ! stop,
     ok.
 
+-doc "Allocate a client-initiated bidirectional stream id (RFC 9000 §2.1).".
+-spec open_bidi(pid()) -> non_neg_integer().
+open_bidi(Pid) ->
+    call(Pid, open_bidi).
+
+-doc "Allocate a client-initiated unidirectional stream id (RFC 9000 §2.1).".
+-spec open_uni(pid()) -> non_neg_integer().
+open_uni(Pid) ->
+    call(Pid, open_uni).
+
+-doc """
+Send `Data` on `StreamId` in a 1-RTT packet, with the FIN bit when `Fin`.
+Received stream data is delivered to the connection owner as
+`{quic_test_stream, Conn, StreamId, Data, Fin}`.
+""".
+-spec send(pid(), non_neg_integer(), binary(), boolean()) -> ok.
+send(Pid, StreamId, Data, Fin) ->
+    Ref = make_ref(),
+    Pid ! {send, self(), Ref, StreamId, Data, Fin},
+    receive
+        {Ref, ok} -> ok
+    after 5000 ->
+        {error, timeout}
+    end.
+
+call(Pid, Request) ->
+    Ref = make_ref(),
+    Pid ! {Request, self(), Ref},
+    receive
+        {Ref, Result} -> Result
+    after 5000 ->
+        {error, timeout}
+    end.
+
 %% =============================================================================
 %% Handshake
 %% =============================================================================
@@ -114,6 +162,7 @@ init(Parent, Ref, Host, Port) ->
         scid = Scid,
         eph_priv = EphPriv,
         ch_framed = ChFramed,
+        owner = Parent,
         server_initial_keys = roadrunner_quic_keys:initial_server(Dcid0)
     },
     case handshake(Conn) of
@@ -225,7 +274,9 @@ complete(Conn, ServerHelloFramed, HandshakeBytes) ->
         {ok, #{installs := Installs, client_finished := ClientFinished}} ->
             send_client_finished(Conn, keys_for(handshake, client, Installs), ClientFinished),
             {continue, Conn#conn{
-                finished_sent = true, app_server_keys = keys_for(application, server, Installs)
+                finished_sent = true,
+                app_server_keys = keys_for(application, server, Installs),
+                app_client_keys = keys_for(application, client, Installs)
             }};
         {error, Reason} ->
             {error, Reason}
@@ -270,16 +321,98 @@ server_public_key(HandshakeBytes) ->
 %% Connected
 %% =============================================================================
 
-%% Idle once connected; the handshake milestone is reached. close/1 stops it.
+%% The 1-RTT loop: serve the owner's stream control calls, and read the
+%% socket for the server's 1-RTT packets, delivering received stream data to
+%% the owner. Owner calls are handled ahead of socket reads (the `after 0`),
+%% and the socket is polled briefly so both stay responsive in one process.
 -spec connected_loop(#conn{}) -> ok.
 connected_loop(#conn{socket = Socket} = Conn) ->
     receive
+        {open_bidi, From, Ref} ->
+            Id = Conn#conn.next_bidi,
+            From ! {Ref, Id},
+            connected_loop(Conn#conn{next_bidi = Id + 4});
+        {open_uni, From, Ref} ->
+            Id = Conn#conn.next_uni,
+            From ! {Ref, Id},
+            connected_loop(Conn#conn{next_uni = Id + 4});
+        {send, From, Ref, StreamId, Data, Fin} ->
+            Conn1 = send_stream(Conn, StreamId, Data, Fin),
+            From ! {Ref, ok},
+            connected_loop(Conn1);
         stop ->
             _ = roadrunner_quic_socket:close(Socket),
             ok;
         _Other ->
             connected_loop(Conn)
+    after 0 ->
+        case roadrunner_quic_socket:recv(Socket, 50) of
+            {ok, _Peer, Datagram} -> connected_loop(handle_app_datagram(Conn, Datagram));
+            {error, timeout} -> connected_loop(Conn)
+        end
     end.
+
+%% Send a STREAM frame on a 1-RTT (short-header) packet addressed to the
+%% server's CID, tracking the per-stream offset and the 1-RTT packet number.
+-spec send_stream(#conn{}, non_neg_integer(), binary(), boolean()) -> #conn{}.
+send_stream(
+    #conn{
+        socket = Socket,
+        host = Host,
+        port = Port,
+        scid = Scid,
+        server_scid = ServerScid,
+        app_client_keys = Keys,
+        send_pn = Pn,
+        send_offsets = Offsets
+    } = Conn,
+    StreamId,
+    Data,
+    Fin
+) ->
+    Offset = maps:get(StreamId, Offsets, 0),
+    Frame = {stream, StreamId, Offset, Data, Fin},
+    {Datagram, _Sent} = roadrunner_quic_send:datagram(
+        #{application => #{frames => [Frame], keys => Keys, pn => Pn}}, ServerScid, Scid
+    ),
+    ok = roadrunner_quic_socket:send(Socket, Host, Port, Datagram),
+    Conn#conn{send_pn = Pn + 1, send_offsets = Offsets#{StreamId => Offset + byte_size(Data)}}.
+
+%% Decrypt a 1-RTT datagram and route its STREAM frames through per-stream
+%% reassembly, delivering deliverable bytes to the owner.
+-spec handle_app_datagram(#conn{}, binary()) -> #conn{}.
+handle_app_datagram(#conn{app_server_keys = Keys, scid = Scid} = Conn, Datagram) ->
+    Outcomes = roadrunner_quic_recv:datagram(
+        Datagram, byte_size(Scid), #{application => Keys}, #{}
+    ),
+    Frames = lists:append([Fs || {ok, #{level := application, frames := Fs}} <- Outcomes]),
+    lists:foldl(fun handle_app_frame/2, Conn, Frames).
+
+-spec handle_app_frame(roadrunner_quic_frame:frame(), #conn{}) -> #conn{}.
+handle_app_frame({stream, StreamId, Offset, Data, Fin}, Conn) ->
+    deliver_stream(Conn, StreamId, Offset, Data, Fin);
+handle_app_frame(_Other, Conn) ->
+    Conn.
+
+-spec deliver_stream(#conn{}, non_neg_integer(), non_neg_integer(), binary(), boolean()) -> #conn{}.
+deliver_stream(#conn{recv_streams = Streams, owner = Owner} = Conn, StreamId, Offset, Data, Fin) ->
+    Stream0 = maps:get(StreamId, Streams, roadrunner_quic_stream:new()),
+    case roadrunner_quic_stream:receive_data(Offset, Data, Fin, Stream0) of
+        {ok, Deliverable, FinReached, Stream1} ->
+            maybe_deliver(Owner, StreamId, Deliverable, FinReached),
+            Conn#conn{recv_streams = Streams#{StreamId => Stream1}};
+        {error, _Reason} ->
+            Conn
+    end.
+
+%% Deliver new contiguous bytes (or a bare FIN) to the owner; a gap that
+%% produced nothing new and no FIN is silent.
+-spec maybe_deliver(pid(), non_neg_integer(), binary(), boolean()) -> ok.
+maybe_deliver(_Owner, _StreamId, <<>>, false) ->
+    ok;
+maybe_deliver(Owner, StreamId, Deliverable, FinReached) ->
+    _ = Owner ! {quic_test_stream, self(), StreamId, Deliverable, FinReached},
+    ok.
 
 %% =============================================================================
 %% Internal

--- a/test/roadrunner_quic_test_conn.erl
+++ b/test/roadrunner_quic_test_conn.erl
@@ -1,0 +1,309 @@
+-module(roadrunner_quic_test_conn).
+-moduledoc false.
+
+%% In-test native QUIC CLIENT connection: a proc_lib process that connects to
+%% the native server over UDP and completes the QUIC + TLS 1.3 handshake, the
+%% client counterpart to roadrunner_quic_connection. Scope: the handshake to
+%% "connected" (the server's HANDSHAKE_DONE received). It owns its own UDP
+%% socket and reads it directly (unlike the server shell, which the listener
+%% feeds). The packet/frame/key pipeline is the production roadrunner_quic_*
+%% modules (role-agnostic); the TLS handshake is driven by
+%% roadrunner_quic_test_handshake over the client primitives in
+%% roadrunner_quic_test_client.
+%%
+%% The CID flow (RFC 9000 §17.2/§7.2): the client picks a random Initial DCID
+%% (the server's Initial-key + original_destination_connection_id anchor) and
+%% a random source CID; the server replies addressed to the client's source
+%% CID and carries its own SCID, which the client then uses as the
+%% destination CID for its Handshake and 1-RTT packets.
+%%
+%% Decryption is two-phase: the client decrypts the server Initial with the
+%% Initial keys to recover the ServerHello, derives the handshake keys from
+%% it, then decrypts the Handshake-level packets (carrying EE/Cert/CertVerify/
+%% Finished). recv drops packets whose level has no key yet, so re-running it
+%% over the buffered datagrams as keys unlock reassembles the full flight.
+
+-include_lib("public_key/include/public_key.hrl").
+
+-export([connect/2, close/1]).
+
+%% v1 connection-id length and signature scheme (the test cert is RSA).
+-define(CID_LEN, 8).
+-define(SIG_SCHEME, 16#0804).
+-define(RECV_TIMEOUT, 3000).
+-define(CONNECT_TIMEOUT, 8000).
+
+%% Handshake message types (RFC 8446 §4).
+-define(CERTIFICATE, 11).
+-define(FINISHED, 20).
+
+-record(conn, {
+    socket :: roadrunner_quic_socket:socket(),
+    host :: inet:ip_address() | inet:hostname(),
+    port :: inet:port_number(),
+    scid :: binary(),
+    server_scid :: binary() | undefined,
+    eph_priv :: binary(),
+    ch_framed :: binary(),
+    server_initial_keys :: roadrunner_quic_keys:keys(),
+    hs_keys ::
+        #{server := roadrunner_quic_keys:keys(), client := roadrunner_quic_keys:keys()}
+        | undefined,
+    app_server_keys :: roadrunner_quic_keys:keys() | undefined,
+    finished_sent = false :: boolean(),
+    datagrams = [] :: [binary()]
+}).
+
+%% =============================================================================
+%% API
+%% =============================================================================
+
+-doc """
+Connect to the native QUIC server at `Host`/`Port` and complete the
+handshake. Blocks until the connection is established (the server's
+HANDSHAKE_DONE arrives) or the handshake fails. Returns the connection pid.
+""".
+-spec connect(inet:ip_address() | inet:hostname(), inet:port_number()) ->
+    {ok, pid()} | {error, term()}.
+connect(Host, Port) ->
+    Ref = make_ref(),
+    Parent = self(),
+    {Pid, Mon} = spawn_monitor(fun() -> init(Parent, Ref, Host, Port) end),
+    receive
+        {Ref, connected} ->
+            erlang:demonitor(Mon, [flush]),
+            {ok, Pid};
+        {Ref, {error, Reason}} ->
+            erlang:demonitor(Mon, [flush]),
+            {error, Reason};
+        {'DOWN', Mon, process, Pid, Reason} ->
+            {error, {client_crashed, Reason}}
+    after ?CONNECT_TIMEOUT ->
+        erlang:demonitor(Mon, [flush]),
+        exit(Pid, kill),
+        {error, handshake_timeout}
+    end.
+
+-doc "Close the connection and its socket.".
+-spec close(pid()) -> ok.
+close(Pid) ->
+    Pid ! stop,
+    ok.
+
+%% =============================================================================
+%% Handshake
+%% =============================================================================
+
+-spec init(pid(), reference(), inet:ip_address() | inet:hostname(), inet:port_number()) -> ok.
+init(Parent, Ref, Host, Port) ->
+    {ok, Socket} = roadrunner_quic_socket:open(0),
+    Dcid0 = crypto:strong_rand_bytes(?CID_LEN),
+    Scid = crypto:strong_rand_bytes(?CID_LEN),
+    {EphPub, EphPriv} = crypto:generate_key(ecdh, x25519),
+    ChFramed = roadrunner_quic_test_client:client_hello_framed(?SIG_SCHEME, EphPub, Scid),
+    %% Send the Initial carrying the ClientHello (padded to 1200 by seal/6).
+    ClientInitialKeys = roadrunner_quic_keys:initial_client(Dcid0),
+    Initial = roadrunner_quic_test_client:seal(
+        initial, 0, ClientInitialKeys, [{crypto, 0, ChFramed}], Dcid0, Scid
+    ),
+    ok = roadrunner_quic_socket:send(Socket, Host, Port, Initial),
+    Conn = #conn{
+        socket = Socket,
+        host = Host,
+        port = Port,
+        scid = Scid,
+        eph_priv = EphPriv,
+        ch_framed = ChFramed,
+        server_initial_keys = roadrunner_quic_keys:initial_server(Dcid0)
+    },
+    case handshake(Conn) of
+        {ok, Conn1} ->
+            Parent ! {Ref, connected},
+            connected_loop(Conn1);
+        {error, Reason} ->
+            _ = roadrunner_quic_socket:close(Socket),
+            Parent ! {Ref, {error, Reason}},
+            ok
+    end.
+
+%% Read one datagram, buffer it, and drive the handshake as far as the
+%% buffered datagrams allow, until connected or a timeout.
+-spec handshake(#conn{}) -> {ok, #conn{}} | {error, term()}.
+handshake(Conn) ->
+    case roadrunner_quic_socket:recv(Conn#conn.socket, ?RECV_TIMEOUT) of
+        {ok, _Peer, Datagram} ->
+            Buffered = Conn#conn{datagrams = Conn#conn.datagrams ++ [Datagram]},
+            case advance(learn_server_scid(Buffered)) of
+                {connected, Conn1} -> {ok, Conn1};
+                {continue, Conn1} -> handshake(Conn1);
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, timeout} ->
+            {error, handshake_timeout}
+    end.
+
+%% The server addresses its reply to the client's source CID and carries its
+%% own SCID in its first long header; capture it for the client's later
+%% Handshake and 1-RTT destination CID.
+-spec learn_server_scid(#conn{}) -> #conn{}.
+learn_server_scid(#conn{server_scid = undefined, datagrams = [First | _]} = Conn) ->
+    case roadrunner_quic_packet:long_header_info(First) of
+        {ok, #{scid := ServerScid}} -> Conn#conn{server_scid = ServerScid};
+        _ -> Conn
+    end;
+learn_server_scid(Conn) ->
+    Conn.
+
+-spec advance(#conn{}) -> {continue | connected, #conn{}} | {error, term()}.
+advance(#conn{finished_sent = false, hs_keys = undefined} = Conn) ->
+    %% Need the ServerHello to derive the handshake keys.
+    case server_hello(Conn) of
+        incomplete ->
+            {continue, Conn};
+        {ok, ServerHelloFramed} ->
+            HsKeys = roadrunner_quic_test_handshake:handshake_keys(
+                #{eph_priv => Conn#conn.eph_priv, client_hello_framed => Conn#conn.ch_framed},
+                ServerHelloFramed
+            ),
+            advance(Conn#conn{hs_keys = HsKeys})
+    end;
+advance(#conn{finished_sent = false} = Conn) ->
+    %% Have the handshake keys; try to complete the server flight.
+    case server_flight(Conn) of
+        incomplete -> {continue, Conn};
+        {ok, ServerHelloFramed, HandshakeBytes} -> complete(Conn, ServerHelloFramed, HandshakeBytes)
+    end;
+advance(#conn{finished_sent = true} = Conn) ->
+    %% Finished sent; the server's HANDSHAKE_DONE confirms the handshake.
+    case handshake_done_received(Conn) of
+        true -> {connected, Conn};
+        false -> {continue, Conn}
+    end.
+
+%% The contiguous Initial CRYPTO bytes, once they hold a complete ServerHello.
+-spec server_hello(#conn{}) -> {ok, binary()} | incomplete.
+server_hello(#conn{datagrams = Datagrams, server_initial_keys = Keys}) ->
+    Bytes = roadrunner_quic_test_client:crypto_bytes(
+        Datagrams, initial, #{initial => Keys}, ?CID_LEN
+    ),
+    case deframe_complete(Bytes) of
+        {complete, [{2, _} | _]} -> {ok, Bytes};
+        _ -> incomplete
+    end.
+
+%% The Initial ServerHello and the Handshake-level flight, once both reassemble
+%% completely (the flight ends with the server Finished).
+-spec server_flight(#conn{}) -> {ok, binary(), binary()} | incomplete.
+server_flight(#conn{datagrams = Datagrams, server_initial_keys = SIK, hs_keys = #{server := SHK}}) ->
+    ShBytes = roadrunner_quic_test_client:crypto_bytes(
+        Datagrams, initial, #{initial => SIK}, ?CID_LEN
+    ),
+    HsBytes = roadrunner_quic_test_client:crypto_bytes(
+        Datagrams, handshake, #{handshake => SHK}, ?CID_LEN
+    ),
+    case {deframe_complete(ShBytes), deframe_complete(HsBytes)} of
+        {{complete, [{2, _} | _]}, {complete, Messages}} ->
+            case lists:keymember(?FINISHED, 1, Messages) of
+                true -> {ok, ShBytes, HsBytes};
+                false -> incomplete
+            end;
+        _ ->
+            incomplete
+    end.
+
+%% Drive the handshake to its end: verify the flight, send the client
+%% Finished, and arm the application keys for HANDSHAKE_DONE.
+-spec complete(#conn{}, binary(), binary()) -> {continue, #conn{}} | {error, term()}.
+complete(Conn, ServerHelloFramed, HandshakeBytes) ->
+    Config = #{
+        eph_priv => Conn#conn.eph_priv,
+        client_hello_framed => Conn#conn.ch_framed,
+        server_pubkey => server_public_key(HandshakeBytes)
+    },
+    Flight = #{initial => ServerHelloFramed, handshake => HandshakeBytes},
+    case roadrunner_quic_test_handshake:process_server_flight(Config, Flight) of
+        {ok, #{installs := Installs, client_finished := ClientFinished}} ->
+            send_client_finished(Conn, keys_for(handshake, client, Installs), ClientFinished),
+            {continue, Conn#conn{
+                finished_sent = true, app_server_keys = keys_for(application, server, Installs)
+            }};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% Send the client Finished as a Handshake-level CRYPTO frame, addressed to
+%% the server's SCID.
+-spec send_client_finished(#conn{}, roadrunner_quic_keys:keys(), iolist()) -> ok.
+send_client_finished(
+    #conn{socket = Socket, host = Host, port = Port, scid = Scid, server_scid = ServerScid},
+    ClientHsKeys,
+    ClientFinished
+) ->
+    Frames = [{crypto, 0, iolist_to_binary(ClientFinished)}],
+    {Datagram, _Sent} = roadrunner_quic_send:datagram(
+        #{handshake => #{frames => Frames, keys => ClientHsKeys, pn => 0}}, ServerScid, Scid
+    ),
+    ok = roadrunner_quic_socket:send(Socket, Host, Port, Datagram).
+
+%% Whether the server's 1-RTT packets carry HANDSHAKE_DONE (RFC 9001 §4.1.2).
+%% Short-header packets are addressed to the client's source CID.
+-spec handshake_done_received(#conn{}) -> boolean().
+handshake_done_received(#conn{datagrams = Datagrams, app_server_keys = AppKeys, scid = Scid}) ->
+    Frames = roadrunner_quic_test_client:frames(
+        Datagrams, application, #{application => AppKeys}, byte_size(Scid)
+    ),
+    lists:member(handshake_done, Frames).
+
+%% The server's public key, from the leaf certificate in the flight, to verify
+%% CertificateVerify.
+-spec server_public_key(binary()) -> public_key:public_key().
+server_public_key(HandshakeBytes) ->
+    {complete, Messages} = deframe_complete(HandshakeBytes),
+    {?CERTIFICATE, CertBody} = lists:keyfind(?CERTIFICATE, 1, Messages),
+    [LeafDer | _] = roadrunner_quic_test_client:parse_certificate(CertBody),
+    OtpCert = public_key:pkix_decode_cert(LeafDer, otp),
+    Tbs = OtpCert#'OTPCertificate'.tbsCertificate,
+    Spki = Tbs#'OTPTBSCertificate'.subjectPublicKeyInfo,
+    Spki#'OTPSubjectPublicKeyInfo'.subjectPublicKey.
+
+%% =============================================================================
+%% Connected
+%% =============================================================================
+
+%% Idle once connected; the handshake milestone is reached. close/1 stops it.
+-spec connected_loop(#conn{}) -> ok.
+connected_loop(#conn{socket = Socket} = Conn) ->
+    receive
+        stop ->
+            _ = roadrunner_quic_socket:close(Socket),
+            ok;
+        _Other ->
+            connected_loop(Conn)
+    end.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% Deframe as many complete handshake messages as the bytes hold; report
+%% whether the buffer ends on a message boundary (`complete`) or needs more.
+-spec deframe_complete(binary()) -> {complete | incomplete, [{byte(), binary()}]}.
+deframe_complete(Bytes) ->
+    deframe_complete(Bytes, []).
+
+deframe_complete(<<>>, Acc) ->
+    {complete, lists:reverse(Acc)};
+deframe_complete(Bytes, Acc) ->
+    case roadrunner_quic_tls_handshake:decode(Bytes) of
+        {ok, {Type, Body}, Rest} -> deframe_complete(Rest, [{Type, Body} | Acc]);
+        {more, _} -> {incomplete, lists:reverse(Acc)}
+    end.
+
+-spec keys_for(
+    handshake | application,
+    server | client,
+    [roadrunner_quic_test_handshake:install()]
+) -> roadrunner_quic_keys:keys().
+keys_for(Level, Role, Installs) ->
+    [Keys] = [K || {L, R, K} <- Installs, L =:= Level, R =:= Role],
+    Keys.

--- a/test/roadrunner_quic_test_conn_SUITE.erl
+++ b/test/roadrunner_quic_test_conn_SUITE.erl
@@ -1,0 +1,115 @@
+-module(roadrunner_quic_test_conn_SUITE).
+-moduledoc false.
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0, init_per_suite/1, end_per_suite/1]).
+-export([native_client_completes_handshake/1]).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [native_client_completes_handshake].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(ssl),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% =============================================================================
+%% The native QUIC client completes a real handshake against the native
+%% connection shell over loopback, with no dep involved on either side.
+%% =============================================================================
+
+native_client_completes_handshake(_Config) ->
+    %% A minimal in-test listener: the pump owns one UDP socket, reads it, and
+    %% routes each datagram to a per-peer native shell that replies on the same
+    %% socket (the same harness the dep-client interop suite uses).
+    Test = self(),
+    Pump = spawn_link(fun() ->
+        {ok, Socket} = roadrunner_quic_socket:open(0),
+        {ok, {_Ip, Port}} = roadrunner_quic_socket:sockname(Socket),
+        Test ! {pump_port, self(), Port},
+        pump_loop(Socket, #{})
+    end),
+    Port =
+        receive
+            {pump_port, Pump, P} -> P
+        after 2000 ->
+            exit(pump_no_port)
+        end,
+
+    Result =
+        case roadrunner_quic_test_conn:connect({127, 0, 0, 1}, Port) of
+            {ok, Conn} ->
+                ok = roadrunner_quic_test_conn:close(Conn),
+                ok;
+            {error, Reason} ->
+                {error, Reason}
+        end,
+
+    unlink(Pump),
+    exit(Pump, shutdown),
+    ?assertEqual(ok, Result).
+
+%% =============================================================================
+%% Listener pump + per-connection shell wiring (mirrors the interop suite)
+%% =============================================================================
+
+pump_loop(Socket, Conns) ->
+    case roadrunner_quic_socket:recv(Socket, 500) of
+        {ok, Peer, Datagram} ->
+            Shell =
+                case Conns of
+                    #{Peer := Existing} -> Existing;
+                    #{} -> start_shell(Socket, Peer, Datagram)
+                end,
+            Shell ! {quic_datagram, Peer, Datagram},
+            pump_loop(Socket, Conns#{Peer => Shell});
+        {error, timeout} ->
+            pump_loop(Socket, Conns)
+    end.
+
+start_shell(Socket, Peer, FirstDatagram) ->
+    {ok, ClientDCID} = roadrunner_quic_packet:dcid(FirstDatagram, 8),
+    {ok, #{scid := ClientSCID}} = roadrunner_quic_packet:long_header_info(FirstDatagram),
+    ServerSCID = crypto:strong_rand_bytes(8),
+    {EphPub, EphPriv} = crypto:generate_key(ecdh, x25519),
+    {CertChain, PrivKey} = cert_key(),
+    Config = #{
+        dcid => ClientDCID,
+        scid => ServerSCID,
+        peer_scid => ClientSCID,
+        peer => Peer,
+        cert_chain => CertChain,
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => #{
+            original_destination_connection_id => ClientDCID,
+            initial_source_connection_id => ServerSCID,
+            initial_max_data => 1048576,
+            initial_max_stream_data_bidi_local => 262144,
+            initial_max_stream_data_bidi_remote => 262144,
+            initial_max_stream_data_uni => 262144,
+            initial_max_streams_bidi => 100,
+            initial_max_streams_uni => 100,
+            max_idle_timeout => 30000
+        },
+        eph_pub => EphPub,
+        eph_priv => EphPriv,
+        server_random => crypto:strong_rand_bytes(32)
+    },
+    {ok, Shell} = roadrunner_quic_connection:start(Socket, Config),
+    true = link(Shell),
+    Shell.
+
+cert_key() ->
+    Opts = roadrunner_test_certs:server_opts(),
+    {cert, CertDer} = lists:keyfind(cert, 1, Opts),
+    {key, {KeyType, KeyDer}} = lists:keyfind(key, 1, Opts),
+    {[CertDer], public_key:der_decode(KeyType, KeyDer)}.

--- a/test/roadrunner_quic_test_h3.erl
+++ b/test/roadrunner_quic_test_h3.erl
@@ -1,0 +1,125 @@
+-module(roadrunner_quic_test_h3).
+-moduledoc false.
+
+%% In-test native HTTP/3 client over roadrunner_quic_test_conn: opens the
+%% client control stream and sends SETTINGS (RFC 9114 §6.2.1), then issues
+%% requests on client-initiated bidirectional streams (QPACK-encoded HEADERS
+%% plus optional DATA) and collects the response. The h3 framing is the
+%% production roadrunner_quic_h3_frame + roadrunner_qpack (static table only,
+%% both directions). The connection delivers received stream data to this
+%% module's caller (the connection owner), so connect/2 and the request calls
+%% run in the same process.
+
+-export([connect/2, close/1, get/2, post/3]).
+
+-define(COLLECT_TIMEOUT, 5000).
+
+%% =============================================================================
+%% API
+%% =============================================================================
+
+-doc """
+Connect to the native HTTP/3 server and set up the client control stream
+with a SETTINGS frame. Returns the underlying connection handle.
+""".
+-spec connect(inet:ip_address() | inet:hostname(), inet:port_number()) ->
+    {ok, pid()} | {error, term()}.
+connect(Host, Port) ->
+    case roadrunner_quic_test_conn:connect(Host, Port) of
+        {ok, Conn} ->
+            Control = roadrunner_quic_test_conn:open_uni(Conn),
+            ok = roadrunner_quic_test_conn:send(Conn, Control, control_with_settings(), false),
+            {ok, Conn};
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc "Close the connection.".
+-spec close(pid()) -> ok.
+close(Conn) ->
+    roadrunner_quic_test_conn:close(Conn).
+
+-doc "Issue a GET and collect the response as `{Status, Headers, Body}`.".
+-spec get(pid(), binary()) -> {non_neg_integer(), [{binary(), binary()}], binary()} | timeout.
+get(Conn, Path) ->
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    send_headers(Conn, StreamId, headers(~"GET", Path), true),
+    collect(Conn, StreamId, <<>>).
+
+-doc "Issue a POST with `Body` and collect the response as `{Status, Headers, Body}`.".
+-spec post(pid(), binary(), binary()) ->
+    {non_neg_integer(), [{binary(), binary()}], binary()} | timeout.
+post(Conn, Path, Body) ->
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    send_headers(Conn, StreamId, headers(~"POST", Path), false),
+    DataFrame = roadrunner_quic_h3_frame:encode_data(Body),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, iolist_to_binary(DataFrame), true),
+    collect(Conn, StreamId, <<>>).
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+-spec send_headers(pid(), non_neg_integer(), [{binary(), binary()}], boolean()) -> ok.
+send_headers(Conn, StreamId, Headers, Fin) ->
+    Frame = roadrunner_quic_h3_frame:encode_headers(roadrunner_qpack:encode(Headers)),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, iolist_to_binary(Frame), Fin).
+
+%% Accumulate the request stream's bytes until its FIN, then decode the h3
+%% response. Stream data for other streams (the server's control / QPACK
+%% streams) is left in the mailbox.
+-spec collect(pid(), non_neg_integer(), binary()) ->
+    {non_neg_integer(), [{binary(), binary()}], binary()} | timeout.
+collect(Conn, StreamId, Acc) ->
+    receive
+        {quic_test_stream, Conn, StreamId, Data, true} ->
+            decode_response(<<Acc/binary, Data/binary>>);
+        {quic_test_stream, Conn, StreamId, Data, false} ->
+            collect(Conn, StreamId, <<Acc/binary, Data/binary>>)
+    after ?COLLECT_TIMEOUT ->
+        timeout
+    end.
+
+-spec decode_response(binary()) -> {non_neg_integer(), [{binary(), binary()}], binary()}.
+decode_response(Bytes) ->
+    Frames = decode_frames(Bytes),
+    {ok, Headers} = roadrunner_qpack:decode(first_headers_block(Frames)),
+    {status(Headers), Headers, response_body(Frames)}.
+
+-spec decode_frames(binary()) -> [tuple()].
+decode_frames(<<>>) ->
+    [];
+decode_frames(Bytes) ->
+    {ok, Frame, Rest} = roadrunner_quic_h3_frame:decode(Bytes),
+    [Frame | decode_frames(Rest)].
+
+-spec first_headers_block([tuple()]) -> binary().
+first_headers_block([{headers, Block} | _]) -> Block;
+first_headers_block([_ | Rest]) -> first_headers_block(Rest).
+
+-spec response_body([tuple()]) -> binary().
+response_body(Frames) ->
+    iolist_to_binary([Data || {data, Data} <- Frames]).
+
+-spec status([{binary(), binary()}]) -> non_neg_integer().
+status(Headers) ->
+    {~":status", Value} = lists:keyfind(~":status", 1, Headers),
+    binary_to_integer(Value).
+
+%% The control stream-type prefix followed by a SETTINGS frame (RFC 9114
+%% §6.2.1 / §7.2.4); static-table-only QPACK advertises a zero table capacity.
+-spec control_with_settings() -> binary().
+control_with_settings() ->
+    iolist_to_binary([
+        roadrunner_quic_h3_frame:encode_stream_type(control),
+        roadrunner_quic_h3_frame:encode_settings(#{qpack_max_table_capacity => 0})
+    ]).
+
+-spec headers(binary(), binary()) -> [{binary(), binary()}].
+headers(Method, Path) ->
+    [
+        {~":method", Method},
+        {~":scheme", ~"https"},
+        {~":authority", ~"localhost"},
+        {~":path", Path}
+    ].

--- a/test/roadrunner_quic_test_h3_SUITE.erl
+++ b/test/roadrunner_quic_test_h3_SUITE.erl
@@ -1,0 +1,80 @@
+-module(roadrunner_quic_test_h3_SUITE).
+-moduledoc false.
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0, init_per_suite/1, end_per_suite/1]).
+-export([init_per_testcase/2, end_per_testcase/2]).
+-export([native_client_get/1, native_client_post/1]).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [native_client_get, native_client_post].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(ssl),
+    %% The h3 listener's drain group lives in the default `pg` scope; start it
+    %% unlinked so it outlives this transient process. Neither the native
+    %% server nor the native client needs the `quic` app.
+    ok = ensure_pg_started(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% A default single-handler h3 listener per testcase (start_link binds it to
+%% the testcase process, RFC-legal h3 responses only).
+init_per_testcase(_Case, Config) ->
+    {ok, _} = roadrunner_listener:start_link(?MODULE, #{
+        port => 0,
+        protocols => [http3],
+        tls => roadrunner_test_certs:server_opts(),
+        routes => roadrunner_h3_test_handler
+    }),
+    [{port, roadrunner_listener:port(?MODULE)} | Config].
+
+end_per_testcase(_Case, _Config) ->
+    _ = roadrunner_listener:stop(?MODULE),
+    ok.
+
+%% =============================================================================
+%% The native HTTP/3 client drives the native h3 server end to end, no dep.
+%% =============================================================================
+
+native_client_get(Config) ->
+    Port = ?config(port, Config),
+    {ok, Conn} = roadrunner_quic_test_h3:connect({127, 0, 0, 1}, Port),
+    {Status, _Headers, Body} = roadrunner_quic_test_h3:get(Conn, ~"/method"),
+    ok = roadrunner_quic_test_h3:close(Conn),
+    ?assertEqual(200, Status),
+    ?assertEqual(~"GET", Body).
+
+native_client_post(Config) ->
+    Port = ?config(port, Config),
+    {ok, Conn} = roadrunner_quic_test_h3:connect({127, 0, 0, 1}, Port),
+    {Status, _Headers, Body} = roadrunner_quic_test_h3:post(Conn, ~"/echo", ~"hello there"),
+    ok = roadrunner_quic_test_h3:close(Conn),
+    ?assertEqual(200, Status),
+    ?assertEqual(~"hello there", Body).
+
+%% =============================================================================
+%% Helpers
+%% =============================================================================
+
+ensure_pg_started() ->
+    case whereis(pg) of
+        undefined ->
+            case pg:start_link() of
+                {ok, Pid} ->
+                    _ = unlink(Pid),
+                    ok;
+                {error, {already_started, _}} ->
+                    ok
+            end;
+        _ ->
+            ok
+    end.

--- a/test/roadrunner_quic_test_handshake.erl
+++ b/test/roadrunner_quic_test_handshake.erl
@@ -1,0 +1,151 @@
+-module(roadrunner_quic_test_handshake).
+-moduledoc false.
+
+%% The client side of the TLS 1.3 / QUIC handshake sequencer, the in-test
+%% mirror of `roadrunner_quic_tls_server`. Given the client's x25519
+%% ephemeral private key, the ClientHello it sent, and the server's public
+%% key, it consumes the server's flight, runs ECDHE over the server's
+%% key_share, derives the handshake and application traffic secrets exactly
+%% as the server does, verifies the server's CertificateVerify and Finished,
+%% and produces the client's Finished. Pure: no process, no socket; the
+%% connection loop reassembles the CRYPTO bytes, installs the returned keys,
+%% and emits the client Finished. The transcript is threaded across the four
+%% hash boundaries (RFC 8446 §7.1) using the re-framed received messages,
+%% byte-identical to the wire bytes.
+
+-export([process_server_flight/2]).
+
+-export_type([config/0, flight/0, install/0, result/0]).
+
+%% Handshake message types (RFC 8446 §4).
+-define(SERVER_HELLO, 2).
+-define(ENCRYPTED_EXTENSIONS, 8).
+-define(CERTIFICATE, 11).
+-define(CERTIFICATE_VERIFY, 15).
+-define(FINISHED, 20).
+
+-type install() ::
+    {handshake | application, server | client, roadrunner_quic_keys:keys()}.
+
+-type config() :: #{
+    eph_priv := binary(),
+    client_hello_framed := binary(),
+    server_pubkey := public_key:public_key()
+}.
+
+-type flight() :: #{initial := iodata(), handshake := iodata()}.
+
+-type result() :: #{
+    installs := [install()],
+    client_finished := iolist(),
+    alpn := binary(),
+    peer_transport_params := roadrunner_quic_transport_params:params()
+}.
+
+-doc """
+Drive the client through the server's flight. `Config` carries the client's
+x25519 ephemeral private key, the framed ClientHello it sent (the transcript
+head), and the server's public key (to verify CertificateVerify). `Flight`
+is the server's `#{initial := ServerHello, handshake := EE++Cert++CertVerify++Finished}`
+CRYPTO bytes. Returns the ordered key installs (handshake before application,
+server then client), the framed client Finished, and the negotiated ALPN
+protocol and the server's transport parameters. Fails with
+`{error, handshake_verification_failed}` if the server CertificateVerify or
+Finished does not check out.
+""".
+-spec process_server_flight(config(), flight()) -> {ok, result()} | {error, atom()}.
+process_server_flight(
+    #{eph_priv := EphPriv, client_hello_framed := ClientHelloFramed, server_pubkey := ServerPubKey},
+    #{initial := InitialBytes, handshake := HandshakeBytes}
+) ->
+    [{?SERVER_HELLO, ShBody}] = roadrunner_quic_test_client:deframe_all(InitialBytes),
+    [
+        {?ENCRYPTED_EXTENSIONS, EeBody},
+        {?CERTIFICATE, CertBody},
+        {?CERTIFICATE_VERIFY, CvBody},
+        {?FINISHED, FinBody}
+    ] = roadrunner_quic_test_client:deframe_all(HandshakeBytes),
+
+    #{key_share := ServerKeyShare} = roadrunner_quic_test_client:parse_server_hello(ShBody),
+    #{alpn := Alpn, transport_params := PeerParams} =
+        roadrunner_quic_test_client:parse_encrypted_extensions(EeBody),
+
+    %% Re-frame the received bodies for the transcript (deterministic framing
+    %% makes this byte-identical to the wire bytes).
+    ServerHelloFramed = roadrunner_quic_tls_handshake:encode(?SERVER_HELLO, ShBody),
+    EeFramed = roadrunner_quic_tls_handshake:encode(?ENCRYPTED_EXTENSIONS, EeBody),
+    CertFramed = roadrunner_quic_tls_handshake:encode(?CERTIFICATE, CertBody),
+    CvFramed = roadrunner_quic_tls_handshake:encode(?CERTIFICATE_VERIFY, CvBody),
+    FinFramed = roadrunner_quic_tls_handshake:encode(?FINISHED, FinBody),
+
+    %% Handshake traffic secrets from the transcript through ServerHello.
+    ThroughServerHello = [ClientHelloFramed, ServerHelloFramed],
+    SharedSecret = crypto:compute_key(ecdh, ServerKeyShare, EphPriv, x25519),
+    HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
+        roadrunner_quic_tls_crypto:early_secret(), SharedSecret
+    ),
+    HelloHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughServerHello),
+    ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        client, handshake, HandshakeSecret, HelloHash
+    ),
+    ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
+        server, handshake, HandshakeSecret, HelloHash
+    ),
+
+    %% The server CertificateVerify signs the transcript through Certificate.
+    ThroughCertificate = [ThroughServerHello, EeFramed, CertFramed],
+    CertificateHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughCertificate),
+    {Scheme, Signature} = roadrunner_quic_test_client:parse_certificate_verify(CvBody),
+
+    %% The server Finished verify_data is over the transcript through CertVerify.
+    ThroughCertVerify = [ThroughCertificate, CvFramed],
+    CertVerifyHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughCertVerify),
+    ServerVerifyData = roadrunner_quic_test_client:parse_finished(FinBody),
+
+    maybe
+        true ?=
+            roadrunner_quic_test_client:verify_server_certificate_verify(
+                Scheme, Signature, ServerPubKey, CertificateHash
+            ),
+        true ?= verify_server_finished(ServerVerifyData, ServerHsSecret, CertVerifyHash),
+
+        %% Application traffic secrets from the transcript through the server
+        %% Finished; the client Finished is built over the same hash.
+        ThroughFinished = [ThroughCertVerify, FinFramed],
+        FinishedHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughFinished),
+        MasterSecret = roadrunner_quic_tls_crypto:master_secret(HandshakeSecret),
+        ClientApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+            client, application, MasterSecret, FinishedHash
+        ),
+        ServerApSecret = roadrunner_quic_tls_crypto:traffic_secret(
+            server, application, MasterSecret, FinishedHash
+        ),
+        ClientFinished = roadrunner_quic_tls_auth:build_finished(ClientHsSecret, FinishedHash),
+        Installs = [
+            {handshake, server, roadrunner_quic_keys:traffic_keys(ServerHsSecret)},
+            {handshake, client, roadrunner_quic_keys:traffic_keys(ClientHsSecret)},
+            {application, server, roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+            {application, client, roadrunner_quic_keys:traffic_keys(ClientApSecret)}
+        ],
+        {ok, #{
+            installs => Installs,
+            client_finished => ClientFinished,
+            alpn => Alpn,
+            peer_transport_params => PeerParams
+        }}
+    else
+        false -> {error, handshake_verification_failed}
+    end.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% The server Finished verify_data is HMAC(finished_key(ServerHsSecret),
+%% TranscriptHash); check it in constant time (RFC 8446 §4.4.4).
+-spec verify_server_finished(binary(), binary(), binary()) -> boolean().
+verify_server_finished(Received, ServerHsSecret, TranscriptHash) ->
+    Expected = roadrunner_quic_tls_crypto:verify_data(
+        roadrunner_quic_tls_crypto:finished_key(ServerHsSecret), TranscriptHash
+    ),
+    crypto:hash_equals(Received, Expected).

--- a/test/roadrunner_quic_test_handshake.erl
+++ b/test/roadrunner_quic_test_handshake.erl
@@ -12,8 +12,13 @@
 %% and emits the client Finished. The transcript is threaded across the four
 %% hash boundaries (RFC 8446 §7.1) using the re-framed received messages,
 %% byte-identical to the wire bytes.
+%%
+%% `handshake_keys/2` derives just the handshake-level packet keys from the
+%% ServerHello, so the connection loop can decrypt the Handshake-level
+%% packets (which carry the rest of the flight) before it has the whole
+%% flight.
 
--export([process_server_flight/2]).
+-export([handshake_keys/2, process_server_flight/2]).
 
 -export_type([config/0, flight/0, install/0, result/0]).
 
@@ -39,8 +44,37 @@
     installs := [install()],
     client_finished := iolist(),
     alpn := binary(),
-    peer_transport_params := roadrunner_quic_transport_params:params()
+    %% The server's transport parameters as raw bytes (see
+    %% roadrunner_quic_test_client:parse_encrypted_extensions/1).
+    peer_transport_params := binary()
 }.
+
+%% The handshake-secret derivation context shared by handshake_keys/2 and
+%% process_server_flight/2: the transcript through ServerHello and the
+%% handshake traffic secrets both ends derive from it.
+-type context() :: #{
+    handshake_secret := binary(),
+    client_hs_secret := binary(),
+    server_hs_secret := binary(),
+    through_server_hello := iolist()
+}.
+
+-doc """
+Derive the server and client handshake-level packet-protection keys from the
+ServerHello alone (the framed ServerHello bytes from the Initial CRYPTO
+stream). `Config` carries the client's x25519 ephemeral private key and the
+framed ClientHello it sent. The connection loop uses the server keys to
+decrypt the Handshake-level packets carrying the rest of the flight.
+""".
+-spec handshake_keys(config(), iodata()) ->
+    #{server := roadrunner_quic_keys:keys(), client := roadrunner_quic_keys:keys()}.
+handshake_keys(Config, ServerHelloFramed) ->
+    #{client_hs_secret := ClientHsSecret, server_hs_secret := ServerHsSecret} =
+        through_server_hello(Config, ServerHelloFramed),
+    #{
+        server => roadrunner_quic_keys:traffic_keys(ServerHsSecret),
+        client => roadrunner_quic_keys:traffic_keys(ClientHsSecret)
+    }.
 
 -doc """
 Drive the client through the server's flight. `Config` carries the client's
@@ -55,42 +89,30 @@ Finished does not check out.
 """.
 -spec process_server_flight(config(), flight()) -> {ok, result()} | {error, atom()}.
 process_server_flight(
-    #{eph_priv := EphPriv, client_hello_framed := ClientHelloFramed, server_pubkey := ServerPubKey},
+    #{server_pubkey := ServerPubKey} = Config,
     #{initial := InitialBytes, handshake := HandshakeBytes}
 ) ->
-    [{?SERVER_HELLO, ShBody}] = roadrunner_quic_test_client:deframe_all(InitialBytes),
+    #{
+        handshake_secret := HandshakeSecret,
+        client_hs_secret := ClientHsSecret,
+        server_hs_secret := ServerHsSecret,
+        through_server_hello := ThroughServerHello
+    } = through_server_hello(Config, InitialBytes),
     [
         {?ENCRYPTED_EXTENSIONS, EeBody},
         {?CERTIFICATE, CertBody},
         {?CERTIFICATE_VERIFY, CvBody},
         {?FINISHED, FinBody}
     ] = roadrunner_quic_test_client:deframe_all(HandshakeBytes),
-
-    #{key_share := ServerKeyShare} = roadrunner_quic_test_client:parse_server_hello(ShBody),
     #{alpn := Alpn, transport_params := PeerParams} =
         roadrunner_quic_test_client:parse_encrypted_extensions(EeBody),
 
     %% Re-frame the received bodies for the transcript (deterministic framing
     %% makes this byte-identical to the wire bytes).
-    ServerHelloFramed = roadrunner_quic_tls_handshake:encode(?SERVER_HELLO, ShBody),
     EeFramed = roadrunner_quic_tls_handshake:encode(?ENCRYPTED_EXTENSIONS, EeBody),
     CertFramed = roadrunner_quic_tls_handshake:encode(?CERTIFICATE, CertBody),
     CvFramed = roadrunner_quic_tls_handshake:encode(?CERTIFICATE_VERIFY, CvBody),
     FinFramed = roadrunner_quic_tls_handshake:encode(?FINISHED, FinBody),
-
-    %% Handshake traffic secrets from the transcript through ServerHello.
-    ThroughServerHello = [ClientHelloFramed, ServerHelloFramed],
-    SharedSecret = crypto:compute_key(ecdh, ServerKeyShare, EphPriv, x25519),
-    HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
-        roadrunner_quic_tls_crypto:early_secret(), SharedSecret
-    ),
-    HelloHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughServerHello),
-    ClientHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
-        client, handshake, HandshakeSecret, HelloHash
-    ),
-    ServerHsSecret = roadrunner_quic_tls_crypto:traffic_secret(
-        server, handshake, HandshakeSecret, HelloHash
-    ),
 
     %% The server CertificateVerify signs the transcript through Certificate.
     ThroughCertificate = [ThroughServerHello, EeFramed, CertFramed],
@@ -140,6 +162,33 @@ process_server_flight(
 %% =============================================================================
 %% Internal
 %% =============================================================================
+
+%% ECDHE over the server's key_share + the handshake key schedule, from the
+%% transcript through ServerHello. Mirrors the first half of the server's
+%% build_flight. Takes the framed ServerHello (the Initial CRYPTO bytes).
+-spec through_server_hello(config(), iodata()) -> context().
+through_server_hello(
+    #{eph_priv := EphPriv, client_hello_framed := ClientHelloFramed}, InitialBytes
+) ->
+    [{?SERVER_HELLO, ShBody}] = roadrunner_quic_test_client:deframe_all(InitialBytes),
+    #{key_share := ServerKeyShare} = roadrunner_quic_test_client:parse_server_hello(ShBody),
+    ServerHelloFramed = roadrunner_quic_tls_handshake:encode(?SERVER_HELLO, ShBody),
+    ThroughServerHello = [ClientHelloFramed, ServerHelloFramed],
+    SharedSecret = crypto:compute_key(ecdh, ServerKeyShare, EphPriv, x25519),
+    HandshakeSecret = roadrunner_quic_tls_crypto:handshake_secret(
+        roadrunner_quic_tls_crypto:early_secret(), SharedSecret
+    ),
+    HelloHash = roadrunner_quic_tls_crypto:transcript_hash(ThroughServerHello),
+    #{
+        handshake_secret => HandshakeSecret,
+        client_hs_secret => roadrunner_quic_tls_crypto:traffic_secret(
+            client, handshake, HandshakeSecret, HelloHash
+        ),
+        server_hs_secret => roadrunner_quic_tls_crypto:traffic_secret(
+            server, handshake, HandshakeSecret, HelloHash
+        ),
+        through_server_hello => ThroughServerHello
+    }.
 
 %% The server Finished verify_data is HMAC(finished_key(ServerHsSecret),
 %% TranscriptHash); check it in constant time (RFC 8446 §4.4.4).

--- a/test/roadrunner_quic_test_handshake_tests.erl
+++ b/test/roadrunner_quic_test_handshake_tests.erl
@@ -1,0 +1,94 @@
+-module(roadrunner_quic_test_handshake_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
+
+-define(SERVER, roadrunner_quic_tls_server).
+-define(CLIENT, roadrunner_quic_test_handshake).
+-define(TC, roadrunner_quic_test_client).
+
+%% The client driver is proven against the production server core: the client
+%% builds a ClientHello, the server processes it and emits its flight, the
+%% client drives the flight, and the two ends must agree on every key. The
+%% server must then accept the client's Finished. No dep oracle is involved.
+
+full_handshake_round_trip_test() ->
+    Scheme = 16#0804,
+    #'RSAPrivateKey'{modulus = N, publicExponent = E} =
+        PrivKey = public_key:generate_key({rsa, 2048, 65537}),
+    ServerPub = #'RSAPublicKey'{modulus = N, publicExponent = E},
+    {ClientPub, ClientPriv} = crypto:generate_key(ecdh, x25519),
+    {ServerEphPub, ServerEphPriv} = crypto:generate_key(ecdh, x25519),
+    ClientSCID = <<1, 2, 3, 4>>,
+    %% Server transport params the production decoder accepts as peer params
+    %% (no server-only parameters, which the server-side decoder rejects).
+    ServerParams = #{initial_source_connection_id => <<9, 9, 9, 9>>, initial_max_data => 65536},
+    ServerState = ?SERVER:new(#{
+        cert_chain => [~"leaf-der"],
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => ServerParams,
+        eph_pub => ServerEphPub,
+        eph_priv => ServerEphPriv,
+        server_random => crypto:strong_rand_bytes(32),
+        peer_scid => ClientSCID
+    }),
+
+    ClientHelloFramed = ?TC:client_hello_framed(Scheme, ClientPub, ClientSCID),
+    [{1, ClientHelloBody}] = ?TC:deframe_all(ClientHelloFramed),
+    {ok, Flight, ServerInstalls, ServerState1} =
+        ?SERVER:process_client_hello(ClientHelloBody, ServerState),
+
+    {ok, Result} = ?CLIENT:process_server_flight(
+        #{
+            eph_priv => ClientPriv,
+            client_hello_framed => ClientHelloFramed,
+            server_pubkey => ServerPub
+        },
+        Flight
+    ),
+
+    %% The client derived the same ordered key installs as the server.
+    ?assertEqual(ServerInstalls, maps:get(installs, Result)),
+    %% The client learned the negotiated ALPN and the server's transport params.
+    ?assertEqual(~"h3", maps:get(alpn, Result)),
+    ?assertEqual(ServerParams, maps:get(peer_transport_params, Result)),
+    %% The server accepts the client's Finished.
+    [{20, ClientFinishedBody}] = ?TC:deframe_all(maps:get(client_finished, Result)),
+    ?assertEqual(ok, ?SERVER:process_client_finished(ClientFinishedBody, ServerState1)).
+
+%% A server CertificateVerify signed with the wrong key fails client verification.
+rejects_bad_certificate_verify_test() ->
+    Scheme = 16#0804,
+    PrivKey = public_key:generate_key({rsa, 2048, 65537}),
+    WrongKey = public_key:generate_key({rsa, 2048, 65537}),
+    #'RSAPrivateKey'{modulus = N, publicExponent = E} = WrongKey,
+    WrongPub = #'RSAPublicKey'{modulus = N, publicExponent = E},
+    {ClientPub, ClientPriv} = crypto:generate_key(ecdh, x25519),
+    {ServerEphPub, ServerEphPriv} = crypto:generate_key(ecdh, x25519),
+    ClientSCID = <<1, 2, 3, 4>>,
+    ServerState = ?SERVER:new(#{
+        cert_chain => [~"leaf-der"],
+        priv_key => PrivKey,
+        alpn => ~"h3",
+        transport_params => #{initial_source_connection_id => <<9, 9, 9, 9>>},
+        eph_pub => ServerEphPub,
+        eph_priv => ServerEphPriv,
+        server_random => crypto:strong_rand_bytes(32),
+        peer_scid => ClientSCID
+    }),
+    ClientHelloFramed = ?TC:client_hello_framed(Scheme, ClientPub, ClientSCID),
+    [{1, ClientHelloBody}] = ?TC:deframe_all(ClientHelloFramed),
+    {ok, Flight, _, _} = ?SERVER:process_client_hello(ClientHelloBody, ServerState),
+    %% Verify the signature against a public key that did not sign it.
+    ?assertEqual(
+        {error, handshake_verification_failed},
+        ?CLIENT:process_server_flight(
+            #{
+                eph_priv => ClientPriv,
+                client_hello_framed => ClientHelloFramed,
+                server_pubkey => WrongPub
+            },
+            Flight
+        )
+    ).

--- a/test/roadrunner_quic_test_handshake_tests.erl
+++ b/test/roadrunner_quic_test_handshake_tests.erl
@@ -50,9 +50,13 @@ full_handshake_round_trip_test() ->
 
     %% The client derived the same ordered key installs as the server.
     ?assertEqual(ServerInstalls, maps:get(installs, Result)),
-    %% The client learned the negotiated ALPN and the server's transport params.
+    %% The client learned the negotiated ALPN and the server's transport
+    %% params (captured as raw bytes, equal to the server's encoding).
     ?assertEqual(~"h3", maps:get(alpn, Result)),
-    ?assertEqual(ServerParams, maps:get(peer_transport_params, Result)),
+    ?assertEqual(
+        iolist_to_binary(roadrunner_quic_transport_params:encode(ServerParams)),
+        maps:get(peer_transport_params, Result)
+    ),
     %% The server accepts the client's Finished.
     [{20, ClientFinishedBody}] = ?TC:deframe_all(maps:get(client_finished, Result)),
     ?assertEqual(ok, ?SERVER:process_client_finished(ClientFinishedBody, ServerState1)).


### PR DESCRIPTION
# Description

Adds an in-tree native QUIC + HTTP/3 client for the test profile, covering the TLS handshake, the connection loop, and HTTP/3 requests. Proven end to end against the native server: a full QUIC + TLS 1.3 handshake over loopback, then HTTP/3 GET and POST against a real h3 listener.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
