### PR TITLE
Cover the GET-side scenarios in the erlang_quic bench comparison

### DIFF
--- a/bench/bench_erlang_quic_server.erl
+++ b/bench/bench_erlang_quic_server.erl
@@ -6,9 +6,13 @@
 %% only under the `bench` rebar3 profile (the dep is bench-profile-only), so it
 %% never touches the dep-free `test` profile.
 %%
-%% It serves the bench's `hello` scenario response: 200 + a 7-byte body,
-%% matching `roadrunner_keepalive_handler` so the loadgen's status + body-length
-%% checks pass identically for both servers under the same client.
+%% It serves the bench's protocol-agnostic GET-side scenarios (hello, json,
+%% large_response, headers_heavy, head_method, cookies_heavy) with the same
+%% response shape roadrunner's fixtures produce, so the loadgen's status check
+%% passes identically for both servers under the same client. The POST-body
+%% scenarios (echo, multi_request_body) are not covered: the dep delivers
+%% request bodies only through a late `set_stream_handler`, which races body
+%% arrival against the spawned handler.
 
 -export([start/2]).
 
@@ -39,14 +43,79 @@ load_keypair(CertDir) ->
     [{KeyType, KeyDer, _} | _] = public_key:pem_decode(KeyPem),
     {CertDer, public_key:der_decode(KeyType, KeyDer)}.
 
-%% A handler fun (RFC 9114 request callback shape the dep expects:
-%% `fun(Conn, StreamId, Method, Path, Headers)`). The `hello` scenario answers
-%% every request with 200 + `alive\r\n` (7 bytes), the same as roadrunner's
-%% keepalive fixture.
+%% A per-scenario handler fun (RFC 9114 request callback shape the dep expects:
+%% `fun(Conn, StreamId, Method, Path, Headers)`). Each clause mirrors the
+%% response of the matching roadrunner bench fixture so the work the dep does is
+%% the same the loadgen drives against roadrunner. `hello` and `headers_heavy`
+%% answer every request with 200 + `alive\r\n` (7 bytes), the same as
+%% roadrunner's keepalive fixture.
 -spec handler(atom()) -> fun().
 handler(hello) ->
     Body = ~"alive\r\n",
     fun(Conn, StreamId, _Method, _Path, _Headers) ->
         ok = quic_h3:send_response(Conn, StreamId, 200, [{~"content-type", ~"text/plain"}]),
         ok = quic_h3:send_data(Conn, StreamId, Body, true)
+    end;
+handler(headers_heavy) ->
+    handler(hello);
+%% `large_response` answers every request with a 64 KB octet-stream body, the
+%% same shape as roadrunner_bench_large_handler; the body is built once here and
+%% captured, so the per-request cost is response framing + send, not body build.
+handler(large_response) ->
+    Body = binary:copy(~"x", 65536),
+    Headers = [
+        {~"content-type", ~"application/octet-stream"},
+        {~"content-length", integer_to_binary(byte_size(Body))}
+    ],
+    fun(Conn, StreamId, _Method, _Path, _Headers) ->
+        ok = quic_h3:send_response(Conn, StreamId, 200, Headers),
+        ok = quic_h3:send_data(Conn, StreamId, Body, true)
+    end;
+%% `json` answers with the same fixed ~115-byte object roadrunner_bench_json_handler
+%% returns, so both servers frame an identical small response.
+handler(json) ->
+    Body =
+        ~"""
+        {"id":"01J8X9Z3K7QFRBQ4PCVE5K8RNH","status":"ok","data":{"name":"roadrunner","version":2,"flags":["alpha","beta"]}}
+        """,
+    Headers = [
+        {~"content-type", ~"application/json"},
+        {~"content-length", integer_to_binary(byte_size(Body))}
+    ],
+    fun(Conn, StreamId, _Method, _Path, _Headers) ->
+        ok = quic_h3:send_response(Conn, StreamId, 200, Headers),
+        ok = quic_h3:send_data(Conn, StreamId, Body, true)
+    end;
+%% `head_method` is a HEAD against the same /large resource: 200 with the 64 KB
+%% `content-length` advertised but an empty body, mirroring roadrunner stripping
+%% the body on HEAD while keeping the headers.
+handler(head_method) ->
+    Headers = [
+        {~"content-type", ~"application/octet-stream"},
+        {~"content-length", integer_to_binary(65536)}
+    ],
+    fun(Conn, StreamId, _Method, _Path, _Headers) ->
+        ok = quic_h3:send_response(Conn, StreamId, 200, Headers),
+        ok = quic_h3:send_data(Conn, StreamId, <<>>, true)
+    end;
+%% `cookies_heavy` parses the request's Cookie header the way
+%% roadrunner_req:parse_cookies/1 does (`; `-separated pairs) and answers with
+%% the pair count, so the dep does the same parse work per request.
+handler(cookies_heavy) ->
+    fun(Conn, StreamId, _Method, _Path, Headers) ->
+        Body = integer_to_binary(count_cookies(Headers)),
+        ok = quic_h3:send_response(Conn, StreamId, 200, [
+            {~"content-type", ~"text/plain"},
+            {~"content-length", integer_to_binary(byte_size(Body))}
+        ]),
+        ok = quic_h3:send_data(Conn, StreamId, Body, true)
+    end.
+
+%% Count the `; `-separated pairs in the request's Cookie header, matching
+%% roadrunner_req:parse_cookies/1 so the per-request work compares like for like.
+-spec count_cookies(list()) -> non_neg_integer().
+count_cookies(Headers) ->
+    case lists:keyfind(~"cookie", 1, Headers) of
+        {_, Value} -> length(binary:split(Value, ~"; ", [global]));
+        false -> 0
     end.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -346,6 +346,26 @@ variance). Eyeball-from-summary covers the v1 use case.
 **Scope:** medium. The parser, distribution stats, baseline storage, and
 presentation are the bulk; the artifact upload already ships.
 
+### Extend the erlang_quic h3 comparison past the small-response scenarios
+
+**What:** `bench_erlang_quic_server` serves the GET-side h3 scenarios (hello,
+json, large_response, headers_heavy, head_method, cookies_heavy) as the
+`erlang_quic` comparison target, but two gaps remain. `large_response` does not
+yield a usable number: the dep server stalls mid-download (CPU ~300%, err=50 at
+the deadline) because the native loadgen (`roadrunner_quic_test_conn`) sustains
+downloads from roadrunner's own server but not from the dep, so it needs to grant
+per-stream `MAX_STREAM_DATA`, not just connection-level `MAX_DATA`. `echo` and
+`multi_request_body` are filtered out (a preflight drops `erlang_quic` for them):
+the dep's 5-arg handler exposes no POST body, so echoing one needs the dep's
+`set_stream_handler` body-receive path.
+
+**Why deferred:** the five small-response scenarios compare cleanly, and the dep
+is bench-only tooling on its way out; the bulk-transfer and upload comparisons
+are the remaining gaps.
+
+**Scope:** small for `large_response` (loadgen per-stream credit grant),
+small-medium for the POST scenarios (dep body-receive wiring).
+
 ### h2 manual-mode body reading
 
 **What:** Parity with the h1 manual-mode body reader for h2 streams

--- a/scripts/bench.escript
+++ b/scripts/bench.escript
@@ -420,6 +420,12 @@ preflight_scenario(#{scenario := httparena_limited_conn, servers := Servers} = O
 preflight_scenario(#{scenario := httparena_static, servers := Servers} = Opts) ->
     filter_servers(httparena_static, [elli], Servers, Opts,
         ~"elli fixture has no static-file route; roadrunner_static vs cowboy_static");
+preflight_scenario(#{scenario := echo, servers := Servers} = Opts) ->
+    filter_servers(echo, [erlang_quic], Servers, Opts,
+        ~"dep's request handler exposes no POST body (only a late set_stream_handler)");
+preflight_scenario(#{scenario := multi_request_body, servers := Servers} = Opts) ->
+    filter_servers(multi_request_body, [erlang_quic], Servers, Opts,
+        ~"dep's request handler exposes no POST body (only a late set_stream_handler)");
 preflight_scenario(Opts) ->
     Opts.
 


### PR DESCRIPTION
# Description

The h3 bench could only compare roadrunner against the `quic` dep's server on `hello`. This adds the rest of the GET-side scenarios (json, large_response, headers_heavy, head_method, cookies_heavy) to `bench_erlang_quic_server`, each mirroring the matching roadrunner fixture, so `--protocols h3 --servers roadrunner,erlang_quic` compares them too.

h3, 50 clients:

| scenario | server | req/s | p50 | p99 | RSS |
|---|---|---|---|---|---|
| hello | roadrunner | 68,574 | 0.72 ms | 1.53 ms | 193 MB |
| | erlang_quic | 34,812 | 1.36 ms | 3.33 ms | 531 MB |
| head_method | roadrunner | 59,179 | 0.85 ms | 1.77 ms | 178 MB |
| | erlang_quic | 32,149 | 1.47 ms | 3.64 ms | 774 MB |
| json | roadrunner | 58,346 | 0.86 ms | 1.82 ms | 178 MB |
| | erlang_quic | 33,361 | 1.41 ms | 3.33 ms | 765 MB |
| cookies_heavy | roadrunner | 51,973 | 0.97 ms | 1.83 ms | 169 MB |
| | erlang_quic | 30,785 | 1.53 ms | 3.51 ms | 780 MB |
| headers_heavy | roadrunner | 47,109 | 1.08 ms | 2.00 ms | 160 MB |
| | erlang_quic | 30,771 | 1.53 ms | 3.77 ms | 531 MB |

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
