### PR TITLE
Drive the http3 tests on the native QUIC client and drop the quic dependency

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,8 +68,9 @@ only). Remaining work:
 
 ## Native QUIC transport follow-ups
 
-The HTTP/3 path now runs on the native `roadrunner_quic_*` stack (the `quic`
-dep is a test-profile differential oracle + CT client only). The RFC MUSTs a
+The HTTP/3 path runs on the native `roadrunner_quic_*` stack end to end, with no
+`quic` dependency in any profile (production deps are just `telemetry`, and the
+test profile drives the server with a native QUIC client). The RFC MUSTs a
 browser depends on are implemented; the items below are conformance hardening
 and transport completeness that a real browser GET / POST does not need.
 
@@ -105,7 +106,7 @@ advisory or malformed cases the server currently tolerates or omits.
   control / QPACK uni streams (it opens ~3, always within a sane client's
   limit) — small
 - Respond to a peer-initiated key update (RFC 9001 §6). Security-sensitive:
-  trial-decrypt the next-phase keys and commit ONLY on success (not the dep's
+  trial-decrypt the next-phase keys and commit ONLY on success (not
   commit-then-decrypt, which a single forged flipped-bit datagram desyncs),
   keep the header-protection key fixed, enforce the AEAD integrity limit —
   large
@@ -124,22 +125,15 @@ advisory or malformed cases the server currently tolerates or omits.
 - A no-flatten / by-reference stream send buffer, so a large response body is
   not flattened into one binary before sending — medium
 
-### Retire the dep
+### External interop check
 
-`quic` is now production-free (test-profile-only; production deps are just
-`telemetry`). The last step to drop it entirely:
+The native test client runs the same codecs as the native server, so a
+symmetric codec bug round-trips cleanly and survives. The RFC published vectors
+cover the codecs and crypto as external truth, but an independent implementation
+is a stronger guard.
 
-- Build a native QUIC test client so the `quic` dep can leave the test profile
-  too; the differential-oracle tests, the h3 SUITE's CT client, and the bench
-  client are its only remaining users — large
-
-### Known dep deviation (informational)
-
-The `quic` dep's QPACK static table has a `:age` typo at index 2 (RFC 9204
-Appendix A is `age`, no colon). The native stack is RFC-correct, so this entry
-is the one place the dep oracle cannot validate the native encode/decode; not a
-roadrunner bug, recorded so a future dep cross-check does not "correct" the
-native value back to the dep's.
+- Drive the native server from a real QUIC stack (quiche / ngtcp2 / headless
+  Chrome) in CI as an end-to-end interop gate — medium
 
 ## HttpArena profile gaps
 

--- a/rebar.config
+++ b/rebar.config
@@ -41,14 +41,7 @@
             %% roadrunner against both. Test-profile-only to keep the
             %% production dep list at one entry (telemetry).
             {cowboy, "2.15.0"},
-            {elli, "3.3.0"},
-            %% The native `roadrunner_quic_*` stack serves the live wire; this
-            %% dep is kept test-profile-only as the byte-for-byte differential
-            %% oracle for the codecs/crypto and the CT/bench client (`quic_h3`)
-            %% driving dep-client -> native-server interop. Production deps are
-            %% just telemetry. A native QUIC test client (roadmap) would let it
-            %% be dropped entirely.
-            {quic, "1.6.1"}
+            {elli, "3.3.0"}
         ]}
     ]}
 ]}.

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -979,13 +979,11 @@ cli() ->
                 help =>
                     """
                     Process seed for the profiler. `roadrunner` (default)
-                    traces only the roadrunner supervisor tree plus the
-                    conns/workers it spawns. `all` traces every process in
-                    the server BEAM — required for h3, whose connection
-                    processes are spawned by the `quic` dependency (not a
-                    roadrunner acceptor) and are invisible to the
-                    roadrunner-only seed; also use it to attribute time
-                    across roadrunner vs quic vs crypto.
+                    traces every `roadrunner_*`-named process (the
+                    listener, connections, and workers). `all` traces
+                    every process in the server BEAM, including
+                    non-roadrunner libraries; use it to attribute time
+                    across roadrunner vs crypto.
                     """
             },
             #{

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -70,7 +70,7 @@ All duration and interval values in `opts()` are in milliseconds —
 %% listeners bind the same UDP port with SO_REUSEPORT and share one
 %% connection registry; the kernel spreads inbound datagrams across them
 %% so demux parallelizes across cores instead of funnelling through one
-%% process. (The dep's pool takes `pool_size`, the count BEYOND its base
+%% process. (The pool sup takes `pool_size`, the count BEYOND its base
 %% listener, so the wiring passes `listeners - 1`.)
 -define(DEFAULT_H3_LISTENERS, 8).
 -define(MAX_H3_LISTENERS, 1024).

--- a/src/roadrunner_quic_listener.erl
+++ b/src/roadrunner_quic_listener.erl
@@ -13,7 +13,7 @@
 %% connection; a miss on an unsupported-version long header answers with a
 %% Version Negotiation packet (RFC 9000 §5.2.2). Spawning follows the strict
 %% ordering the handshake depends on
-%% (RFC 9000 / the dep's contract): spawn the connection, link it (so the
+%% (RFC 9000): spawn the connection, link it (so the
 %% listener's own shutdown tears its connections down, and a connection's death
 %% reaps its routing rows), register its CIDs (so a fast follow-up datagram
 %% already routes), run the connection_handler to get the application owner,

--- a/test/roadrunner_bench_profiler.erl
+++ b/test/roadrunner_bench_profiler.erl
@@ -20,9 +20,9 @@ framework processes whose `lists:foldl` / `gen:do_call` chatter would
 otherwise dominate the totals.
 
 `start_all/0` / `start_fprof_all/1` seed every process in the node
-instead. Use them for HTTP/3 (whose connections the `quic` dependency
-spawns outside the roadrunner tree, invisible to the seed above) and to
-attribute time across roadrunner vs `quic` vs `crypto`.
+instead, so non-roadrunner libraries are traced too. Use them to
+attribute time across roadrunner vs `crypto`, which the roadrunner-only
+seed above cannot show.
 
 If `roadrunner_sup` isn't registered (e.g. the app didn't start),
 falls back to `processes()` so the profiler still works for
@@ -50,12 +50,9 @@ start() ->
 
 -doc """
 Like `start/0` but seeds *every* process in the node (`processes()`),
-not just the roadrunner tree. Required for HTTP/3: its connection
-processes are spawned by the `quic` dependency (the `connection_handler`
-fun runs in a dep process), not by a roadrunner acceptor, so they are
-neither in the roadrunner seed nor children of a traced process and the
-`set_on_spawn` propagation in `start/0` misses them entirely. Also use
-it to attribute time across roadrunner vs `quic` vs `crypto` modules.
+not just the `roadrunner_*`-named ones. The name-based `start/0` seed
+omits non-roadrunner libraries, so use this to attribute time across
+roadrunner vs `crypto` (and other library) modules.
 """.
 -spec start_all() -> ok.
 start_all() ->

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -1,9 +1,8 @@
 -module(roadrunner_http3_SUITE).
 -moduledoc """
 End-to-end HTTP/3 tests. Each testcase starts a roadrunner h3 listener
-(`protocols => [http3]` over QUIC) and drives it with the `quic`
-dependency's HTTP/3 *client* (`quic_h3:connect`) — only the turnkey
-*server* is avoided; the client is fine as a test driver.
+(`protocols => [http3]` over QUIC) and drives it with the native test
+client (`roadrunner_quic_test_h3` / `roadrunner_quic_test_conn`).
 
 Lives as a CT suite (not eunit) so each testcase runs in its own
 process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
@@ -144,14 +143,6 @@ all() ->
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
     {ok, _} = application:ensure_all_started(ssl),
-    %% roadrunner's h3 listener is self-contained and does NOT start the
-    %% `quic` app (see `roadrunner_listener:start_quic/4`); the test CLIENT
-    %% below is what needs it, so bring it up once for the whole suite.
-    %% Consequence: these cases run with `quic` already up, so they don't
-    %% exercise the server's standalone (no-app) path — that's covered
-    %% separately by `bench.escript --protocols h3`, where the server peer
-    %% serves h3 with no `quic` app running.
-    {ok, _} = application:ensure_all_started(quic),
     %% Start the default `pg` scope standalone (the drain group lives
     %% there) rather than the whole roadrunner app, so this suite
     %% coexists with others that started pg in the shared CT node.
@@ -258,7 +249,7 @@ head_request(Config) ->
     %% RFC 9110 §9.3.2: a HEAD response carries the GET headers but no
     %% body — `/big` would be 100 KB on GET, empty on HEAD.
     Conn = connect(?config(port, Config)),
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"HEAD", ~"/big")),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"HEAD", ~"/big")),
     ?assertEqual({200, ~""}, status_body(collect(Conn, StreamId))),
     close(Conn).
 
@@ -320,7 +311,7 @@ loop_response(Config) ->
     %% A `{loop, ...}` response: HEADERS, then DATA chunks pushed from
     %% the handler's `handle_info/3`, FIN on `{stop, _}`.
     Conn = connect(?config(port, Config)),
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/loop")),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
     Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
     Worker ! {push, ~"hi"},
     Worker ! push_empty,
@@ -335,7 +326,7 @@ loop_filters_otp(Config) ->
     %% counter: `sys:get_state/1` returns the loop counter, a gen-call
     %% gets `{error, not_supported}`, and a gen-cast is a no-op.
     Conn = connect(?config(port, Config)),
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/loop")),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
     Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
     ?assertEqual(0, sys:get_state(Worker)),
     ?assertEqual({error, not_supported}, gen_server:call(Worker, ping)),
@@ -352,7 +343,7 @@ loop_conn_close_stops_worker(Config) ->
     %% the QUIC connection, which fires the worker's monitor.
     Name = ?config(listener, Config),
     Conn = connect(?config(port, Config)),
-    {ok, _StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/loop")),
+    {ok, _StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
     Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
     WorkerRef = monitor(process, Worker),
     ok = roadrunner_listener:stop(Name),
@@ -388,7 +379,9 @@ head_sendfile(Config) ->
     %% RFC 9110 §9.3.2: HEAD on a sendfile route returns the headers but
     %% no body (and never reads the file).
     Conn = connect(?config(port, Config)),
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"HEAD", ~"/sendfile-small")),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(
+        Conn, headers(~"HEAD", ~"/sendfile-small")
+    ),
     ?assertEqual({200, ~""}, status_body(collect(Conn, StreamId))),
     close(Conn).
 
@@ -438,13 +431,15 @@ stream_trailer_injection_aborts(Config) ->
     %% check the server sends the 200 HEADERS then RESETS the stream, so the
     %% malformed value ("a\r\nb" = <<97,13,10,98>>) is never emitted; without
     %% it, QPACK encodes those bytes into a trailer frame and the stream
-    %% finishes cleanly. The conformant `quic_h3` client cannot show this --
-    %% it rejects the bad field either way -- so this drives a raw client.
+    %% finishes cleanly. A conformant h3 client cannot show this -- it
+    %% rejects the bad field either way -- so this drives a raw client.
     Conn = ll_connect(?config(port, Config)),
     try
-        {ok, StreamId} = quic:open_stream(Conn),
-        Block = quic_qpack:encode(headers(~"GET", ~"/stream-bad-trailers")),
-        ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_headers(Block), true),
+        StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+        Block = roadrunner_qpack:encode(headers(~"GET", ~"/stream-bad-trailers")),
+        ok = roadrunner_quic_test_conn:send(
+            Conn, StreamId, roadrunner_quic_h3_frame:encode_headers(Block), true
+        ),
         Result = ll_collect_until_end(Conn, StreamId, <<>>),
         %% The server aborts the stream rather than completing it normally,
         ?assertMatch({reset, _, _}, Result),
@@ -460,12 +455,14 @@ oversized_413(_Config) ->
     {ok, _} = start_h3(Name, #{max_content_length => 8}),
     Conn = connect(roadrunner_listener:port(Name)),
     try
-        {ok, StreamId} = quic_h3:request(Conn, headers(~"POST", ~"/echo"), #{end_stream => false}),
+        {ok, StreamId} = roadrunner_quic_test_h3:open_request(
+            Conn, headers(~"POST", ~"/echo"), false
+        ),
         %% First chunk already exceeds the 8-byte cap → 413.
-        ok = quic_h3:send_data(Conn, StreamId, binary:copy(<<"x">>, 32), false),
+        ok = roadrunner_quic_test_h3:send_data(Conn, StreamId, binary:copy(<<"x">>, 32), false),
         ?assertMatch({413, _, _}, collect(Conn, StreamId)),
         %% A trailing chunk on the already-answered stream is ignored.
-        _ = quic_h3:send_data(Conn, StreamId, ~"more", true),
+        _ = roadrunner_quic_test_h3:send_data(Conn, StreamId, ~"more", true),
         ok
     after
         close(Conn),
@@ -473,20 +470,21 @@ oversized_413(_Config) ->
     end.
 
 oversized_headers_431(_Config) ->
-    %% A request whose encoded field section exceeds MAX_HEADER_BLOCK
-    %% (16384) is answered 431, rejected by the conn loop before dispatch
-    %% (parity with the body 413). Advertise a huge MAX_FIELD_SECTION_SIZE
-    %% so the conformant client doesn't self-limit on the decoded size
-    %% before the request reaches the encoded cap.
+    %% A request whose encoded field section exceeds `max_header_block` is
+    %% answered 431, rejected by the conn loop before dispatch (parity with
+    %% the body 413). A small cap keeps the over-cap header inside one packet,
+    %% so the server rejects it on the first frame rather than mid-flood.
     Name = listener_name(oversized_headers_431),
     {ok, _} = start_h3(Name, #{
-        protocols => [{http3, #{max_field_section_size => 16#7FFFFFFF}}]
+        protocols => [{http3, #{max_header_block => 100}}]
     }),
     Conn = connect(roadrunner_listener:port(Name)),
     try
-        Big = binary:copy(<<"x">>, 50000),
-        {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/") ++ [{~"x-big", Big}]),
-        ?assertMatch({431, _, _}, collect(Conn, StreamId))
+        Headers = headers(~"GET", ~"/") ++ [{~"x-big", binary:copy(<<"v">>, 300)}],
+        {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, Headers, false),
+        ?assertMatch({431, _, _}, collect(Conn, StreamId)),
+        %% The connection survives the rejection and serves a fresh request.
+        ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/")))
     after
         close(Conn),
         roadrunner_listener:stop(Name)
@@ -502,7 +500,7 @@ advertises_max_field_section_size(_Config) ->
     }),
     Conn = connect(roadrunner_listener:port(Name)),
     try
-        Settings = quic_h3:get_peer_settings(Conn),
+        Settings = roadrunner_quic_test_h3:get_peer_settings(Conn),
         ?assertEqual(54321, maps:get(max_field_section_size, Settings))
     after
         close(Conn),
@@ -511,10 +509,10 @@ advertises_max_field_section_size(_Config) ->
 
 field_section_too_large_431(_Config) ->
     %% RFC 9114 §4.2.2: a request whose DECODED field section exceeds the
-    %% advertised MAX_FIELD_SECTION_SIZE is answered 431. The conformant
-    %% `quic_h3` client self-limits to the advertised value, so this drives
-    %% a raw, non-conformant client (the same codecs roadrunner's server
-    %% uses) over a plain QUIC stream. A 300-byte header stays well under
+    %% advertised MAX_FIELD_SECTION_SIZE is answered 431. A conformant h3
+    %% client self-limits to the advertised value, so this drives a raw,
+    %% non-conformant client (the same codecs roadrunner's server uses)
+    %% over a plain QUIC stream. A 300-byte header stays well under
     %% the 16384 encoded cap but blows the tiny 200-byte decoded limit.
     Name = listener_name(field_section_too_large_431),
     {ok, _} = start_h3(Name, #{
@@ -522,13 +520,15 @@ field_section_too_large_431(_Config) ->
     }),
     Conn = ll_connect(roadrunner_listener:port(Name)),
     try
-        {ok, StreamId} = quic:open_stream(Conn),
+        StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
         Headers = headers(~"GET", ~"/") ++ [{~"x-pad", binary:copy(<<"v">>, 300)}],
-        Block = quic_qpack:encode(Headers),
+        Block = iolist_to_binary(roadrunner_qpack:encode(Headers)),
         %% Stay under the 16384 encoded cap so the ENCODED gate can't fire;
         %% the decoded size (well over the 200 cap) is what triggers the 431.
         ?assert(byte_size(Block) < 16384),
-        ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_headers(Block), true),
+        ok = roadrunner_quic_test_conn:send(
+            Conn, StreamId, roadrunner_quic_h3_frame:encode_headers(Block), true
+        ),
         ?assertEqual(431, raw_h3_response_status(Conn, StreamId, <<>>))
     after
         ll_close(Conn),
@@ -540,11 +540,11 @@ field_section_too_large_431(_Config) ->
 %% as an integer. Ignores frames on the server's control / QPACK streams.
 raw_h3_response_status(Conn, StreamId, Acc) ->
     receive
-        {quic, Conn, {stream_data, StreamId, Bin, _Fin}} ->
+        {quic_test_stream, Conn, StreamId, Bin, _Fin} ->
             Buf = <<Acc/binary, Bin/binary>>,
-            case quic_h3_frame:decode(Buf) of
+            case roadrunner_quic_h3_frame:decode(Buf) of
                 {ok, {headers, Block}, _Rest} ->
-                    {ok, Hdrs} = quic_qpack:decode(Block),
+                    {ok, Hdrs} = roadrunner_qpack:decode(Block),
                     binary_to_integer(proplists:get_value(~":status", Hdrs));
                 {more, _} ->
                     raw_h3_response_status(Conn, StreamId, Buf);
@@ -762,7 +762,7 @@ max_concurrent_requests_refuse(_Config) ->
     Port = roadrunner_listener:port(Name),
     Conn = connect(Port),
     try
-        {ok, _StreamId} = quic_h3:request(Conn, headers(~"GET", ~"/loop")),
+        {ok, _StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
         Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
         %% The parked worker holds the single in-flight slot, so the next
         %% request is over the ceiling and gets no response.
@@ -801,8 +801,8 @@ retry_get(Conn, Path, Tries) ->
 
 stream_cancel(Config) ->
     Conn = connect(?config(port, Config)),
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"POST", ~"/echo"), #{end_stream => false}),
-    _ = quic_h3:cancel(Conn, StreamId),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"POST", ~"/echo"), false),
+    _ = roadrunner_quic_test_h3:cancel(Conn, StreamId),
     %% The connection survives a peer stream cancel — a fresh request works.
     ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/"))),
     close(Conn).
@@ -812,10 +812,12 @@ response_to_cancelled_stream(Config) ->
     %% is still running, so the worker's later send onto the stopped
     %% stream fails — that must be tolerated, not crash the connection.
     Conn = ll_connect(?config(port, Config)),
-    Frame = quic_h3_frame:encode_headers(quic_qpack:encode(headers(~"GET", ~"/slow"))),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, Frame, true),
-    _ = quic:stop_sending(Conn, StreamId, 0),
+    Frame = roadrunner_quic_h3_frame:encode_headers(
+        roadrunner_qpack:encode(headers(~"GET", ~"/slow"))
+    ),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, Frame, true),
+    _ = roadrunner_quic_test_conn:stop_sending(Conn, StreamId, 0),
     timer:sleep(300),
     ?assertEqual({200, ~"ok"}, ll_get(Conn, ~"/")),
     ll_close(Conn).
@@ -842,9 +844,11 @@ malformed_request(Config) ->
     %% pseudo-header (`:path`) is a malformed message (RFC 9114 §4.1.2):
     %% the stream is reset with H3_MESSAGE_ERROR, the connection lives.
     Conn = ll_connect(?config(port, Config)),
-    Block = quic_qpack:encode([{~":method", ~"GET"}, {~":scheme", ~"https"}]),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_headers(Block), true),
+    Block = roadrunner_qpack:encode([{~":method", ~"GET"}, {~":scheme", ~"https"}]),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(
+        Conn, StreamId, roadrunner_quic_h3_frame:encode_headers(Block), true
+    ),
     timer:sleep(100),
     ?assertEqual({200, ~"ok"}, ll_get(Conn, ~"/")),
     ll_close(Conn).
@@ -853,19 +857,27 @@ data_before_headers(Config) ->
     %% A DATA frame before any HEADERS is an invalid frame sequence
     %% (RFC 9114 §4.1) → H3_FRAME_UNEXPECTED connection error.
     Conn = ll_connect(?config(port, Config)),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_data(~"x"), false),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(
+        Conn, StreamId, roadrunner_quic_h3_frame:encode_data(~"x"), false
+    ),
     ll_await_closed(Conn).
 
 request_with_trailers(Config) ->
     %% A request with trailing HEADERS (trailers) after the body is valid
     %% (RFC 9114 §4.1); the trailers are ignored and the request is served.
     Conn = ll_connect(?config(port, Config)),
-    ReqHeaders = quic_h3_frame:encode_headers(quic_qpack:encode(headers(~"POST", ~"/echo"))),
-    Data = quic_h3_frame:encode_data(~"body"),
-    Trailers = quic_h3_frame:encode_headers(quic_qpack:encode([{~"x-checksum", ~"abc"}])),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, <<ReqHeaders/binary, Data/binary, Trailers/binary>>, true),
+    ReqHeaders = roadrunner_quic_h3_frame:encode_headers(
+        roadrunner_qpack:encode(headers(~"POST", ~"/echo"))
+    ),
+    Data = roadrunner_quic_h3_frame:encode_data(~"body"),
+    Trailers = roadrunner_quic_h3_frame:encode_headers(
+        roadrunner_qpack:encode([{~"x-checksum", ~"abc"}])
+    ),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(
+        Conn, StreamId, [ReqHeaders, Data, Trailers], true
+    ),
     ?assertEqual({200, ~"body"}, ll_collect(Conn, StreamId, <<>>)),
     ll_close(Conn).
 
@@ -881,17 +893,21 @@ oversized_frame(Config) ->
     %% A frame declaring a length above the max is a frame error
     %% (RFC 9114 §7.1, H3_FRAME_ERROR) — a connection error.
     Conn = ll_connect(?config(port, Config)),
-    Oversized = iolist_to_binary([quic_varint:encode(0), quic_varint:encode(16#FFFFFFFF)]),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, Oversized, false),
+    Oversized = iolist_to_binary([
+        roadrunner_quic_varint:encode(0), roadrunner_quic_varint:encode(16#FFFFFFFF)
+    ]),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, Oversized, false),
     ll_await_closed(Conn).
 
 qpack_decompression_failed(Config) ->
     %% A HEADERS frame whose field block can't be QPACK-decoded is a
     %% connection error (RFC 9204 §2.2): the connection closes.
     Conn = ll_connect(?config(port, Config)),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_headers(<<>>), true),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(
+        Conn, StreamId, roadrunner_quic_h3_frame:encode_headers(<<>>), true
+    ),
     ll_await_closed(Conn).
 
 extra_data_after_413(_Config) ->
@@ -904,16 +920,24 @@ extra_data_after_413(_Config) ->
     {ok, _} = start_h3(Name, #{max_content_length => 8}),
     Conn = ll_connect(roadrunner_listener:port(Name)),
     try
-        {ok, StreamId} = quic:open_stream(Conn),
-        ReqHeaders = quic_h3_frame:encode_headers(quic_qpack:encode(headers(~"POST", ~"/echo"))),
-        Over = quic_h3_frame:encode_data(binary:copy(<<"x">>, 32)),
-        ok = quic:send_data(Conn, StreamId, <<ReqHeaders/binary, Over/binary>>, false),
+        StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+        ReqHeaders = roadrunner_quic_h3_frame:encode_headers(
+            roadrunner_qpack:encode(headers(~"POST", ~"/echo"))
+        ),
+        Over = roadrunner_quic_h3_frame:encode_data(binary:copy(<<"x">>, 32)),
+        ok = roadrunner_quic_test_conn:send(
+            Conn, StreamId, [ReqHeaders, Over], false
+        ),
         timer:sleep(100),
         %% residual DATA without FIN — ignored
-        ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_data(~"more"), false),
+        ok = roadrunner_quic_test_conn:send(
+            Conn, StreamId, roadrunner_quic_h3_frame:encode_data(~"more"), false
+        ),
         timer:sleep(50),
         %% final residual DATA with FIN — drops the discarding marker
-        ok = quic:send_data(Conn, StreamId, quic_h3_frame:encode_data(~"end"), true),
+        ok = roadrunner_quic_test_conn:send(
+            Conn, StreamId, roadrunner_quic_h3_frame:encode_data(~"end"), true
+        ),
         timer:sleep(50),
         ?assertEqual({200, ~"ok"}, ll_get(Conn, ~"/"))
     after
@@ -925,9 +949,9 @@ stop_sending_ignored(Config) ->
     %% A peer STOP_SENDING surfaces as an event the conn loop doesn't act
     %% on; it is ignored and the connection keeps serving.
     Conn = ll_connect(?config(port, Config)),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, <<>>, false),
-    _ = quic:stop_sending(Conn, StreamId, 0),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, <<>>, false),
+    _ = roadrunner_quic_test_conn:stop_sending(Conn, StreamId, 0),
     timer:sleep(100),
     ?assertEqual({200, ~"ok"}, ll_get(Conn, ~"/")),
     ll_close(Conn).
@@ -937,7 +961,7 @@ peer_push_stream_closes_conn(Config) ->
     %% client-initiated one is a connection error
     %% (H3_STREAM_CREATION_ERROR) — the connection closes.
     Conn = ll_connect(?config(port, Config)),
-    _ = ll_open_uni(Conn, quic_h3_frame:encode_stream_type(push), false),
+    _ = ll_open_uni(Conn, roadrunner_quic_h3_frame:encode_stream_type(push), false),
     ll_await_closed(Conn).
 
 peer_control_stream_closed(Config) ->
@@ -951,7 +975,7 @@ unknown_uni_stream_ignored(Config) ->
     %% RFC 9114 §6.2.3: an unknown unidirectional stream type is ignored
     %% (read and discarded); the connection keeps serving.
     Conn = ll_connect(?config(port, Config)),
-    _ = ll_open_uni(Conn, quic_h3_frame:encode_stream_type(16#21), true),
+    _ = ll_open_uni(Conn, roadrunner_quic_h3_frame:encode_stream_type(16#21), true),
     timer:sleep(50),
     ?assertEqual({200, ~"ok"}, ll_get(Conn, ~"/")),
     ll_close(Conn).
@@ -966,16 +990,16 @@ peer_control_stream_reset(Config) ->
     %% before we reset it — a fixed sleep races under load, leaving the
     %% reset to hit an unclassified stream that is silently dropped.
     ?assertEqual({200, ~"ok"}, ll_get(Conn, ~"/")),
-    _ = quic:reset_stream(Conn, StreamId, 0),
+    _ = roadrunner_quic_test_conn:reset_stream(Conn, StreamId, 0),
     ll_await_closed(Conn).
 
 noncritical_uni_stream_reset(Config) ->
     %% RESET_STREAM on a non-critical uni stream just drops its state;
     %% the connection keeps serving.
     Conn = ll_connect(?config(port, Config)),
-    StreamId = ll_open_uni(Conn, quic_h3_frame:encode_stream_type(16#21), false),
+    StreamId = ll_open_uni(Conn, roadrunner_quic_h3_frame:encode_stream_type(16#21), false),
     timer:sleep(50),
-    _ = quic:reset_stream(Conn, StreamId, 0),
+    _ = roadrunner_quic_test_conn:reset_stream(Conn, StreamId, 0),
     timer:sleep(50),
     ?assertEqual({200, ~"ok"}, ll_get(Conn, ~"/")),
     ll_close(Conn).
@@ -999,9 +1023,11 @@ refuse_request_during_drain(Config) ->
     Name = ?config(listener, Config),
     Conn = ll_connect(?config(port, Config)),
     %% A slow request keeps a worker in flight across the drain.
-    SlowFrame = quic_h3_frame:encode_headers(quic_qpack:encode(headers(~"GET", ~"/slow"))),
-    {ok, SlowId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, SlowId, SlowFrame, true),
+    SlowFrame = roadrunner_quic_h3_frame:encode_headers(
+        roadrunner_qpack:encode(headers(~"GET", ~"/slow"))
+    ),
+    SlowId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, SlowId, SlowFrame, true),
     timer:sleep(20),
     %% Drive the conn loop's drain directly — the same message the
     %% listener broadcasts (its synchronous `drain/2` would block here).
@@ -1009,9 +1035,11 @@ refuse_request_during_drain(Config) ->
     LoopPid ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 5000},
     timer:sleep(20),
     %% A request opened after the GOAWAY is rejected.
-    NewFrame = quic_h3_frame:encode_headers(quic_qpack:encode(headers(~"GET", ~"/"))),
-    {ok, NewId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, NewId, NewFrame, true),
+    NewFrame = roadrunner_quic_h3_frame:encode_headers(
+        roadrunner_qpack:encode(headers(~"GET", ~"/"))
+    ),
+    NewId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, NewId, NewFrame, true),
     ?assertEqual(16#10b, ll_await_reset(Conn, NewId)),
     %% The in-flight slow request still completes.
     ?assertEqual({200, ~"slow"}, ll_collect(Conn, SlowId, <<>>)),
@@ -1061,37 +1089,28 @@ udp_occupied_tcp_free_port() ->
 %% --- h3 client helpers ---
 
 connect(Port) ->
-    {ok, Conn} = quic_h3:connect(~"127.0.0.1", Port, #{verify => verify_none}),
-    ok = quic_h3:wait_connected(Conn, 5000),
+    {ok, Conn} = roadrunner_quic_test_h3:connect({127, 0, 0, 1}, Port),
     Conn.
 
 try_connect(Port) ->
-    case quic_h3:connect(~"127.0.0.1", Port, #{verify => verify_none}) of
-        {ok, Conn} ->
-            case quic_h3:wait_connected(Conn, 2000) of
-                ok -> {ok, Conn};
-                {error, _} = E -> E
-            end;
-        {error, _} = E ->
-            E
-    end.
+    roadrunner_quic_test_h3:connect({127, 0, 0, 1}, Port).
 
 close(Conn) ->
-    _ = quic_h3:close(Conn),
+    _ = roadrunner_quic_test_h3:close(Conn),
     ok.
 
 get(Conn, Path) ->
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", Path)),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", Path)),
     collect(Conn, StreamId).
 
 post(Conn, Path, Body) ->
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"POST", Path), #{end_stream => false}),
-    ok = quic_h3:send_data(Conn, StreamId, Body, true),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"POST", Path), false),
+    ok = roadrunner_quic_test_h3:send_data(Conn, StreamId, Body, true),
     collect(Conn, StreamId).
 
 %% A request expected to fail (reset / no response) — returns `error`.
 try_get(Conn, Path) ->
-    {ok, StreamId} = quic_h3:request(Conn, headers(~"GET", Path)),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", Path)),
     case collect(Conn, StreamId) of
         {error, _} -> error;
         timeout -> error;
@@ -1110,57 +1129,26 @@ status_body({Status, _Headers, Body}) -> {Status, Body};
 status_body(Other) -> Other.
 
 collect(Conn, StreamId) ->
-    receive
-        {quic_h3, Conn, {response, StreamId, Status, Headers}} ->
-            collect_body(Conn, StreamId, Status, Headers, <<>>);
-        {quic_h3, Conn, {stream_reset, StreamId, ErrorCode}} ->
-            {error, {stream_reset, ErrorCode}};
-        {quic_h3, Conn, {error, ErrorCode, _Reason}} ->
-            {error, {conn_error, ErrorCode}};
-        {quic_h3, Conn, closed} ->
-            {error, closed}
-    after 5000 ->
-        timeout
-    end.
-
-collect_body(Conn, StreamId, Status, Headers, Acc) ->
-    receive
-        {quic_h3, Conn, {data, StreamId, Data, true}} ->
-            {Status, Headers, <<Acc/binary, Data/binary>>};
-        {quic_h3, Conn, {data, StreamId, Data, false}} ->
-            collect_body(Conn, StreamId, Status, Headers, <<Acc/binary, Data/binary>>);
-        %% Trailing HEADERS (trailers) end the stream with no fin DATA.
-        {quic_h3, Conn, {trailers, StreamId, _Trailers}} ->
-            {Status, Headers, Acc}
-    after 5000 ->
-        timeout
-    end.
+    roadrunner_quic_test_h3:collect(Conn, StreamId).
 
 %% --- low-level QUIC client (raw h3 framing under our control) ---
 %%
-%% Drives the server over the bare `quic` transport so a testcase can
-%% put exact bytes on a request stream — malformed frames, a FIN with
-%% no HEADERS, trailing DATA — that the turnkey `quic_h3` client would
-%% never emit. We own the HEADERS/QPACK framing here.
+%% Drives the server over a raw QUIC connection (`roadrunner_quic_test_conn`)
+%% so a testcase can put exact bytes on a request stream — malformed frames, a
+%% FIN with no HEADERS, trailing DATA — that a conformant h3 client would never
+%% emit. We own the HEADERS/QPACK framing here.
 
 ll_connect(Port) ->
-    {ok, Conn} = quic:connect(
-        ~"127.0.0.1", Port, #{alpn => [~"h3"], verify => verify_none}, self()
-    ),
-    receive
-        {quic, Conn, {connected, _}} -> ok
-    after 5000 ->
-        ct:fail(ll_not_connected)
-    end,
+    {ok, Conn} = roadrunner_quic_test_conn:connect({127, 0, 0, 1}, Port),
     Conn.
 
 ll_close(Conn) ->
-    _ = quic:close(Conn),
+    _ = roadrunner_quic_test_conn:close(Conn),
     ok.
 
 ll_await_closed(Conn) ->
     receive
-        {quic, Conn, {closed, _}} -> ok
+        {quic_test_closed, Conn, _} -> ok
     after 5000 ->
         ct:fail(connection_not_closed)
     end.
@@ -1168,7 +1156,7 @@ ll_await_closed(Conn) ->
 %% Wait for the server to reset `StreamId`, returning the error code.
 ll_await_reset(Conn, StreamId) ->
     receive
-        {quic, Conn, {stream_reset, StreamId, ErrorCode}} -> ErrorCode
+        {quic_test_stream_reset, Conn, StreamId, ErrorCode} -> ErrorCode
     after 5000 ->
         ct:fail(no_stream_reset)
     end.
@@ -1178,11 +1166,11 @@ ll_await_reset(Conn, StreamId) ->
 %% test can inspect exactly what reached the wire.
 ll_collect_until_end(Conn, StreamId, Acc) ->
     receive
-        {quic, Conn, {stream_data, StreamId, Bin, true}} ->
+        {quic_test_stream, Conn, StreamId, Bin, true} ->
             {fin, <<Acc/binary, Bin/binary>>};
-        {quic, Conn, {stream_data, StreamId, Bin, false}} ->
+        {quic_test_stream, Conn, StreamId, Bin, false} ->
             ll_collect_until_end(Conn, StreamId, <<Acc/binary, Bin/binary>>);
-        {quic, Conn, {stream_reset, StreamId, ErrorCode}} ->
+        {quic_test_stream_reset, Conn, StreamId, ErrorCode} ->
             {reset, ErrorCode, Acc}
     after 5000 ->
         ct:fail(no_stream_end)
@@ -1202,47 +1190,47 @@ wait_for_register(Name, RemainingMs) ->
     end.
 
 ll_send(Conn, Bytes, Fin) ->
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, Bytes, Fin),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, Bytes, Fin),
     StreamId.
 
 %% Open a client-initiated unidirectional stream and write `Bytes` (the
 %% stream-type prefix + any frames) onto it.
 ll_open_uni(Conn, Bytes, Fin) ->
-    {ok, StreamId} = quic:open_unidirectional_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, Bytes, Fin),
+    StreamId = roadrunner_quic_test_conn:open_uni(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, Bytes, Fin),
     StreamId.
 
 %% A valid control stream payload: the control stream-type prefix
 %% followed by a SETTINGS frame.
 control_with_settings() ->
-    <<
-        (quic_h3_frame:encode_stream_type(control))/binary,
-        (quic_h3_frame:encode_settings(#{qpack_max_table_capacity => 0}))/binary
-    >>.
+    iolist_to_binary([
+        roadrunner_quic_h3_frame:encode_stream_type(control),
+        roadrunner_quic_h3_frame:encode_settings(#{qpack_max_table_capacity => 0})
+    ]).
 
 ll_get(Conn, Path) ->
-    Frame = quic_h3_frame:encode_headers(quic_qpack:encode(headers(~"GET", Path))),
-    {ok, StreamId} = quic:open_stream(Conn),
-    ok = quic:send_data(Conn, StreamId, Frame, true),
+    Frame = roadrunner_quic_h3_frame:encode_headers(roadrunner_qpack:encode(headers(~"GET", Path))),
+    StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, Frame, true),
     ll_collect(Conn, StreamId, <<>>).
 
 ll_collect(Conn, StreamId, Acc) ->
     receive
-        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+        {quic_test_stream, Conn, StreamId, Data, true} ->
             ll_decode(<<Acc/binary, Data/binary>>);
-        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+        {quic_test_stream, Conn, StreamId, Data, false} ->
             ll_collect(Conn, StreamId, <<Acc/binary, Data/binary>>)
     after 5000 ->
         ct:fail(ll_no_response)
     end.
 
 ll_decode(Bytes) ->
-    {ok, {headers, Block}, Rest} = quic_h3_frame:decode(Bytes),
-    {ok, RespHeaders} = quic_qpack:decode(Block),
+    {ok, {headers, Block}, Rest} = roadrunner_quic_h3_frame:decode(Bytes),
+    {ok, RespHeaders} = roadrunner_qpack:decode(Block),
     Status = binary_to_integer(proplists:get_value(~":status", RespHeaders)),
     Body =
-        case quic_h3_frame:decode(Rest) of
+        case roadrunner_quic_h3_frame:decode(Rest) of
             {ok, {data, Data}, _} -> Data;
             _ -> <<>>
         end,

--- a/test/roadrunner_qpack_tests.erl
+++ b/test/roadrunner_qpack_tests.erl
@@ -119,8 +119,8 @@ decode_second_field_line_error_propagates_test() ->
 %% =============================================================================
 
 %% `roadrunner_qpack:encode/1` returns iodata (it is framed and sent as
-%% iodata in production); flatten it here, where the dep oracle and the
-%% native decoder both want the on-wire binary.
+%% iodata in production); flatten it here, where the decoder wants the
+%% on-wire binary.
 enc(Headers) ->
     iolist_to_binary(roadrunner_qpack:encode(Headers)).
 

--- a/test/roadrunner_quic_test_conn.erl
+++ b/test/roadrunner_quic_test_conn.erl
@@ -31,11 +31,14 @@
 
 -include_lib("public_key/include/public_key.hrl").
 
--export([connect/2, close/1, open_bidi/1, open_uni/1, send/4]).
+-export([connect/2, close/1, open_bidi/1, open_uni/1, send/4, reset_stream/3, stop_sending/3]).
 
 %% v1 connection-id length and signature scheme (the test cert is RSA).
 -define(CID_LEN, 8).
 -define(SIG_SCHEME, 16#0804).
+%% Max stream bytes per 1-RTT packet, leaving room for the short header,
+%% STREAM frame header, and AEAD tag within the MTU.
+-define(MAX_STREAM_CHUNK, 1000).
 -define(RECV_TIMEOUT, 3000).
 -define(CONNECT_TIMEOUT, 8000).
 
@@ -59,6 +62,9 @@
     app_client_keys :: roadrunner_quic_keys:keys() | undefined,
     owner :: pid() | undefined,
     finished_sent = false :: boolean(),
+    %% Client Handshake-level packet number space (RFC 9000 §12.3): the
+    %% address-validation PING takes pn 0, the client Finished pn 1.
+    hs_pn = 0 :: non_neg_integer(),
     datagrams = [] :: [binary()],
     %% 1-RTT stream state (RFC 9000 §2.1 client-initiated stream ids).
     next_bidi = 0 :: non_neg_integer(),
@@ -119,10 +125,34 @@ Send `Data` on `StreamId` in a 1-RTT packet, with the FIN bit when `Fin`.
 Received stream data is delivered to the connection owner as
 `{quic_test_stream, Conn, StreamId, Data, Fin}`.
 """.
--spec send(pid(), non_neg_integer(), binary(), boolean()) -> ok.
+-spec send(pid(), non_neg_integer(), iodata(), boolean()) -> ok.
 send(Pid, StreamId, Data, Fin) ->
     Ref = make_ref(),
     Pid ! {send, self(), Ref, StreamId, Data, Fin},
+    receive
+        {Ref, ok} -> ok
+    after 5000 ->
+        {error, timeout}
+    end.
+
+-doc """
+Send a RESET_STREAM for `StreamId` with `ErrorCode` (RFC 9000 §19.4). The
+final size is the number of bytes already sent on the stream; declaring a
+smaller one than the peer received is a FINAL_SIZE_ERROR (§4.5), so the loop
+fills it in from its per-stream send offset.
+""".
+-spec reset_stream(pid(), non_neg_integer(), non_neg_integer()) -> ok.
+reset_stream(Pid, StreamId, ErrorCode) ->
+    cast_frame(Pid, {reset_stream, StreamId, ErrorCode}).
+
+-doc "Send a STOP_SENDING for `StreamId` with `ErrorCode` (RFC 9000 §19.5).".
+-spec stop_sending(pid(), non_neg_integer(), non_neg_integer()) -> ok.
+stop_sending(Pid, StreamId, ErrorCode) ->
+    cast_frame(Pid, {stop_sending, StreamId, ErrorCode}).
+
+cast_frame(Pid, Frame) ->
+    Ref = make_ref(),
+    Pid ! {frame, self(), Ref, Frame},
     receive
         {Ref, ok} -> ok
     after 5000 ->
@@ -167,6 +197,10 @@ init(Parent, Ref, Host, Port) ->
     },
     case handshake(Conn) of
         {ok, Conn1} ->
+            %% Switch to active-once so the loop's single receive wakes on
+            %% both owner control calls and inbound datagrams; a blocking
+            %% socket recv would starve owner calls while the peer is idle.
+            ok = roadrunner_quic_socket:activate(Socket),
             Parent ! {Ref, connected},
             connected_loop(Conn1);
         {error, Reason} ->
@@ -214,7 +248,14 @@ advance(#conn{finished_sent = false, hs_keys = undefined} = Conn) ->
                 #{eph_priv => Conn#conn.eph_priv, client_hello_framed => Conn#conn.ch_framed},
                 ServerHelloFramed
             ),
-            advance(Conn#conn{hs_keys = HsKeys})
+            %% A Handshake-level packet from the client validates its address and
+            %% lifts the server's 3x anti-amplification limit (RFC 9000 §8.1), so
+            %% the server flushes the rest of its flight. Send a PING now, before
+            %% the whole flight is in hand: a larger flight (e.g. a cert chain)
+            %% exceeds the 3x budget, and the server stalls without it.
+            #{client := ClientHsKeys} = HsKeys,
+            Conn1 = send_handshake_ping(Conn#conn{hs_keys = HsKeys}, ClientHsKeys),
+            advance(Conn1)
     end;
 advance(#conn{finished_sent = false} = Conn) ->
     %% Have the handshake keys; try to complete the server flight.
@@ -272,8 +313,10 @@ complete(Conn, ServerHelloFramed, HandshakeBytes) ->
     Flight = #{initial => ServerHelloFramed, handshake => HandshakeBytes},
     case roadrunner_quic_test_handshake:process_server_flight(Config, Flight) of
         {ok, #{installs := Installs, client_finished := ClientFinished}} ->
-            send_client_finished(Conn, keys_for(handshake, client, Installs), ClientFinished),
-            {continue, Conn#conn{
+            Conn1 = send_client_finished(
+                Conn, keys_for(handshake, client, Installs), ClientFinished
+            ),
+            {continue, Conn1#conn{
                 finished_sent = true,
                 app_server_keys = keys_for(application, server, Installs),
                 app_client_keys = keys_for(application, client, Installs)
@@ -282,19 +325,40 @@ complete(Conn, ServerHelloFramed, HandshakeBytes) ->
             {error, Reason}
     end.
 
+%% Send a bare Handshake-level PING to validate the client's address, lifting
+%% the server's 3x anti-amplification limit (RFC 9000 §8.1) so it flushes the
+%% rest of its flight.
+-spec send_handshake_ping(#conn{}, roadrunner_quic_keys:keys()) -> #conn{}.
+send_handshake_ping(Conn, ClientHsKeys) ->
+    send_handshake(Conn, ClientHsKeys, [ping]).
+
 %% Send the client Finished as a Handshake-level CRYPTO frame, addressed to
 %% the server's SCID.
--spec send_client_finished(#conn{}, roadrunner_quic_keys:keys(), iolist()) -> ok.
-send_client_finished(
-    #conn{socket = Socket, host = Host, port = Port, scid = Scid, server_scid = ServerScid},
+-spec send_client_finished(#conn{}, roadrunner_quic_keys:keys(), iolist()) -> #conn{}.
+send_client_finished(Conn, ClientHsKeys, ClientFinished) ->
+    send_handshake(Conn, ClientHsKeys, [{crypto, 0, iolist_to_binary(ClientFinished)}]).
+
+%% Send a Handshake-level datagram carrying `Frames`, addressed to the server's
+%% SCID, taking the next handshake packet number so each packet is distinct.
+-spec send_handshake(#conn{}, roadrunner_quic_keys:keys(), [roadrunner_quic_frame:frame()]) ->
+    #conn{}.
+send_handshake(
+    #conn{
+        socket = Socket,
+        host = Host,
+        port = Port,
+        scid = Scid,
+        server_scid = ServerScid,
+        hs_pn = Pn
+    } = Conn,
     ClientHsKeys,
-    ClientFinished
+    Frames
 ) ->
-    Frames = [{crypto, 0, iolist_to_binary(ClientFinished)}],
     {Datagram, _Sent} = roadrunner_quic_send:datagram(
-        #{handshake => #{frames => Frames, keys => ClientHsKeys, pn => 0}}, ServerScid, Scid
+        #{handshake => #{frames => Frames, keys => ClientHsKeys, pn => Pn}}, ServerScid, Scid
     ),
-    ok = roadrunner_quic_socket:send(Socket, Host, Port, Datagram).
+    ok = roadrunner_quic_socket:send(Socket, Host, Port, Datagram),
+    Conn#conn{hs_pn = Pn + 1}.
 
 %% Whether the server's 1-RTT packets carry HANDSHAKE_DONE (RFC 9001 §4.1.2).
 %% Short-header packets are addressed to the client's source CID.
@@ -321,10 +385,11 @@ server_public_key(HandshakeBytes) ->
 %% Connected
 %% =============================================================================
 
-%% The 1-RTT loop: serve the owner's stream control calls, and read the
-%% socket for the server's 1-RTT packets, delivering received stream data to
-%% the owner. Owner calls are handled ahead of socket reads (the `after 0`),
-%% and the socket is polled briefly so both stay responsive in one process.
+%% The 1-RTT loop: serve the owner's stream control calls and process the
+%% server's 1-RTT datagrams, delivering received stream data to the owner.
+%% The socket is active-once, so both owner calls and inbound datagrams
+%% arrive as mailbox messages and a single receive handles both without a
+%% blocking socket read that would delay owner calls while the peer is idle.
 -spec connected_loop(#conn{}) -> ok.
 connected_loop(#conn{socket = Socket} = Conn) ->
     receive
@@ -340,22 +405,46 @@ connected_loop(#conn{socket = Socket} = Conn) ->
             Conn1 = send_stream(Conn, StreamId, Data, Fin),
             From ! {Ref, ok},
             connected_loop(Conn1);
+        {frame, From, Ref, Frame} ->
+            Conn1 = send_frame(Conn, Frame),
+            From ! {Ref, ok},
+            connected_loop(Conn1);
         stop ->
+            %% RFC 9000 §10.2: send an application CONNECTION_CLOSE so the
+            %% server tears the connection down promptly (its owner loop
+            %% observes the close) instead of waiting out the idle timeout.
+            _ = send_wire_frame(Conn, {connection_close, application, 0, 0, <<>>}),
             _ = roadrunner_quic_socket:close(Socket),
             ok;
-        _Other ->
-            connected_loop(Conn)
-    after 0 ->
-        case roadrunner_quic_socket:recv(Socket, 50) of
-            {ok, _Peer, Datagram} -> connected_loop(handle_app_datagram(Conn, Datagram));
-            {error, timeout} -> connected_loop(Conn)
-        end
+        Message ->
+            case roadrunner_quic_socket:from_message(Socket, Message) of
+                {ok, _Peer, Datagram} ->
+                    %% Re-arm before processing so the next datagram is already
+                    %% queued while we work (1-RTT packets keep arriving).
+                    ok = roadrunner_quic_socket:activate(Socket),
+                    connected_loop(handle_app_datagram(Conn, Datagram));
+                ignore ->
+                    connected_loop(Conn)
+            end
     end.
 
-%% Send a STREAM frame on a 1-RTT (short-header) packet addressed to the
-%% server's CID, tracking the per-stream offset and the 1-RTT packet number.
--spec send_stream(#conn{}, non_neg_integer(), binary(), boolean()) -> #conn{}.
-send_stream(
+%% Send stream data, splitting it across 1-RTT packets so each datagram stays
+%% within the MTU; the FIN rides the last chunk.
+-spec send_stream(#conn{}, non_neg_integer(), iodata(), boolean()) -> #conn{}.
+send_stream(Conn, StreamId, Data, Fin) ->
+    send_stream_bin(Conn, StreamId, iolist_to_binary(Data), Fin).
+
+-spec send_stream_bin(#conn{}, non_neg_integer(), binary(), boolean()) -> #conn{}.
+send_stream_bin(Conn, StreamId, Bin, Fin) when byte_size(Bin) =< ?MAX_STREAM_CHUNK ->
+    send_stream_packet(Conn, StreamId, Bin, Fin);
+send_stream_bin(Conn, StreamId, Bin, Fin) ->
+    <<Chunk:(?MAX_STREAM_CHUNK)/binary, Rest/binary>> = Bin,
+    send_stream_bin(send_stream_packet(Conn, StreamId, Chunk, false), StreamId, Rest, Fin).
+
+%% One STREAM frame on a 1-RTT (short-header) packet addressed to the server's
+%% CID, tracking the per-stream offset and the 1-RTT packet number.
+-spec send_stream_packet(#conn{}, non_neg_integer(), binary(), boolean()) -> #conn{}.
+send_stream_packet(
     #conn{
         socket = Socket,
         host = Host,
@@ -367,16 +456,48 @@ send_stream(
         send_offsets = Offsets
     } = Conn,
     StreamId,
-    Data,
+    Chunk,
     Fin
 ) ->
     Offset = maps:get(StreamId, Offsets, 0),
-    Frame = {stream, StreamId, Offset, Data, Fin},
+    Frame = {stream, StreamId, Offset, Chunk, Fin},
     {Datagram, _Sent} = roadrunner_quic_send:datagram(
         #{application => #{frames => [Frame], keys => Keys, pn => Pn}}, ServerScid, Scid
     ),
-    ok = roadrunner_quic_socket:send(Socket, Host, Port, Datagram),
-    Conn#conn{send_pn = Pn + 1, send_offsets = Offsets#{StreamId => Offset + byte_size(Data)}}.
+    _ = roadrunner_quic_socket:send(Socket, Host, Port, Datagram),
+    Conn#conn{send_pn = Pn + 1, send_offsets = Offsets#{StreamId => Offset + byte_size(Chunk)}}.
+
+%% Send a single non-STREAM frame (RESET_STREAM, STOP_SENDING) on a 1-RTT
+%% packet. A RESET_STREAM marker (no final size) is resolved here against the
+%% bytes already sent on the stream, since a final size below the largest sent
+%% offset is a FINAL_SIZE_ERROR (RFC 9000 §4.5).
+-spec send_frame(
+    #conn{}, {reset_stream, non_neg_integer(), non_neg_integer()} | roadrunner_quic_frame:frame()
+) -> #conn{}.
+send_frame(#conn{send_offsets = Offsets} = Conn, {reset_stream, StreamId, ErrorCode}) ->
+    FinalSize = maps:get(StreamId, Offsets, 0),
+    send_wire_frame(Conn, {reset_stream, StreamId, ErrorCode, FinalSize});
+send_frame(Conn, Frame) ->
+    send_wire_frame(Conn, Frame).
+
+-spec send_wire_frame(#conn{}, roadrunner_quic_frame:frame()) -> #conn{}.
+send_wire_frame(
+    #conn{
+        socket = Socket,
+        host = Host,
+        port = Port,
+        scid = Scid,
+        server_scid = ServerScid,
+        app_client_keys = Keys,
+        send_pn = Pn
+    } = Conn,
+    Frame
+) ->
+    {Datagram, _Sent} = roadrunner_quic_send:datagram(
+        #{application => #{frames => [Frame], keys => Keys, pn => Pn}}, ServerScid, Scid
+    ),
+    _ = roadrunner_quic_socket:send(Socket, Host, Port, Datagram),
+    Conn#conn{send_pn = Pn + 1}.
 
 %% Decrypt a 1-RTT datagram and route its STREAM frames through per-stream
 %% reassembly, delivering deliverable bytes to the owner.
@@ -391,6 +512,12 @@ handle_app_datagram(#conn{app_server_keys = Keys, scid = Scid} = Conn, Datagram)
 -spec handle_app_frame(roadrunner_quic_frame:frame(), #conn{}) -> #conn{}.
 handle_app_frame({stream, StreamId, Offset, Data, Fin}, Conn) ->
     deliver_stream(Conn, StreamId, Offset, Data, Fin);
+handle_app_frame({reset_stream, StreamId, ErrorCode, _FinalSize}, #conn{owner = Owner} = Conn) ->
+    _ = Owner ! {quic_test_stream_reset, self(), StreamId, ErrorCode},
+    Conn;
+handle_app_frame({connection_close, _Domain, ErrorCode, _FrameType, _Reason}, Conn) ->
+    _ = Conn#conn.owner ! {quic_test_closed, self(), ErrorCode},
+    Conn;
 handle_app_frame(_Other, Conn) ->
     Conn.
 

--- a/test/roadrunner_quic_test_h3.erl
+++ b/test/roadrunner_quic_test_h3.erl
@@ -9,13 +9,22 @@
 %% both directions). The connection delivers received stream data to this
 %% module's caller (the connection owner), so connect/2 and the request calls
 %% run in the same process.
+%%
+%% Both a synchronous surface (get/post/request, which return the whole
+%% response) and the dep-shaped split surface (open_request -> stream id,
+%% send_data, collect) are offered, so a test can interleave work between the
+%% request and the response.
 
--export([connect/2, close/1, get/2, post/3, request/3]).
+-export([connect/2, close/1]).
+-export([get/2, post/3, request/3]).
+-export([open_request/2, open_request/3, send_data/4, collect/2, cancel/2, get_peer_settings/1]).
 
 -define(COLLECT_TIMEOUT, 5000).
+%% RFC 9114 §8.1 H3_REQUEST_CANCELLED.
+-define(H3_REQUEST_CANCELLED, 16#010C).
 
 %% =============================================================================
-%% API
+%% Connection
 %% =============================================================================
 
 -doc """
@@ -39,62 +48,109 @@ connect(Host, Port) ->
 close(Conn) ->
     roadrunner_quic_test_conn:close(Conn).
 
+%% =============================================================================
+%% Requests
+%% =============================================================================
+
 -doc "Issue a GET and collect the response as `{Status, Headers, Body}`.".
--spec get(pid(), binary()) -> {non_neg_integer(), [{binary(), binary()}], binary()} | timeout.
+-spec get(pid(), binary()) -> response() | timeout | {error, term()}.
 get(Conn, Path) ->
     request(Conn, headers(~"GET", Path), <<>>).
 
 -doc "Issue a POST with `Body` and collect the response as `{Status, Headers, Body}`.".
--spec post(pid(), binary(), binary()) ->
-    {non_neg_integer(), [{binary(), binary()}], binary()} | timeout.
+-spec post(pid(), binary(), binary()) -> response() | timeout | {error, term()}.
 post(Conn, Path, Body) ->
     request(Conn, headers(~"POST", Path), Body).
 
 -doc """
 Issue a request with the given full header list (pseudo-headers included)
-and body on a fresh bidirectional stream, collecting the response as
-`{Status, Headers, Body}`. An empty body finishes the stream on the HEADERS
-frame; a non-empty body finishes on the trailing DATA.
+and body, collecting the response. An empty body finishes the stream on the
+HEADERS frame; a non-empty body finishes on the trailing DATA.
 """.
--spec request(pid(), [{binary(), binary()}], binary()) ->
-    {non_neg_integer(), [{binary(), binary()}], binary()} | timeout.
+-spec request(pid(), headers(), binary()) -> response() | timeout | {error, term()}.
+request(Conn, Headers, <<>>) ->
+    {ok, StreamId} = open_request(Conn, Headers),
+    collect(Conn, StreamId);
 request(Conn, Headers, Body) ->
+    {ok, StreamId} = open_request(Conn, Headers, false),
+    ok = send_data(Conn, StreamId, Body, true),
+    collect(Conn, StreamId).
+
+-doc "Open a request stream and send its HEADERS, finishing the stream.".
+-spec open_request(pid(), headers()) -> {ok, non_neg_integer()}.
+open_request(Conn, Headers) ->
+    open_request(Conn, Headers, true).
+
+-doc "Open a request stream and send its HEADERS, finishing the stream when `EndStream`.".
+-spec open_request(pid(), headers(), boolean()) -> {ok, non_neg_integer()}.
+open_request(Conn, Headers, EndStream) ->
     StreamId = roadrunner_quic_test_conn:open_bidi(Conn),
-    case Body of
-        <<>> ->
-            send_headers(Conn, StreamId, Headers, true);
-        _ ->
-            send_headers(Conn, StreamId, Headers, false),
-            DataFrame = roadrunner_quic_h3_frame:encode_data(Body),
-            ok = roadrunner_quic_test_conn:send(Conn, StreamId, iolist_to_binary(DataFrame), true)
-    end,
+    Frame = roadrunner_quic_h3_frame:encode_headers(roadrunner_qpack:encode(Headers)),
+    ok = roadrunner_quic_test_conn:send(Conn, StreamId, iolist_to_binary(Frame), EndStream),
+    {ok, StreamId}.
+
+-doc "Send a DATA frame on a request stream, with the FIN bit when `Fin`.".
+-spec send_data(pid(), non_neg_integer(), binary(), boolean()) -> ok.
+send_data(Conn, StreamId, Data, Fin) ->
+    Frame = roadrunner_quic_h3_frame:encode_data(Data),
+    roadrunner_quic_test_conn:send(Conn, StreamId, iolist_to_binary(Frame), Fin).
+
+-doc "Cancel a request: RESET_STREAM + STOP_SENDING with H3_REQUEST_CANCELLED.".
+-spec cancel(pid(), non_neg_integer()) -> ok.
+cancel(Conn, StreamId) ->
+    ok = roadrunner_quic_test_conn:reset_stream(Conn, StreamId, ?H3_REQUEST_CANCELLED),
+    ok = roadrunner_quic_test_conn:stop_sending(Conn, StreamId, ?H3_REQUEST_CANCELLED).
+
+-doc """
+Collect the response on `StreamId`: accumulate its bytes until FIN, then
+decode the h3 response. Returns `{error, {stream_reset, Code}}` if the server
+resets the stream. Stream data for other streams stays in the mailbox.
+""".
+-spec collect(pid(), non_neg_integer()) -> response() | timeout | {error, term()}.
+collect(Conn, StreamId) ->
     collect(Conn, StreamId, <<>>).
+
+%% =============================================================================
+%% Peer settings
+%% =============================================================================
+
+-doc """
+Read the server's SETTINGS off its control stream (the server unidirectional
+stream whose type prefix is `control`), returning the decoded settings map.
+""".
+-spec get_peer_settings(pid()) -> map().
+get_peer_settings(Conn) ->
+    receive
+        {quic_test_stream, Conn, StreamId, Data, _Fin} when StreamId rem 4 =:= 3 ->
+            case control_settings(Data) of
+                {ok, Settings} -> Settings;
+                more -> get_peer_settings(Conn)
+            end
+    after ?COLLECT_TIMEOUT ->
+        #{}
+    end.
 
 %% =============================================================================
 %% Internal
 %% =============================================================================
 
--spec send_headers(pid(), non_neg_integer(), [{binary(), binary()}], boolean()) -> ok.
-send_headers(Conn, StreamId, Headers, Fin) ->
-    Frame = roadrunner_quic_h3_frame:encode_headers(roadrunner_qpack:encode(Headers)),
-    ok = roadrunner_quic_test_conn:send(Conn, StreamId, iolist_to_binary(Frame), Fin).
+-type headers() :: [{binary(), binary()}].
+-type response() :: {non_neg_integer(), headers(), binary()}.
 
-%% Accumulate the request stream's bytes until its FIN, then decode the h3
-%% response. Stream data for other streams (the server's control / QPACK
-%% streams) is left in the mailbox.
--spec collect(pid(), non_neg_integer(), binary()) ->
-    {non_neg_integer(), [{binary(), binary()}], binary()} | timeout.
+-spec collect(pid(), non_neg_integer(), binary()) -> response() | timeout | {error, term()}.
 collect(Conn, StreamId, Acc) ->
     receive
         {quic_test_stream, Conn, StreamId, Data, true} ->
             decode_response(<<Acc/binary, Data/binary>>);
         {quic_test_stream, Conn, StreamId, Data, false} ->
-            collect(Conn, StreamId, <<Acc/binary, Data/binary>>)
+            collect(Conn, StreamId, <<Acc/binary, Data/binary>>);
+        {quic_test_stream_reset, Conn, StreamId, ErrorCode} ->
+            {error, {stream_reset, ErrorCode}}
     after ?COLLECT_TIMEOUT ->
         timeout
     end.
 
--spec decode_response(binary()) -> {non_neg_integer(), [{binary(), binary()}], binary()}.
+-spec decode_response(binary()) -> response().
 decode_response(Bytes) ->
     Frames = decode_frames(Bytes),
     {ok, Headers} = roadrunner_qpack:decode(first_headers_block(Frames)),
@@ -115,10 +171,24 @@ first_headers_block([_ | Rest]) -> first_headers_block(Rest).
 response_body(Frames) ->
     iolist_to_binary([Data || {data, Data} <- Frames]).
 
--spec status([{binary(), binary()}]) -> non_neg_integer().
+-spec status(headers()) -> non_neg_integer().
 status(Headers) ->
     {~":status", Value} = lists:keyfind(~":status", 1, Headers),
     binary_to_integer(Value).
+
+%% The SETTINGS map from a control stream's bytes (its `control` type prefix
+%% then a SETTINGS frame), or `more` when the bytes are not the control stream.
+-spec control_settings(binary()) -> {ok, map()} | more.
+control_settings(Data) ->
+    case roadrunner_quic_h3_frame:decode_stream_type(Data) of
+        {ok, control, Rest} ->
+            case roadrunner_quic_h3_frame:decode(Rest) of
+                {ok, {settings, Settings}, _} -> {ok, Settings};
+                _ -> more
+            end;
+        _ ->
+            more
+    end.
 
 %% The control stream-type prefix followed by a SETTINGS frame (RFC 9114
 %% §6.2.1 / §7.2.4); static-table-only QPACK advertises a zero table capacity.
@@ -129,7 +199,7 @@ control_with_settings() ->
         roadrunner_quic_h3_frame:encode_settings(#{qpack_max_table_capacity => 0})
     ]).
 
--spec headers(binary(), binary()) -> [{binary(), binary()}].
+-spec headers(binary(), binary()) -> headers().
 headers(Method, Path) ->
     [
         {~":method", Method},


### PR DESCRIPTION
# Description

The HTTP/3 tests now run on roadrunner's native QUIC client instead of the `quic` dependency, so the dep leaves the test profile and no profile depends on it (production stays `telemetry`-only).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
