### PR TITLE
Bench roadrunner's HTTP/3 server against the quic dep's server

### DIFF
--- a/bench/bench_erlang_quic_server.erl
+++ b/bench/bench_erlang_quic_server.erl
@@ -1,0 +1,52 @@
+-module(bench_erlang_quic_server).
+-moduledoc false.
+
+%% Bench-only: stands up the `quic` dependency's turnkey HTTP/3 server as the
+%% `erlang_quic` comparison target for roadrunner's native h3 server. Compiled
+%% only under the `bench` rebar3 profile (the dep is bench-profile-only), so it
+%% never touches the dep-free `test` profile.
+%%
+%% It serves the bench's `hello` scenario response: 200 + a 7-byte body,
+%% matching `roadrunner_keepalive_handler` so the loadgen's status + body-length
+%% checks pass identically for both servers under the same client.
+
+-export([start/2]).
+
+%% The dep registers a server under a name; we read the bound port back from it.
+-define(SERVER_NAME, bench_erlang_quic_h3).
+
+%% Start the dep h3 server for `Scenario` on an ephemeral UDP port, reading the
+%% PEM cert/key the bench generated under `CertDir`. Returns the bound port.
+-spec start(file:filename(), atom()) -> {ok, inet:port_number()} | {error, term()}.
+start(CertDir, Scenario) ->
+    {ok, _} = application:ensure_all_started(quic),
+    {Cert, Key} = load_keypair(CertDir),
+    Handler = handler(Scenario),
+    {ok, _Pid} = quic_h3:start_server(?SERVER_NAME, 0, #{
+        cert => Cert,
+        key => Key,
+        handler => Handler
+    }),
+    quic:get_server_port(?SERVER_NAME).
+
+%% The leaf cert as DER and the private key as the decoded term the dep wants
+%% (mirrors the dep's own `quic_h3_server` PEM loading).
+-spec load_keypair(file:filename()) -> {binary(), term()}.
+load_keypair(CertDir) ->
+    {ok, CertPem} = file:read_file(filename:join(CertDir, "cert.pem")),
+    [{_CertType, CertDer, _} | _] = public_key:pem_decode(CertPem),
+    {ok, KeyPem} = file:read_file(filename:join(CertDir, "key.pem")),
+    [{KeyType, KeyDer, _} | _] = public_key:pem_decode(KeyPem),
+    {CertDer, public_key:der_decode(KeyType, KeyDer)}.
+
+%% A handler fun (RFC 9114 request callback shape the dep expects:
+%% `fun(Conn, StreamId, Method, Path, Headers)`). The `hello` scenario answers
+%% every request with 200 + `alive\r\n` (7 bytes), the same as roadrunner's
+%% keepalive fixture.
+-spec handler(atom()) -> fun().
+handler(hello) ->
+    Body = ~"alive\r\n",
+    fun(Conn, StreamId, _Method, _Path, _Headers) ->
+        ok = quic_h3:send_response(Conn, StreamId, 200, [{~"content-type", ~"text/plain"}]),
+        ok = quic_h3:send_data(Conn, StreamId, Body, true)
+    end.

--- a/bench/bench_quic_h3_loadgen.erl
+++ b/bench/bench_quic_h3_loadgen.erl
@@ -1,0 +1,113 @@
+-module(bench_quic_h3_loadgen).
+-moduledoc false.
+
+%% Bench-only HTTP/3 loadgen over the `quic` dependency's `quic_h3` client.
+%% Compiled only under the `bench` rebar3 profile. It exposes the same
+%% `open/3` + `request/5` + `close/1` surface as `roadrunner_bench_client`, so
+%% the bench worker loop can drive ANY h3 server (roadrunner's native server or
+%% the dep's `erlang_quic` server) through the SAME strong client base, which
+%% is what makes the server-vs-server comparison honest. The dep's client is a
+%% mature loadgen (it sustained tens of thousands of req/s in the bench),
+%% unlike the native test client which is built for correctness, not load.
+%%
+%% This is the pre-native-client `roadrunner_bench_client` h3 path (commit
+%% 65e4760) lifted verbatim: the dep delivers responses as `{quic_h3, Conn, _}`
+%% messages, collected per request into `{Status, Headers, Body}`.
+
+-export([open/3, request/5, close/1]).
+
+-record(h3_conn, {
+    conn :: pid(),
+    authority :: binary()
+}).
+
+%% Open one keep-alive QUIC connection. Under load the dep's handshake can
+%% intermittently stall even though a fresh connection completes immediately,
+%% so retry with a new connection a few times rather than lean on one deadline.
+-spec open(inet:hostname() | inet:ip_address(), inet:port_number(), h3) ->
+    {ok, #h3_conn{}} | {error, term()}.
+open(Host, Port, h3) ->
+    open_h3(host_to_authority(Host), Port, 5).
+
+open_h3(_HostBin, _Port, 0) ->
+    {error, timeout};
+open_h3(HostBin, Port, Attempts) ->
+    case quic_h3:connect(HostBin, Port, #{verify => verify_none}) of
+        {ok, Conn} ->
+            case quic_h3:wait_connected(Conn, 5000) of
+                ok ->
+                    {ok, #h3_conn{conn = Conn, authority = HostBin}};
+                {error, _} ->
+                    _ = quic_h3:close(Conn),
+                    open_h3(HostBin, Port, Attempts - 1)
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+%% Issue one request on the keep-alive connection and collect the response.
+-spec request(#h3_conn{}, binary(), binary(), [{binary(), binary()}], binary()) ->
+    {ok, non_neg_integer(), [{binary(), binary()}], binary(), #h3_conn{}} | {error, term()}.
+request(#h3_conn{conn = Conn, authority = Auth} = C, Method, Path, Headers, Body) ->
+    AllHeaders = [
+        {~":method", Method},
+        {~":scheme", ~"https"},
+        {~":authority", Auth},
+        {~":path", Path}
+        | Headers
+    ],
+    case h3_send_request(Conn, AllHeaders, Body) of
+        {ok, StreamId} ->
+            case h3_collect(Conn, StreamId, undefined, [], <<>>) of
+                {ok, Status, RespHeaders, RespBody} ->
+                    {ok, Status, RespHeaders, RespBody, C};
+                {error, _} = E ->
+                    E
+            end;
+        {error, _} = E ->
+            E
+    end.
+
+-spec close(#h3_conn{}) -> ok.
+close(#h3_conn{conn = Conn}) ->
+    _ = quic_h3:close(Conn),
+    ok.
+
+h3_send_request(Conn, AllHeaders, <<>>) ->
+    quic_h3:request(Conn, AllHeaders);
+h3_send_request(Conn, AllHeaders, Body) ->
+    case quic_h3:request(Conn, AllHeaders, #{end_stream => false}) of
+        {ok, StreamId} ->
+            case quic_h3:send_data(Conn, StreamId, Body, true) of
+                ok -> {ok, StreamId};
+                {error, _} = E -> E
+            end;
+        {error, _} = E ->
+            E
+    end.
+
+h3_collect(Conn, StreamId, Status, Headers, Acc) ->
+    receive
+        {quic_h3, Conn, {response, StreamId, S, H}} ->
+            h3_collect(Conn, StreamId, S, H, Acc);
+        {quic_h3, Conn, {data, StreamId, Data, true}} ->
+            {ok, Status, Headers, <<Acc/binary, Data/binary>>};
+        {quic_h3, Conn, {data, StreamId, Data, false}} ->
+            h3_collect(Conn, StreamId, Status, Headers, <<Acc/binary, Data/binary>>);
+        {quic_h3, Conn, {trailers, StreamId, _Trailers}} ->
+            {ok, Status, Headers, Acc};
+        {quic_h3, Conn, {stream_reset, StreamId, ErrorCode}} ->
+            {error, {stream_reset, ErrorCode}};
+        {quic_h3, Conn, {error, ErrorCode, _Reason}} ->
+            {error, {conn_error, ErrorCode}};
+        {quic_h3, Conn, closed} ->
+            {error, closed};
+        {quic_h3, Conn, _Other} ->
+            h3_collect(Conn, StreamId, Status, Headers, Acc)
+    after 5000 ->
+        {error, timeout}
+    end.
+
+host_to_authority(Host) when is_list(Host) -> list_to_binary(Host);
+host_to_authority(Host) when is_binary(Host) -> Host;
+host_to_authority(Host) when is_tuple(Host) -> list_to_binary(inet:ntoa(Host)).

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,8 @@
     {files, [
         "rebar.config",
         "src/*.{erl,hrl,app.src}",
-        "test/*.{erl,hrl}"
+        "test/*.{erl,hrl}",
+        "bench/*.{erl,hrl}"
     ]}
 ]}.
 
@@ -43,6 +44,16 @@
             {cowboy, "2.15.0"},
             {elli, "3.3.0"}
         ]}
+    ]},
+    %% Bench-only: the `quic` dep as an HTTP/3 comparison server (`erlang_quic`)
+    %% and a strong h3 loadgen, kept OUT of the `test` profile so the test
+    %% suite stays dep-free on the native client. The dep-using bench code
+    %% lives in `bench/` and is compiled only here. Build the bench with
+    %% `rebar3 as test,bench compile` so the `test` fixtures and the `bench`
+    %% dep code are both on the path.
+    {bench, [
+        {deps, [{quic, "1.6.1"}]},
+        {extra_src_dirs, [{"bench", [{recursive, true}]}]}
     ]}
 ]}.
 

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -54,7 +54,7 @@
 %% Servers known to the bench, in default-run order. Adding a new
 %% server is two steps: append it here and add a clause for it in
 %% `start_server/2` (plus any `scenario_*` config helpers below).
--define(KNOWN_SERVERS, [roadrunner, cowboy, elli]).
+-define(KNOWN_SERVERS, [roadrunner, cowboy, elli, erlang_quic]).
 
 %% Wire protocols the bench can drive. `--protocols` accepts a
 %% comma-separated subset; omitting the flag iterates every protocol.
@@ -454,11 +454,11 @@ preflight_protocol(#{protocol := h3, servers := Servers} = Opts) ->
     %% generated cert, and the bench node needs `ssl` started for the
     %% cert / crypto primitives the native client and server share.
     CertDir = generate_test_cert(),
-    Filtered = [S || S <- Servers, S =:= roadrunner],
+    Filtered = [S || S <- Servers, S =:= roadrunner orelse S =:= erlang_quic],
     case Filtered =/= Servers of
         true ->
             io:format(
-                "note: --protocols h3 is roadrunner-only here "
+                "note: --protocols h3 runs roadrunner + erlang_quic only "
                 "(cowboy/elli have no HTTP/3)~n",
                 []
             );
@@ -1008,6 +1008,23 @@ cli() ->
                     """
             },
             #{
+                name => h3_client,
+                long => "-h3-client",
+                type => {atom, [native, dep]},
+                default => native,
+                help =>
+                    """
+                    h3 loadgen to drive the `--protocols h3` servers with.
+                      native (default): the in-tree native client
+                          (`roadrunner_quic_test_h3`), dep-free.
+                      dep: the `quic` dep's `quic_h3` client (a strong
+                          loadgen), for an honest server-vs-server compare
+                          of roadrunner against `erlang_quic` under the
+                          same base. Needs the `bench` profile
+                          (`rebar3 as test,bench compile`).
+                    """
+            },
+            #{
                 name => standalone,
                 long => "-standalone",
                 type => boolean,
@@ -1399,6 +1416,8 @@ start_server(roadrunner, #{protocol := h2c, scenario := Scenario}) ->
     start_roadrunner_h2c(Scenario);
 start_server(roadrunner, #{protocol := h3, scenario := Scenario, cert_dir := CertDir}) ->
     start_roadrunner_h3(Scenario, CertDir);
+start_server(erlang_quic, #{protocol := h3, scenario := Scenario, cert_dir := CertDir}) ->
+    start_erlang_quic_h3(Scenario, CertDir);
 start_server(cowboy, #{protocol := h1, scenario := Scenario}) ->
     start_cowboy_h1(Scenario);
 start_server(cowboy, #{protocol := h2, scenario := Scenario, cert_dir := CertDir}) ->
@@ -1567,6 +1586,23 @@ start_roadrunner_h3(Scenario, CertDir) ->
     {ok, _} = peer:call(Peer, roadrunner, start_listener, [bench_rr_h3, ListenerOpts]),
     Port = peer:call(Peer, roadrunner_listener, port, [bench_rr_h3]),
     print_listener_config([{"listener_opts", ListenerOpts}]),
+    {Peer, Port}.
+
+%% The `quic` dep's turnkey HTTP/3 server, the `erlang_quic` comparison target.
+%% Mirrors `start_roadrunner_h3/2`: a peer BEAM serves the scenario over QUIC
+%% with the same generated cert, and the bound UDP port is read back. The
+%% dep-using starter lives in `bench/bench_erlang_quic_server.erl` (bench
+%% profile only).
+start_erlang_quic_h3(Scenario, CertDir) ->
+    {ok, Peer, _Node} = peer:start_link(#{
+        name => peer:random_name(),
+        connection => standard_io,
+        args => pa_args_for_peer(),
+        wait_boot => 10000
+    }),
+    {ok, _} = peer:call(Peer, application, ensure_all_started, [quic]),
+    {ok, Port} = peer:call(Peer, bench_erlang_quic_server, start, [CertDir, Scenario]),
+    print_listener_config([{"server", "erlang_quic (quic dep) http3"}, {"port", Port}]),
     {Peer, Port}.
 
 start_cowboy_h2(Scenario, CertDir) ->
@@ -3517,7 +3553,8 @@ run_phase_h2(Port, #{clients := C, host := Host, scenario := Scenario}, Duration
     EndUs = erlang:monotonic_time(microsecond),
     aggregate(PerWorker, EndUs - StartUs).
 
-run_phase_h3(Port, #{clients := C, host := Host, scenario := Scenario}, DurationMs) ->
+run_phase_h3(Port, #{clients := C, host := Host, scenario := Scenario} = Opts, DurationMs) ->
+    Client = h3_client_mod(Opts),
     Deadline = erlang:monotonic_time(millisecond) + DurationMs,
     {Method, Path, ReqHeaders, ReqBody} = h2_request_shape(Scenario),
     Self = self(),
@@ -3527,7 +3564,7 @@ run_phase_h3(Port, #{clients := C, host := Host, scenario := Scenario}, Duration
             Self !
                 {self(),
                     h3_worker_loop(
-                        Host, Port, Method, Path, ReqHeaders, ReqBody, Deadline, init_acc()
+                        Client, Host, Port, Method, Path, ReqHeaders, ReqBody, Deadline, init_acc()
                     )}
         end)
      || _ <- lists:seq(1, C)
@@ -3540,12 +3577,20 @@ run_phase_h3(Port, #{clients := C, host := Host, scenario := Scenario}, Duration
 %% `h2_keep_alive_loop` (it only calls `roadrunner_bench_client:request/
 %% close`, which dispatch on the conn record) + the shared
 %% `h2_request_shape/1` scenario table.
-h3_worker_loop(Host, Port, Method, Path, ReqHeaders, ReqBody, Deadline, Acc) ->
-    case roadrunner_bench_client:open(Host, Port, h3) of
+h3_worker_loop(Client, Host, Port, Method, Path, ReqHeaders, ReqBody, Deadline, Acc) ->
+    case Client:open(Host, Port, h3) of
         {ok, Conn} ->
-            h2_keep_alive_loop(Conn, Method, Path, ReqHeaders, ReqBody, Deadline, Acc);
+            h2_keep_alive_loop(Client, Conn, Method, Path, ReqHeaders, ReqBody, Deadline, Acc);
         {error, _} ->
             bump_err(Acc)
+    end.
+
+%% The h3 loadgen module for the run (`--h3-client`): the dep-free native
+%% client by default, or the `quic` dep client for the server comparison.
+h3_client_mod(Opts) ->
+    case maps:get(h3_client, Opts, native) of
+        dep -> bench_quic_h3_loadgen;
+        native -> roadrunner_bench_client
     end.
 
 %% tls_handshake_throughput: open a fresh TLS+ALPN-h2 conn per
@@ -3883,27 +3928,32 @@ h2_request_shape(httparena_static) ->
 h2_worker_loop(Host, Port, Method, Path, ReqHeaders, ReqBody, Deadline, Acc) ->
     case roadrunner_bench_client:open(Host, Port, h2_client_proto()) of
         {ok, Conn} ->
-            h2_keep_alive_loop(Conn, Method, Path, ReqHeaders, ReqBody, Deadline, Acc);
+            h2_keep_alive_loop(
+                roadrunner_bench_client, Conn, Method, Path, ReqHeaders, ReqBody, Deadline, Acc
+            );
         {error, _} ->
             bump_err(Acc)
     end.
 
-h2_keep_alive_loop(Conn, Method, Path, ReqHeaders, ReqBody, Deadline, Acc) ->
+%% Shared keep-alive request loop for h2 and h3. `Client` is the loadgen module
+%% (`roadrunner_bench_client` or, for the h3 dep comparison,
+%% `bench_quic_h3_loadgen`); both expose `request/5` + `close/1` over the conn.
+h2_keep_alive_loop(Client, Conn, Method, Path, ReqHeaders, ReqBody, Deadline, Acc) ->
     case erlang:monotonic_time(millisecond) >= Deadline of
         true ->
-            _ = roadrunner_bench_client:close(Conn),
+            _ = Client:close(Conn),
             Acc;
         false ->
             T0 = erlang:monotonic_time(nanosecond),
-            case roadrunner_bench_client:request(Conn, Method, Path, ReqHeaders, ReqBody) of
+            case Client:request(Conn, Method, Path, ReqHeaders, ReqBody) of
                 {ok, 200, _RespHeaders, RespBody, Conn1} ->
                     T1 = erlang:monotonic_time(nanosecond),
                     h2_keep_alive_loop(
-                        Conn1, Method, Path, ReqHeaders, ReqBody, Deadline,
+                        Client, Conn1, Method, Path, ReqHeaders, ReqBody, Deadline,
                         bump_ok(Acc, T1 - T0, byte_size(RespBody))
                     );
                 _Other ->
-                    _ = roadrunner_bench_client:close(Conn),
+                    _ = Client:close(Conn),
                     bump_err(Acc)
             end
     end.
@@ -4379,6 +4429,10 @@ fmt_ns(N) -> io_lib:format("~.2f s", [N / 1000000000]).
 
 setup_code_paths(BaseDir) ->
     Candidates = [
+        %% `--h3-client dep` / `--servers erlang_quic` build with the `bench`
+        %% profile combined with `test`, which lands under `test+bench`; prefer
+        %% it so the `quic` dep beams are on the path.
+        filename:join([BaseDir, "_build", "test+bench", "lib"]),
         filename:join([BaseDir, "_build", "test", "lib"]),
         filename:join([BaseDir, "_build", "default", "lib"])
     ],
@@ -4403,6 +4457,13 @@ setup_code_paths(BaseDir) ->
             TestDir = filename:join([LibDir, Lib, "test"]),
             case filelib:is_dir(TestDir) of
                 true -> code:add_pathz(TestDir);
+                false -> ok
+            end,
+            %% The `bench` profile's extra_src_dir (the dep-using h3
+            %% comparison code) lands here, not in ebin.
+            BenchDir = filename:join([LibDir, Lib, "bench"]),
+            case filelib:is_dir(BenchDir) of
+                true -> code:add_pathz(BenchDir);
                 false -> ok
             end
         end,


### PR DESCRIPTION
# Description

Adds a bench-only `bench` profile carrying the `quic` dep so `scripts/bench.escript` can compare roadrunner's native HTTP/3 server against the dep's `erlang_quic` server under the same client (`--h3-client dep`). The `test` profile stays dep-free.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
