### PR TITLE
Linger in draining after an established QUIC connection closes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,28 +93,24 @@ advisory or malformed cases the server currently tolerates or omits.
 
 ### Transport completeness — bites large transfers / advanced cases
 
-- Send-side flow control: seed send windows from the peer's advertised
-  transport params, process inbound `MAX_DATA` / `MAX_STREAM_DATA`, grant
-  outbound `MAX_DATA` / `MAX_STREAM_DATA`, and emit `DATA_BLOCKED` /
-  `STREAM_DATA_BLOCKED` (RFC 9000 §4). Each window is seeded from our own
-  advertised value and never raised, so a transfer past the initial grant
-  stalls; the suite max is 100 KB, well under it — medium
-- Stream-count grants and self-limiting (RFC 9000 §4.6): the server now rejects
-  a client stream id over the advertised `initial_max_streams_*`, but never
-  *sends* `MAX_STREAMS` to raise the limit, ignores an inbound `MAX_STREAMS`, and
-  does not check the peer's `initial_max_streams_uni` before opening its own
-  control / QPACK uni streams (it opens ~3, always within a sane client's
-  limit) — small
+- Send-side flow control: emit `DATA_BLOCKED` / `STREAM_DATA_BLOCKED` when a
+  transfer is held at the current limit (RFC 9000 §4) so the peer knows to grant
+  more. Seeding the windows from the peer's transport params, raising them on
+  inbound `MAX_DATA` / `MAX_STREAM_DATA`, and granting outbound credit are done;
+  the blocked-frame signal is the advisory remainder — small
+- Stream-count self-limiting (RFC 9000 §4.6): honor an inbound `MAX_STREAMS`, and
+  check the peer's `initial_max_streams_uni` before opening the server's own
+  control / QPACK uni streams (it opens ~3, always within a sane client's limit).
+  Sending `MAX_STREAMS` to raise the peer's limit is done — small
 - Respond to a peer-initiated key update (RFC 9001 §6). Security-sensitive:
   trial-decrypt the next-phase keys and commit ONLY on success (not
   commit-then-decrypt, which a single forged flipped-bit datagram desyncs),
   keep the header-protection key fixed, enforce the AEAD integrity limit —
   large
-- Draining state: linger ~3×PTO to absorb the peer's reordered packets before
-  close, and reject `send_data` on a draining connection (RFC 9000 §10.2) —
-  medium
-- Seed the idle timeout from the negotiated `max_idle_timeout` (a fixed 30s
-  today) (RFC 9000 §10.1) — small-medium
+- Closing-state CONNECTION_CLOSE retransmission (RFC 9000 §10.2.1): a connection
+  draining after a local close absorbs the peer's late packets but does not
+  re-send its CONNECTION_CLOSE in response (rate-limited), so a peer that lost the
+  close learns only by timeout — small-medium
 - NewReno congestion control (RFC 9002 §7); needs the loss layer to surface
   acked bytes + sent times. Sending is bounded only by the §8.1
   anti-amplification limit and flow control today — large
@@ -124,13 +120,6 @@ advisory or malformed cases the server currently tolerates or omits.
   the oldest-unacked) — medium
 - A no-flatten / by-reference stream send buffer, so a large response body is
   not flattened into one binary before sending — medium
-- Prune fully-terminal streams (send + receive both closed, or reset) from the
-  connection's stream map, which grows unbounded over a keep-alive connection
-  today (every served request's bidi stream lingers). The send pass already
-  walks only a pending-data working set, so this is now a memory bound, not a
-  CPU one; it needs an RFC 9000 §3 late-packet guard (a high-water mark so a
-  late or retransmitted frame for a removed id is ignored, not recreated) —
-  medium
 
 ### Throughput levers identified by profiling
 

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -314,6 +314,24 @@ handle_datagram(
 %% with {connected, _} ordered ahead of any stream events from the same
 %% datagram so the owner opens its control stream before the first request.
 -spec finish_datagram(integer(), phase(), t()) -> {t(), [effect()]}.
+finish_datagram(_Now, draining, #state{phase = draining} = State) ->
+    %% A packet arrived during an established connection's drain window: absorb it
+    %% silently (RFC 9000 §10.2.2). Send nothing and arm no timer, so the drain
+    %% timer set on entry keeps running in the shell.
+    drain_emits(State);
+finish_datagram(Now, _Before, #state{phase = draining, pending_close = undefined} = State) ->
+    %% Just entered draining via a peer CONNECTION_CLOSE: deliver {closed, _} and
+    %% arm the drain timer; send nothing.
+    {State1, EmitEffects} = drain_emits(State),
+    {State1, [{arm_timer, drain, drain_deadline(Now, State1)} | EmitEffects]};
+finish_datagram(Now, _Before, #state{phase = draining} = State) ->
+    %% Just entered draining via a locally-detected error: send our one
+    %% CONNECTION_CLOSE, deliver {closed, _}, and arm the drain timer. An
+    %% established connection's address is validated, so the close always fits the
+    %% §8.1 budget (send_close emits exactly one datagram).
+    {State1, [Close]} = send_close(State),
+    {State2, EmitEffects} = drain_emits(State1),
+    {State2, [Close, {arm_timer, drain, drain_deadline(Now, State2)} | EmitEffects]};
 finish_datagram(_Now, _Before, #state{phase = closed, pending_close = undefined} = State) ->
     drain_emits(State);
 finish_datagram(_Now, _Before, #state{phase = closed} = State) ->
@@ -399,46 +417,47 @@ handle_call(From, Ref, {reset_stream, Sid, ErrorCode}, Now, State) ->
 handle_call(From, Ref, {stop_sending, Sid, ErrorCode}, Now, State) ->
     {State1, SendEffects} = do_stop_sending(Sid, ErrorCode, Now, State),
     {State1, [{reply, From, Ref, ok} | SendEffects]};
-handle_call(From, Ref, {close, ErrorCode}, _Now, State) ->
-    {State1, CloseEffects} = owner_close(ErrorCode, <<>>, State),
+handle_call(From, Ref, {close, ErrorCode}, Now, State) ->
+    {State1, CloseEffects} = owner_close(ErrorCode, <<>>, Now, State),
     {State1, [{reply, From, Ref, ok} | CloseEffects]};
-handle_call(From, Ref, {close, ErrorCode, Reason}, _Now, State) ->
-    {State1, CloseEffects} = owner_close(ErrorCode, Reason, State),
+handle_call(From, Ref, {close, ErrorCode, Reason}, Now, State) ->
+    {State1, CloseEffects} = owner_close(ErrorCode, Reason, Now, State),
     {State1, [{reply, From, Ref, ok} | CloseEffects]}.
 
 %% The owner closes the connection (RFC 9000 §10.2.2): send one application
 %% CONNECTION_CLOSE (0x1d, carrying the h3 error code and reason phrase) at the
-%% 1-RTT level and mark the connection closed so the shell exits. The owner
-%% triggered this, so no {closed, _} is emitted back; this runs only once the
-%% connection is established (1-RTT keys present), which is the only state the
-%% owner has a connection to close in. Distinct from connection_fatal/send_close
-%% (a locally-detected transport error during datagram processing): this is the
+%% 1-RTT level and linger in `draining` for 3x PTO so the peer's reordered
+%% packets are absorbed before the shell tears down. The owner triggered this, so
+%% no {closed, _} is emitted back; this runs only once the connection is
+%% established (1-RTT keys present), which is the only state the owner has a
+%% connection to close in. Distinct from connection_fatal/send_close (a
+%% locally-detected transport error during datagram processing): this is the
 %% application-variant close and never coalesces with other frames.
--spec owner_close(non_neg_integer(), binary(), t()) -> {t(), [effect()]}.
-owner_close(ErrorCode, Reason, #state{send_keys = SendKeys} = State) ->
+-spec owner_close(non_neg_integer(), binary(), integer(), t()) -> {t(), [effect()]}.
+owner_close(ErrorCode, Reason, Now, #state{send_keys = SendKeys} = State) ->
     case SendKeys of
         #{application := Keys} ->
-            send_owner_close(ErrorCode, Reason, Keys, State);
+            send_owner_close(ErrorCode, Reason, Keys, Now, State);
         #{} ->
             %% The owner closed before the handshake completed (e.g. the
             %% connection_handler refusing on max_clients): there are no 1-RTT
             %% keys to carry an application CONNECTION_CLOSE, so close silently
-            %% and let the client time out. The connection still ends.
+            %% and let the client time out. No 1-RTT packets exist to drain.
             {State#state{phase = closed}, []}
     end.
 
--spec send_owner_close(non_neg_integer(), binary(), roadrunner_quic_keys:keys(), t()) ->
+-spec send_owner_close(non_neg_integer(), binary(), roadrunner_quic_keys:keys(), integer(), t()) ->
     {t(), [effect()]}.
-send_owner_close(ErrorCode, Reason, Keys, #state{peer_scid = DCID, scid = SCID} = State) ->
+send_owner_close(ErrorCode, Reason, Keys, Now, #state{peer_scid = DCID, scid = SCID} = State) ->
     Space = space(application, State),
     PN = Space#space.next_pn,
     Frame = {connection_close, application, ErrorCode, undefined, Reason},
     Entry = #{application => #{frames => [Frame], keys => Keys, pn => PN}},
     {Datagram, _Sent} = roadrunner_quic_send:datagram(Entry, DCID, SCID),
     State1 = put_space(
-        application, Space#space{next_pn = PN + 1}, State#state{phase = closed}
+        application, Space#space{next_pn = PN + 1}, State#state{phase = draining}
     ),
-    {State1, [{send, Datagram}]}.
+    {State1, [{send, Datagram}, {arm_timer, drain, drain_deadline(Now, State1)}]}.
 
 %% Abandon the send side of a stream and tell the peer with a RESET_STREAM (RFC
 %% 9000 §19.4): discard the unsent buffer, record the bytes already sent as the
@@ -476,11 +495,13 @@ Buffer outbound stream data and run a send pass: the shell forwards
 `{quic_send, From, Ref, Sid, IoData, Fin}` here. The data is enqueued on the
 stream's send buffer (the stream is created on first reference), an optional
 FIN is flagged, then the queued bytes are flushed as STREAM frames within the
-connection and per-stream send-flow credit. Always replies `ok`; rejecting a
-send on a draining/closed connection is a teardown-slice follow-up.
+connection and per-stream send-flow credit. Replies `ok`, or `{error, closed}`
+on a draining connection, which sends no application data (RFC 9000 §10.2.2).
 """.
 -spec handle_send(pid(), reference(), non_neg_integer(), iodata(), boolean(), integer(), t()) ->
     {t(), [effect()]}.
+handle_send(From, Ref, _Sid, _IoData, _Fin, _Now, #state{phase = draining} = State) ->
+    {State, [{reply, From, Ref, {error, closed}}]};
 handle_send(From, Ref, Sid, IoData, Fin, Now, State) ->
     State1 = enqueue_send(Sid, IoData, Fin, State),
     {State2, SendEffects} = send_pass(Now, State1),
@@ -523,10 +544,13 @@ stream_for_send(
     end.
 
 -spec process_outcome(integer(), roadrunner_quic_recv:outcome(), t()) -> t().
-process_outcome(_Now, _Outcome, #state{phase = closed} = State) ->
-    %% A close fired on an earlier packet in this datagram; skip the rest so we
-    %% neither act on their frames nor discard (via validate_on_handshake) the
-    %% space and keys a pending local close still needs to send its frame.
+process_outcome(_Now, _Outcome, #state{phase = Phase} = State) when
+    Phase =:= closed; Phase =:= draining
+->
+    %% A close fired on an earlier packet in this datagram, or a packet arrived
+    %% during the drain window: skip the rest so we neither act on their frames
+    %% nor discard (via validate_on_handshake) the space and keys a pending local
+    %% close still needs to send its frame.
     State;
 process_outcome(
     Now, {ok, #{level := Level, pn := PN, frames := Frames}}, #state{spaces = Spaces} = State
@@ -575,9 +599,12 @@ record_received(Level, PN, Frames, #state{spaces = Spaces} = State) ->
 %% =============================================================================
 
 -spec process_frame(integer(), level(), roadrunner_quic_frame:frame(), t()) -> t().
-process_frame(_Now, _Level, _Frame, #state{phase = closed} = State) ->
-    %% A CONNECTION_CLOSE earlier in this packet already closed the connection;
-    %% ignore the remaining frames (RFC 9000 §10.2.2).
+process_frame(_Now, _Level, _Frame, #state{phase = Phase} = State) when
+    Phase =:= closed; Phase =:= draining
+->
+    %% A CONNECTION_CLOSE earlier in this packet already closed the connection, or
+    %% the packet arrived during the drain window; ignore the remaining frames
+    %% (RFC 9000 §10.2.2).
     State;
 process_frame(
     _Now, application, {connection_close, _Variant, ErrorCode, _FrameType, _Reason}, State
@@ -869,25 +896,50 @@ process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
     end.
 
 %% A well-placed peer CONNECTION_CLOSE (transport at any level, or application
-%% at 1-RTT) ends the connection: surface it to the owner and mark the
-%% connection closed so the send pass is skipped and the shell exits. Lingering
-%% in `draining` for 3x PTO to absorb the peer's reordered packets is a
-%% follow-up; for now the listener drops late packets to the gone pid.
+%% at 1-RTT) ends the connection: surface it to the owner and move to the
+%% terminal phase so the send pass is skipped. An established connection lingers
+%% in `draining` (closing_phase/1) to absorb the peer's reordered 1-RTT packets;
+%% a handshake-phase close ends at once.
 -spec process_close(non_neg_integer(), t()) -> t().
 process_close(ErrorCode, State) ->
-    emit({closed, {peer, ErrorCode}}, State#state{phase = closed}).
+    emit({closed, {peer, ErrorCode}}, State#state{phase = closing_phase(State)}).
 
 %% Close this single, isolated connection on a peer-reachable protocol error
 %% (flow control §4.1, final size §4.5, stream state §19.8, an out-of-place
 %% application CONNECTION_CLOSE §19.19, or a failed TLS handshake): record a
-%% CONNECTION_CLOSE to transmit at the triggering packet's level (Level), mark
-%% the connection closed so the fold short-circuits and the shell exits
-%% cleanly (no crash, no slot leak), and surface a terminal {closed, {local,
-%% Reason}} to the owner.
+%% CONNECTION_CLOSE to transmit at the triggering packet's level (Level), move to
+%% the terminal phase so the fold short-circuits and the shell tears down cleanly
+%% (no crash, no slot leak), and surface a terminal {closed, {local, Reason}} to
+%% the owner. An established connection lingers in `draining` (closing_phase/1).
 -spec connection_fatal(level(), atom(), t()) -> t().
 connection_fatal(Level, Reason, State) ->
-    State1 = State#state{phase = closed, pending_close = {Level, close_code(Reason)}},
+    State1 = State#state{
+        phase = closing_phase(State), pending_close = {Level, close_code(Reason)}
+    },
     emit({closed, {local, Reason}}, State1).
+
+%% The terminal phase a close moves to (RFC 9000 §10.2): an established
+%% connection lingers in `draining` for 3x PTO so the peer's reordered 1-RTT
+%% packets are absorbed before its connection id is freed; a close during the
+%% handshake has no 1-RTT packets to absorb, so it ends immediately (and a
+%% handshake flood cannot accrue lingering draining connections).
+-spec closing_phase(t()) -> phase().
+closing_phase(#state{phase = connected}) -> draining;
+closing_phase(_State) -> closed.
+
+%% The absolute time the drain window ends: three PTOs from now (RFC 9000 §10.2),
+%% the largest across the still-present spaces.
+-spec drain_deadline(integer(), t()) -> integer().
+drain_deadline(Now, State) ->
+    Now + 3 * max_pto(State).
+
+-spec max_pto(t()) -> non_neg_integer().
+max_pto(#state{spaces = Spaces}) ->
+    maps:fold(
+        fun(_Level, #space{loss = Loss}, Acc) -> max(Acc, roadrunner_quic_loss:get_pto(Loss)) end,
+        0,
+        Spaces
+    ).
 
 %% Map a connection-error reason to its CONNECTION_CLOSE wire error code: a TLS
 %% handshake failure becomes a CRYPTO_ERROR (RFC 9001 §4.8: 0x0100 + alert), a
@@ -1301,7 +1353,11 @@ handle_timeout(Now, pto, State) ->
     State1 = lists:foldl(fun(Level, S) -> on_pto(Now, Level, S) end, State, present_levels(State)),
     send_pass(Now, State1);
 handle_timeout(_Now, idle, State) ->
-    drain_emits(emit({closed, {local, idle_timeout}}, State#state{phase = closed})).
+    drain_emits(emit({closed, {local, idle_timeout}}, State#state{phase = closed}));
+handle_timeout(_Now, drain, State) ->
+    %% The drain window elapsed (RFC 9000 §10.2): become closed so the shell
+    %% tears the connection down. The owner already learned of the close on entry.
+    {State#state{phase = closed}, []}.
 
 %% On a probe timeout: queue any time-threshold losses to retransmit and
 %% increment the space's probe-timeout backoff (RFC 9002 §6.2.1), so the

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -300,7 +300,7 @@ application_close_at_1rtt_closes_test() ->
     {State, ApSecret} = connected_with_owner(),
     Close = app_datagram([{connection_close, application, 9, undefined, <<>>}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Close, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {peer, 9}}}], emits(Effects)).
 
 %% =============================================================================
@@ -514,7 +514,7 @@ stream_on_server_initiated_id_closes_test() ->
     {State, ApSecret} = connected_with_owner(),
     Bad = app_datagram([{stream, 3, 0, ~"x", true}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, stream_state_error}}}], emits(Effects)).
 
 reset_stream_on_server_initiated_id_closes_test() ->
@@ -523,7 +523,7 @@ reset_stream_on_server_initiated_id_closes_test() ->
     {State, ApSecret} = connected_with_owner(),
     Bad = app_datagram([{reset_stream, 1, 7, 0}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, stream_state_error}}}], emits(Effects)).
 
 stream_over_advertised_bidi_count_closes_test() ->
@@ -534,7 +534,7 @@ stream_over_advertised_bidi_count_closes_test() ->
     OverLimit = ?MAX_STREAMS_BIDI * 4,
     Bad = app_datagram([{stream, OverLimit, 0, ~"x", true}], 0, ClientApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)),
     ExpectedCode = roadrunner_quic_error:code_int(stream_limit_error),
     ?assert(
@@ -551,7 +551,7 @@ stream_over_advertised_uni_count_closes_test() ->
     OverLimit = ?MAX_STREAMS_UNI * 4 + 2,
     Bad = app_datagram([{stream, OverLimit, 0, ~"x", true}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)).
 
 reset_over_advertised_bidi_count_closes_test() ->
@@ -560,7 +560,7 @@ reset_over_advertised_bidi_count_closes_test() ->
     OverLimit = ?MAX_STREAMS_BIDI * 4,
     Bad = app_datagram([{reset_stream, OverLimit, 7, 0}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)).
 
 reset_over_advertised_uni_count_closes_test() ->
@@ -569,7 +569,7 @@ reset_over_advertised_uni_count_closes_test() ->
     OverLimit = ?MAX_STREAMS_UNI * 4 + 2,
     Bad = app_datagram([{reset_stream, OverLimit, 7, 0}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, stream_limit_error}}}], emits(Effects)).
 
 stream_final_size_violation_closes_test() ->
@@ -581,7 +581,7 @@ stream_final_size_violation_closes_test() ->
     ),
     Bad = app_datagram([{stream, 0, 0, <<>>, true}], 1, ApSecret),
     {State2, Effects} = ?M:handle_datagram(?NOW, Bad, State1),
-    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual(draining, ?M:phase(State2)),
     ?assertEqual([{emit, self(), {closed, {local, final_size_error}}}], emits(Effects)).
 
 reset_final_size_violation_closes_test() ->
@@ -593,7 +593,7 @@ reset_final_size_violation_closes_test() ->
     ),
     Bad = app_datagram([{reset_stream, 0, 7, 2}], 1, ApSecret),
     {State2, Effects} = ?M:handle_datagram(?NOW, Bad, State1),
-    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual(draining, ?M:phase(State2)),
     ?assertEqual([{emit, self(), {closed, {local, final_size_error}}}], emits(Effects)).
 
 stream_over_advertised_stream_flow_limit_closes_test() ->
@@ -606,7 +606,7 @@ stream_over_advertised_stream_flow_limit_closes_test() ->
     Oversized = binary:copy(~"x", ?STREAM_RECV_WINDOW + 1),
     Bad = app_datagram([{stream, 0, 0, Oversized, false}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, flow_control_error}}}], emits(Effects)).
 
 data_over_advertised_connection_flow_limit_closes_test() ->
@@ -620,7 +620,7 @@ data_over_advertised_connection_flow_limit_closes_test() ->
     Oversized = binary:copy(~"x", ?CONN_RECV_WINDOW + 1),
     Bad = app_datagram([{stream, 0, 0, Oversized, false}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Bad, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {local, flow_control_error}}}], emits(Effects)).
 
 %% As the peer uploads past the refill threshold, the server advertises fresh
@@ -734,14 +734,15 @@ stop_sending_sends_stop_sending_frame_test() ->
 
 owner_close_sends_application_close_test() ->
     %% An owner close sends one application-variant CONNECTION_CLOSE carrying the
-    %% h3 error code and reason phrase, marks the connection closed, and replies
-    %% ok (no {closed, _} back: the owner triggered it).
+    %% h3 error code and reason phrase, lingers in draining with a drain timer
+    %% armed, and replies ok (no {closed, _} back: the owner triggered it).
     {State, ApSecret} = connected_for_send(),
     Ref = make_ref(),
     {State1, Effects} = ?M:handle_call(self(), Ref, {close, 16#0100, ~"bye"}, ?NOW, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual({reply, self(), Ref, ok}, hd(Effects)),
     ?assertEqual([], emits(Effects)),
+    ?assertMatch([_], [At || {arm_timer, drain, At} <- Effects]),
     ?assert(
         lists:member(
             {connection_close, application, 16#0100, undefined, ~"bye"},
@@ -753,7 +754,7 @@ owner_close_without_reason_sends_empty_phrase_test() ->
     %% close/2 (no reason) carries an empty reason phrase.
     {State, ApSecret} = connected_for_send(),
     {State1, Effects} = ?M:handle_call(self(), make_ref(), {close, 16#0100}, ?NOW, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assert(
         lists:member(
             {connection_close, application, 16#0100, undefined, <<>>},
@@ -924,14 +925,17 @@ fully_sent_stream_is_skipped_on_later_pass_test() ->
 %% =============================================================================
 
 peer_connection_close_emits_closed_and_sends_nothing_test() ->
-    %% A peer CONNECTION_CLOSE moves the connection to `closed`, surfaces
-    %% {closed, {peer, ErrorCode}} to the owner, and sends nothing back.
+    %% A peer CONNECTION_CLOSE on an established connection lingers in `draining`
+    %% with a drain timer armed, surfaces {closed, {peer, ErrorCode}} to the
+    %% owner, and sends nothing back (RFC 9000 §10.2).
     {State, ApSecret} = connected_with_owner(),
     Close = app_datagram([{connection_close, transport, 0, 0, <<>>}], 0, ApSecret),
     {State1, Effects} = ?M:handle_datagram(?NOW, Close, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {peer, 0}}}], emits(Effects)),
-    ?assertEqual([], sends(Effects)).
+    ?assertEqual([], sends(Effects)),
+    [DrainAt] = [At || {arm_timer, drain, At} <- Effects],
+    ?assert(DrainAt > ?NOW).
 
 frames_after_connection_close_are_ignored_test() ->
     %% Once a CONNECTION_CLOSE is seen, the rest of the packet is dropped: a
@@ -941,7 +945,7 @@ frames_after_connection_close_are_ignored_test() ->
         [{connection_close, transport, 7, 0, <<>>}, {stream, 0, 0, ~"x", true}], 0, ApSecret
     ),
     {State1, Effects} = ?M:handle_datagram(?NOW, Close, State),
-    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual(draining, ?M:phase(State1)),
     ?assertEqual([{emit, self(), {closed, {peer, 7}}}], emits(Effects)).
 
 peer_handshake_level_close_test() ->
@@ -1018,6 +1022,44 @@ coalesced_initial_error_then_handshake_does_not_crash_test() ->
     ),
     ?assertEqual(closed, ?M:phase(State2)),
     ?assertEqual([{emit, self(), {closed, {local, protocol_violation}}}], emits(Effects)).
+
+late_packet_during_draining_is_absorbed_test() ->
+    %% A packet arriving during the drain window is absorbed silently (RFC 9000
+    %% §10.2.2): the phase stays draining, the late frame is not reprocessed,
+    %% nothing is sent, and no timer is re-armed so the entry drain timer keeps
+    %% running.
+    {State, ApSecret} = connected_with_owner(),
+    Close = app_datagram([{connection_close, transport, 0, 0, <<>>}], 0, ApSecret),
+    {Draining, _} = ?M:handle_datagram(?NOW, Close, State),
+    Late = app_datagram([{stream, 0, 0, ~"x", true}], 1, ApSecret),
+    {Draining1, Effects} = ?M:handle_datagram(?NOW + 10, Late, Draining),
+    ?assertEqual(draining, ?M:phase(Draining1)),
+    ?assertEqual([], sends(Effects)),
+    ?assertEqual([], emits(Effects)),
+    ?assertEqual([], [E || {arm_timer, _, _} = E <- Effects]).
+
+drain_timeout_closes_test() ->
+    %% When the drain timer fires the connection becomes closed (the shell then
+    %% tears it down); the owner already learned of the close on entry, so the
+    %% timeout emits nothing.
+    {State, ApSecret} = connected_with_owner(),
+    Close = app_datagram([{connection_close, transport, 0, 0, <<>>}], 0, ApSecret),
+    {Draining, _} = ?M:handle_datagram(?NOW, Close, State),
+    {Closed, Effects} = ?M:handle_timeout(?NOW + 999999, drain, Draining),
+    ?assertEqual(closed, ?M:phase(Closed)),
+    ?assertEqual([], Effects).
+
+send_on_draining_connection_is_rejected_test() ->
+    %% RFC 9000 §10.2.2: a draining connection sends no application data; an owner
+    %% write is answered {error, closed} and nothing goes out.
+    {State, ApSecret} = connected_with_owner(),
+    Close = app_datagram([{connection_close, transport, 0, 0, <<>>}], 0, ApSecret),
+    {Draining, _} = ?M:handle_datagram(?NOW, Close, State),
+    Ref = make_ref(),
+    {Draining1, Effects} = ?M:handle_send(self(), Ref, 0, ~"data", true, ?NOW, Draining),
+    ?assertEqual(draining, ?M:phase(Draining1)),
+    ?assertEqual([{reply, self(), Ref, {error, closed}}], Effects),
+    ?assertEqual([], sends(Effects)).
 
 %% =============================================================================
 %% Handshake driver (plays the QUIC client with the shared test client)

--- a/test/roadrunner_quic_connection_tests.erl
+++ b/test/roadrunner_quic_connection_tests.erl
@@ -80,8 +80,11 @@ send_data_round_trip(#{shell := Shell, peer := Peer, client := ClientSocket, ctx
         ?assert(lists:member({stream, 0, 0, ~"hello", true}, Frames))
     end.
 
-%% A peer CONNECTION_CLOSE emits {closed, _} to the owner and terminates the
-%% shell process cleanly (a normal proc_lib exit, not a crash).
+%% A peer CONNECTION_CLOSE emits {closed, _} to the owner immediately, lingers in
+%% draining for ~3x PTO (RFC 9000 §10.2), then terminates the shell cleanly (a
+%% normal proc_lib exit, not a crash). The close also acks the server's
+%% HANDSHAKE_DONE so a real RTT sample collapses the drain to tens of ms, the way
+%% an established connection that exchanged data drains.
 peer_close_terminates_shell(#{shell := Shell, peer := Peer, client := ClientSocket, ctx := Ctx}) ->
     {timeout, 10, fun() ->
         {ClientApSecret, _ServerApSecret} = do_handshake(Shell, Peer, ClientSocket, Ctx),
@@ -103,7 +106,7 @@ peer_close_terminates_shell(#{shell := Shell, peer := Peer, client := ClientSock
             application,
             0,
             roadrunner_quic_keys:traffic_keys(ClientApSecret),
-            [{connection_close, transport, 0, 0, <<>>}],
+            [{ack, 0, 0, 0, [], undefined}, {connection_close, transport, 0, 0, <<>>}],
             ?DCID,
             ?SCID
         ),
@@ -113,7 +116,7 @@ peer_close_terminates_shell(#{shell := Shell, peer := Peer, client := ClientSock
         after 1000 ->
             erlang:error(no_closed_event)
         end,
-        wait_dead(Shell, 50)
+        wait_dead(Shell, 150)
     end}.
 
 %% A synchronous peername control call round-trips through the shell.


### PR DESCRIPTION
# Description

A QUIC connection used to jump straight to closed on any close, freeing its connection id at once, so a peer's reordered or retransmitted 1-RTT packets arriving just after the close hit a gone process. The server now lingers in the draining state for three PTOs (RFC 9000 §10.2) after an established connection closes, absorbing those late packets before it frees the connection, and rejects owner stream writes while draining (§10.2.2). Only established connections drain, since a close during the handshake has no 1-RTT packets to absorb and draining there would let a handshake flood pile up lingering connections. The shell process is unchanged: it already loops on any non-closed phase and a drain timer routes back through the existing timeout path.

- Peer or local close on a connected connection -> drains ~3x PTO, then the process exits
- Close during the handshake (bad ClientHello, handshake-level close) -> exits immediately, as before
- A stream write on a draining connection -> `{error, closed}`, nothing sent

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)