### PR TITLE
Grant QUIC receive credit so large uploads don't stall

### DIFF
--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -750,11 +750,39 @@ process_stream(Sid, Offset, Data, Fin, State) ->
                 {ok, StreamFlow1} ?= roadrunner_quic_flow:on_data_received(Delta, StreamFlow0),
                 {ok, Deliverable, FinReached, Stream1} ?=
                     roadrunner_quic_stream:receive_data(Offset, Data, Fin, Stream0),
-                State2 = put_stream(Sid, Stream1, StreamFlow1, State1#state{conn_flow = ConnFlow1}),
-                deliver_stream(Sid, Deliverable, FinReached, State2)
+                {ConnFlow2, State2} = grant_conn_credit(ConnFlow1, State1),
+                {StreamFlow2, State3} = grant_stream_credit(Sid, StreamFlow1, State2),
+                State4 = put_stream(Sid, Stream1, StreamFlow2, State3#state{conn_flow = ConnFlow2}),
+                deliver_stream(Sid, Deliverable, FinReached, State4)
             else
                 {error, Reason} -> connection_fatal(application, Reason, State)
             end
+    end.
+
+%% Refill the connection-level receive window as the peer consumes it (RFC 9000
+%% §4.1): once more than the refill threshold is used, advertise a fresh window
+%% with a MAX_DATA frame so a large upload keeps flowing instead of stalling at
+%% the initial grant.
+-spec grant_conn_credit(roadrunner_quic_flow:t(), t()) -> {roadrunner_quic_flow:t(), t()}.
+grant_conn_credit(ConnFlow, State) ->
+    case roadrunner_quic_flow:should_send_max_data(ConnFlow) of
+        true ->
+            {NewMax, ConnFlow1} = roadrunner_quic_flow:grant_max_data(ConnFlow),
+            {ConnFlow1, queue_frame(application, {max_data, NewMax}, State)};
+        false ->
+            {ConnFlow, State}
+    end.
+
+%% Refill a stream's receive window the same way, with MAX_STREAM_DATA.
+-spec grant_stream_credit(non_neg_integer(), roadrunner_quic_flow:t(), t()) ->
+    {roadrunner_quic_flow:t(), t()}.
+grant_stream_credit(Sid, StreamFlow, State) ->
+    case roadrunner_quic_flow:should_send_max_data(StreamFlow) of
+        true ->
+            {NewMax, StreamFlow1} = roadrunner_quic_flow:grant_max_data(StreamFlow),
+            {StreamFlow1, queue_frame(application, {max_stream_data, Sid, NewMax}, State)};
+        false ->
+            {StreamFlow, State}
     end.
 
 %% A RESET_STREAM aborts the peer's send side and surfaces the abort code. On

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -596,26 +596,30 @@ stream_over_advertised_stream_flow_limit_closes_test() ->
     ?assertEqual([{emit, self(), {closed, {local, flow_control_error}}}], emits(Effects)).
 
 data_over_advertised_connection_flow_limit_closes_test() ->
-    %% Data spread across streams, each within its per-stream window but
-    %% together exceeding the advertised connection window (initial_max_data),
-    %% is an RFC 9000 §4.1 flow-control connection error. Two full per-stream
-    %% windows fill the connection window exactly; one more byte on a third
-    %% stream overflows it, proving the window is the advertised value (it would
-    %% not trip this early under a larger default).
-    {State0, ApSecret} = connected_with_owner(),
-    Chunk = binary:copy(~"x", ?STREAM_RECV_WINDOW),
-    {State1, _} = ?M:handle_datagram(
-        ?NOW, app_datagram([{stream, 0, 0, Chunk, false}], 0, ApSecret), State0
-    ),
-    {State2, _} = ?M:handle_datagram(
-        ?NOW, app_datagram([{stream, 4, 0, Chunk, false}], 1, ApSecret), State1
-    ),
-    ?assertEqual(connected, ?M:phase(State2)),
-    {State3, Effects} = ?M:handle_datagram(
-        ?NOW, app_datagram([{stream, 8, 0, ~"x", false}], 2, ApSecret), State2
-    ),
-    ?assertEqual(closed, ?M:phase(State3)),
+    %% A STREAM frame whose length exceeds the advertised connection window
+    %% (initial_max_data, checked before the per-stream window) is an RFC 9000
+    %% §4.1 flow-control connection error. Incremental uploads within the window
+    %% are instead kept flowing by MAX_DATA grants (see
+    %% recv_window_refilled_with_max_data_and_max_stream_data_test); enforcement
+    %% trips only on exceeding the current limit in one shot, ahead of any grant.
+    {State, ApSecret} = connected_with_owner(),
+    Oversized = binary:copy(~"x", ?CONN_RECV_WINDOW + 1),
+    Bad = app_datagram([{stream, 0, 0, Oversized, false}], 0, ApSecret),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
+    ?assertEqual(closed, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, flow_control_error}}}], emits(Effects)).
+
+%% As the peer uploads past the refill threshold, the server advertises fresh
+%% receive credit with MAX_DATA (connection) and MAX_STREAM_DATA (stream) so a
+%% large upload keeps flowing (RFC 9000 §4.1). 600 bytes is past 3/4 of both the
+%% connection (2000) and stream (1000) windows.
+recv_window_refilled_with_max_data_and_max_stream_data_test() ->
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Upload = app_datagram([{stream, 0, 0, binary:copy(~"u", 600), false}], 0, ClientApSecret),
+    {_State1, Effects} = ?M:handle_datagram(?NOW, Upload, State),
+    Frames = sent_app_frames(Effects, ServerApSecret),
+    ?assert(lists:member({max_data, 600 + ?CONN_RECV_WINDOW}, Frames)),
+    ?assert(lists:member({max_stream_data, 0, 600 + ?STREAM_RECV_WINDOW}, Frames)).
 
 stream_retransmit_does_not_re_consume_flow_test() ->
     %% Flow control is charged by the increase in the highest received offset,


### PR DESCRIPTION
QUIC receive-side flow control, the upload mirror of #147: the server advertised a fixed receive window (`initial_max_data` / `initial_max_stream_data`) and never raised it, so a client upload larger than that initial grant stalled. As the peer consumes the window past the refill threshold, the server now advertises a fresh window with `MAX_DATA` (connection-level) and `MAX_STREAM_DATA` (per stream), reusing the flow module's grant the loop never called (RFC 9000 §4.1). A frame that exceeds the current limit in one shot is still a flow-control error.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
