### PR TITLE
Honor the client's advertised flow-control limits when sending

### DIFF
--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -121,6 +121,11 @@
     uni_opened = 0 :: non_neg_integer(),
     %% Connection-level flow control (RFC 9000 §4).
     conn_flow :: roadrunner_quic_flow:t(),
+    %% The client's advertised transport parameters, captured from the
+    %% ClientHello. The send windows (connection and per-stream) are seeded from
+    %% these so the server never sends past what the peer granted (RFC 9000 §4.1);
+    %% empty until the handshake delivers them.
+    peer_params = #{} :: roadrunner_quic_transport_params:params(),
     %% Owner events accumulated while folding a datagram's frames, drained in
     %% order at the end of handle_datagram (newest-first, reversed on drain).
     emits = [] :: [effect()],
@@ -485,10 +490,22 @@ enqueue_send(Sid, IoData, Fin, State) ->
 %% peer stream the owner has not already seen via {stream_opened, _}.
 -spec stream_for_send(non_neg_integer(), t()) ->
     {roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()}.
-stream_for_send(Sid, #state{streams = Streams} = State) ->
+stream_for_send(
+    Sid,
+    #state{streams = Streams, info = #{transport_params := TP}, peer_params = PeerParams} = State
+) ->
     case Streams of
-        #{Sid := {Stream, Flow}} -> {Stream, Flow, State};
-        #{} -> {roadrunner_quic_stream:new(), roadrunner_quic_flow:new(#{}), State}
+        #{Sid := {Stream, Flow}} ->
+            {Stream, Flow, State};
+        #{} ->
+            %% A server-first stream (response on a client request stream, or a
+            %% server control / QPACK stream): seed its send window from what the
+            %% client granted for that stream type, like the receive path does.
+            Flow = roadrunner_quic_flow:new(#{
+                initial_max_data => stream_recv_window(Sid, TP),
+                peer_initial_max_data => peer_stream_send_window(Sid, PeerParams)
+            }),
+            {roadrunner_quic_stream:new(), Flow, State}
     end.
 
 -spec process_outcome(integer(), roadrunner_quic_recv:outcome(), t()) -> t().
@@ -618,10 +635,24 @@ deframe(Buffer) ->
     end.
 
 -spec process_handshake(level(), {byte(), binary()}, t()) -> t().
-process_handshake(initial, {?CLIENT_HELLO, Body}, #state{tls = Tls} = State) ->
+process_handshake(
+    initial,
+    {?CLIENT_HELLO, Body},
+    #state{tls = Tls, info = #{transport_params := #{initial_max_data := OurMaxData}}} = State
+) ->
     case roadrunner_quic_tls_server:process_client_hello(Body, Tls) of
-        {ok, #{initial := InitialFlight, handshake := HandshakeFlight}, Installs, Tls1} ->
-            State1 = install_keys(Installs, State#state{tls = Tls1}),
+        {ok, #{initial := InitialFlight, handshake := HandshakeFlight}, Installs, PeerParams, Tls1} ->
+            %% Seed the connection send window from the client's advertised
+            %% initial_max_data (absent -> 0, RFC 9000 §18.2), not a default. Safe
+            %% to re-create conn_flow here: no 1-RTT data flows before the
+            %% handshake completes.
+            ConnFlow = roadrunner_quic_flow:new(#{
+                initial_max_data => OurMaxData,
+                peer_initial_max_data => maps:get(initial_max_data, PeerParams, 0)
+            }),
+            State1 = install_keys(
+                Installs, State#state{tls = Tls1, peer_params = PeerParams, conn_flow = ConnFlow}
+            ),
             State2 = queue_crypto(initial, InitialFlight, State1),
             queue_crypto(handshake, HandshakeFlight, State2);
         {error, Reason} ->
@@ -925,10 +956,28 @@ opened_before(Sid, #state{uni_opened = Opened}) ->
 %% and announce it with {stream_opened, Sid}.
 -spec open_stream(non_neg_integer(), t()) ->
     {ok, roadrunner_quic_stream:t(), roadrunner_quic_flow:t(), t()}.
-open_stream(Sid, #state{info = #{transport_params := TP}} = State) ->
+open_stream(Sid, #state{info = #{transport_params := TP}, peer_params = PeerParams} = State) ->
     Stream = roadrunner_quic_stream:new(),
-    Flow = roadrunner_quic_flow:new(#{initial_max_data => stream_recv_window(Sid, TP)}),
+    Flow = roadrunner_quic_flow:new(#{
+        initial_max_data => stream_recv_window(Sid, TP),
+        peer_initial_max_data => peer_stream_send_window(Sid, PeerParams)
+    }),
     {ok, Stream, Flow, emit({stream_opened, Sid}, bump_opened(Sid, State))}.
+
+%% The send window for a stream the server writes to: the limit the client
+%% advertised for that stream type (RFC 9000 §18.2; absent -> 0). A
+%% client-initiated bidi (request) stream where the server sends the response
+%% uses initial_max_stream_data_bidi_local; a server-initiated uni (control /
+%% QPACK) stream uses initial_max_stream_data_uni. A client uni stream is
+%% receive-only for the server, so 0.
+-spec peer_stream_send_window(non_neg_integer(), roadrunner_quic_transport_params:params()) ->
+    non_neg_integer().
+peer_stream_send_window(Sid, PeerParams) when Sid rem 4 =:= 0 ->
+    maps:get(initial_max_stream_data_bidi_local, PeerParams, 0);
+peer_stream_send_window(Sid, PeerParams) when Sid rem 4 =:= 3 ->
+    maps:get(initial_max_stream_data_uni, PeerParams, 0);
+peer_stream_send_window(_Sid, _PeerParams) ->
+    0.
 
 %% Advance the per-type high-water past `Sid`'s ordinal. Opening a bidi stream
 %% also tops up the peer's bidi-stream credit.
@@ -962,11 +1011,12 @@ grant_max_streams_bidi(
             State
     end.
 
-%% The receive window we advertised for a peer-initiated stream (RFC 9000
-%% §18.2): client-initiated bidirectional streams (Sid rem 4 == 0) get
-%% initial_max_stream_data_bidi_remote, client-initiated unidirectional streams
-%% (Sid rem 4 == 2) get initial_max_stream_data_uni. Server-initiated ids never
-%% reach here (process_stream/process_reset_stream reject them upstream).
+%% Our advertised receive window for a stream by type (RFC 9000 §18.2):
+%% client-initiated bidirectional streams (Sid rem 4 == 0) get
+%% initial_max_stream_data_bidi_remote; every other type gets
+%% initial_max_stream_data_uni. The receive path passes only client-initiated
+%% ids; the send path (stream_for_send) also passes server uni ids, where the
+%% receive window is moot since the server never receives there.
 -spec stream_recv_window(non_neg_integer(), roadrunner_quic_transport_params:params()) ->
     non_neg_integer().
 stream_recv_window(Sid, #{initial_max_stream_data_bidi_remote := Bidi}) when Sid rem 4 =:= 0 ->

--- a/src/roadrunner_quic_tls_server.erl
+++ b/src/roadrunner_quic_tls_server.erl
@@ -148,7 +148,7 @@ Source Connection ID of its first Initial packet (`transport_parameter_error`,
 RFC 9000 §7.3).
 """.
 -spec process_client_hello(binary(), t()) ->
-    {ok, flight(), [install()], t()} | {error, atom()}.
+    {ok, flight(), [install()], roadrunner_quic_transport_params:params(), t()} | {error, atom()}.
 process_client_hello(
     ClientHelloBody, #server{priv_key = PrivKey, alpn = Alpn, peer_scid = PeerSCID} = State
 ) ->
@@ -165,7 +165,11 @@ process_client_hello(
         ok ?= check_alpn(Alpn, ClientAlpns),
         ok ?= check_transport_params(ClientHello),
         ok ?= check_initial_scid(ClientHello, PeerSCID),
-        build_flight(ClientHelloBody, SessionId, ClientKeyShare, Scheme, State)
+        {ok, Flight, Installs, State1} =
+            build_flight(ClientHelloBody, SessionId, ClientKeyShare, Scheme, State),
+        %% Surface the client's advertised transport params (presence already
+        %% checked) so the loop can seed its send windows from them.
+        {ok, Flight, Installs, maps:get(transport_params, ClientHello), State1}
     end.
 
 -doc """

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -796,13 +796,16 @@ send_blocked_by_exhausted_send_window_test() ->
     %% send pass walking only streams that have pending data, this block is the
     %% one path that reaches take_stream's no-frame branch.
     {State, ApSecret} = connected_for_send(),
-    %% The conn and per-stream send windows both default to roadrunner_quic_flow's
-    %% initial_max_data (786432), so the payload must exceed it to block.
-    Payload = binary:copy(~"x", 786432 + 1000),
+    %% The send windows are seeded from the client's advertised 800000-byte
+    %% initial_max_data / initial_max_stream_data (see roadrunner_quic_test_client),
+    %% so the payload must exceed that to block — and the server stops at exactly
+    %% the client's window, proving the limit is sourced from the peer rather than
+    %% roadrunner_quic_flow's 786432 default.
+    Window = 800000,
+    Payload = binary:copy(~"x", Window + 1000),
     {_State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
     Sent = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(Effects, ApSecret)]),
-    ?assert(byte_size(Sent) > 0),
-    ?assert(byte_size(Sent) < byte_size(Payload)).
+    ?assertEqual(Window, byte_size(Sent)).
 
 send_resumes_after_max_data_and_max_stream_data_test() ->
     %% After the send window fills (RFC 9000 §4.1), the peer's MAX_DATA /
@@ -810,12 +813,13 @@ send_resumes_after_max_data_and_max_stream_data_test() ->
     %% the next send pass resumes the still-pending stream, so the whole payload
     %% eventually reaches the wire.
     {State, ClientApSecret, ServerApSecret} = connect_owned(),
-    Payload = binary:copy(~"x", 786432 + 1000),
+    Window = 800000,
+    Payload = binary:copy(~"x", Window + 1000),
     {State1, E1} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
     Sent1 = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(E1, ServerApSecret)]),
     ?assert(byte_size(Sent1) < byte_size(Payload)),
     Grant = app_datagram(
-        [{max_data, 786432 * 2}, {max_stream_data, 0, 786432 * 2}], 0, ClientApSecret
+        [{max_data, Window * 2}, {max_stream_data, 0, Window * 2}], 0, ClientApSecret
     ),
     {_State2, E2} = ?M:handle_datagram(?NOW, Grant, State1),
     Sent2 = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(E2, ServerApSecret)]),

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -105,14 +105,23 @@ key_share_ext(PubKey) ->
     Entry = <<?GROUP_X25519:16, (byte_size(PubKey)):16, PubKey/binary>>,
     extension(?EXT_KEY_SHARE, <<(byte_size(Entry)):16, Entry/binary>>).
 
-%% A quic_transport_parameters extension carrying just the client's
-%% initial_source_connection_id, encoded with the production codec so the wire
-%% bytes stay authoritative. `none` emits no extension at all.
+%% A quic_transport_parameters extension carrying the client's
+%% initial_source_connection_id plus flow-control limits, encoded with the
+%% production codec so the wire bytes stay authoritative. The 800000-byte
+%% windows are what the server seeds its send windows from (deliberately
+%% distinct from roadrunner_quic_flow's 786432 default, so a send test proves
+%% the window is the client's advertised value, not a hardcoded fallback).
+%% `none` emits no extension at all.
 transport_params_ext(none) ->
     <<>>;
 transport_params_ext(ClientSCID) ->
     Body = iolist_to_binary(
-        roadrunner_quic_transport_params:encode(#{initial_source_connection_id => ClientSCID})
+        roadrunner_quic_transport_params:encode(#{
+            initial_source_connection_id => ClientSCID,
+            initial_max_data => 800000,
+            initial_max_stream_data_bidi_local => 800000,
+            initial_max_stream_data_uni => 800000
+        })
     ),
     extension(?EXT_QUIC_TRANSPORT_PARAMS, Body).
 

--- a/test/roadrunner_quic_test_handshake_tests.erl
+++ b/test/roadrunner_quic_test_handshake_tests.erl
@@ -36,7 +36,7 @@ full_handshake_round_trip_test() ->
 
     ClientHelloFramed = ?TC:client_hello_framed(Scheme, ClientPub, ClientSCID),
     [{1, ClientHelloBody}] = ?TC:deframe_all(ClientHelloFramed),
-    {ok, Flight, ServerInstalls, ServerState1} =
+    {ok, Flight, ServerInstalls, _PeerParams, ServerState1} =
         ?SERVER:process_client_hello(ClientHelloBody, ServerState),
 
     {ok, Result} = ?CLIENT:process_server_flight(
@@ -83,7 +83,7 @@ rejects_bad_certificate_verify_test() ->
     }),
     ClientHelloFramed = ?TC:client_hello_framed(Scheme, ClientPub, ClientSCID),
     [{1, ClientHelloBody}] = ?TC:deframe_all(ClientHelloFramed),
-    {ok, Flight, _, _} = ?SERVER:process_client_hello(ClientHelloBody, ServerState),
+    {ok, Flight, _, _, _} = ?SERVER:process_client_hello(ClientHelloBody, ServerState),
     %% Verify the signature against a public key that did not sign it.
     ?assertEqual(
         {error, handshake_verification_failed},

--- a/test/roadrunner_quic_tls_server_tests.erl
+++ b/test/roadrunner_quic_tls_server_tests.erl
@@ -71,7 +71,7 @@ assert_full_handshake(KeyType) ->
         peer_scid => ClientSCID
     }),
 
-    {ok, Flight, Installs, State1} = ?M:process_client_hello(ClientHelloBody, State),
+    {ok, Flight, Installs, _PeerParams, State1} = ?M:process_client_hello(ClientHelloBody, State),
 
     %% Flight grouping: ServerHello at Initial; EE/Cert/CertVerify/Finished
     %% at Handshake, in order, each properly framed and concatenable.


### PR DESCRIPTION
QUIC send-side flow-control correctness: the server seeded its connection and per-stream send windows from a hardcoded 768 KB default rather than the client's advertised `initial_max_data` / `initial_max_stream_data_*`. A conformant client advertising a smaller window would be over-sent and would reset the connection (RFC 9000 §4.1). The client's transport params are now threaded out of the handshake (`tls_server:process_client_hello` parsed but discarded them) and seed both send windows (absent field → 0, the §18.2 default). This completes the send window: #147 refills it from inbound `MAX_DATA`, this fixes its initial value. The native test client now advertises flow params (a real client does), and a send test asserts the server stops at exactly the client-advertised window rather than the old default.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
