### PR TITLE
Add a client-disconnect signal for streaming handlers (h1/h2/h3)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -395,24 +395,6 @@ grammar enforcement is callers-write-bugs ergonomics, not security.
 
 **Scope:** small per attribute. Add when a real caller hits the gap.
 
-### Cancel a handler on client disconnect — medium
-
-**What:** Signal a running handler when the client goes away. For
-`{loop, ...}` (SSE / long-poll) and streaming handlers that block in
-`receive` or keep producing chunks after the request, deliver a
-`{roadrunner_disconnect, _}` message (or expose a monitor) the moment
-the connection closes, so the handler can drop pubsub subscriptions and
-stop expensive work instead of discovering the dead socket only on its
-next write.
-
-**Why deferred:** ordinary request/response handlers finish before the
-client can leave, so they never need it; it only matters for the
-long-lived streaming shapes, and none has a caller blocked on it today.
-
-**Scope:** medium. The conn loop already owns the socket so it can watch
-for close; the work is routing that into the loop/stream lifecycle
-across h1, h2, and h3 without racing the normal finish path.
-
 ### NDJSON streaming response builder — small
 
 **What:** A first-class newline-delimited-JSON response, the JSON

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -112,6 +112,9 @@
     streams = #{} :: #{non_neg_integer() => map()},
     %% Worker monitor ref => StreamId, for correlating `'DOWN'`.
     worker_refs = #{} :: #{reference() => non_neg_integer()},
+    %% StreamId => worker pid, so a peer RESET_STREAM on a dispatched
+    %% stream can be routed to its worker (`{roadrunner_stream_reset, _}`).
+    worker_pids = #{} :: #{non_neg_integer() => pid()},
     %% StreamId => peer-uni-stream state (see `uni_event/4`).
     uni = #{} :: #{non_neg_integer() => uni_state()},
     %% Critical stream roles already claimed, so a duplicate control or
@@ -426,7 +429,7 @@ handle_uni_stream(#h3{uni = Uni, critical = Critical} = State, StreamId, Data, F
 %% not-yet-typed or unknown uni stream) it just drops the per-stream
 %% state we hold.
 -spec handle_stream_reset(#h3{}, non_neg_integer()) -> handle_result().
-handle_stream_reset(#h3{uni = Uni, streams = Streams} = State, StreamId) ->
+handle_stream_reset(#h3{uni = Uni, streams = Streams, worker_pids = WorkerPids} = State, StreamId) ->
     case Uni of
         #{StreamId := UniState} ->
             case uni_reset(UniState) of
@@ -436,7 +439,20 @@ handle_stream_reset(#h3{uni = Uni, streams = Streams} = State, StreamId) ->
                     State#h3{uni = maps:remove(StreamId, Uni)}
             end;
         _ ->
-            State#h3{streams = maps:remove(StreamId, Streams)}
+            case WorkerPids of
+                #{StreamId := WorkerPid} ->
+                    %% Peer cancelled a dispatched request stream. Tell the
+                    %% worker so a `{loop, ...}` handler gets its disconnect;
+                    %% the worker's normal exit then releases the slot and
+                    %% drops the stream via `handle_worker_down/3` (no RST
+                    %% back — the peer already reset it).
+                    _ = (WorkerPid ! {roadrunner_stream_reset, StreamId}),
+                    State;
+                _ ->
+                    %% Still mid-receive (or already gone) — drop the
+                    %% in-progress frame-accumulation entry.
+                    State#h3{streams = maps:remove(StreamId, Streams)}
+            end
     end.
 
 %% RFC 9114 §7.2.8: HTTP/2-reserved frame types → H3_FRAME_UNEXPECTED;
@@ -764,15 +780,17 @@ dispatch_decoded(#h3{streams = Streams} = State, StreamId, Headers, Body) ->
                 )
             of
                 true ->
-                    {_WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
+                    {WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
                         State1#h3.conn, StreamId, Req, State1#h3.proto_opts
                     ),
                     %% The worker owns the response now, tracked by its monitor
                     %% ref; drop the (no-longer-needed) frame-accumulation entry
                     %% so the streams map only ever holds in-progress requests.
+                    %% Record the pid too so a peer reset can reach the worker.
                     State1#h3{
                         streams = maps:remove(StreamId, Streams),
-                        worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId}
+                        worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId},
+                        worker_pids = (State1#h3.worker_pids)#{StreamId => WorkerPid}
                     };
                 false ->
                     %% Listener-wide in-flight ceiling reached — refuse the
@@ -788,7 +806,7 @@ dispatch_decoded(#h3{streams = Streams} = State, StreamId, Headers, Body) ->
 %% pseudo-headers, response encoding) resets the stream, leaving the
 %% connection's other streams untouched.
 -spec handle_worker_down(#h3{}, reference(), term()) -> #h3{}.
-handle_worker_down(#h3{worker_refs = WorkerRefs} = State, MonRef, Reason) ->
+handle_worker_down(#h3{worker_refs = WorkerRefs, worker_pids = WorkerPids} = State, MonRef, Reason) ->
     %% Every monitor the loop holds is a stream worker (the QUIC conn is
     %% linked, not monitored), so the ref is always present.
     {StreamId, WorkerRefs1} = maps:take(MonRef, WorkerRefs),
@@ -798,7 +816,9 @@ handle_worker_down(#h3{worker_refs = WorkerRefs} = State, MonRef, Reason) ->
     ok = roadrunner_conn:release_request_slot(
         State#h3.max_concurrent_requests, State#h3.inflight_counter
     ),
-    State1 = State#h3{worker_refs = WorkerRefs1},
+    State1 = State#h3{
+        worker_refs = WorkerRefs1, worker_pids = maps:remove(StreamId, WorkerPids)
+    },
     case Reason of
         normal ->
             drop_stream(State1, StreamId);

--- a/src/roadrunner_handler.erl
+++ b/src/roadrunner_handler.erl
@@ -138,6 +138,24 @@ writes one chunk to the wire. Return `{ok, NewState}` to keep
 looping or `{stop, NewState}` to emit the size-0 terminator and
 close. Handlers that don't export this callback can't use
 `{loop, ...}` responses.
+
+When the client connection goes away while the loop is still running,
+the framework delivers a final `{roadrunner_disconnect, Reason}`
+message through this callback so the handler can drop pubsub
+subscriptions and stop work instead of discovering the dead socket on
+its next push:
+
+- `{roadrunner_disconnect, closed}` — the peer closed (or errored) the
+  HTTP/1 connection.
+- `{roadrunner_disconnect, reset}` — the peer cancelled this stream
+  (HTTP/2 `RST_STREAM`, HTTP/3 `RESET_STREAM`).
+- `{roadrunner_disconnect, conn_down}` — the owning connection process
+  died (HTTP/2 / HTTP/3).
+
+It is delivered at most once, the loop then ends regardless of the
+return value (the wire is gone, so no terminator is written). A handler
+that does not match it explicitly falls through to its catch-all clause;
+the loop still ends.
 """.
 -callback handle_info(Info :: term(), Push :: push_fun(), State :: term()) ->
     {ok, NewState :: term()} | {stop, NewState :: term()}.

--- a/src/roadrunner_http2_loop_response.erl
+++ b/src/roadrunner_http2_loop_response.erl
@@ -17,6 +17,14 @@
 %% On `{stop, _NewState}` the worker emits an empty DATA frame with
 %% END_STREAM and returns; the conn cleans up the stream slot via the
 %% worker's `'DOWN'` signal.
+%%
+%% If the client goes away first, the loop hands the handler one final
+%% `{roadrunner_disconnect, Reason}` through `handle_info/3` (its chance
+%% to drop subscriptions) and ends without the END_STREAM DATA frame —
+%% the wire is gone. `Reason` is `reset` when the peer cancelled this
+%% stream (`RST_STREAM`, surfaced by the conn as `{h2_stream_reset, _}`)
+%% or `conn_down` when the owning conn process died (the worker's monitor
+%% `'DOWN'`).
 
 -export([run/5]).
 
@@ -46,14 +54,14 @@ run(ConnPid, StreamId, Status, Headers, {Handler, State}) ->
 info_loop(ConnPid, StreamId, Handler, Push, State) ->
     receive
         {'DOWN', _MonRef, process, ConnPid, _Reason} ->
-            %% Connection gone — stop looping.
-            ok;
+            %% Connection gone — give the handler its disconnect and stop.
+            deliver_disconnect(Handler, Push, State, conn_down);
         {h2_stream_reset, StreamId} ->
-            %% The conn reset this stream (peer RST_STREAM, or a
-            %% protocol violation on the conn side) and already dropped
-            %% it. Stop looping rather than forwarding the reset to the
-            %% handler's `handle_info/3` as if it were application data.
-            ok;
+            %% The conn reset this stream (peer RST_STREAM, or a protocol
+            %% violation on the conn side) and already dropped it. Hand
+            %% the handler the disconnect and stop; no END_STREAM frame —
+            %% the stream is gone.
+            deliver_disconnect(Handler, Push, State, reset);
         {system, From, Req} ->
             Resume = fun(S) -> info_loop(ConnPid, StreamId, Handler, Push, S) end,
             roadrunner_loop_sys:handle_system(Req, From, State, Resume);
@@ -71,6 +79,14 @@ info_loop(ConnPid, StreamId, Handler, Push, State) ->
                     ok
             end
     end.
+
+%% Hand the handler one final `{roadrunner_disconnect, Reason}` so it can
+%% drop subscriptions / stop work, then end the loop. The stream/conn is
+%% gone: we neither emit the END_STREAM frame nor honour the return.
+-spec deliver_disconnect(module(), roadrunner_handler:push_fun(), term(), reset | conn_down) -> ok.
+deliver_disconnect(Handler, Push, State, Reason) ->
+    _ = Handler:handle_info({roadrunner_disconnect, Reason}, Push, State),
+    ok.
 
 %% Push fun handed to the user handler. Empty data is a no-op: an
 %% empty DATA frame would be legal on the wire but doesn't advance

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -376,16 +376,20 @@ sendfile_loop(IoDev, Remaining, Send) ->
 ) -> ok.
 send_loop(Conn, StreamId, Status, Headers, Handler, State) ->
     _ = roadrunner_quic:send_data(Conn, StreamId, header_frame(Status, Headers), false),
-    %% Stop looping if the connection dies — otherwise an idle loop
-    %% worker (blocked in `info_loop` waiting for a message) leaks
-    %% forever once the conn is gone. The monitor fires when the QUIC
-    %% connection process exits (promptly on a force-close / abort, or
-    %% after its drain timeout on a graceful close).
+    %% Monitor the conn so an idle loop worker (blocked in `info_loop`)
+    %% does not leak once the conn is gone: its `'DOWN'` becomes a
+    %% `{roadrunner_disconnect, conn_down}` for the handler. The monitor
+    %% fires when the QUIC connection process exits (promptly on a
+    %% force-close / abort, or after its drain timeout on a graceful
+    %% close).
     _ = monitor(process, Conn),
     Push = fun(Data) -> loop_push(Conn, StreamId, Data) end,
     info_loop(Conn, StreamId, Handler, Push, State).
 
-%% OTP message shapes are answered via `roadrunner_loop_sys` rather than
+%% The conn's `'DOWN'` and a peer `{roadrunner_stream_reset, _}` (routed
+%% by the conn loop on RESET_STREAM) each deliver one final
+%% `{roadrunner_disconnect, _}` to the handler and end the loop. OTP
+%% message shapes are answered via `roadrunner_loop_sys` rather than
 %% surfacing in `handle_info/3`: `sys:get_state/1` & friends work and a
 %% `gen_server:call/2,3` against the worker gets `{error, not_supported}`
 %% instead of hanging (see `roadrunner_loop_response` for the full
@@ -394,8 +398,13 @@ send_loop(Conn, StreamId, Status, Headers, Handler, State) ->
 info_loop(Conn, StreamId, Handler, Push, State) ->
     receive
         {'DOWN', _MonRef, process, Conn, _Reason} ->
-            %% Connection gone — stop looping.
-            ok;
+            %% Connection gone — give the handler its disconnect and stop.
+            deliver_disconnect(Handler, Push, State, conn_down);
+        {roadrunner_stream_reset, StreamId} ->
+            %% The conn loop routed a peer RESET_STREAM for this stream
+            %% (RFC 9114 §4.1). Hand the handler the disconnect and stop;
+            %% no FIN frame — the stream is gone.
+            deliver_disconnect(Handler, Push, State, reset);
         {system, From, Req} ->
             Resume = fun(S) -> info_loop(Conn, StreamId, Handler, Push, S) end,
             roadrunner_loop_sys:handle_system(Req, From, State, Resume);
@@ -414,6 +423,14 @@ info_loop(Conn, StreamId, Handler, Push, State) ->
                     ok
             end
     end.
+
+%% Hand the handler one final `{roadrunner_disconnect, Reason}` so it can
+%% drop subscriptions / stop work, then end the loop. The stream/conn is
+%% gone: we neither emit the FIN frame nor honour the return.
+-spec deliver_disconnect(module(), roadrunner_handler:push_fun(), term(), reset | conn_down) -> ok.
+deliver_disconnect(Handler, Push, State, Reason) ->
+    _ = Handler:handle_info({roadrunner_disconnect, Reason}, Push, State),
+    ok.
 
 %% Push handed to the loop handler: empty data is a no-op (matches the
 %% h1/h2 contract), non-empty ships as one DATA frame (no FIN).

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -32,6 +32,18 @@
 %% - Any other Erlang message reaches the handler's `handle_info/3`
 %%   verbatim. Handlers should pattern-match defensively (with a
 %%   catch-all clause) rather than crash on unexpected messages.
+%%
+%% ## Client disconnect
+%%
+%% The socket is armed `{active, once}` before the loop blocks, so a
+%% peer close/error arrives as a mailbox message the selective receive
+%% can match — otherwise a passive, unread socket only reveals the dead
+%% peer on the next write, which may be minutes away on a quiet SSE
+%% channel. On close/error the loop delivers one final
+%% `{roadrunner_disconnect, closed}` through `handle_info/3` (the
+%% handler's chance to drop subscriptions) and then ends without writing
+%% the chunked terminator — the wire is already gone. Inbound bytes (an
+%% h1 streaming response is unidirectional) re-arm and are discarded.
 
 -export([run/5]).
 
@@ -53,42 +65,90 @@ run(Socket, Status, UserHeaders, Handler, State) ->
         roadrunner_transport:send(Socket, Head), loop_response_head
     ),
     Push = make_push(Socket),
-    info_loop(Socket, Handler, Push, State).
+    %% Active-mode tags for this transport (`{tcp, tcp_closed, tcp_error}`
+    %% / `{ssl, ssl_closed, ssl_error}`), matched in `info_loop` so a peer
+    %% close surfaces as a message rather than only on the next write.
+    Tags = roadrunner_transport:messages(Socket),
+    arm_and_loop(Socket, Tags, Handler, Push, State).
+
+%% Arm `{active, once}` and enter the loop. If arming fails the socket
+%% is already gone, so deliver the disconnect straight away. Shared by
+%% `run/5` (initial arm) and the inbound-data clause (re-arm).
+-spec arm_and_loop(
+    roadrunner_transport:socket(),
+    {atom(), atom(), atom()},
+    module(),
+    roadrunner_handler:push_fun(),
+    term()
+) -> ok.
+arm_and_loop(Socket, Tags, Handler, Push, State) ->
+    case roadrunner_transport:setopts(Socket, [{active, once}]) of
+        ok -> info_loop(Socket, Tags, Handler, Push, State);
+        {error, _} -> deliver_disconnect(Handler, Push, State, closed)
+    end.
 
 %% Selective receive on every Erlang message → handler:handle_info/3,
-%% **except** the OTP-internal shapes, which are answered via
-%% `roadrunner_loop_sys` rather than delivered to the user handler:
-%% `{system, _, _}` goes to the `sys` protocol handler, `{'$gen_call', _, _}`
-%% is replied `{error, not_supported}`, and `{'$gen_cast', _}` is a no-op.
-%% Non-OTP messages fall through to the catch-all `Info` clause. On
-%% `{stop, _}` we emit the size-0 chunked terminator and return.
+%% **except** the active-mode socket events and the OTP-internal shapes.
+%% The transport's close/error tags deliver a final
+%% `{roadrunner_disconnect, closed}` and end the loop (no terminator —
+%% the wire is gone); its data tag re-arms and discards inbound bytes.
+%% The OTP shapes are answered via `roadrunner_loop_sys` rather than
+%% delivered to the user handler: `{system, _, _}` goes to the `sys`
+%% protocol handler, `{'$gen_call', _, _}` is replied
+%% `{error, not_supported}`, and `{'$gen_cast', _}` is a no-op. Non-OTP
+%% messages fall through to the catch-all `Info` clause. On `{stop, _}`
+%% we emit the size-0 chunked terminator and return.
 %%
-%% **No `after` clause:** the loop blocks indefinitely until the
-%% handler returns `{stop, _}` from `handle_info/3`. A handler that
-%% never receives a stop-triggering message keeps the connection
-%% open forever; that's the contract for `{loop, ...}` responses
-%% (e.g. SSE feeds).
--spec info_loop(roadrunner_transport:socket(), module(), roadrunner_handler:push_fun(), term()) ->
-    ok.
-info_loop(Socket, Handler, Push, State) ->
+%% **No `after` clause:** absent a peer disconnect the loop blocks
+%% indefinitely until the handler returns `{stop, _}` from
+%% `handle_info/3`. A handler that never receives a stop-triggering
+%% message keeps the connection open until the client goes away; that's
+%% the contract for `{loop, ...}` responses (e.g. SSE feeds).
+-spec info_loop(
+    roadrunner_transport:socket(),
+    {atom(), atom(), atom()},
+    module(),
+    roadrunner_handler:push_fun(),
+    term()
+) -> ok.
+info_loop(Socket, {DataTag, ClosedTag, ErrorTag} = Tags, Handler, Push, State) ->
     receive
+        {ClosedTag, _} ->
+            deliver_disconnect(Handler, Push, State, closed);
+        {ErrorTag, _, _} ->
+            deliver_disconnect(Handler, Push, State, closed);
+        {DataTag, _, _} ->
+            %% Inbound bytes on a unidirectional streaming response (the
+            %% request body was already read before dispatch); discard
+            %% them and re-arm so the next socket event is still seen.
+            arm_and_loop(Socket, Tags, Handler, Push, State);
         {system, From, Req} ->
-            Resume = fun(S) -> info_loop(Socket, Handler, Push, S) end,
+            Resume = fun(S) -> info_loop(Socket, Tags, Handler, Push, S) end,
             roadrunner_loop_sys:handle_system(Req, From, State, Resume);
         {'$gen_call', From, _} ->
             ok = roadrunner_loop_sys:gen_call_unsupported(From),
-            info_loop(Socket, Handler, Push, State);
+            info_loop(Socket, Tags, Handler, Push, State);
         {'$gen_cast', _} ->
-            info_loop(Socket, Handler, Push, State);
+            info_loop(Socket, Tags, Handler, Push, State);
         Info ->
             case Handler:handle_info(Info, Push, State) of
                 {ok, NewState} ->
-                    info_loop(Socket, Handler, Push, NewState);
+                    info_loop(Socket, Tags, Handler, Push, NewState);
                 {stop, _NewState} ->
                     _ = roadrunner_transport:send(Socket, ~"0\r\n\r\n"),
                     ok
             end
     end.
+
+%% Hand the handler one final `{roadrunner_disconnect, Reason}` so it can
+%% drop subscriptions / stop work, then end the loop. The wire is gone:
+%% we neither write the chunked terminator nor honour the return (the
+%% channel is dead either way). A handler with no matching clause falls
+%% through to its catch-all; the loop ends regardless.
+-spec deliver_disconnect(module(), roadrunner_handler:push_fun(), term(), closed) -> ok.
+deliver_disconnect(Handler, Push, State, Reason) ->
+    _ = Handler:handle_info({roadrunner_disconnect, Reason}, Push, State),
+    ok.
 
 %% Push fun handed to the user handler. Same special-case as
 %% `roadrunner_stream_response:stream_frame/2`: zero-length data

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -1046,10 +1046,16 @@ loop_response_worker_stops_when_conn_dies() ->
     end.
 
 loop_response_worker_stops_on_stream_reset() ->
-    %% A peer RST_STREAM on a live loop stream must stop the worker, not
-    %% deliver `{h2_stream_reset, _}` to the handler's `handle_info/3`
-    %% (the `/loop` handler has no clause for it, so a misdelivery would
-    %% crash with function_clause — the worker must exit `normal`).
+    %% A peer RST_STREAM on a live loop stream delivers
+    %% `{roadrunner_disconnect, reset}` to the handler's `handle_info/3`
+    %% (its one chance to drop subscriptions) and then stops the worker
+    %% cleanly, with no END_STREAM DATA frame — the stream is gone.
+    try
+        unregister(roadrunner_h2_loop_observer)
+    catch
+        _:_ -> ok
+    end,
+    true = register(roadrunner_h2_loop_observer, self()),
     {Pid, Ref} = run_stream_request(~"/loop"),
     Worker = wait_for_register(roadrunner_h2_loop_test, 1000),
     %% Drain the 200 HEADERS so the worker is past `sync_send_headers`
@@ -1059,11 +1065,18 @@ loop_response_worker_stops_on_stream_reset() ->
     Rst = iolist_to_binary(roadrunner_http2_frame:encode({rst_stream, 1, cancel})),
     serve_recv(Pid, Rst),
     receive
+        {handler_disconnect, DisReason} ->
+            ?assertEqual(reset, DisReason)
+    after 1000 ->
+        error(disconnect_not_delivered)
+    end,
+    receive
         {'DOWN', WorkerRef, process, Worker, Reason} ->
             ?assertEqual(normal, Reason)
     after 1000 ->
         error(loop_worker_did_not_stop)
     end,
+    true = unregister(roadrunner_h2_loop_observer),
     cleanup(Pid, Ref).
 
 sendfile_empty_emits_empty_data() ->

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -177,4 +177,14 @@ handle_info({push, Data}, Push, N) ->
     {ok, N + 1};
 handle_info(stop, Push, N) ->
     _ = Push([~"data: bye(", integer_to_binary(N), ~")\n\n"]),
+    {stop, N};
+handle_info({roadrunner_disconnect, Reason}, _Push, N) ->
+    %% The client went away: surface the reason to the test observer (if
+    %% one registered) so the end-to-end disconnect path can be asserted,
+    %% then stop. The wire is gone, so the loop ends regardless.
+    _ =
+        case whereis(roadrunner_h2_loop_observer) of
+            undefined -> ok;
+            Observer -> Observer ! {handler_disconnect, Reason}
+        end,
     {stop, N}.

--- a/test/roadrunner_h3_test_handler.erl
+++ b/test/roadrunner_h3_test_handler.erl
@@ -107,7 +107,9 @@ handle(Req) ->
 %% `handle_info/3` is consulted only by `{loop, _}` responses. The
 %% `/loop` clause registers the worker; the test sends `{push, _}` to
 %% emit an SSE chunk, `push_empty` to exercise the empty-push no-op, and
-%% `stop` to terminate.
+%% `stop` to terminate. On a client disconnect the framework delivers
+%% `{roadrunner_disconnect, _}`, surfaced to a test observer (if
+%% registered) so the reset path can be asserted.
 -spec handle_info(term(), roadrunner_handler:push_fun(), term()) ->
     {ok, term()} | {stop, term()}.
 handle_info({push, Data}, Push, N) ->
@@ -118,4 +120,11 @@ handle_info(push_empty, Push, N) ->
     {ok, N};
 handle_info(stop, Push, N) ->
     _ = Push([~"data: bye(", integer_to_binary(N), ~")\n\n"]),
+    {stop, N};
+handle_info({roadrunner_disconnect, Reason}, _Push, N) ->
+    _ =
+        case whereis(roadrunner_h3_loop_observer) of
+            undefined -> ok;
+            Observer -> Observer ! {handler_disconnect, Reason}
+        end,
     {stop, N}.

--- a/test/roadrunner_http2_loop_response_tests.erl
+++ b/test/roadrunner_http2_loop_response_tests.erl
@@ -15,7 +15,11 @@ handle_info(go, Push, [{push, Data} | Rest]) ->
     self() ! go,
     {ok, Rest};
 handle_info(go, _Push, [stop | _]) ->
-    {stop, undefined}.
+    {stop, undefined};
+%% Disconnect tests run the loop with the probe pid as state.
+handle_info({roadrunner_disconnect, Reason}, _Push, Probe) when is_pid(Probe) ->
+    Probe ! {handler_got_disconnect, Reason},
+    {ok, Probe}.
 
 %% --- empty push is a no-op ---
 
@@ -61,6 +65,37 @@ sync_exits_on_stream_reset_test() ->
     end,
     FakeConn ! stop.
 
+%% --- client disconnect delivers {roadrunner_disconnect, _} ---
+
+%% A peer RST_STREAM arriving while the loop is idle (surfaced by the
+%% conn as `{h2_stream_reset, StreamId}`) delivers
+%% `{roadrunner_disconnect, reset}` and ends the loop with no END_STREAM
+%% DATA frame. Spawned so the fake conn's `{sends, _}` reply can't bleed
+%% into a sibling test's mailbox.
+loop_delivers_disconnect_on_stream_reset_test_() ->
+    {spawn, fun() ->
+        {FakeConn, Worker} = spawn_loop_with_state(self()),
+        ok = wait_until_looping(Worker),
+        Worker ! {h2_stream_reset, 1},
+        ok = wait_for_exit(Worker, 1000),
+        ?assertEqual(reset, recv_disconnect()),
+        ?assertEqual([{send_headers, 1, 200, [], false}], collect_sends(FakeConn)),
+        FakeConn ! stop
+    end}.
+
+%% The conn process dying (the worker's monitor `'DOWN'`) delivers
+%% `{roadrunner_disconnect, conn_down}` and ends the loop.
+loop_delivers_disconnect_on_conn_down_test_() ->
+    {spawn, fun() ->
+        {FakeConn, Worker} = spawn_loop_with_state(self()),
+        ok = wait_until_looping(Worker),
+        Worker ! {'DOWN', make_ref(), process, FakeConn, killed},
+        ok = wait_for_exit(Worker, 1000),
+        ?assertEqual(conn_down, recv_disconnect()),
+        ?assertEqual([{send_headers, 1, 200, [], false}], collect_sends(FakeConn)),
+        FakeConn ! stop
+    end}.
+
 %% --- OTP messages are answered, not delivered to the handler ---
 
 loop_answers_otp_messages_test() ->
@@ -86,6 +121,28 @@ spawn_loop(Directives) ->
         roadrunner_http2_loop_response:run(FakeConn, 1, 200, [], {?MODULE, Directives})
     end),
     {FakeConn, Worker}.
+
+spawn_loop_with_state(State) ->
+    Self = self(),
+    FakeConn = spawn(fun() -> fake_conn_loop(Self, []) end),
+    Worker = spawn(fun() ->
+        roadrunner_http2_loop_response:run(FakeConn, 1, 200, [], {?MODULE, State})
+    end),
+    {FakeConn, Worker}.
+
+%% Block until the worker has sent its headers and is idle in
+%% `info_loop`. `sys:get_state/1` is answered only from the loop, so it
+%% returns only after the worker is past `sync_send_headers` — without
+%% this a disconnect message could be intercepted by the sync receive.
+wait_until_looping(Worker) ->
+    _ = sys:get_state(Worker, 1000),
+    ok.
+
+recv_disconnect() ->
+    receive
+        {handler_got_disconnect, Reason} -> Reason
+    after 1000 -> error(no_disconnect_delivered)
+    end.
 
 fake_conn_loop(Reporter, Sends) ->
     fake_conn_loop(Reporter, Sends, undefined).

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -30,6 +30,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     loop_filters_otp/1,
     loop_conn_close_stops_worker/1,
     loop_stream_reset_delivers_disconnect/1,
+    loop_push_flushes_per_event/1,
     stream_response/1,
     stream_trailers/1,
     stream_autoclose/1,
@@ -97,6 +98,7 @@ all() ->
         loop_filters_otp,
         loop_conn_close_stops_worker,
         loop_stream_reset_delivers_disconnect,
+        loop_push_flushes_per_event,
         stream_response,
         stream_trailers,
         stream_autoclose,
@@ -379,6 +381,38 @@ loop_stream_reset_delivers_disconnect(Config) ->
     end,
     true = unregister(roadrunner_h3_loop_observer),
     close(Conn).
+
+loop_push_flushes_per_event(Config) ->
+    %% Each Push on a `{loop, _}` stream reaches the wire at emit time: the
+    %% client receives event 1 *before* event 2 is pushed, so there is no
+    %% coalescing that would batch SSE notifications behind a later flush
+    %% boundary (the QUIC send path emits a STREAM frame per push).
+    Conn = connect(?config(port, Config)),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
+    Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
+    Worker ! {push, ~"e1"},
+    Acc1 = await_stream_bytes(Conn, StreamId, ~"data: e1\n\n", <<>>),
+    Worker ! {push, ~"e2"},
+    _Acc2 = await_stream_bytes(Conn, StreamId, ~"data: e2\n\n", Acc1),
+    Worker ! stop,
+    close(Conn).
+
+%% Accumulate the stream's raw bytes until they contain `Needle` (the SSE
+%% payload appears verbatim in the DATA frame), failing if it doesn't
+%% arrive — proving the bytes were flushed without waiting for a later
+%% push or the FIN. `Acc` threads bytes already pulled from the mailbox.
+await_stream_bytes(Conn, StreamId, Needle, Acc) ->
+    case binary:match(Acc, Needle) of
+        nomatch ->
+            receive
+                {quic_test_stream, Conn, StreamId, Data, _Fin} ->
+                    await_stream_bytes(Conn, StreamId, Needle, <<Acc/binary, Data/binary>>)
+            after 2000 ->
+                ct:fail({event_not_flushed, Needle})
+            end;
+        _ ->
+            Acc
+    end.
 
 sendfile_empty(Config) ->
     %% A zero-length sendfile range is a header-only response.

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -29,6 +29,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     loop_response/1,
     loop_filters_otp/1,
     loop_conn_close_stops_worker/1,
+    loop_stream_reset_delivers_disconnect/1,
     stream_response/1,
     stream_trailers/1,
     stream_autoclose/1,
@@ -95,6 +96,7 @@ all() ->
         loop_response,
         loop_filters_otp,
         loop_conn_close_stops_worker,
+        loop_stream_reset_delivers_disconnect,
         stream_response,
         stream_trailers,
         stream_autoclose,
@@ -352,6 +354,30 @@ loop_conn_close_stops_worker(Config) ->
     after 5000 ->
         ct:fail(loop_worker_did_not_exit)
     end,
+    close(Conn).
+
+loop_stream_reset_delivers_disconnect(Config) ->
+    %% A peer cancelling a live `{loop, _}` stream (RESET_STREAM) is routed
+    %% by the conn loop to the worker, which hands the handler
+    %% `{roadrunner_disconnect, reset}` and stops — rather than leaking
+    %% until the whole connection dies.
+    Conn = connect(?config(port, Config)),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
+    Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
+    true = register(roadrunner_h3_loop_observer, self()),
+    WorkerRef = monitor(process, Worker),
+    ok = roadrunner_quic_test_h3:cancel(Conn, StreamId),
+    receive
+        {handler_disconnect, Reason} -> ?assertEqual(reset, Reason)
+    after 5000 ->
+        ct:fail(disconnect_not_delivered)
+    end,
+    receive
+        {'DOWN', WorkerRef, process, Worker, _} -> ok
+    after 5000 ->
+        ct:fail(loop_worker_did_not_exit)
+    end,
+    true = unregister(roadrunner_h3_loop_observer),
     close(Conn).
 
 sendfile_empty(Config) ->

--- a/test/roadrunner_loop_response_tests.erl
+++ b/test/roadrunner_loop_response_tests.erl
@@ -50,6 +50,66 @@ loop_skips_otp_internal_messages_test() ->
     %% nothing else.
     ?assertEqual([user_msg_1, user_msg_2], Got).
 
+%% A peer close (the transport's `closed` tag) delivers one
+%% `{roadrunner_disconnect, closed}` to the handler and ends the loop
+%% without writing the chunked terminator.
+loop_delivers_disconnect_on_close_test_() ->
+    {spawn, fun() ->
+        {Worker, Sink, Tag} = start_disconnect_worker(),
+        Worker ! {roadrunner_fake_closed, fake_sock},
+        await_worker_done(Worker),
+        Sink ! stop,
+        ?assertEqual([{roadrunner_disconnect, closed}], collect_handler_msgs([], 100)),
+        ?assertNot(lists:member(~"0\r\n\r\n", collect_sent([], Tag, 100)))
+    end}.
+
+%% A transport error (the transport's `error` tag) is treated the same
+%% as a close: one `{roadrunner_disconnect, closed}`, no terminator.
+loop_delivers_disconnect_on_error_test_() ->
+    {spawn, fun() ->
+        {Worker, Sink, Tag} = start_disconnect_worker(),
+        Worker ! {roadrunner_fake_error, fake_sock, econnreset},
+        await_worker_done(Worker),
+        Sink ! stop,
+        ?assertEqual([{roadrunner_disconnect, closed}], collect_handler_msgs([], 100)),
+        ?assertNot(lists:member(~"0\r\n\r\n", collect_sent([], Tag, 100)))
+    end}.
+
+%% Inbound bytes on the (unidirectional) streaming socket are discarded
+%% and the loop keeps running — the handler never sees them, and a later
+%% `done` still stops cleanly with the chunked terminator.
+loop_discards_inbound_data_and_continues_test_() ->
+    {spawn, fun() ->
+        {Worker, Sink, Tag} = start_disconnect_worker(),
+        Worker ! {roadrunner_fake_data, fake_sock, ~"junk"},
+        Worker ! user_msg_1,
+        Worker ! done,
+        await_worker_done(Worker),
+        Sink ! stop,
+        ?assertEqual([user_msg_1], collect_handler_msgs([], 100)),
+        ?assert(lists:member(~"0\r\n\r\n", collect_sent([], Tag, 100)))
+    end}.
+
+%% If arming `{active, once}` fails (socket already gone), the loop
+%% delivers the disconnect immediately rather than blocking forever.
+loop_arm_failure_delivers_disconnect_test_() ->
+    {spawn, fun() ->
+        Self = self(),
+        DeadSink = spawn(fun() -> ok end),
+        DeadRef = monitor(process, DeadSink),
+        receive
+            {'DOWN', DeadRef, process, DeadSink, _} -> ok
+        after 1000 -> error(sink_not_dead)
+        end,
+        Probe = self(),
+        Worker = spawn(fun() ->
+            roadrunner_loop_response:run({fake, DeadSink}, 200, [], ?MODULE, Probe),
+            Self ! {worker_done, self()}
+        end),
+        await_worker_done(Worker),
+        ?assertEqual([{roadrunner_disconnect, closed}], collect_handler_msgs([], 100))
+    end}.
+
 %% A `gen_server:call/2,3` against the loop replies `{error, not_supported}`
 %% instead of hanging.
 loop_gen_call_replies_not_supported_test() ->
@@ -96,6 +156,32 @@ start_loop_worker(State) ->
 collect_handler_msgs(Acc, Timeout) ->
     receive
         {handler_got, Msg} -> collect_handler_msgs([Msg | Acc], 0)
+    after Timeout ->
+        lists:reverse(Acc)
+    end.
+
+%% Spawn the loop over a fresh send-logging sink, forwarding handler
+%% messages and finish notifications to the test process. Returns the
+%% worker pid, the sink pid, and the send-log tag.
+start_disconnect_worker() ->
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_send_log_sink(Self, Tag),
+    Worker = spawn(fun() ->
+        roadrunner_loop_response:run({fake, Sink}, 200, [], ?MODULE, Self),
+        Self ! {worker_done, self()}
+    end),
+    {Worker, Sink, Tag}.
+
+await_worker_done(Worker) ->
+    receive
+        {worker_done, Worker} -> ok
+    after 1000 -> error(worker_did_not_finish)
+    end.
+
+collect_sent(Acc, Tag, Timeout) ->
+    receive
+        {sent, Tag, Data} -> collect_sent([iolist_to_binary(Data) | Acc], Tag, 0)
     after Timeout ->
         lists:reverse(Acc)
     end.


### PR DESCRIPTION
# Description

Deliver a `{roadrunner_disconnect, closed|reset|conn_down}` to a `{loop, ...}` handler's `handle_info/3` the moment the client, stream, or connection goes away, across HTTP/1, HTTP/2, and HTTP/3, so a streaming handler can drop subscriptions and stop work promptly instead of discovering the dead socket on its next (maybe minutes-away) write. Also adds a test confirming each loop `Push` reaches the wire at emit time.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)