### PR TITLE
Replenish the native h3 loadgen's receive window so downloads don't stall

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,34 +111,54 @@ advisory or malformed cases the server currently tolerates or omits.
   draining after a local close absorbs the peer's late packets but does not
   re-send its CONNECTION_CLOSE in response (rate-limited), so a peer that lost the
   close learns only by timeout — small-medium
-- NewReno congestion control (RFC 9002 §7); needs the loss layer to surface
-  acked bytes + sent times. Sending is bounded only by the §8.1
-  anti-amplification limit and flow control today — large
+- NewReno congestion control (RFC 9002 §7): `roadrunner_quic_cc_newreno` is built
+  and tested but wired nowhere — `drain_send` gates only on anti-amplification +
+  flow control, never on a congestion window, so on a lossy WAN the server
+  overshoots and self-induces loss with no backoff. The acked/lost bytes per ACK
+  are already computed in `roadrunner_quic_loss:on_ack_received`; the work is
+  threading a `cc` state into the connection and gating the send loop on it.
+  Validate by the CC unit tests + a simulated-loss test, not loopback throughput
+  (it correctly adds ACK-pacing the loopback bench can't show) — large
 - PTO explicit probe (RFC 9002 §6.2.4): a probe timeout only re-checks for
   losses and backs off; it does not retransmit the oldest unacked ack-eliciting
   frames as a probe. Bundle with NewReno (both need the loss layer to surface
   the oldest-unacked) — medium
-- A no-flatten / by-reference stream send buffer, so a large response body is
-  not flattened into one binary before sending — medium
 
 ### Throughput levers identified by profiling
 
-Profiling the native h3 server under load (`scripts/bench.escript --servers
-roadrunner --protocols h3 --scenarios large_response --profile --profile-tool
-eprof --profile-scope all`) leaves two large costs that are not hot-path Erlang,
-so the send-path optimizations did not touch them.
+All-scope eprof on current `main` over a steady-state download (`scripts/bench.escript
+--servers roadrunner --protocols h3 --scenarios large_response --profile
+--profile-tool eprof --profile-scope all`). Harness note: the native loadgen now
+replenishes its receive window with MAX_DATA, so a connection sustains a download
+(~330 MB/s aggregate on a 24-core box) instead of stalling at the advertised
+`initial_max_data`; the per-connection bench numbers stay loadgen-bound (one
+Erlang process per connection, serial per-datagram decrypt), so validate server
+changes by profile-share, not headline req/s.
 
-- Batch UDP sends: each datagram is one `gen_udp:send`, i.e. one `port_command`
-  syscall, and that is ~7% of server time on a download. Sending several
-  datagrams per syscall via `sendmmsg` or UDP generic segmentation offload (GSO)
-  would cut it, but `gen_udp` has no batched-send primitive, so it needs the OTP
-  `socket` API (or a NIF) plus careful per-path sizing — large
-- TLS session resumption / 0-RTT (RFC 8446 §2.2, RFC 9001 §4.6): the RSA-2048
-  CertificateVerify signature is ~6-7 ms per full handshake, the single biggest
-  per-connection cost. Session tickets let a returning client skip the signature
-  entirely. Independently, deploying an ECDSA P-256 server certificate instead of
-  RSA-2048 cuts that signature ~30-60x today with no code change (operator
-  guidance, worth a deployment note) — large
+- Batch UDP sends — the #1 steady-state download cost (~18%): each datagram is
+  one `gen_udp:send`, i.e. one `port_command` syscall, ~56 per 64 KB response.
+  Coalescing them into one `socket:sendmsg` with a `UDP_SEGMENT` cmsg (GSO) cuts
+  it, but `gen_udp` has no batched-send primitive, so it needs the OTP `socket`
+  API (or a NIF) plus per-path sizing; Linux-only with a per-datagram fallback.
+  Helps multi-datagram downloads only (a 1-datagram small response can't batch).
+  `drain_send` already accumulates a pass's datagrams into one list, so the core
+  can emit one `{send_batch, [Datagram]}` effect — large
+- Per-packet AEAD + header protection (~10%) and packet assembly
+  (`build_packet/4` + `stream_data_budget/5`, ~13% together): mostly inherent
+  per-packet work. `stream_data_budget/5` re-encodes the pending ACK frames each
+  packet just to size them; caching that size across a burst is a possible
+  micro-lever — small
+- QPACK / HPACK-Huffman response-header encode (~10% on small responses): the
+  Huffman encoder is unvalidated, so an interleaved A/B of the encode loop is a
+  possible small-response lever — small-medium
+- TLS handshake is a connection-SETUP lever only, not steady-state: with the
+  loadgen sustaining connections the RSA-2048 CertificateVerify is ~0% of
+  steady-state time (it read ~10% only on the old stall-and-die loadgen). It
+  still dominates connection churn — deploying an ECDSA P-256 cert cuts the
+  signature ~30-60x with no server code change (the server already signs ECDSA;
+  the bench generates RSA-2048), so switch the bench cert + add a deployment
+  note. TLS session tickets / 0-RTT (RFC 8446 §2.2, RFC 9001 §4.6) skip the
+  signature entirely for returning clients — small (cert/note) / large (tickets)
 
 ### External interop check
 

--- a/test/roadrunner_quic_test_conn.erl
+++ b/test/roadrunner_quic_test_conn.erl
@@ -41,6 +41,10 @@
 -define(MAX_STREAM_CHUNK, 1000).
 -define(RECV_TIMEOUT, 3000).
 -define(CONNECT_TIMEOUT, 8000).
+%% The connection-level receive window this client advertises and replenishes.
+%% Must match the `initial_max_data` in roadrunner_quic_test_client's transport
+%% params: the flow accounting starts from the value the handshake advertised.
+-define(CONN_MAX_DATA, 800000).
 
 %% Handshake message types (RFC 8446 §4).
 -define(CERTIFICATE, 11).
@@ -71,7 +75,11 @@
     next_uni = 2 :: non_neg_integer(),
     send_pn = 0 :: non_neg_integer(),
     send_offsets = #{} :: #{non_neg_integer() => non_neg_integer()},
-    recv_streams = #{} :: #{non_neg_integer() => roadrunner_quic_stream:t()}
+    recv_streams = #{} :: #{non_neg_integer() => roadrunner_quic_stream:t()},
+    %% Connection-level receive flow control (RFC 9000 §4.1): tracks received
+    %% bytes and replenishes the limit with MAX_DATA so the server's send window
+    %% never stalls on a long-lived connection.
+    conn_flow :: roadrunner_quic_flow:t() | undefined
 }).
 
 %% =============================================================================
@@ -193,7 +201,8 @@ init(Parent, Ref, Host, Port) ->
         eph_priv = EphPriv,
         ch_framed = ChFramed,
         owner = Parent,
-        server_initial_keys = roadrunner_quic_keys:initial_server(Dcid0)
+        server_initial_keys = roadrunner_quic_keys:initial_server(Dcid0),
+        conn_flow = roadrunner_quic_flow:new(#{initial_max_data => ?CONN_MAX_DATA})
     },
     case handshake(Conn) of
         {ok, Conn1} ->
@@ -511,7 +520,7 @@ handle_app_datagram(#conn{app_server_keys = Keys, scid = Scid} = Conn, Datagram)
 
 -spec handle_app_frame(roadrunner_quic_frame:frame(), #conn{}) -> #conn{}.
 handle_app_frame({stream, StreamId, Offset, Data, Fin}, Conn) ->
-    deliver_stream(Conn, StreamId, Offset, Data, Fin);
+    deliver_stream(grant_conn_credit(byte_size(Data), Conn), StreamId, Offset, Data, Fin);
 handle_app_frame({reset_stream, StreamId, ErrorCode, _FinalSize}, #conn{owner = Owner} = Conn) ->
     _ = Owner ! {quic_test_stream_reset, self(), StreamId, ErrorCode},
     Conn;
@@ -540,6 +549,22 @@ maybe_deliver(_Owner, _StreamId, <<>>, false) ->
 maybe_deliver(Owner, StreamId, Deliverable, FinReached) ->
     _ = Owner ! {quic_test_stream, self(), StreamId, Deliverable, FinReached},
     ok.
+
+%% Account received stream bytes against the connection-level receive window and,
+%% as it fills, send MAX_DATA so the server's send window is replenished (RFC 9000
+%% §4.1). Mirrors the server's own receive-credit granting: without it the server
+%% correctly stops after the advertised initial_max_data, so a connection serving
+%% more than that many bytes (many responses, or a large download) stalls.
+-spec grant_conn_credit(non_neg_integer(), #conn{}) -> #conn{}.
+grant_conn_credit(Size, #conn{conn_flow = Flow0} = Conn) ->
+    {ok, Flow1} = roadrunner_quic_flow:on_data_received(Size, Flow0),
+    case roadrunner_quic_flow:should_send_max_data(Flow1) of
+        true ->
+            {NewMax, Flow2} = roadrunner_quic_flow:grant_max_data(Flow1),
+            send_wire_frame(Conn#conn{conn_flow = Flow2}, {max_data, NewMax});
+        false ->
+            Conn#conn{conn_flow = Flow1}
+    end.
 
 %% =============================================================================
 %% Internal


### PR DESCRIPTION
# Description

The native HTTP/3 test client (`roadrunner_quic_test_conn`) advertised an 800 KB connection-level flow-control window at the handshake and then never sent `MAX_DATA` to replenish it. So after ~768 KB of responses on a connection (about twelve 64 KB downloads), the server correctly stopped at the advertised limit (RFC 9000 §4.1), the client never granted more, the request timed out, and that connection died — which showed up in the bench as exactly one error per connection on every download-shaped scenario. The client now tracks received bytes and sends `MAX_DATA` as the window fills, reusing the production `roadrunner_quic_flow` (the mirror of the server's own receive-credit granting), so a connection sustains a download instead of stalling. This is a test/loadgen fix; the server was already behaving correctly.

- `large_response` at 50 clients: 117 req/s with 50 errors -> **5,141 req/s with 0 errors** (the bench now measures real sustained throughput, ~330 MB/s, instead of a 768 KB-per-connection stall)

The roadmap's profiling section is refreshed from a post-fix steady-state profile: batch UDP sends are the #1 server cost (~18%), the TLS handshake is confirmed a connection-setup lever only (~0% in steady state), and the QPACK/Huffman header codec is a new small-response candidate.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)