### PR TITLE
Refill the QUIC send window so large transfers don't stall

### DIFF
--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -563,11 +563,29 @@ process_frame(_Now, application, {stream, Sid, Offset, Data, Fin}, State) ->
     process_stream(Sid, Offset, Data, Fin, State);
 process_frame(_Now, application, {reset_stream, Sid, ErrorCode, FinalSize}, State) ->
     process_reset_stream(Sid, ErrorCode, FinalSize, State);
+process_frame(_Now, application, {max_data, Max}, #state{conn_flow = ConnFlow} = State) ->
+    %% Peer raised the connection-level send limit (RFC 9000 §4.1): grow the
+    %% send window so a transfer past the initial grant keeps flowing. The send
+    %% pass at the end of the datagram serves any stream this unblocks.
+    State#state{conn_flow = roadrunner_quic_flow:on_max_data_received(Max, ConnFlow)};
+process_frame(_Now, application, {max_stream_data, Sid, Max}, State) ->
+    on_max_stream_data(Sid, Max, State);
 process_frame(_Now, _Level, _Frame, State) ->
-    %% ping / padding are no-ops. Peer flow-credit grants (MAX_DATA /
-    %% MAX_STREAM_DATA) and MAX_STREAMS are accepted but not yet acted on, so
-    %% the send side keeps the default window until that follow-up lands.
+    %% ping / padding are no-ops. MAX_STREAMS is accepted but not yet acted on
+    %% (the server never opens enough streams to need the raised limit).
     State.
+
+%% Raise a stream's send limit from a received MAX_STREAM_DATA (RFC 9000 §4.1).
+%% Only a tracked stream can have unsent data to unblock; a grant for an unknown
+%% id is ignored.
+-spec on_max_stream_data(non_neg_integer(), non_neg_integer(), t()) -> t().
+on_max_stream_data(Sid, Max, #state{streams = Streams} = State) ->
+    case Streams of
+        #{Sid := {Stream, Flow}} ->
+            put_stream(Sid, Stream, roadrunner_quic_flow:on_max_data_received(Max, Flow), State);
+        #{} ->
+            State
+    end.
 
 %% Reassemble CRYPTO, deframe complete handshake messages, and drive the
 %% TLS sequencer.

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -800,6 +800,32 @@ send_blocked_by_exhausted_send_window_test() ->
     ?assert(byte_size(Sent) > 0),
     ?assert(byte_size(Sent) < byte_size(Payload)).
 
+send_resumes_after_max_data_and_max_stream_data_test() ->
+    %% After the send window fills (RFC 9000 §4.1), the peer's MAX_DATA /
+    %% MAX_STREAM_DATA grants raise the connection and per-stream send limits and
+    %% the next send pass resumes the still-pending stream, so the whole payload
+    %% eventually reaches the wire.
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Payload = binary:copy(~"x", 786432 + 1000),
+    {State1, E1} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    Sent1 = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(E1, ServerApSecret)]),
+    ?assert(byte_size(Sent1) < byte_size(Payload)),
+    Grant = app_datagram(
+        [{max_data, 786432 * 2}, {max_stream_data, 0, 786432 * 2}], 0, ClientApSecret
+    ),
+    {_State2, E2} = ?M:handle_datagram(?NOW, Grant, State1),
+    Sent2 = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(E2, ServerApSecret)]),
+    ?assert(byte_size(Sent2) > 0),
+    ?assertEqual(byte_size(Payload), byte_size(Sent1) + byte_size(Sent2)).
+
+max_stream_data_for_untracked_stream_ignored_test() ->
+    %% A MAX_STREAM_DATA grant for a stream the server is not tracking is ignored
+    %% (on_max_stream_data's unknown-id branch); the connection survives.
+    {State, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Grant = app_datagram([{max_stream_data, 4, 1000000}], 0, ClientApSecret),
+    {State1, _Effects} = ?M:handle_datagram(?NOW, Grant, State),
+    ?assertEqual(connected, ?M:phase(State1)).
+
 send_data_on_control_then_request_stream_test() ->
     %% The two load-bearing GET writes: SETTINGS on the server control stream
     %% (id 3) then a response on the client request stream (id 0), each on its


### PR DESCRIPTION
QUIC connection-level flow control: the frame dispatch dropped inbound `MAX_DATA` / `MAX_STREAM_DATA`, so the send window stayed at its initial 768 KB grant and a keep-alive connection stalled once it had sent that much response data (about twelve 64 KB responses). Process those frames so the window refills as the peer reads; the existing send pass serves whatever the grant unblocks.

Proof: the h3 `large_response` bench (50 keep-alive connections, dep client) goes from 106 req/s (connections dying after ~12 requests) to 4,007 req/s.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
