### PR TITLE
Speed up the native QUIC send and receive paths

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,6 +132,25 @@ advisory or malformed cases the server currently tolerates or omits.
   late or retransmitted frame for a removed id is ignored, not recreated) —
   medium
 
+### Throughput levers identified by profiling
+
+Profiling the native h3 server under load (`scripts/bench.escript --servers
+roadrunner --protocols h3 --scenarios large_response --profile --profile-tool
+eprof --profile-scope all`) leaves two large costs that are not hot-path Erlang,
+so the send-path optimizations did not touch them.
+
+- Batch UDP sends: each datagram is one `gen_udp:send`, i.e. one `port_command`
+  syscall, and that is ~7% of server time on a download. Sending several
+  datagrams per syscall via `sendmmsg` or UDP generic segmentation offload (GSO)
+  would cut it, but `gen_udp` has no batched-send primitive, so it needs the OTP
+  `socket` API (or a NIF) plus careful per-path sizing — large
+- TLS session resumption / 0-RTT (RFC 8446 §2.2, RFC 9001 §4.6): the RSA-2048
+  CertificateVerify signature is ~6-7 ms per full handshake, the single biggest
+  per-connection cost. Session tickets let a returning client skip the signature
+  entirely. Independently, deploying an ECDSA P-256 server certificate instead of
+  RSA-2048 cuts that signature ~30-60x today with no code change (operator
+  guidance, worth a deployment note) — large
+
 ### External interop check
 
 The native test client runs the same codecs as the native server, so a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,6 +124,13 @@ advisory or malformed cases the server currently tolerates or omits.
   the oldest-unacked) — medium
 - A no-flatten / by-reference stream send buffer, so a large response body is
   not flattened into one binary before sending — medium
+- Prune fully-terminal streams (send + receive both closed, or reset) from the
+  connection's stream map, which grows unbounded over a keep-alive connection
+  today (every served request's bidi stream lingers). The send pass already
+  walks only a pending-data working set, so this is now a memory bound, not a
+  CPU one; it needs an RFC 9000 §3 late-packet guard (a high-water mark so a
+  late or retransmitted frame for a removed id is ignored, not recreated) —
+  medium
 
 ### External interop check
 

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -294,17 +294,30 @@ finish_datagram(_Now, _Before, #state{phase = closed, pending_close = undefined}
 finish_datagram(_Now, _Before, #state{phase = closed} = State) ->
     {State1, CloseEffects} = send_close(State),
     {State2, EmitEffects} = drain_emits(State1),
-    {State2, CloseEffects ++ EmitEffects};
+    case CloseEffects of
+        [] -> {State2, EmitEffects};
+        [Close] -> {State2, [Close | EmitEffects]}
+    end;
 finish_datagram(Now, Before, State) ->
     {State3, SendEffects} = send_pass(Now, State),
-    {State4, EmitEffects} = drain_emits(State3),
-    {State4, connected_effects(Before, State4) ++ EmitEffects ++ SendEffects}.
+    {State4, Emits} = take_emits(State3),
+    %% {connected, _} first (so the owner opens its control stream before the
+    %% first request), then the datagram's owner events in arrival order, then
+    %% the sends; reverse the newest-first emits onto the sends in one pass.
+    {State4, connected_effects(Before, State4, lists:reverse(Emits, SendEffects))}.
 
 %% Owner events accumulate (newest-first) in #state.emits while the
 %% datagram's frames are folded; hand them back in arrival order and clear.
 -spec drain_emits(t()) -> {t(), [effect()]}.
-drain_emits(#state{emits = Emits} = State) ->
-    {State#state{emits = []}, lists:reverse(Emits)}.
+drain_emits(State) ->
+    {State1, Emits} = take_emits(State),
+    {State1, lists:reverse(Emits)}.
+
+%% Take the owner events newest-first (as accumulated) and clear them, for a
+%% caller that will reverse them onto a tail itself.
+-spec take_emits(t()) -> {t(), [effect()]}.
+take_emits(#state{emits = Emits} = State) ->
+    {State#state{emits = []}, Emits}.
 
 %% Queue an owner event for the current datagram (dropped if no owner yet).
 -spec emit(event(), t()) -> t().
@@ -317,13 +330,13 @@ emit(Event, #state{owner = Owner, emits = Emits} = State) ->
 %% handshaking -> connected transition AND an owner is installed. With no
 %% owner yet (the listener has not run set_owner), the emit is deferred to
 %% install_owner. The two sites are mutually exclusive, so it fires once.
--spec connected_effects(phase(), t()) -> [effect()].
-connected_effects(handshaking, #state{phase = connected, owner = Owner, info = Info}) when
+-spec connected_effects(phase(), t(), [effect()]) -> [effect()].
+connected_effects(handshaking, #state{phase = connected, owner = Owner, info = Info}, Tail) when
     is_pid(Owner)
 ->
-    [{emit, Owner, {connected, Info}}];
-connected_effects(_Before, _State) ->
-    [].
+    [{emit, Owner, {connected, Info}} | Tail];
+connected_effects(_Before, _State, Tail) ->
+    Tail.
 
 %% =============================================================================
 %% Control calls (owner / listener -> conn, synchronous)
@@ -645,11 +658,13 @@ queue_crypto(Level, Bytes, State) ->
         State
     ).
 
-%% Queue a control frame to send at a level.
+%% Queue a control frame to send at a level. The pending list is flushed into
+%% one packet wholesale and frame order within a packet is irrelevant, so a
+%% frame is consed on rather than appended.
 -spec queue_frame(level(), roadrunner_quic_frame:frame(), t()) -> t().
 queue_frame(Level, Frame, State) ->
     Space = space(Level, State),
-    put_space(Level, Space#space{pending = Space#space.pending ++ [Frame]}, State).
+    put_space(Level, Space#space{pending = [Frame | Space#space.pending]}, State).
 
 -spec process_ack(integer(), level(), tuple(), t()) -> t().
 process_ack(Now, Level, Ack, State) ->
@@ -660,7 +675,9 @@ process_ack(Now, Level, Ack, State) ->
         {Loss, _Acked, Lost} ->
             put_space(
                 Level,
-                Space#space{loss = Loss, pending = Space#space.pending ++ retransmittable(Lost)},
+                Space#space{
+                    loss = Loss, pending = lists:reverse(retransmittable(Lost), Space#space.pending)
+                },
                 State
             )
     end.
@@ -1080,7 +1097,11 @@ on_pto(Now, Level, State) ->
     #space{loss = Loss0, pending = Pending} = Space = space(Level, State),
     {Loss1, Lost} = roadrunner_quic_loss:detect_lost(Now, Loss0),
     Loss2 = roadrunner_quic_loss:on_pto_expired(Loss1),
-    put_space(Level, Space#space{loss = Loss2, pending = Pending ++ retransmittable(Lost)}, State).
+    put_space(
+        Level,
+        Space#space{loss = Loss2, pending = lists:reverse(retransmittable(Lost), Pending)},
+        State
+    ).
 
 %% Arm ONE timer at the nearest deadline: the earliest per-space probe timeout
 %% (across spaces with ack-eliciting bytes in flight) or the always-present
@@ -1157,7 +1178,9 @@ min_defined(A, B) -> min(A, B).
 %% frames worth resending: ACK / PADDING / CONNECTION_CLOSE are regenerated
 %% fresh or terminal, never replayed (RFC 9002 §13.3).
 %% `roadrunner_quic_send:ack_eliciting/1` is the single source of truth for
-%% which frames are ack-eliciting.
+%% which frames are ack-eliciting. Callers fold the result onto the existing
+%% pending list with `lists:reverse/2` (order within the flushed packet is
+%% irrelevant), so no list append is needed.
 -spec retransmittable([[roadrunner_quic_frame:frame()]]) -> [roadrunner_quic_frame:frame()].
 retransmittable(Lost) ->
     [Frame || Frame <- lists:append(Lost), roadrunner_quic_send:is_ack_eliciting(Frame)].

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -101,6 +101,12 @@
     %% by stream id (peer-initiated on receive; server-initiated and client
     %% request streams on send).
     streams = #{} :: #{non_neg_integer() => stream()},
+    %% The subset of `streams` ids with unsent data or an unsent FIN, kept
+    %% ascending (RFC 9000 stream priority: lowest id first). The send pass
+    %% walks only these instead of re-sorting and scanning every stream
+    %% (finished streams stay in `streams` but leave this set), so per-pass
+    %% work is O(streams-with-pending-data), not O(all-streams-ever).
+    sendable = [] :: ordsets:ordset(non_neg_integer()),
     %% Next server-initiated unidirectional stream id to hand out (RFC 9000
     %% §2.1: server uni ids are 3, 7, 11, ...); the owner opens its h3
     %% control stream this way.
@@ -842,8 +848,16 @@ stream_recv_window(_Sid, #{initial_max_stream_data_uni := Uni}) ->
 
 -spec put_stream(non_neg_integer(), roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()) ->
     t().
-put_stream(Sid, Stream, Flow, #state{streams = Streams} = State) ->
-    State#state{streams = Streams#{Sid => {Stream, Flow}}}.
+put_stream(Sid, Stream, Flow, #state{streams = Streams, sendable = Sendable} = State) ->
+    %% The single writer of `streams`, so it is also where the `sendable`
+    %% working set stays in step: a stream with unsent data/FIN joins it, a
+    %% drained or finished one leaves it.
+    Sendable1 =
+        case roadrunner_quic_stream:send_pending(Stream) of
+            true -> ordsets:add_element(Sid, Sendable);
+            false -> ordsets:del_element(Sid, Sendable)
+        end,
+    State#state{streams = Streams#{Sid => {Stream, Flow}}, sendable = Sendable1}.
 
 %% Emit {stream_data, ...} when there are newly-contiguous bytes OR the FIN
 %% was reached (the FIN-only {<<>>, true} end-of-stream the h3 layer needs).
@@ -943,8 +957,10 @@ build_data(Level, AckFrames, Space, State) ->
 %% by the connection and per-stream send windows and the per-packet budget,
 %% and the bytes are accounted against both windows.
 -spec take_stream(t()) -> {[roadrunner_quic_frame:frame()], t()}.
-take_stream(#state{streams = Streams} = State) ->
-    take_stream(lists:sort(maps:keys(Streams)), State).
+take_stream(#state{sendable = Sendable} = State) ->
+    %% Only streams with pending send data are candidates, already ascending;
+    %% finished/drained streams never enter the walk (see `put_stream/4`).
+    take_stream(Sendable, State).
 
 -spec take_stream([non_neg_integer()], t()) -> {[roadrunner_quic_frame:frame()], t()}.
 take_stream([], State) ->

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -1087,11 +1087,14 @@ earliest_deadline(Now, #state{idle_deadline = Idle} = State) ->
     end.
 
 -spec earliest_pto(integer(), t()) -> integer() | undefined.
-earliest_pto(Now, State) ->
-    lists:foldl(
-        fun(Level, Earliest) -> min_defined(Earliest, space_pto(Now, space(Level, State))) end,
+earliest_pto(Now, #state{spaces = Spaces}) ->
+    %% The earliest PTO across all spaces; fold the map directly (order is
+    %% irrelevant to a min) rather than rebuilding the level list and looking
+    %% each space up again.
+    maps:fold(
+        fun(_Level, Space, Earliest) -> min_defined(Earliest, space_pto(Now, Space)) end,
         undefined,
-        present_levels(State)
+        Spaces
     ).
 
 -spec space_pto(integer(), #space{}) -> integer() | undefined.

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -46,10 +46,6 @@
 %% A CRYPTO slice budget that leaves room for the packet header, an ACK
 %% frame, and the AEAD tag within the 1200-byte datagram (RFC 9000 §14).
 -define(CRYPTO_BUDGET, 1000).
-%% A STREAM data-slice budget, leaving room for the short header, an ACK
-%% frame, the STREAM frame header, and the AEAD tag within the 1200-byte
-%% datagram (RFC 9000 §14).
--define(STREAM_BUDGET, 1000).
 %% Default idle timeout (RFC 9000 §10.1): the connection silently closes after
 %% this many ms with no packet received. Seeding it from the advertised / peer
 %% max_idle_timeout is a follow-up.
@@ -937,8 +933,8 @@ build_level(Level, State) ->
 %% fresh data: CRYPTO at the handshake levels, application STREAM frames at
 %% the application level (which never carries CRYPTO).
 -spec build_data(level(), [roadrunner_quic_frame:frame()], #space{}, t()) -> none | {map(), t()}.
-build_data(application, AckFrames, Space, State) ->
-    {StreamFrames, State1} = take_stream(State),
+build_data(application, AckFrames, #space{next_pn = PN} = Space, State) ->
+    {StreamFrames, State1} = take_stream(AckFrames, PN, State),
     case AckFrames ++ StreamFrames of
         [] -> none;
         Frames -> build_entry(application, Frames, Space, State1)
@@ -954,27 +950,38 @@ build_data(Level, AckFrames, Space, State) ->
 %% FIN to send and the credit to send it, skipping streams blocked by send
 %% flow control (a buffered-but-unsendable stream yields `nothing`; a pending
 %% FIN-only frame costs no credit and is always emitted). The slice is bounded
-%% by the connection and per-stream send windows and the per-packet budget,
-%% and the bytes are accounted against both windows.
--spec take_stream(t()) -> {[roadrunner_quic_frame:frame()], t()}.
-take_stream(#state{sendable = Sendable} = State) ->
+%% by the connection and per-stream send windows and by the room left in the
+%% datagram after the header, the same-packet ACK, the STREAM frame header, and
+%% the AEAD tag (so the datagram fills the 1200-byte path limit without
+%% exceeding it); the bytes are accounted against both windows. The same-packet
+%% ACK frames and the packet number size the per-datagram room.
+-spec take_stream([roadrunner_quic_frame:frame()], non_neg_integer(), t()) ->
+    {[roadrunner_quic_frame:frame()], t()}.
+take_stream(AckFrames, PN, #state{sendable = Sendable} = State) ->
     %% Only streams with pending send data are candidates, already ascending;
     %% finished/drained streams never enter the walk (see `put_stream/4`).
-    take_stream(Sendable, State).
+    take_stream(Sendable, AckFrames, PN, State).
 
--spec take_stream([non_neg_integer()], t()) -> {[roadrunner_quic_frame:frame()], t()}.
-take_stream([], State) ->
+-spec take_stream([non_neg_integer()], [roadrunner_quic_frame:frame()], non_neg_integer(), t()) ->
+    {[roadrunner_quic_frame:frame()], t()}.
+take_stream([], _AckFrames, _PN, State) ->
     {[], State};
-take_stream([Sid | Rest], #state{streams = Streams, conn_flow = ConnFlow} = State) ->
+take_stream(
+    [Sid | Rest],
+    AckFrames,
+    PN,
+    #state{streams = Streams, conn_flow = ConnFlow, peer_scid = DCID} = State
+) ->
     #{Sid := {Stream0, StreamFlow0}} = Streams,
+    Offset0 = roadrunner_quic_stream:send_offset(Stream0),
     Budget = lists:min([
-        ?STREAM_BUDGET,
+        roadrunner_quic_send:stream_data_budget(DCID, PN, AckFrames, Sid, Offset0),
         roadrunner_quic_flow:send_window(ConnFlow),
         roadrunner_quic_flow:send_window(StreamFlow0)
     ]),
     case roadrunner_quic_stream:next_frame(Budget, Stream0) of
         nothing ->
-            take_stream(Rest, State);
+            take_stream(Rest, AckFrames, PN, State);
         {Offset, Data, Fin, Stream1} ->
             Size = byte_size(Data),
             {_, ConnFlow1} = roadrunner_quic_flow:on_data_sent(Size, ConnFlow),

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -869,12 +869,16 @@ deliver_stream(_Sid, _Deliverable, _FinReached, State) ->
 
 -spec send_pass(integer(), t()) -> {t(), [effect()]}.
 send_pass(Now, State) ->
-    {State1, SendEffects} = drain_send(Now, State, []),
-    {State1, SendEffects ++ timer_effects(Now, State1)}.
+    {State1, RevSends} = drain_send(Now, State, []),
+    %% `drain_send` returns the send effects newest-first; reverse them into
+    %% order and fold the (single) timer effect onto the end in the same pass,
+    %% rather than a second traversal to append it.
+    {State1, lists:reverse(RevSends, timer_effects(Now, State1))}.
 
 %% Build and send one datagram per iteration until nothing is pending or
 %% the anti-amplification budget blocks; roll back the built state if the
-%% datagram cannot be sent.
+%% datagram cannot be sent. Returns the send effects newest-first (the caller
+%% reverses them and adds the timer effect).
 -spec drain_send(integer(), t(), [effect()]) -> {t(), [effect()]}.
 drain_send(Now, State, Acc) ->
     %% The present encryption levels are invariant across a send burst (spaces
@@ -886,13 +890,13 @@ drain_send(Now, State, Acc) ->
 drain_send(Now, Levels, State, Acc) ->
     case build_first(Levels, State) of
         none ->
-            {State, lists:reverse(Acc)};
+            {State, Acc};
         {Entries, Built} ->
             #state{peer_scid = DCID, scid = SCID, amp = Amp} = State,
             {Datagram, Sent} = roadrunner_quic_send:datagram(Entries, DCID, SCID),
             case roadrunner_quic_amp:can_send(byte_size(Datagram), Amp) of
                 false ->
-                    {State, lists:reverse(Acc)};
+                    {State, Acc};
                 true ->
                     Recorded = record_sent(Now, Sent, Built),
                     Amp1 = roadrunner_quic_amp:sent(byte_size(Datagram), Amp),
@@ -927,7 +931,9 @@ build_level(Level, State) ->
             %% Retransmits travel in their own packet (no fresh CRYPTO or
             %% STREAM slice), so a replayed frame plus a new slice can never
             %% overflow the datagram.
-            build_entry(Level, AckFrames ++ Pending, Space#space{ack = Ack, pending = []}, State);
+            build_entry(
+                Level, prepend_ack(AckFrames, Pending), Space#space{ack = Ack, pending = []}, State
+            );
         [] ->
             build_data(Level, AckFrames, Space#space{ack = Ack}, State)
     end.
@@ -938,16 +944,24 @@ build_level(Level, State) ->
 -spec build_data(level(), [roadrunner_quic_frame:frame()], #space{}, t()) -> none | {map(), t()}.
 build_data(application, AckFrames, #space{next_pn = PN} = Space, State) ->
     {StreamFrames, State1} = take_stream(AckFrames, PN, State),
-    case AckFrames ++ StreamFrames of
+    case prepend_ack(AckFrames, StreamFrames) of
         [] -> none;
         Frames -> build_entry(application, Frames, Space, State1)
     end;
 build_data(Level, AckFrames, Space, State) ->
     {CryptoFrames, Crypto} = take_crypto(Space#space.crypto),
-    case AckFrames ++ CryptoFrames of
+    case prepend_ack(AckFrames, CryptoFrames) of
         [] -> none;
         Frames -> build_entry(Level, Frames, Space#space{crypto = Crypto}, State)
     end.
+
+%% Put the ACK frame (if any) ahead of the data frames. `take_ack` yields an
+%% empty list or a single `[AckFrame]`, so this prepends without the traversal a
+%% list append would cost on the hot send path.
+-spec prepend_ack([roadrunner_quic_frame:frame()], [roadrunner_quic_frame:frame()]) ->
+    [roadrunner_quic_frame:frame()].
+prepend_ack([], Frames) -> Frames;
+prepend_ack([Ack], Frames) -> [Ack | Frames].
 
 %% Pull ONE outbound STREAM frame from the lowest-id stream that has data or a
 %% FIN to send and the credit to send it, skipping streams blocked by send

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -877,7 +877,14 @@ send_pass(Now, State) ->
 %% datagram cannot be sent.
 -spec drain_send(integer(), t(), [effect()]) -> {t(), [effect()]}.
 drain_send(Now, State, Acc) ->
-    case build_packets(State) of
+    %% The present encryption levels are invariant across a send burst (spaces
+    %% are added or discarded only on the receive path), so resolve them once
+    %% here rather than on every packet built in the loop.
+    drain_send(Now, present_levels(State), State, Acc).
+
+-spec drain_send(integer(), [level()], t(), [effect()]) -> {t(), [effect()]}.
+drain_send(Now, Levels, State, Acc) ->
+    case build_first(Levels, State) of
         none ->
             {State, lists:reverse(Acc)};
         {Entries, Built} ->
@@ -889,7 +896,7 @@ drain_send(Now, State, Acc) ->
                 true ->
                     Recorded = record_sent(Now, Sent, Built),
                     Amp1 = roadrunner_quic_amp:sent(byte_size(Datagram), Amp),
-                    drain_send(Now, Recorded#state{amp = Amp1}, [{send, Datagram} | Acc])
+                    drain_send(Now, Levels, Recorded#state{amp = Amp1}, [{send, Datagram} | Acc])
             end
     end.
 
@@ -902,10 +909,6 @@ drain_send(Now, State, Acc) ->
 %% flight would overflow. It also makes the forbidden Initial+1-RTT
 %% coalescing structurally impossible. Coalescing Initial+Handshake is a
 %% deferred optimization. Returns `none` when nothing is pending anywhere.
--spec build_packets(t()) -> none | {#{level() => map()}, t()}.
-build_packets(State) ->
-    build_first(present_levels(State), State).
-
 -spec build_first([level()], t()) -> none | {#{level() => map()}, t()}.
 build_first([], _State) ->
     none;

--- a/src/roadrunner_quic_frame.erl
+++ b/src/roadrunner_quic_frame.erl
@@ -402,11 +402,30 @@ decode_ack_ecn(Largest, AckDelay, FirstRange, Ranges, ecn, Bin) ->
 -spec decode_all(binary()) -> {ok, [frame()]} | {error, term()}.
 decode_all(<<>>) ->
     {ok, []};
+decode_all(<<?PADDING, Rest/binary>>) ->
+    %% PADDING is a no-op (RFC 9000 §19.1) and packets pad in long runs (a
+    %% client Initial is padded to 1200 bytes), so collapse a whole run into a
+    %% single `padding` frame rather than decoding each zero byte on its own.
+    decode_all_padding(Rest);
 decode_all(Bin) ->
     maybe
         {ok, Frame, Rest} ?= decode(Bin),
         {ok, Frames} ?= decode_all(Rest),
         {ok, [Frame | Frames]}
+    end.
+
+%% Skip the rest of a PADDING run, then emit one `padding` frame ahead of
+%% whatever follows it. Pad runs are long (a client Initial pads ~1150 bytes),
+%% so step a machine word at a time and fall back to single bytes at the tail.
+-spec decode_all_padding(binary()) -> {ok, [frame()]} | {error, term()}.
+decode_all_padding(<<0:64, Rest/binary>>) ->
+    decode_all_padding(Rest);
+decode_all_padding(<<?PADDING, Rest/binary>>) ->
+    decode_all_padding(Rest);
+decode_all_padding(Bin) ->
+    maybe
+        {ok, Frames} ?= decode_all(Bin),
+        {ok, [padding | Frames]}
     end.
 
 %% =============================================================================

--- a/src/roadrunner_quic_listener.erl
+++ b/src/roadrunner_quic_listener.erl
@@ -46,6 +46,10 @@
 %% datagram whose payload is smaller than 1200 bytes, so a too-small Initial
 %% never spawns a connection (clients pad Initial datagrams to this floor).
 -define(MIN_INITIAL_DATAGRAM, 1200).
+%% Datagrams the shared socket delivers per re-arm: large enough that the
+%% per-batch `{active, N}` setopts is a small fraction of the per-datagram work,
+%% small enough that the listener mailbox between re-arms stays bounded.
+-define(ACTIVE_N, 100).
 
 -type opts() :: #{
     port := inet:port_number(),
@@ -125,7 +129,7 @@ init(
     process_flag(trap_exit, true),
     [Parent | _] = get('$ancestors'),
     ReusePort = maps:get(reuseport, Opts, false),
-    case roadrunner_quic_socket:open(Port, #{active => once, reuseport => ReusePort}) of
+    case roadrunner_quic_socket:open(Port, #{active => ?ACTIVE_N, reuseport => ReusePort}) of
         {ok, Socket} ->
             {ok, {_Ip, BoundPort}} = roadrunner_quic_socket:sockname(Socket),
             proc_lib:set_label({?MODULE, BoundPort}),
@@ -183,15 +187,17 @@ loop(#listener{socket = Socket, parent = Parent} = State) ->
             loop(handle_message(Message, State))
     end.
 
-%% A datagram from the active socket is routed (re-arming the socket first so
-%% the next datagram is already queued during the spawn round-trip); anything
-%% else is a stray message and dropped.
+%% A datagram from the active socket is routed; the socket delivers up to
+%% `?ACTIVE_N` datagrams before a `passive` notice, at which point we re-arm
+%% the whole batch in one syscall. Anything else is a stray message and dropped.
 -spec handle_message(term(), #listener{}) -> #listener{}.
 handle_message(Message, #listener{socket = Socket} = State) ->
     case roadrunner_quic_socket:from_message(Socket, Message) of
         {ok, Peer, Datagram} ->
-            ok = roadrunner_quic_socket:activate(Socket),
             route(Datagram, Peer, State);
+        passive ->
+            ok = roadrunner_quic_socket:activate(Socket, ?ACTIVE_N),
+            State;
         ignore ->
             State
     end.

--- a/src/roadrunner_quic_loss.erl
+++ b/src/roadrunner_quic_loss.erl
@@ -6,13 +6,17 @@
 %%
 %% The module is pure: the monotonic clock is passed in as `Now`
 %% (milliseconds) on every state transition, so all timing decisions are
-%% deterministic and unit-testable. Sent packets are tracked newest-first
-%% (an O(1) prepend on send); on an ACK they are classified acknowledged,
-%% lost, or still in flight in one pass, the RTT is updated from the
-%% largest acknowledged ack-eliciting packet (RFC 9002 §5), and the rest
-%% are checked against the packet and time loss thresholds (§6.1). The
-%% caller retransmits the data carried by the returned lost packets and
-%% feeds the acknowledged/lost byte counts to congestion control.
+%% deterministic and unit-testable. Sent packets are tracked in a queue,
+%% oldest at the front (an O(1) enqueue on send); on an ACK only the
+%% packets at or below the largest acknowledged are resolved off the front
+%% (acknowledged, lost, or a still-in-flight gap), while the higher-numbered
+%% packets sent ahead stay in the queue untouched. This keeps ACK processing
+%% O(packets-this-ack-resolves) rather than O(in flight), which matters for a
+%% large response burst with no congestion window to bound the in-flight set.
+%% The RTT is updated from the largest acknowledged ack-eliciting packet (RFC
+%% 9002 §5) and loss is judged by the packet and time thresholds (§6.1). The
+%% caller retransmits the data carried by the returned lost packets and feeds
+%% the acknowledged/lost byte counts to congestion control.
 
 -export([
     new/1,
@@ -63,8 +67,10 @@
 }).
 
 -record(loss, {
-    %% Sent-but-not-resolved packets, newest first.
-    sent = [] :: [#sent{}],
+    %% Sent-but-not-resolved packets, a queue with the oldest (lowest packet
+    %% number) at the front, so an ACK resolves them from the front and the
+    %% higher-numbered in-flight packets stay as the shared remaining queue.
+    sent = queue:new() :: queue:queue(#sent{}),
     %% RTT estimation (RFC 9002 §5).
     latest_rtt = 0 :: non_neg_integer(),
     smoothed_rtt :: non_neg_integer(),
@@ -130,7 +136,7 @@ on_packet_sent(
         pn = PN, time_sent = Now, ack_eliciting = AckEliciting, size = Size, data = Data
     },
     Loss#loss{
-        sent = [Packet | Sent],
+        sent = queue:in(Packet, Sent),
         bytes_in_flight = InFlight + ack_eliciting_bytes(AckEliciting, Size)
     }.
 
@@ -154,15 +160,19 @@ on_ack_received(Ack, Now, Loss) ->
         {error, _} = Error ->
             Error;
         Ranges ->
-            {Acked, Unacked} = classify(Loss#loss.sent, Ranges),
-            Loss1 = maybe_update_rtt(Loss, LargestAcked, Acked, AckDelay, Now),
             NewLargest = max_largest_acked(Loss#loss.largest_acked, LargestAcked),
-            LossDelay = loss_delay(Loss1),
-            {Lost, Survivors} = split_lost(Unacked, NewLargest, Now, LossDelay),
+            %% Only packets at or below the largest acknowledged can be
+            %% acknowledged or declared lost by this ACK; the higher-numbered
+            %% packets sent ahead stay in flight. Resolving just that prefix off
+            %% the front keeps the work O(packets-this-ack-resolves).
+            {Resolvable, Ahead} = pop_resolvable(Loss#loss.sent, NewLargest, []),
+            {Acked, Unacked} = classify(Resolvable, Ranges),
+            Loss1 = maybe_update_rtt(Loss, LargestAcked, Acked, AckDelay, Now),
+            {Lost, Survivors} = split_lost(Unacked, NewLargest, Now, loss_delay(Loss1)),
             AckedBytes = in_flight_bytes(Acked),
             LostBytes = in_flight_bytes(Lost),
             Loss2 = Loss1#loss{
-                sent = Survivors,
+                sent = requeue(Survivors, Ahead),
                 largest_acked = NewLargest,
                 pto_count = 0,
                 bytes_in_flight = max(0, Loss1#loss.bytes_in_flight - AckedBytes - LostBytes)
@@ -185,7 +195,10 @@ retransmit.
 detect_lost(_Now, #loss{largest_acked = undefined} = Loss) ->
     {Loss, []};
 detect_lost(Now, #loss{sent = Sent, largest_acked = LargestAcked} = Loss) ->
-    {Lost, Survivors} = split_lost(Sent, LargestAcked, Now, loss_delay(Loss)),
+    %% The loss condition is monotonic from the oldest end (lowest number,
+    %% earliest sent), so the lost packets are a front prefix: take them off
+    %% and stop at the first survivor (the rest of the queue stays).
+    {Lost, Survivors} = take_lost_front(Sent, LargestAcked, Now, loss_delay(Loss), []),
     Loss1 = Loss#loss{
         sent = Survivors,
         bytes_in_flight = max(0, Loss#loss.bytes_in_flight - in_flight_bytes(Lost))
@@ -197,11 +210,11 @@ When the loss timer should next fire: the oldest sent packet's send time
 plus the loss delay, or `undefined` if nothing is outstanding.
 """.
 -spec loss_time(t()) -> non_neg_integer() | undefined.
-loss_time(#loss{sent = []}) ->
-    undefined;
 loss_time(#loss{sent = Sent} = Loss) ->
-    #sent{time_sent = Oldest} = lists:last(Sent),
-    Oldest + loss_delay(Loss).
+    case queue:peek(Sent) of
+        empty -> undefined;
+        {value, #sent{time_sent = Oldest}} -> Oldest + loss_delay(Loss)
+    end.
 
 %% =============================================================================
 %% RTT estimation (RFC 9002 §5)
@@ -330,18 +343,62 @@ classify([#sent{pn = PN} = Packet | Rest], Ranges) ->
     {[#sent{}], [#sent{}]}.
 split_lost([], _LargestAcked, _Now, _LossDelay) ->
     {[], []};
-split_lost([#sent{pn = PN, time_sent = Sent} = Packet | Rest], LargestAcked, Now, LossDelay) ->
+split_lost([Packet | Rest], LargestAcked, Now, LossDelay) ->
     {Lost, Survivors} = split_lost(Rest, LargestAcked, Now, LossDelay),
-    %% Only packets below the largest acknowledged are loss candidates
-    %% (RFC 9002 §6.1): declaring loss requires a later packet to have been
-    %% acknowledged, so packets above the largest acked stay in flight.
-    case
-        PN < LargestAcked andalso
-            (PN =< LargestAcked - ?PACKET_THRESHOLD orelse Now - Sent > LossDelay)
-    of
+    case lost_packet(Packet, LargestAcked, Now, LossDelay) of
         true -> {[Packet | Lost], Survivors};
         false -> {Lost, [Packet | Survivors]}
     end.
+
+%% Whether a still-unacknowledged packet is lost (RFC 9002 §6.1): only packets
+%% below the largest acknowledged are candidates (declaring loss requires a
+%% later packet to have been acknowledged), then by the packet threshold (at
+%% least three below the largest acked) or the time threshold.
+-spec lost_packet(#sent{}, non_neg_integer(), non_neg_integer(), non_neg_integer()) -> boolean().
+lost_packet(#sent{pn = PN, time_sent = Sent}, LargestAcked, Now, LossDelay) ->
+    PN < LargestAcked andalso
+        (PN =< LargestAcked - ?PACKET_THRESHOLD orelse Now - Sent > LossDelay).
+
+%% Take the packets at or below `NewLargest` off the front (oldest first) into a
+%% newest-first list, the candidates this ACK can resolve; the higher-numbered
+%% in-flight packets stay in the returned queue. The queue is ordered by packet
+%% number, so the candidates are exactly a front prefix.
+-spec pop_resolvable(queue:queue(#sent{}), non_neg_integer(), [#sent{}]) ->
+    {[#sent{}], queue:queue(#sent{})}.
+pop_resolvable(Queue, NewLargest, Acc) ->
+    case queue:peek(Queue) of
+        {value, #sent{pn = PN} = Packet} when PN =< NewLargest ->
+            {{value, Packet}, Rest} = queue:out(Queue),
+            pop_resolvable(Rest, NewLargest, [Packet | Acc]);
+        _ ->
+            {Acc, Queue}
+    end.
+
+%% Take the lost packets off the front (oldest first), stopping at the first
+%% survivor; `lost_packet/4` is monotonic from the front, so the lost packets
+%% are a prefix and the rest of the queue stays in flight.
+-spec take_lost_front(
+    queue:queue(#sent{}), non_neg_integer(), non_neg_integer(), non_neg_integer(), [#sent{}]
+) -> {[#sent{}], queue:queue(#sent{})}.
+take_lost_front(Queue, LargestAcked, Now, LossDelay, Acc) ->
+    case queue:peek(Queue) of
+        {value, #sent{} = Packet} ->
+            case lost_packet(Packet, LargestAcked, Now, LossDelay) of
+                true ->
+                    {{value, Packet}, Rest} = queue:out(Queue),
+                    take_lost_front(Rest, LargestAcked, Now, LossDelay, [Packet | Acc]);
+                false ->
+                    {Acc, Queue}
+            end;
+        empty ->
+            {Acc, Queue}
+    end.
+
+%% Put the still-in-flight gap survivors (newest-first, all numbered below the
+%% queue's front) back onto the front, restoring the by-packet-number order.
+-spec requeue([#sent{}], queue:queue(#sent{})) -> queue:queue(#sent{}).
+requeue(Survivors, Queue) ->
+    lists:foldl(fun queue:in_r/2, Queue, Survivors).
 
 %% RFC 9002 §6.1.2: max(time_threshold * max(latest, smoothed), granularity).
 loss_delay(#loss{latest_rtt = Latest, smoothed_rtt = SRtt}) ->

--- a/src/roadrunner_quic_send.erl
+++ b/src/roadrunner_quic_send.erl
@@ -194,9 +194,9 @@ stream_data_budget(DCID, PN, AckFrames, Sid, Offset) ->
     OffsetBytes =
         case Offset of
             0 -> 0;
-            _ -> byte_size(roadrunner_quic_varint:encode(Offset))
+            _ -> roadrunner_quic_varint:encoded_size(Offset)
         end,
-    StreamHeader = 1 + byte_size(roadrunner_quic_varint:encode(Sid)) + OffsetBytes + 2,
+    StreamHeader = 1 + roadrunner_quic_varint:encoded_size(Sid) + OffsetBytes + 2,
     Overhead = ShortHeader + AckBytes + StreamHeader + ?TAG_LEN,
     max(0, ?MAX_1RTT_DATAGRAM - Overhead).
 

--- a/src/roadrunner_quic_send.erl
+++ b/src/roadrunner_quic_send.erl
@@ -35,7 +35,7 @@
 %% the returned datagram's size. The record also carries the packet's
 %% frames so the loop can retransmit them if it is later declared lost.
 
--export([datagram/3]).
+-export([datagram/3, stream_data_budget/5]).
 %% Exported for the connection loop's ack-tracking and loss-retransmit
 %% decisions: the single source of truth for which frames are ack-eliciting.
 -export([ack_eliciting/1, is_ack_eliciting/1]).
@@ -46,6 +46,10 @@
 -define(QUIC_V1, 16#00000001).
 %% RFC 9000 §14.1: a datagram carrying an Initial packet is >= 1200 bytes.
 -define(MIN_INITIAL_DATAGRAM, 1200).
+%% RFC 9000 §14: 1200 bytes is the conservative path limit every QUIC path is
+%% guaranteed to carry without fragmentation, and the ceiling a 1-RTT datagram
+%% targets until path MTU discovery (a follow-up) proves a larger size.
+-define(MAX_1RTT_DATAGRAM, 1200).
 %% RFC 9001 §5.4.2: the header-protection sample is 16 bytes at 4 past the
 %% packet-number start, so the plaintext must seal to at least that; 4
 %% bytes of plaintext covers the worst case (a 1-byte packet number).
@@ -166,6 +170,35 @@ pad_datagram(Datagram, #{initial := _}) when byte_size(Datagram) < ?MIN_INITIAL_
     <<Datagram/binary, 0:((?MIN_INITIAL_DATAGRAM - byte_size(Datagram)) * 8)>>;
 pad_datagram(Datagram, _Entries) ->
     Datagram.
+
+-doc """
+The largest STREAM-frame data slice whose 1-RTT datagram still fits the
+conservative `?MAX_1RTT_DATAGRAM` path limit. The datagram is the short header
+(first byte, the peer's `DCID`, the packet number), the ACK frame carried in
+the same packet (if any), the STREAM frame header (type, Stream ID, Offset,
+Length), the data, and the AEAD tag. The Length field is sized for a 2-byte
+varint, which holds for every slice up to 16383 bytes (far past the limit), so
+the returned budget can never make the datagram exceed it.
+""".
+-spec stream_data_budget(
+    binary(),
+    non_neg_integer(),
+    [roadrunner_quic_frame:frame()],
+    non_neg_integer(),
+    non_neg_integer()
+) ->
+    non_neg_integer().
+stream_data_budget(DCID, PN, AckFrames, Sid, Offset) ->
+    ShortHeader = 1 + byte_size(DCID) + roadrunner_quic_packet:pn_length(PN),
+    AckBytes = iolist_size([roadrunner_quic_frame:encode(F) || F <- AckFrames]),
+    OffsetBytes =
+        case Offset of
+            0 -> 0;
+            _ -> byte_size(roadrunner_quic_varint:encode(Offset))
+        end,
+    StreamHeader = 1 + byte_size(roadrunner_quic_varint:encode(Sid)) + OffsetBytes + 2,
+    Overhead = ShortHeader + AckBytes + StreamHeader + ?TAG_LEN,
+    max(0, ?MAX_1RTT_DATAGRAM - Overhead).
 
 %% A packet is ack-eliciting if it carries any frame other than PADDING,
 %% ACK, or CONNECTION_CLOSE (RFC 9002 §2).

--- a/src/roadrunner_quic_socket.erl
+++ b/src/roadrunner_quic_socket.erl
@@ -13,17 +13,21 @@
 %% send/receive pipeline, not the shared socket. The socket delivers each
 %% UDP datagram whole, with its source address.
 
--export([open/1, open/2, send/4, recv/2, activate/1, from_message/2, close/1, sockname/1]).
+-export([
+    open/1, open/2, send/4, recv/2, activate/1, activate/2, from_message/2, close/1, sockname/1
+]).
 
 -export_type([socket/0, open_opts/0]).
 
 -opaque socket() :: {gen_udp, gen_udp:socket()}.
 
+-type active() :: once | false | pos_integer().
+
 -type open_opts() :: #{
     recbuf => pos_integer(),
     sndbuf => pos_integer(),
     reuseport => boolean(),
-    active => once | false
+    active => active()
 }.
 
 %% Larger than the OS default, so a burst of datagrams is not dropped
@@ -42,10 +46,13 @@ Open a UDP socket on `Port`. The socket is binary, with `reuseaddr` set;
 port (read it back with `sockname/1`).
 
 `active` defaults to `false` (passive: drain with `recv/2`). Set it to `once`
-for the listener: each datagram is then delivered to the controlling process
-as one message, parsed with `from_message/2` and re-armed with `activate/1`,
-so the listener can interleave datagrams with monitor/system messages in a
-single receive loop.
+or a positive integer `N` for the listener: each datagram is then delivered to
+the controlling process as one message, parsed with `from_message/2`, so the
+listener can interleave datagrams with monitor/system messages in a single
+receive loop. With `N`, the socket delivers up to `N` datagrams and then one
+`{udp_passive, _}` message (`from_message/2` returns `passive`); re-arming once
+per `N` datagrams with `activate/2` instead of once per datagram with
+`activate/1` amortizes the re-arm syscall while keeping the mailbox bounded.
 
 Set `reuseport` to `true` to enable `SO_REUSEPORT`, which lets a pool of
 sockets share one concrete port with kernel datagram fan-out (the shape the
@@ -91,24 +98,37 @@ recv({gen_udp, Socket}, Timeout) ->
     end.
 
 -doc """
-Re-arm an `active => once` socket for the next datagram. Called after each
-message parsed with `from_message/2`, giving one-datagram-at-a-time
-back-pressure rather than an unbounded `{active, true}` flood.
+Re-arm a socket for one more datagram (`{active, once}`). Re-arms after a single
+datagram; for batched re-arming use `activate/2`.
 """.
 -spec activate(socket()) -> ok | {error, term()}.
-activate({gen_udp, Socket}) ->
-    inet:setopts(Socket, [{active, once}]).
+activate(Socket) ->
+    activate(Socket, once).
 
 -doc """
-Parse a mailbox message from an `active => once` socket: returns the source
-address and datagram bytes for this socket's data message, or `ignore` for
-anything else (a different socket's data, a monitor `DOWN`, a system message),
-so the listener loop can dispatch the rest itself.
+Re-arm a socket with the given active mode: `once` for one more datagram, or a
+positive integer `N` to deliver up to `N` datagrams before the next
+`{udp_passive, _}`. The listener re-arms with its `N` on each `passive` so the
+re-arm syscall is paid once per `N` datagrams, not once per datagram.
+""".
+-spec activate(socket(), once | pos_integer()) -> ok | {error, term()}.
+activate({gen_udp, Socket}, Active) ->
+    inet:setopts(Socket, [{active, Active}]).
+
+-doc """
+Parse a mailbox message from an active socket: returns the source address and
+datagram bytes for this socket's data message, `passive` for its
+`{udp_passive, _}` budget-exhausted notice (the loop should re-arm with
+`activate/2`), or `ignore` for anything else (a different socket's data, a
+monitor `DOWN`, a system message), so the listener loop can dispatch the rest
+itself.
 """.
 -spec from_message(socket(), term()) ->
-    {ok, {inet:ip_address(), inet:port_number()}, binary()} | ignore.
+    {ok, {inet:ip_address(), inet:port_number()}, binary()} | passive | ignore.
 from_message({gen_udp, Socket}, {udp, Socket, Ip, Port, Data}) ->
     {ok, {Ip, Port}, Data};
+from_message({gen_udp, Socket}, {udp_passive, Socket}) ->
+    passive;
 from_message(_Socket, _Message) ->
     ignore.
 
@@ -133,7 +153,7 @@ sockname({gen_udp, Socket}) ->
         recbuf := pos_integer(),
         sndbuf := pos_integer(),
         reuseport := boolean(),
-        active := once | false
+        active := active()
     }.
 validate_opts(Opts) ->
     Defaults = #{
@@ -152,6 +172,8 @@ validate_opt(sndbuf, Value, Acc) when is_integer(Value), Value > 0 ->
 validate_opt(reuseport, Value, Acc) when is_boolean(Value) ->
     Acc#{reuseport => Value};
 validate_opt(active, Value, Acc) when Value =:= once; Value =:= false ->
+    Acc#{active => Value};
+validate_opt(active, Value, Acc) when is_integer(Value), Value > 0 ->
     Acc#{active => Value};
 validate_opt(Key, Value, _Acc) ->
     error({invalid_quic_socket_opt, Key, Value}).

--- a/src/roadrunner_quic_stream.erl
+++ b/src/roadrunner_quic_stream.erl
@@ -128,6 +128,11 @@ reset(FinalSize, #stream{final_size = Existing} = Stream) ->
 
 -doc "Append outbound bytes to the stream's send buffer.".
 -spec enqueue(iodata(), t()) -> t().
+enqueue(Data, #stream{send_buf = <<>>} = Stream) ->
+    %% First write into an empty buffer (the common single-response case): store
+    %% the bytes directly, with no copy when Data is already a binary, instead of
+    %% concatenating onto the empty buffer (which copies the whole body).
+    Stream#stream{send_buf = iolist_to_binary(Data)};
 enqueue(Data, #stream{send_buf = Buf} = Stream) ->
     Stream#stream{send_buf = <<Buf/binary, (iolist_to_binary(Data))/binary>>}.
 

--- a/src/roadrunner_quic_stream.erl
+++ b/src/roadrunner_quic_stream.erl
@@ -262,17 +262,21 @@ insert_segment(Offset, Data, [{SegOffset, SegData} = Segment | Rest]) ->
         Offset >= SegEnd ->
             [Segment | insert_segment(Offset, Data, Rest)];
         true ->
-            before_segment(Offset, Data, SegOffset) ++
-                [Segment | after_segment(Offset, Data, End, SegEnd, Rest)]
+            before_segment(
+                Offset, Data, SegOffset, [Segment | after_segment(Offset, Data, End, SegEnd, Rest)]
+            )
     end.
 
-%% The part of an overlapping piece that falls before the segment it hit.
--spec before_segment(non_neg_integer(), binary(), non_neg_integer()) ->
+%% The part of an overlapping piece that falls before the segment it hit, consed
+%% onto the rest of the segment list (no list append).
+-spec before_segment(non_neg_integer(), binary(), non_neg_integer(), [
+    {non_neg_integer(), binary()}
+]) ->
     [{non_neg_integer(), binary()}].
-before_segment(Offset, Data, SegOffset) when Offset < SegOffset ->
-    [{Offset, binary:part(Data, 0, SegOffset - Offset)}];
-before_segment(_Offset, _Data, _SegOffset) ->
-    [].
+before_segment(Offset, Data, SegOffset, Tail) when Offset < SegOffset ->
+    [{Offset, binary:part(Data, 0, SegOffset - Offset)} | Tail];
+before_segment(_Offset, _Data, _SegOffset, Tail) ->
+    Tail.
 
 %% The part of an overlapping piece that falls after the segment it hit,
 %% re-inserted against the remaining segments.

--- a/src/roadrunner_quic_varint.erl
+++ b/src/roadrunner_quic_varint.erl
@@ -18,7 +18,7 @@
 %% crashing, so callers (`roadrunner_quic_h3_frame`, the packet/frame
 %% codecs) can thread incremental input without a `try`.
 
--export([encode/1, decode/1]).
+-export([encode/1, encoded_size/1, decode/1]).
 
 -export_type([decode_result/0]).
 
@@ -50,6 +50,17 @@ encode(V) when is_integer(V), V >= 0, V =< ?MAX_1 -> <<0:2, V:6>>;
 encode(V) when is_integer(V), V > ?MAX_1, V =< ?MAX_2 -> <<1:2, V:14>>;
 encode(V) when is_integer(V), V > ?MAX_2, V =< ?MAX_4 -> <<2:2, V:30>>;
 encode(V) when is_integer(V), V > ?MAX_4, V =< ?MAX_8 -> <<3:2, V:62>>.
+
+-doc """
+The number of bytes `encode/1` produces for `V`, computed from its range
+without building the binary (RFC 9000 §16 minimal-length form). The value must
+fit in 62 bits.
+""".
+-spec encoded_size(non_neg_integer()) -> 1 | 2 | 4 | 8.
+encoded_size(V) when is_integer(V), V >= 0, V =< ?MAX_1 -> 1;
+encoded_size(V) when is_integer(V), V > ?MAX_1, V =< ?MAX_2 -> 2;
+encoded_size(V) when is_integer(V), V > ?MAX_2, V =< ?MAX_4 -> 4;
+encoded_size(V) when is_integer(V), V > ?MAX_4, V =< ?MAX_8 -> 8.
 
 %% =============================================================================
 %% decode/1

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -780,6 +780,21 @@ send_data_slices_large_payload_test() ->
     ?assertEqual([false, false, true], [Fin || {stream, 0, _, _, Fin} <- Frames]),
     ?assertEqual(Payload, iolist_to_binary([D || {stream, 0, _, D, _} <- Frames])).
 
+send_blocked_by_exhausted_send_window_test() ->
+    %% Send-side flow control (RFC 9000 §4.1): a payload larger than the send
+    %% window fills the window across packets, then the send pass finds the
+    %% still-pending stream flow-blocked and emits nothing more for it. With the
+    %% send pass walking only streams that have pending data, this block is the
+    %% one path that reaches take_stream's no-frame branch.
+    {State, ApSecret} = connected_for_send(),
+    %% The conn and per-stream send windows both default to roadrunner_quic_flow's
+    %% initial_max_data (786432), so the payload must exceed it to block.
+    Payload = binary:copy(~"x", 786432 + 1000),
+    {_State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    Sent = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(Effects, ApSecret)]),
+    ?assert(byte_size(Sent) > 0),
+    ?assert(byte_size(Sent) < byte_size(Payload)).
+
 send_data_on_control_then_request_stream_test() ->
     %% The two load-bearing GET writes: SETTINGS on the server control stream
     %% (id 3) then a response on the client request stream (id 0), each on its

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -771,12 +771,17 @@ send_data_multi_call_advances_offset_test() ->
 send_data_slices_large_payload_test() ->
     %% A payload larger than the per-packet budget is sliced across datagrams
     %% (one STREAM frame each), offsets contiguous, FIN on the last slice, and
-    %% the bytes reassemble to the original.
+    %% the bytes reassemble to the original. Each slice fills toward the
+    %% 1200-byte datagram, so the first slice carries well past the bytes an
+    %% old fixed 1000-byte budget would have allowed.
     {State, ApSecret} = connected_for_send(),
     Payload = binary:copy(~"x", 2500),
     {_State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, true, ?NOW, State),
     Frames = sent_stream_frames(Effects, ApSecret),
-    ?assertEqual([0, 1000, 2000], [Off || {stream, 0, Off, _, _} <- Frames]),
+    Sizes = [byte_size(D) || {stream, 0, _, D, _} <- Frames],
+    ?assert(length(Frames) > 1),
+    ?assert(hd(Sizes) > 1000),
+    ?assertEqual(expected_offsets(0, Sizes), [Off || {stream, 0, Off, _, _} <- Frames]),
     ?assertEqual([false, false, true], [Fin || {stream, 0, _, _, Fin} <- Frames]),
     ?assertEqual(Payload, iolist_to_binary([D || {stream, 0, _, D, _} <- Frames])).
 
@@ -1131,3 +1136,10 @@ emits(Effects) ->
 arm_deadline(Effects) ->
     [AtMs] = [At || {arm_timer, pto, At} <- Effects],
     AtMs.
+
+%% The contiguous send offsets for a run of slice sizes: each offset is the
+%% total bytes emitted before it.
+expected_offsets(_Acc, []) ->
+    [];
+expected_offsets(Acc, [Size | Rest]) ->
+    [Acc | expected_offsets(Acc + Size, Rest)].

--- a/test/roadrunner_quic_frame_tests.erl
+++ b/test/roadrunner_quic_frame_tests.erl
@@ -73,6 +73,23 @@ decode_all_propagates_error_test() ->
     Bin = <<16#01, 16#06, 16#00>>,
     ?assertEqual({error, truncated}, ?M:decode_all(Bin)).
 
+%% A run of consecutive PADDING bytes decodes to a single `padding` frame
+%% (RFC 9000 §19.1 makes padding a no-op), whether the run trails the packet
+%% or sits between other frames.
+decode_all_collapses_padding_run_test() ->
+    %% A trailing run longer than a machine word exercises the word-wide skip
+    %% and the single-byte tail; a short middle run uses the single-byte path.
+    Trailing = iolist_to_binary([?M:encode(ping), binary:copy(<<0>>, 10)]),
+    ?assertEqual({ok, [ping, padding]}, ?M:decode_all(Trailing)),
+    Middle = iolist_to_binary([<<0, 0, 0>>, ?M:encode(ping), <<0, 0>>]),
+    ?assertEqual({ok, [padding, ping, padding]}, ?M:decode_all(Middle)).
+
+%% An error after a leading PADDING run still propagates (covers the run
+%% fast-path's error branch).
+decode_all_padding_run_then_error_test() ->
+    %% Two PADDING bytes, then a CRYPTO frame truncated mid-field.
+    ?assertEqual({error, truncated}, ?M:decode_all(<<0, 0, 16#06, 16#00>>)).
+
 %% =============================================================================
 %% Malformed input: errors, never a crash.
 %% =============================================================================

--- a/test/roadrunner_quic_listener_SUITE.erl
+++ b/test/roadrunner_quic_listener_SUITE.erl
@@ -23,6 +23,7 @@ an outer guard. The pure routing decision (`classify/2`) is unit-tested in
     system_message_exposes_state/1,
     stray_message_is_ignored/1,
     malformed_datagram_is_dropped/1,
+    rearms_after_active_batch/1,
     sends_version_negotiation_for_unsupported_version/1,
     uses_injected_registry/1,
     conn_death_before_set_owner_does_not_wedge/1,
@@ -45,6 +46,7 @@ all() ->
         system_message_exposes_state,
         stray_message_is_ignored,
         malformed_datagram_is_dropped,
+        rearms_after_active_batch,
         sends_version_negotiation_for_unsupported_version,
         uses_injected_registry,
         conn_death_before_set_owner_does_not_wedge,
@@ -170,6 +172,35 @@ malformed_datagram_is_dropped(_Config) ->
     %% A short-header first byte with too few bytes for the fixed 8-byte SCID:
     %% dcid/2 reports {error, truncated}, so classify -> drop.
     ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, <<16#40, 1, 2, 3>>),
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, crafted_initial()),
+    ConnPid = receive_server_conn(),
+    ?assert(is_pid(ConnPid)),
+    ?assertEqual(Port, roadrunner_quic_listener:get_port(Listener)),
+    exit(ConnPid, kill),
+    ok = roadrunner_quic_socket:close(Client),
+    ok = roadrunner_quic_listener:stop(Listener).
+
+%% The shared socket runs in `{active, N}` mode, so it delivers up to ?ACTIVE_N
+%% datagrams and then a `{udp_passive, _}` notice that drives handle_message's
+%% `passive` branch (re-arm via activate/2). Flooding more than ?ACTIVE_N
+%% malformed datagrams (each dropped) before a valid Initial proves the re-arm
+%% works: the Initial lands past the first batch, so the handler firing for it
+%% means a passive re-arm already ran. The refusing handler keeps the spawned
+%% connection owner-less, so killing it for cleanup cannot race a set_owner_sync.
+rearms_after_active_batch(_Config) ->
+    Test = self(),
+    Handler = fun(ConnPid) ->
+        Test ! {server_conn, ConnPid},
+        {error, max_clients}
+    end,
+    {Listener, Port} = start_listener(Handler),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    %% More than roadrunner_quic_listener's ?ACTIVE_N (100), so at least one
+    %% batch boundary is crossed before the Initial is delivered.
+    _ = [
+        roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, <<16#40, 1, 2, 3>>)
+     || _ <- lists:seq(1, 120)
+    ],
     ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, Port, crafted_initial()),
     ConnPid = receive_server_conn(),
     ?assert(is_pid(ConnPid)),

--- a/test/roadrunner_quic_loss_tests.erl
+++ b/test/roadrunner_quic_loss_tests.erl
@@ -177,6 +177,14 @@ detect_lost_test() ->
     {_Loss2, Lost} = ?M:detect_lost(10000, Loss1),
     ?assertEqual([2, 3], lists:sort(Lost)).
 
+detect_lost_stops_at_in_flight_packet_test() ->
+    %% Packets numbered above the largest acknowledged were sent ahead and are
+    %% not loss candidates; the loss timer reaches the oldest of them and stops,
+    %% declaring nothing lost and leaving the in-flight set unchanged.
+    Loss0 = send_run(0, 4, ?M:new(#{})),
+    {Loss1, _, _} = ?M:on_ack_received({ack, 0, 0, 0, []}, 100, Loss0),
+    ?assertEqual({Loss1, []}, ?M:detect_lost(100, Loss1)).
+
 loss_time_test() ->
     ?assertEqual(undefined, ?M:loss_time(?M:new(#{}))),
     %% First sample sets srtt; oldest packet sent at 0, loss delay 9*srtt/8.

--- a/test/roadrunner_quic_send_tests.erl
+++ b/test/roadrunner_quic_send_tests.erl
@@ -162,8 +162,49 @@ ack_eliciting_classification_test() ->
     ].
 
 %% =============================================================================
+%% STREAM data budget: a budgeted slice fills the 1200-byte datagram without
+%% exceeding it (RFC 9000 §14).
+%% =============================================================================
+
+%% With the minimal overhead (8-byte DCID, 1-byte packet number, stream 0 at
+%% offset 0, no same-packet ACK), the budgeted slice plus its framing exactly
+%% fills the 1200-byte datagram.
+stream_data_budget_fills_to_limit_test() ->
+    {Budget, Size} = budget_datagram_size(?DCID, 0, [], 0, 0),
+    ?assertEqual(1170, Budget),
+    ?assertEqual(1200, Size).
+
+%% Across a same-packet ACK, wide stream id / offset / packet number, and a
+%% zero-length DCID, the budgeted slice never pushes the datagram past 1200.
+stream_data_budget_never_exceeds_limit_test() ->
+    Cases = [
+        {?DCID, 0, [{ack, 5, 0, 3, [], undefined}], 0, 0},
+        {?DCID, 16#1234, [], 100000, 1000000},
+        {?DCID, 16#123456, [{ack, 9, 0, 0, [{0, 0}], undefined}], 16#3FFFFFFF, 16#3FFFFFFF},
+        {<<>>, 0, [], 0, 0}
+    ],
+    [
+        begin
+            {Budget, Size} = budget_datagram_size(DCID, PN, AckFrames, Sid, Offset),
+            ?assert(Budget > 0),
+            ?assert(Size =< 1200)
+        end
+     || {DCID, PN, AckFrames, Sid, Offset} <- Cases
+    ].
+
+%% =============================================================================
 %% Helpers
 %% =============================================================================
+
+%% Build a 1-RTT datagram whose STREAM frame carries exactly a budgeted slice
+%% (preceded by any same-packet ACK), returning the budget and the datagram
+%% size for the fits-within-1200 assertions.
+budget_datagram_size(DCID, PN, AckFrames, Sid, Offset) ->
+    Budget = ?M:stream_data_budget(DCID, PN, AckFrames, Sid, Offset),
+    Frames = AckFrames ++ [{stream, Sid, Offset, <<0:(Budget * 8)>>, false}],
+    Entry = #{frames => Frames, keys => application_keys(), pn => PN},
+    {Datagram, _} = ?M:datagram(#{application => Entry}, DCID, ?SCID),
+    {Budget, byte_size(Datagram)}.
 
 recv(Datagram, Keys) ->
     roadrunner_quic_recv:datagram(Datagram, byte_size(?DCID), Keys, #{}).

--- a/test/roadrunner_quic_socket_SUITE.erl
+++ b/test/roadrunner_quic_socket_SUITE.erl
@@ -19,7 +19,8 @@ clause is unit-tested in `roadrunner_quic_socket_tests`.
     open_in_use_errors/1,
     open_with_custom_buffers/1,
     reuseport_allows_shared_bind/1,
-    active_once_delivers_messages/1
+    active_once_delivers_messages/1,
+    active_n_batches_then_passive/1
 ]).
 
 -define(LOOPBACK, {127, 0, 0, 1}).
@@ -34,7 +35,8 @@ all() ->
         open_in_use_errors,
         open_with_custom_buffers,
         reuseport_allows_shared_bind,
-        active_once_delivers_messages
+        active_once_delivers_messages,
+        active_n_batches_then_passive
     ].
 
 %% An `active => once` socket delivers each datagram as one mailbox message,
@@ -75,6 +77,31 @@ active_once_delivers_messages(_Config) ->
 
     ok = roadrunner_quic_socket:close(Server),
     ok = roadrunner_quic_socket:close(Client).
+
+%% An `active => N` socket delivers up to N datagrams, then a `passive` notice
+%% (from_message/2's udp_passive clause); the (N+1)th buffers until re-armed
+%% with activate/2.
+active_n_batches_then_passive(_Config) ->
+    N = 2,
+    {ok, Server} = roadrunner_quic_socket:open(0, #{active => N}),
+    {ok, Client} = roadrunner_quic_socket:open(0),
+    {ok, {_, ServerPort}} = roadrunner_quic_socket:sockname(Server),
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, ServerPort, ~"a"),
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, ServerPort, ~"b"),
+    ok = roadrunner_quic_socket:send(Client, ?LOOPBACK, ServerPort, ~"c"),
+    ?assertMatch({ok, _, _}, next_parsed(Server)),
+    ?assertMatch({ok, _, _}, next_parsed(Server)),
+    ?assertEqual(passive, next_parsed(Server)),
+    ok = roadrunner_quic_socket:activate(Server, N),
+    ?assertMatch({ok, _, _}, next_parsed(Server)),
+    ok = roadrunner_quic_socket:close(Server),
+    ok = roadrunner_quic_socket:close(Client).
+
+next_parsed(Socket) ->
+    receive
+        Msg -> roadrunner_quic_socket:from_message(Socket, Msg)
+    after 1000 -> ct:fail(no_active_message)
+    end.
 
 %% A datagram travels client -> server with its source address, then the
 %% server echoes back to that address. Exercises open/1 (default opts),

--- a/test/roadrunner_quic_varint_tests.erl
+++ b/test/roadrunner_quic_varint_tests.erl
@@ -59,6 +59,17 @@ encode_class_boundaries_test() ->
 encode_above_max_crashes_test() ->
     ?assertError(function_clause, roadrunner_quic_varint:encode(4611686018427387904)).
 
+%% encoded_size/1 returns the width encode/1 would produce, at every class
+%% boundary and above the maximum (function_clause).
+encoded_size_class_boundaries_test() ->
+    [
+        ?assertEqual(
+            byte_size(roadrunner_quic_varint:encode(V)), roadrunner_quic_varint:encoded_size(V)
+        )
+     || V <- [0, 63, 64, 16383, 16384, 1073741823, 1073741824, 4611686018427387903]
+    ],
+    ?assertError(function_clause, roadrunner_quic_varint:encoded_size(4611686018427387904)).
+
 %% =============================================================================
 %% decode/1 — trailing bytes, incomplete buffers, empty buffer.
 %% =============================================================================


### PR DESCRIPTION
Profile-driven optimizations to the native QUIC/HTTP3 server's send and receive hot paths.

Interleaved A/B against main on the 64 KB large_response h3 bench (same quic dep client): p50 down 37%, p99 down 30%, with every branch run faster than every main run.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
