### PR TITLE
Serve unbounded requests per QUIC connection with bounded memory

### DIFF
--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -902,12 +902,37 @@ open_stream(Sid, #state{info = #{transport_params := TP}} = State) ->
     Flow = roadrunner_quic_flow:new(#{initial_max_data => stream_recv_window(Sid, TP)}),
     {ok, Stream, Flow, emit({stream_opened, Sid}, bump_opened(Sid, State))}.
 
-%% Advance the per-type high-water past `Sid`'s ordinal.
+%% Advance the per-type high-water past `Sid`'s ordinal. Opening a bidi stream
+%% also tops up the peer's bidi-stream credit.
 -spec bump_opened(non_neg_integer(), t()) -> t().
 bump_opened(Sid, #state{bidi_opened = Opened} = State) when Sid rem 4 =:= 0 ->
-    State#state{bidi_opened = max(Opened, Sid div 4 + 1)};
+    grant_max_streams_bidi(State#state{bidi_opened = max(Opened, Sid div 4 + 1)});
 bump_opened(Sid, #state{uni_opened = Opened} = State) ->
     State#state{uni_opened = max(Opened, Sid div 4 + 1)}.
+
+%% Keep the peer in bidi-stream credit (RFC 9000 §4.6): once the opened count is
+%% within a quarter-window of the advertised limit, raise the limit to a fresh
+%% window above what is opened and queue a MAX_STREAMS so the peer can keep
+%% opening request streams. Mirrors the receive-flow MAX_DATA refill
+%% (`roadrunner_quic_flow`, the 3/4 threshold); the window is the originally
+%% advertised `initial_max_streams_bidi`.
+-spec grant_max_streams_bidi(t()) -> t().
+grant_max_streams_bidi(
+    #state{
+        bidi_opened = Opened,
+        max_streams_bidi = Max,
+        info = #{transport_params := #{initial_max_streams_bidi := Window}}
+    } = State
+) ->
+    case Opened > Max - Window * 3 div 4 of
+        true ->
+            NewMax = Opened + Window,
+            queue_frame(
+                application, {max_streams, bidi, NewMax}, State#state{max_streams_bidi = NewMax}
+            );
+        false ->
+            State
+    end.
 
 %% The receive window we advertised for a peer-initiated stream (RFC 9000
 %% §18.2): client-initiated bidirectional streams (Sid rem 4 == 0) get

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -99,9 +99,9 @@
     streams = #{} :: #{non_neg_integer() => stream()},
     %% The subset of `streams` ids with unsent data or an unsent FIN, kept
     %% ascending (RFC 9000 stream priority: lowest id first). The send pass
-    %% walks only these instead of re-sorting and scanning every stream
-    %% (finished streams stay in `streams` but leave this set), so per-pass
-    %% work is O(streams-with-pending-data), not O(all-streams-ever).
+    %% walks only these instead of re-sorting and scanning every stream, so
+    %% per-pass work is O(streams-with-pending-data); a fully-terminal stream
+    %% leaves both this set and `streams` (pruned in `put_stream`).
     sendable = [] :: ordsets:ordset(non_neg_integer()),
     %% Next server-initiated unidirectional stream id to hand out (RFC 9000
     %% §2.1: server uni ids are 3, 7, 11, ...); the owner opens its h3
@@ -113,6 +113,12 @@
     %% STREAM_LIMIT_ERROR.
     max_streams_bidi :: non_neg_integer(),
     max_streams_uni :: non_neg_integer(),
+    %% Per-type count of peer-initiated stream ordinals opened so far (1 + the
+    %% highest ordinal seen). A peer frame for an ordinal below this that is no
+    %% longer in `streams` is a late/reordered frame for a pruned stream
+    %% (RFC 9000 §3): it is ignored, not recreated as a fresh stream.
+    bidi_opened = 0 :: non_neg_integer(),
+    uni_opened = 0 :: non_neg_integer(),
     %% Connection-level flow control (RFC 9000 §4).
     conn_flow :: roadrunner_quic_flow:t(),
     %% Owner events accumulated while folding a datagram's frames, drained in
@@ -729,18 +735,26 @@ process_stream(Sid, _Offset, _Data, _Fin, #state{max_streams_uni = Max} = State)
 ->
     connection_fatal(application, stream_limit_error, State);
 process_stream(Sid, Offset, Data, Fin, State) ->
-    {Stream0, StreamFlow0, State1} = ensure_stream(Sid, State),
-    #state{conn_flow = ConnFlow} = State1,
-    Delta = max(0, Offset + byte_size(Data) - roadrunner_quic_flow:bytes_received(StreamFlow0)),
-    maybe
-        {ok, ConnFlow1} ?= roadrunner_quic_flow:on_data_received(Delta, ConnFlow),
-        {ok, StreamFlow1} ?= roadrunner_quic_flow:on_data_received(Delta, StreamFlow0),
-        {ok, Deliverable, FinReached, Stream1} ?=
-            roadrunner_quic_stream:receive_data(Offset, Data, Fin, Stream0),
-        State2 = put_stream(Sid, Stream1, StreamFlow1, State1#state{conn_flow = ConnFlow1}),
-        deliver_stream(Sid, Deliverable, FinReached, State2)
-    else
-        {error, Reason} -> connection_fatal(application, Reason, State)
+    case ensure_stream(Sid, State) of
+        closed ->
+            %% Late/reordered STREAM frame for a pruned stream (RFC 9000 §3): the
+            %% packet is still acknowledged, but the frame is ignored.
+            State;
+        {ok, Stream0, StreamFlow0, State1} ->
+            #state{conn_flow = ConnFlow} = State1,
+            Delta = max(
+                0, Offset + byte_size(Data) - roadrunner_quic_flow:bytes_received(StreamFlow0)
+            ),
+            maybe
+                {ok, ConnFlow1} ?= roadrunner_quic_flow:on_data_received(Delta, ConnFlow),
+                {ok, StreamFlow1} ?= roadrunner_quic_flow:on_data_received(Delta, StreamFlow0),
+                {ok, Deliverable, FinReached, Stream1} ?=
+                    roadrunner_quic_stream:receive_data(Offset, Data, Fin, Stream0),
+                State2 = put_stream(Sid, Stream1, StreamFlow1, State1#state{conn_flow = ConnFlow1}),
+                deliver_stream(Sid, Deliverable, FinReached, State2)
+            else
+                {error, Reason} -> connection_fatal(application, Reason, State)
+            end
     end.
 
 %% A RESET_STREAM aborts the peer's send side and surfaces the abort code. On
@@ -758,12 +772,17 @@ process_reset_stream(Sid, _ErrorCode, _FinalSize, #state{max_streams_uni = Max} 
 ->
     connection_fatal(application, stream_limit_error, State);
 process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
-    {Stream0, Flow, State1} = ensure_stream(Sid, State),
-    case roadrunner_quic_stream:reset(FinalSize, Stream0) of
-        {ok, Stream1} ->
-            emit({stream_reset, Sid, ErrorCode}, put_stream(Sid, Stream1, Flow, State1));
-        {error, Reason} ->
-            connection_fatal(application, Reason, State)
+    case ensure_stream(Sid, State) of
+        closed ->
+            %% Late/reordered RESET_STREAM for a pruned stream (RFC 9000 §3).
+            State;
+        {ok, Stream0, Flow, State1} ->
+            case roadrunner_quic_stream:reset(FinalSize, Stream0) of
+                {ok, Stream1} ->
+                    emit({stream_reset, Sid, ErrorCode}, put_stream(Sid, Stream1, Flow, State1));
+                {error, Reason} ->
+                    connection_fatal(application, Reason, State)
+            end
     end.
 
 %% A well-placed peer CONNECTION_CLOSE (transport at any level, or application
@@ -847,23 +866,48 @@ send_close(
             {State1, [{send, Datagram}]}
     end.
 
-%% Look up a stream, or create it. The first frame of a peer-initiated stream
-%% is announced with {stream_opened, Sid} (server-initiated ids never reach
-%% here; process_stream/process_reset_stream reject them upstream). Returns
-%% the stream, its flow, and the state carrying any queued event.
+%% Look up a peer stream and return `{ok, Stream, Flow, State}`: an existing
+%% entry, or a fresh one for a genuinely new id (announced with
+%% {stream_opened, Sid}). A first frame of a new id advances the per-type
+%% high-water; an id at or below the high-water that is no longer tracked was
+%% opened and pruned, so `closed` is returned and the frame ignored (RFC 9000
+%% §3). Server-initiated ids never reach here (rejected upstream).
 -spec ensure_stream(non_neg_integer(), t()) ->
-    {roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()}.
-ensure_stream(Sid, #state{streams = Streams, info = #{transport_params := TP}} = State) ->
+    {ok, roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()} | closed.
+ensure_stream(Sid, #state{streams = Streams} = State) ->
     case Streams of
         #{Sid := {Stream, Flow}} ->
-            {Stream, Flow, State};
+            {ok, Stream, Flow, State};
         #{} ->
-            {
-                roadrunner_quic_stream:new(),
-                roadrunner_quic_flow:new(#{initial_max_data => stream_recv_window(Sid, TP)}),
-                emit({stream_opened, Sid}, State)
-            }
+            case opened_before(Sid, State) of
+                true -> closed;
+                false -> open_stream(Sid, State)
+            end
     end.
+
+%% Whether `Sid`'s ordinal is below the per-type high-water: it was opened
+%% earlier and, since it is no longer in `streams`, has been pruned.
+-spec opened_before(non_neg_integer(), t()) -> boolean().
+opened_before(Sid, #state{bidi_opened = Opened}) when Sid rem 4 =:= 0 ->
+    Sid div 4 < Opened;
+opened_before(Sid, #state{uni_opened = Opened}) ->
+    Sid div 4 < Opened.
+
+%% Create a fresh peer stream, advance the per-type high-water past its ordinal,
+%% and announce it with {stream_opened, Sid}.
+-spec open_stream(non_neg_integer(), t()) ->
+    {ok, roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()}.
+open_stream(Sid, #state{info = #{transport_params := TP}} = State) ->
+    Stream = roadrunner_quic_stream:new(),
+    Flow = roadrunner_quic_flow:new(#{initial_max_data => stream_recv_window(Sid, TP)}),
+    {ok, Stream, Flow, emit({stream_opened, Sid}, bump_opened(Sid, State))}.
+
+%% Advance the per-type high-water past `Sid`'s ordinal.
+-spec bump_opened(non_neg_integer(), t()) -> t().
+bump_opened(Sid, #state{bidi_opened = Opened} = State) when Sid rem 4 =:= 0 ->
+    State#state{bidi_opened = max(Opened, Sid div 4 + 1)};
+bump_opened(Sid, #state{uni_opened = Opened} = State) ->
+    State#state{uni_opened = max(Opened, Sid div 4 + 1)}.
 
 %% The receive window we advertised for a peer-initiated stream (RFC 9000
 %% §18.2): client-initiated bidirectional streams (Sid rem 4 == 0) get
@@ -880,15 +924,25 @@ stream_recv_window(_Sid, #{initial_max_stream_data_uni := Uni}) ->
 -spec put_stream(non_neg_integer(), roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()) ->
     t().
 put_stream(Sid, Stream, Flow, #state{streams = Streams, sendable = Sendable} = State) ->
-    %% The single writer of `streams`, so it is also where the `sendable`
-    %% working set stays in step: a stream with unsent data/FIN joins it, a
-    %% drained or finished one leaves it.
-    Sendable1 =
-        case roadrunner_quic_stream:send_pending(Stream) of
-            true -> ordsets:add_element(Sid, Sendable);
-            false -> ordsets:del_element(Sid, Sendable)
-        end,
-    State#state{streams = Streams#{Sid => {Stream, Flow}}, sendable = Sendable1}.
+    %% The single writer of `streams`. A fully-terminal stream (both directions
+    %% finished) is pruned so the map stays bounded to live streams; the
+    %% high-water keeps a late frame for its id from recreating it. Otherwise it
+    %% is stored and the `sendable` working set kept in step (unsent data/FIN
+    %% joins it, a drained one leaves it).
+    case roadrunner_quic_stream:is_terminal(Stream) of
+        true ->
+            State#state{
+                streams = maps:remove(Sid, Streams),
+                sendable = ordsets:del_element(Sid, Sendable)
+            };
+        false ->
+            Sendable1 =
+                case roadrunner_quic_stream:send_pending(Stream) of
+                    true -> ordsets:add_element(Sid, Sendable);
+                    false -> ordsets:del_element(Sid, Sendable)
+                end,
+            State#state{streams = Streams#{Sid => {Stream, Flow}}, sendable = Sendable1}
+    end.
 
 %% Emit {stream_data, ...} when there are newly-contiguous bytes OR the FIN
 %% was reached (the FIN-only {<<>>, true} end-of-stream the h3 layer needs).

--- a/src/roadrunner_quic_stream.erl
+++ b/src/roadrunner_quic_stream.erl
@@ -31,7 +31,9 @@
 %% the per-stream flow window.
 
 -export([new/0, receive_data/4, reset/2]).
--export([enqueue/2, finish/1, next_frame/2, stop_sending/1, send_pending/1, send_offset/1]).
+-export([
+    enqueue/2, finish/1, next_frame/2, stop_sending/1, send_pending/1, send_offset/1, is_terminal/1
+]).
 
 -export_type([t/0]).
 
@@ -186,6 +188,23 @@ stop_sending(#stream{} = Stream) ->
 send_pending(#stream{fin_sent = true}) -> false;
 send_pending(#stream{send_buf = <<>>, send_fin = false}) -> false;
 send_pending(#stream{}) -> true.
+
+-doc """
+Whether both directions are finished, so the stream can be pruned: the send FIN
+is on the wire (`fin_sent`) and the receive side has reached its final size and
+either delivered its FIN or been reset (RFC 9000 §3). A send side abandoned via
+STOP_SENDING without a FIN is conservatively not terminal (it lingers rather
+than risk pruning a stream still in use).
+""".
+-spec is_terminal(t()) -> boolean().
+is_terminal(#stream{
+    fin_sent = true, final_size = FinalSize, fin_delivered = FinDelivered, aborted = Aborted
+}) when
+    FinalSize =/= undefined
+->
+    FinDelivered orelse Aborted;
+is_terminal(#stream{}) ->
+    false.
 
 -doc """
 The send offset: the number of stream bytes already put on the wire, which is

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -826,6 +826,42 @@ max_stream_data_for_untracked_stream_ignored_test() ->
     {State1, _Effects} = ?M:handle_datagram(?NOW, Grant, State),
     ?assertEqual(connected, ?M:phase(State1)).
 
+%% A request stream finishes both ways (client FIN received, server response +
+%% FIN sent) and is pruned. A later STREAM frame for that id carrying data past
+%% its final size would be a final_size_error and close the connection if the
+%% stream were still tracked; pruned and guarded as closed (RFC 9000 §3) it is
+%% ignored and the connection stays up.
+terminal_stream_is_pruned_and_late_frame_ignored_test() ->
+    {State0, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Req = app_datagram([{stream, 0, 0, ~"req", true}], 0, ClientApSecret),
+    {State1, _} = ?M:handle_datagram(?NOW, Req, State0),
+    {State2, _} = ?M:handle_send(self(), make_ref(), 0, ~"resp", true, ?NOW, State1),
+    Late = app_datagram([{stream, 0, 100, ~"late", false}], 1, ClientApSecret),
+    {State3, _} = ?M:handle_datagram(?NOW, Late, State2),
+    ?assertEqual(connected, ?M:phase(State3)).
+
+%% After a stream is pruned, a genuinely new request on a higher id (above the
+%% per-type high-water) still opens normally.
+new_stream_after_prune_opens_test() ->
+    {State0, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Req0 = app_datagram([{stream, 0, 0, ~"a", true}], 0, ClientApSecret),
+    {State1, _} = ?M:handle_datagram(?NOW, Req0, State0),
+    {State2, _} = ?M:handle_send(self(), make_ref(), 0, ~"r", true, ?NOW, State1),
+    Req4 = app_datagram([{stream, 4, 0, ~"b", true}], 1, ClientApSecret),
+    {_State3, Effects} = ?M:handle_datagram(?NOW, Req4, State2),
+    ?assert(lists:member({stream_opened, 4}, [E || {emit, _Owner, E} <- Effects])).
+
+%% A late/reordered RESET_STREAM for a pruned stream is ignored as closed
+%% (RFC 9000 §3), not recreated; the connection stays up.
+reset_for_pruned_stream_ignored_test() ->
+    {State0, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Req = app_datagram([{stream, 0, 0, ~"req", true}], 0, ClientApSecret),
+    {State1, _} = ?M:handle_datagram(?NOW, Req, State0),
+    {State2, _} = ?M:handle_send(self(), make_ref(), 0, ~"resp", true, ?NOW, State1),
+    Rst = app_datagram([{reset_stream, 0, 7, 3}], 1, ClientApSecret),
+    {State3, _} = ?M:handle_datagram(?NOW, Rst, State2),
+    ?assertEqual(connected, ?M:phase(State3)).
+
 send_data_on_control_then_request_stream_test() ->
     %% The two load-bearing GET writes: SETTINGS on the server control stream
     %% (id 3) then a response on the client request stream (id 0), each on its

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -862,6 +862,22 @@ reset_for_pruned_stream_ignored_test() ->
     {State3, _} = ?M:handle_datagram(?NOW, Rst, State2),
     ?assertEqual(connected, ?M:phase(State3)).
 
+%% As the peer opens bidi streams toward the advertised limit (test TP = 3), the
+%% server raises the limit and sends MAX_STREAMS so the peer can keep opening
+%% request streams (RFC 9000 §4.6). The first open is still within credit (no
+%% grant); the second crosses the refill threshold and grants a fresh window.
+max_streams_granted_as_bidi_credit_consumed_test() ->
+    {State0, ClientApSecret, ServerApSecret} = connect_owned(),
+    Open0 = app_datagram([{stream, 0, 0, ~"a", true}], 0, ClientApSecret),
+    {State1, E0} = ?M:handle_datagram(?NOW, Open0, State0),
+    ?assertEqual([], max_streams_frames(E0, ServerApSecret)),
+    Open4 = app_datagram([{stream, 4, 0, ~"b", true}], 1, ClientApSecret),
+    {_State2, E4} = ?M:handle_datagram(?NOW, Open4, State1),
+    ?assertEqual([{max_streams, bidi, 5}], max_streams_frames(E4, ServerApSecret)).
+
+max_streams_frames(Effects, ServerApSecret) ->
+    [F || {max_streams, _, _} = F <- sent_app_frames(Effects, ServerApSecret)].
+
 send_data_on_control_then_request_stream_test() ->
     %% The two load-bearing GET writes: SETTINGS on the server control stream
     %% (id 3) then a response on the client request stream (id 0), each on its

--- a/test/roadrunner_quic_stream_tests.erl
+++ b/test/roadrunner_quic_stream_tests.erl
@@ -226,6 +226,20 @@ send_pending_test() ->
     {_, _, _, Sent} = ?M:next_frame(100, ?M:finish(?M:enqueue(<<"d">>, ?M:new()))),
     ?assertNot(?M:send_pending(Sent)).
 
+%% A stream is terminal only when the send FIN is on the wire AND the receive
+%% side has reached its final size (FIN delivered or reset) — one side alone is
+%% not enough.
+is_terminal_test() ->
+    ?assertNot(?M:is_terminal(?M:new())),
+    {_, _, true, SendDone} = ?M:next_frame(100, ?M:finish(?M:enqueue(~"x", ?M:new()))),
+    ?assertNot(?M:is_terminal(SendDone)),
+    {ok, _, true, RecvDone} = ?M:receive_data(0, ~"y", true, ?M:new()),
+    ?assertNot(?M:is_terminal(RecvDone)),
+    {ok, _, true, BothDone} = ?M:receive_data(0, ~"y", true, SendDone),
+    ?assert(?M:is_terminal(BothDone)),
+    {ok, ResetDone} = ?M:reset(0, SendDone),
+    ?assert(?M:is_terminal(ResetDone)).
+
 %% A response enqueued + finished on a sender drains into small slices that
 %% reassemble, in order, to the original bytes with the FIN on the receiver.
 send_recv_round_trip_test() ->


### PR DESCRIPTION
A keep-alive HTTP/3 connection was doubly limited: it kept every request's stream in memory forever (the stream map only grew), and it never raised the peer's bidirectional stream limit, so it stalled after `initial_max_streams_bidi` request streams. This prunes a stream once both directions finish, guards against a late or reordered frame recreating a pruned stream (RFC 9000 §3, via a per-type high-water mark like HTTP/2's `last_stream_id`), and grants `MAX_STREAMS` as the peer consumes credit (RFC 9000 §4.6). Together a connection serves unbounded requests with memory bounded to its live streams.

Proof: the h3 `large_response` bench (50 keep-alive connections, dep client) lifts from `total=5000` (the old per-connection cap) to 9600, with the BEAM holding ~116 MB across ~50 live streams and sustaining ~1157 req/s.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
