### PR TITLE
Add NewReno congestion control to the native QUIC server

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,18 +111,15 @@ advisory or malformed cases the server currently tolerates or omits.
   draining after a local close absorbs the peer's late packets but does not
   re-send its CONNECTION_CLOSE in response (rate-limited), so a peer that lost the
   close learns only by timeout — small-medium
-- NewReno congestion control (RFC 9002 §7): `roadrunner_quic_cc_newreno` is built
-  and tested but wired nowhere — `drain_send` gates only on anti-amplification +
-  flow control, never on a congestion window, so on a lossy WAN the server
-  overshoots and self-induces loss with no backoff. The acked/lost bytes per ACK
-  are already computed in `roadrunner_quic_loss:on_ack_received`; the work is
-  threading a `cc` state into the connection and gating the send loop on it.
-  Validate by the CC unit tests + a simulated-loss test, not loopback throughput
-  (it correctly adds ACK-pacing the loopback bench can't show) — large
+- Congestion-control refinements (RFC 9002): NewReno gates the send loop (slow
+  start, congestion avoidance, and recovery halving on ACK-detected loss), but two
+  pieces are deferred — feeding timer/PTO-detected losses to the controller (only
+  ACK-detected losses back off the window today), and persistent congestion (§7.6,
+  resetting the window to the minimum when a PTO spans all in-flight packets) —
+  medium
 - PTO explicit probe (RFC 9002 §6.2.4): a probe timeout only re-checks for
   losses and backs off; it does not retransmit the oldest unacked ack-eliciting
-  frames as a probe. Bundle with NewReno (both need the loss layer to surface
-  the oldest-unacked) — medium
+  frames as a probe — medium
 
 ### Throughput levers identified by profiling
 

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -40,6 +40,8 @@
 ]).
 %% Exported for direct eunit branch coverage of the idle-timeout negotiation.
 -export([negotiated_idle_timeout/2]).
+%% Exported so tests can observe the congestion window's growth and backoff.
+-export([cwnd/1]).
 
 -export_type([t/0, config/0, effect/0, event/0, info/0]).
 
@@ -123,6 +125,10 @@
     uni_opened = 0 :: non_neg_integer(),
     %% Connection-level flow control (RFC 9000 §4).
     conn_flow :: roadrunner_quic_flow:t(),
+    %% Connection-wide congestion control (RFC 9002 §7): bounds the bytes in
+    %% flight across all spaces by the congestion window, grown on ACK and halved
+    %% on loss.
+    cc :: roadrunner_quic_cc_newreno:t(),
     %% The client's advertised transport parameters, captured from the
     %% ClientHello. The send windows (connection and per-stream) are seeded from
     %% these so the server never sends past what the peer granted (RFC 9000 §4.1);
@@ -259,6 +265,7 @@ new(
         max_streams_bidi = MaxStreamsBidi,
         max_streams_uni = MaxStreamsUni,
         conn_flow = roadrunner_quic_flow:new(#{initial_max_data => ConnMaxData}),
+        cc = roadrunner_quic_cc_newreno:new(),
         idle_timeout = IdleTimeout,
         idle_deadline = Now + IdleTimeout
     }.
@@ -280,6 +287,13 @@ peername(#state{peer = Peer}) ->
 -spec phase(t()) -> phase().
 phase(#state{phase = Phase}) ->
     Phase.
+
+%% The congestion window in bytes (RFC 9002 §7), for tests to observe its
+%% slow-start growth and on-loss backoff.
+-doc false.
+-spec cwnd(t()) -> non_neg_integer().
+cwnd(#state{cc = Cc}) ->
+    roadrunner_quic_cc_newreno:cwnd(Cc).
 
 %% =============================================================================
 %% Inbound datagram
@@ -773,19 +787,42 @@ queue_frame(Level, Frame, State) ->
     put_space(Level, Space#space{pending = [Frame | Space#space.pending]}, State).
 
 -spec process_ack(integer(), level(), tuple(), t()) -> t().
-process_ack(Now, Level, Ack, State) ->
+process_ack(Now, Level, Ack, #state{cc = Cc} = State) ->
     Space = space(Level, State),
     case roadrunner_quic_loss:on_ack_received(Ack, Now, Space#space.loss) of
         {error, _} ->
             State;
         {Loss, _Acked, Lost} ->
+            Cc1 = apply_cc_signal(roadrunner_quic_loss:cc_signal(Loss), Now, Cc),
             put_space(
                 Level,
                 Space#space{
                     loss = Loss, pending = lists:reverse(retransmittable(Lost), Space#space.pending)
                 },
-                State
+                State#state{cc = Cc1}
             )
+    end.
+
+%% Feed the loss layer's per-ACK congestion signal to NewReno: grow the window
+%% for the acknowledged bytes first, then react to any loss (RFC 9002 §7.3, ack
+%% before loss). A defined largest-acked send time means the largest acked was
+%% ack-eliciting, so the acked bytes are positive; `undefined` (nothing newly
+%% acked, or a non-ack-eliciting largest) skips the growth.
+-spec apply_cc_signal(roadrunner_quic_loss:cc_signal(), integer(), roadrunner_quic_cc_newreno:t()) ->
+    roadrunner_quic_cc_newreno:t().
+apply_cc_signal(
+    #{acked_bytes := AckedBytes, largest_acked_time := AckedTime, largest_lost_time := LostTime},
+    Now,
+    Cc
+) ->
+    Grown =
+        case AckedTime of
+            undefined -> Cc;
+            _ -> roadrunner_quic_cc_newreno:on_packets_acked(AckedBytes, AckedTime, Cc)
+        end,
+    case LostTime of
+        undefined -> Grown;
+        _ -> roadrunner_quic_cc_newreno:on_congestion_event(LostTime, Now, Grown)
     end.
 
 %% =============================================================================
@@ -1177,9 +1214,17 @@ drain_send(Now, Levels, State, Acc) ->
         none ->
             {State, Acc};
         {Entries, Built} ->
-            #state{peer_scid = DCID, scid = SCID, amp = Amp} = State,
+            #state{peer_scid = DCID, scid = SCID, amp = Amp, cc = Cc} = State,
             {Datagram, Sent} = roadrunner_quic_send:datagram(Entries, DCID, SCID),
-            case roadrunner_quic_amp:can_send(byte_size(Datagram), Amp) of
+            %% Gate ack-eliciting datagrams on the congestion window (RFC 9002
+            %% §7); ACK-only datagrams are not congestion-controlled and always
+            %% pass. On a block, return the pre-build State so the consumed ACK /
+            %% stream slice stays pending for the next pass.
+            AckEliciting = lists:any(fun(#{ack_eliciting := Elicit}) -> Elicit end, Sent),
+            CcOk =
+                not AckEliciting orelse
+                    roadrunner_quic_cc_newreno:can_send(total_bytes_in_flight(State), Cc),
+            case roadrunner_quic_amp:can_send(byte_size(Datagram), Amp) andalso CcOk of
                 false ->
                     {State, Acc};
                 true ->
@@ -1392,6 +1437,19 @@ earliest_deadline(Now, #state{idle_deadline = Idle} = State) ->
         PtoAt when PtoAt =< Idle -> {pto, PtoAt};
         _PtoAt -> {idle, Idle}
     end.
+
+%% The congestion-controlled bytes in flight across every space, the value the
+%% congestion window bounds (RFC 9002 §B.2 keeps one count per connection). A
+%% discarded space leaves the map, so its in-flight cannot count stale.
+-spec total_bytes_in_flight(t()) -> non_neg_integer().
+total_bytes_in_flight(#state{spaces = Spaces}) ->
+    maps:fold(
+        fun(_Level, #space{loss = Loss}, Total) ->
+            Total + roadrunner_quic_loss:bytes_in_flight(Loss)
+        end,
+        0,
+        Spaces
+    ).
 
 -spec earliest_pto(integer(), t()) -> integer() | undefined.
 earliest_pto(Now, #state{spaces = Spaces}) ->

--- a/src/roadrunner_quic_loss.erl
+++ b/src/roadrunner_quic_loss.erl
@@ -22,6 +22,7 @@
     new/1,
     on_packet_sent/6,
     on_ack_received/3,
+    cc_signal/1,
     detect_lost/2,
     loss_time/1,
     update_rtt/3,
@@ -37,7 +38,7 @@
     pto_count/1
 ]).
 
--export_type([t/0, opts/0]).
+-export_type([t/0, opts/0, cc_signal/0]).
 
 %% RFC 9002 §6.1.1: a packet is lost if one numbered at least three higher
 %% has been acknowledged.
@@ -57,6 +58,10 @@
 %% Bound the packet numbers expanded from one received ACK frame, so a
 %% peer cannot make us materialise an enormous range (RFC 9000 §13.2.3).
 -define(MAX_ACK_RANGE, 65536).
+%% A congestion-control signal with nothing acknowledged or lost.
+-define(NO_CC_SIGNAL, #{
+    acked_bytes => 0, largest_acked_time => undefined, largest_lost_time => undefined
+}).
 
 -record(sent, {
     pn :: non_neg_integer(),
@@ -83,11 +88,22 @@
     pto_count = 0 :: non_neg_integer(),
     %% Congestion-controlled bytes outstanding.
     bytes_in_flight = 0 :: non_neg_integer(),
+    %% The congestion-control signal from the most recent on_ack_received: the
+    %% acknowledged bytes and the send times of the largest acked / latest lost
+    %% ack-eliciting packets, for the connection's congestion controller to read
+    %% via cc_signal/1 immediately after the ACK.
+    cc_signal = ?NO_CC_SIGNAL :: cc_signal(),
     max_ack_delay :: non_neg_integer(),
     ack_delay_exponent :: non_neg_integer()
 }).
 
 -opaque t() :: #loss{}.
+
+-type cc_signal() :: #{
+    acked_bytes := non_neg_integer(),
+    largest_acked_time := non_neg_integer() | undefined,
+    largest_lost_time := non_neg_integer() | undefined
+}.
 
 -type opts() :: #{
     initial_rtt => non_neg_integer(),
@@ -175,9 +191,42 @@ on_ack_received(Ack, Now, Loss) ->
                 sent = requeue(Survivors, Ahead),
                 largest_acked = NewLargest,
                 pto_count = 0,
-                bytes_in_flight = max(0, Loss1#loss.bytes_in_flight - AckedBytes - LostBytes)
+                bytes_in_flight = max(0, Loss1#loss.bytes_in_flight - AckedBytes - LostBytes),
+                cc_signal = #{
+                    acked_bytes => AckedBytes,
+                    largest_acked_time => largest_acked_time(NewLargest, Acked),
+                    largest_lost_time => largest_lost_time(Lost)
+                }
             },
             {Loss2, datas(Acked), datas(Lost)}
+    end.
+
+-doc """
+The congestion-control signal from the most recent `on_ack_received/3`: a map
+with the acknowledged bytes and the send times of the largest acknowledged and
+latest lost ack-eliciting packets (`undefined` when none), for the connection's
+congestion controller. Read it immediately after the ACK.
+""".
+-spec cc_signal(t()) -> cc_signal().
+cc_signal(#loss{cc_signal = Signal}) ->
+    Signal.
+
+%% The send time of the largest acknowledged packet, the same one the RTT
+%% sample uses, or `undefined` when it is not an ack-eliciting tracked packet.
+-spec largest_acked_time(non_neg_integer(), [#sent{}]) -> non_neg_integer() | undefined.
+largest_acked_time(LargestAcked, Acked) ->
+    case lists:keyfind(LargestAcked, #sent.pn, Acked) of
+        #sent{ack_eliciting = true, time_sent = Sent} -> Sent;
+        _ -> undefined
+    end.
+
+%% The send time of the latest (largest) lost ack-eliciting packet, the
+%% congestion event's trigger time, or `undefined` when nothing was lost.
+-spec largest_lost_time([#sent{}]) -> non_neg_integer() | undefined.
+largest_lost_time(Lost) ->
+    case [Sent || #sent{ack_eliciting = true, time_sent = Sent} <- Lost] of
+        [] -> undefined;
+        Times -> lists:max(Times)
     end.
 
 %% =============================================================================

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -805,41 +805,87 @@ send_data_slices_large_payload_test() ->
     ?assertEqual(Payload, iolist_to_binary([D || {stream, 0, _, D, _} <- Frames])).
 
 send_blocked_by_exhausted_send_window_test() ->
-    %% Send-side flow control (RFC 9000 §4.1): a payload larger than the send
-    %% window fills the window across packets, then the send pass finds the
-    %% still-pending stream flow-blocked and emits nothing more for it. With the
-    %% send pass walking only streams that have pending data, this block is the
-    %% one path that reaches take_stream's no-frame branch.
-    {State, ApSecret} = connected_for_send(),
-    %% The send windows are seeded from the client's advertised 800000-byte
-    %% initial_max_data / initial_max_stream_data (see roadrunner_quic_test_client),
-    %% so the payload must exceed that to block — and the server stops at exactly
-    %% the client's window, proving the limit is sourced from the peer rather than
-    %% roadrunner_quic_flow's 786432 default.
+    %% Send-side flow control (RFC 9000 §4.1): across ACK-paced rounds (which grow
+    %% the congestion window past the flow window) the server sends at most the
+    %% client's advertised 800000-byte initial_max_data / initial_max_stream_data
+    %% (see roadrunner_quic_test_client), proving the cap is sourced from the peer
+    %% rather than roadrunner_quic_flow's 786432 default.
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
     Window = 800000,
     Payload = binary:copy(~"x", Window + 1000),
-    {_State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
-    Sent = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(Effects, ApSecret)]),
+    {State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    {Sent, _State2, _AckPN} = flush_with_acks(State1, Effects, ServerApSecret, ClientApSecret, 0),
     ?assertEqual(Window, byte_size(Sent)).
 
 send_resumes_after_max_data_and_max_stream_data_test() ->
     %% After the send window fills (RFC 9000 §4.1), the peer's MAX_DATA /
     %% MAX_STREAM_DATA grants raise the connection and per-stream send limits and
-    %% the next send pass resumes the still-pending stream, so the whole payload
-    %% eventually reaches the wire.
+    %% the rest of the payload reaches the wire on the following ACK-paced rounds.
     {State, ClientApSecret, ServerApSecret} = connect_owned(),
     Window = 800000,
     Payload = binary:copy(~"x", Window + 1000),
-    {State1, E1} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
-    Sent1 = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(E1, ServerApSecret)]),
-    ?assert(byte_size(Sent1) < byte_size(Payload)),
+    {State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    {Sent1, State2, AckPN} = flush_with_acks(State1, Effects, ServerApSecret, ClientApSecret, 0),
+    ?assertEqual(Window, byte_size(Sent1)),
     Grant = app_datagram(
-        [{max_data, Window * 2}, {max_stream_data, 0, Window * 2}], 0, ClientApSecret
+        [{max_data, Window * 2}, {max_stream_data, 0, Window * 2}], AckPN, ClientApSecret
     ),
-    {_State2, E2} = ?M:handle_datagram(?NOW, Grant, State1),
-    Sent2 = iolist_to_binary([D || {stream, 0, _, D, _} <- sent_stream_frames(E2, ServerApSecret)]),
+    {State3, E3} = ?M:handle_datagram(?NOW, Grant, State2),
+    {Sent2, _State4, _} = flush_with_acks(State3, E3, ServerApSecret, ClientApSecret, AckPN + 1),
     ?assert(byte_size(Sent2) > 0),
     ?assertEqual(byte_size(Payload), byte_size(Sent1) + byte_size(Sent2)).
+
+congestion_window_caps_first_burst_test() ->
+    %% A payload far larger than the initial congestion window is capped at about
+    %% one window on the first pass, with no ACKs yet to grow it (RFC 9002 §7).
+    {State, ServerApSecret} = connected_for_send(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    Sent = iolist_to_binary([
+        D
+     || {stream, 0, _, D, _} <- sent_stream_frames(Effects, ServerApSecret)
+    ]),
+    ?assert(byte_size(Sent) < byte_size(Payload)),
+    %% Initial window 12000 bytes; the strict-< gate allows one datagram overshoot.
+    ?assert(byte_size(Sent) =< 12000 + 1200),
+    ?assertEqual(12000, ?M:cwnd(State1)).
+
+ack_grows_congestion_window_test() ->
+    %% Acknowledging in-flight packets grows the window in slow start (RFC 9002
+    %% §7.3.1); a duplicate ACK that acknowledges nothing new does not.
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    Largest = largest_app_pn(Effects, ServerApSecret),
+    Ack = app_datagram([{ack, Largest, 0, Largest, [], undefined}], 0, ClientApSecret),
+    {State2, _E2} = ?M:handle_datagram(?NOW, Ack, State1),
+    Grown = ?M:cwnd(State2),
+    ?assert(Grown > ?M:cwnd(State1)),
+    Dup = app_datagram([{ack, Largest, 0, Largest, [], undefined}], 1, ClientApSecret),
+    {State3, _E3} = ?M:handle_datagram(?NOW, Dup, State2),
+    ?assertEqual(Grown, ?M:cwnd(State3)).
+
+loss_halves_congestion_window_test() ->
+    %% A gap ACK that acknowledges only the largest packet leaves the older
+    %% packets past the packet threshold, so they are declared lost and the window
+    %% halves (RFC 9002 §7.3.2).
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    Largest = largest_app_pn(Effects, ServerApSecret),
+    Gap = app_datagram([{ack, Largest, 0, 0, [], undefined}], 0, ClientApSecret),
+    {State2, _E2} = ?M:handle_datagram(?NOW, Gap, State1),
+    ?assert(?M:cwnd(State2) < ?M:cwnd(State1)).
+
+ack_only_datagram_not_congestion_controlled_test() ->
+    %% A datagram carrying only an ACK is not ack-eliciting, so the congestion
+    %% window never gates it (RFC 9002 §7): the gate short-circuits on
+    %% not-ack-eliciting before consulting the window, full or not. A peer PING
+    %% with no server data to send produces exactly such an ACK-only datagram.
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Ping = app_datagram([ping], 0, ClientApSecret),
+    {_State1, Effects} = ?M:handle_datagram(?NOW, Ping, State),
+    ?assert(lists:any(fun is_ack/1, sent_app_frames(Effects, ServerApSecret))).
 
 max_stream_data_for_untracked_stream_ignored_test() ->
     %% A MAX_STREAM_DATA grant for a stream the server is not tracking is ignored
@@ -1274,6 +1320,40 @@ sent_app_frames(Effects, ServerApSecret) ->
 
 emits(Effects) ->
     [Emit || {emit, _Owner, _Event} = Emit <- Effects].
+
+%% The largest 1-RTT packet number among the server's sent datagrams, decoded
+%% with the server's application keys; used to acknowledge what is in flight.
+largest_app_pn(Effects, ServerApSecret) ->
+    Keys = #{application => roadrunner_quic_keys:traffic_keys(ServerApSecret)},
+    PNs = [
+        PN
+     || Datagram <- sends(Effects),
+        {ok, #{level := application, pn := PN}} <-
+            roadrunner_quic_recv:datagram(Datagram, byte_size(?DCID), Keys, #{})
+    ],
+    lists:max(PNs).
+
+%% Drive send + ACK rounds until the server stops sending stream-0 data
+%% (flow-blocked): each cumulative ACK grows the congestion window and frees the
+%% in-flight bytes so the next pass sends more. Returns the total stream bytes
+%% sent, the final state, and the next free client packet number.
+flush_with_acks(State, Effects, ServerApSecret, ClientApSecret, AckPN) ->
+    Sent = iolist_to_binary([
+        D
+     || {stream, 0, _, D, _} <- sent_stream_frames(Effects, ServerApSecret)
+    ]),
+    case Sent of
+        <<>> ->
+            {<<>>, State, AckPN};
+        _ ->
+            Largest = largest_app_pn(Effects, ServerApSecret),
+            Ack = app_datagram([{ack, Largest, 0, Largest, [], undefined}], AckPN, ClientApSecret),
+            {State1, Effects1} = ?M:handle_datagram(?NOW, Ack, State),
+            {Rest, Final, FinalAckPN} = flush_with_acks(
+                State1, Effects1, ServerApSecret, ClientApSecret, AckPN + 1
+            ),
+            {<<Sent/binary, Rest/binary>>, Final, FinalAckPN}
+    end.
 
 arm_deadline(Effects) ->
     [AtMs] = [At || {arm_timer, pto, At} <- Effects],

--- a/test/roadrunner_quic_loss_tests.erl
+++ b/test/roadrunner_quic_loss_tests.erl
@@ -95,6 +95,30 @@ on_ack_received_ecn_variant_test() ->
     {_Loss1, Acked, _Lost} = ?M:on_ack_received({ack, 9, 0, 0, [], {1, 2, 3}}, 20, Loss),
     ?assertEqual([9], Acked).
 
+%% The congestion-control signal an ACK leaves for the connection: acked bytes
+%% and the send times of the largest acked / latest lost ack-eliciting packets.
+cc_signal_test() ->
+    Fresh = ?M:cc_signal(?M:new(#{})),
+    ?assertEqual(0, maps:get(acked_bytes, Fresh)),
+    ?assertEqual(undefined, maps:get(largest_acked_time, Fresh)),
+    ?assertEqual(undefined, maps:get(largest_lost_time, Fresh)),
+    %% Ack the largest of ten in-flight packets (send time = packet number): the
+    %% signal carries the acked bytes, the largest's time, and the latest lost.
+    Loss = send_run(0, 9, ?M:new(#{})),
+    {Loss1, _, _} = ?M:on_ack_received({ack, 9, 0, 0, []}, 20, Loss),
+    ?assertEqual(
+        #{acked_bytes => 100, largest_acked_time => 9, largest_lost_time => 7},
+        ?M:cc_signal(Loss1)
+    ),
+    %% A non-ack-eliciting largest acked yields no acked send time and no lost
+    %% time, so the connection grows nothing.
+    NonElic = ?M:on_packet_sent(3, 100, false, 3, 3, ?M:new(#{})),
+    {Loss2, _, _} = ?M:on_ack_received({ack, 3, 0, 0, []}, 30, NonElic),
+    ?assertEqual(
+        #{acked_bytes => 0, largest_acked_time => undefined, largest_lost_time => undefined},
+        ?M:cc_signal(Loss2)
+    ).
+
 %% A non-ack-eliciting largest acked, and a largest we never sent, both
 %% leave the RTT untouched (no sample taken).
 on_ack_received_no_rtt_sample_test() ->

--- a/test/roadrunner_quic_test_conn.erl
+++ b/test/roadrunner_quic_test_conn.erl
@@ -45,6 +45,9 @@
 %% Must match the `initial_max_data` in roadrunner_quic_test_client's transport
 %% params: the flow accounting starts from the value the handshake advertised.
 -define(CONN_MAX_DATA, 800000).
+%% Delayed-ACK bound (RFC 9000 §13.2.1): acknowledge every second ack-eliciting
+%% packet, and otherwise within this many ms so a lone tail packet is still acked.
+-define(MAX_ACK_DELAY, 25).
 
 %% Handshake message types (RFC 8446 §4).
 -define(CERTIFICATE, 11).
@@ -79,7 +82,15 @@
     %% Connection-level receive flow control (RFC 9000 §4.1): tracks received
     %% bytes and replenishes the limit with MAX_DATA so the server's send window
     %% never stalls on a long-lived connection.
-    conn_flow :: roadrunner_quic_flow:t() | undefined
+    conn_flow :: roadrunner_quic_flow:t() | undefined,
+    %% 1-RTT received-packet tracking (RFC 9000 §13.1): the client acknowledges
+    %% the server's ack-eliciting packets so the server samples RTT, detects loss,
+    %% and frees its in-flight window for congestion control.
+    ack = undefined :: roadrunner_quic_ack:t() | undefined,
+    %% Ack-eliciting packets received since the last ACK; an ACK goes out on the
+    %% second one, or after ?MAX_ACK_DELAY if a lone packet is left (RFC 9000
+    %% §13.2.1), halving the client's per-packet crypto versus acking every one.
+    unacked = 0 :: non_neg_integer()
 }).
 
 %% =============================================================================
@@ -202,7 +213,8 @@ init(Parent, Ref, Host, Port) ->
         ch_framed = ChFramed,
         owner = Parent,
         server_initial_keys = roadrunner_quic_keys:initial_server(Dcid0),
-        conn_flow = roadrunner_quic_flow:new(#{initial_max_data => ?CONN_MAX_DATA})
+        conn_flow = roadrunner_quic_flow:new(#{initial_max_data => ?CONN_MAX_DATA}),
+        ack = roadrunner_quic_ack:new()
     },
     case handshake(Conn) of
         {ok, Conn1} ->
@@ -400,7 +412,14 @@ server_public_key(HandshakeBytes) ->
 %% arrive as mailbox messages and a single receive handles both without a
 %% blocking socket read that would delay owner calls while the peer is idle.
 -spec connected_loop(#conn{}) -> ok.
-connected_loop(#conn{socket = Socket} = Conn) ->
+connected_loop(#conn{socket = Socket, unacked = Unacked} = Conn) ->
+    %% Wait indefinitely with nothing to acknowledge; with a lone unacked packet,
+    %% flush it after ?MAX_ACK_DELAY (RFC 9000 §13.2.1) if no second arrives.
+    AckDeadline =
+        case Unacked of
+            0 -> infinity;
+            _ -> ?MAX_ACK_DELAY
+        end,
     receive
         {open_bidi, From, Ref} ->
             Id = Conn#conn.next_bidi,
@@ -435,6 +454,8 @@ connected_loop(#conn{socket = Socket} = Conn) ->
                 ignore ->
                     connected_loop(Conn)
             end
+    after AckDeadline ->
+        connected_loop(flush_ack(Conn))
     end.
 
 %% Send stream data, splitting it across 1-RTT packets so each datagram stays
@@ -515,8 +536,45 @@ handle_app_datagram(#conn{app_server_keys = Keys, scid = Scid} = Conn, Datagram)
     Outcomes = roadrunner_quic_recv:datagram(
         Datagram, byte_size(Scid), #{application => Keys}, #{}
     ),
-    Frames = lists:append([Fs || {ok, #{level := application, frames := Fs}} <- Outcomes]),
-    lists:foldl(fun handle_app_frame/2, Conn, Frames).
+    maybe_send_ack(lists:foldl(fun handle_app_packet/2, Conn, Outcomes)).
+
+%% Record one decrypted 1-RTT packet against the ack tracker (so its ack-eliciting
+%% packets get acknowledged) and fold its frames.
+-spec handle_app_packet(roadrunner_quic_recv:outcome(), #conn{}) -> #conn{}.
+handle_app_packet({ok, #{level := application, pn := PN, frames := Frames}}, Conn) ->
+    Elicit = roadrunner_quic_send:ack_eliciting(Frames),
+    Ack = roadrunner_quic_ack:record(PN, Elicit, Conn#conn.ack),
+    Unacked = Conn#conn.unacked + ack_eliciting_count(Elicit),
+    lists:foldl(fun handle_app_frame/2, Conn#conn{ack = Ack, unacked = Unacked}, Frames);
+handle_app_packet(_Outcome, Conn) ->
+    Conn.
+
+-spec ack_eliciting_count(boolean()) -> 0 | 1.
+ack_eliciting_count(true) -> 1;
+ack_eliciting_count(false) -> 0.
+
+%% Acknowledge the server's 1-RTT packets once a second ack-eliciting one has
+%% arrived (RFC 9000 §13.2.1); a lone one is flushed later by the loop's
+%% ?MAX_ACK_DELAY timeout. The ACK is not itself ack-eliciting, so the server
+%% never acknowledges it back.
+-spec maybe_send_ack(#conn{}) -> #conn{}.
+maybe_send_ack(#conn{unacked = Unacked} = Conn) when Unacked >= 2 ->
+    flush_ack(Conn);
+maybe_send_ack(Conn) ->
+    Conn.
+
+%% Send one ACK frame covering everything received so far, or nothing if there is
+%% no ack-eliciting packet outstanding.
+-spec flush_ack(#conn{}) -> #conn{}.
+flush_ack(#conn{ack = Ack} = Conn) ->
+    case roadrunner_quic_ack:needs_ack(Ack) of
+        false ->
+            Conn#conn{unacked = 0};
+        true ->
+            {Largest, FirstRange, Ranges} = roadrunner_quic_ack:to_ack(Ack),
+            Conn1 = send_wire_frame(Conn, {ack, Largest, 0, FirstRange, Ranges, undefined}),
+            Conn1#conn{ack = roadrunner_quic_ack:mark_ack_sent(Ack), unacked = 0}
+    end.
 
 -spec handle_app_frame(roadrunner_quic_frame:frame(), #conn{}) -> #conn{}.
 handle_app_frame({stream, StreamId, Offset, Data, Fin}, Conn) ->


### PR DESCRIPTION
# Description

The native QUIC server sent bounded only by anti-amplification and flow control, so on a lossy WAN it would overshoot and self-induce loss with no backoff. This gates `drain_send` on a connection-wide NewReno window: ack-eliciting datagrams wait on it (ACK-only ones never do), it grows in slow start as ACKs arrive and halves on ACK-detected loss (RFC 9002 §7.3). A prerequisite first commit teaches the native test client to acknowledge the server's 1-RTT packets, without which the window could never grow.

- Send 100 KB with the window at 12 KB -> about one window goes out, the rest waits for ACKs

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
