### PR TITLE
Backpressure HTTP/3 loop sends by deferring the stream-send reply

### DIFF
--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -30,6 +30,8 @@
 %% Exported for `roadrunner_conn_loop_http3` to emit a buffered
 %% response (e.g. 413) directly, without spawning a worker.
 -export([send_buffered/5]).
+%% Exported for eunit branch coverage of the stop-on-send-error path.
+-export([sendfile_loop/3]).
 
 %% RFC 9114 §7.2.1: the DATA frame type is 0x00. We frame the body by
 %% hand (type + length varints, then the body by reference) instead of
@@ -356,8 +358,14 @@ sendfile_loop(IoDev, Remaining, Send) ->
             _ = Send(Bin, fin),
             ok;
         NextRemaining ->
-            _ = Send(Bin, nofin),
-            sendfile_loop(IoDev, NextRemaining, Send)
+            %% Stop if the chunk could not be sent (the stream was reset /
+            %% the conn closed). Continuing would re-`Push` to a gone stream,
+            %% which the conn would recreate — read the rest only while the
+            %% wire is live.
+            case Send(Bin, nofin) of
+                ok -> sendfile_loop(IoDev, NextRemaining, Send);
+                {error, _} -> ok
+            end
     end.
 
 %% `{loop, ...}` response: HEADERS (no FIN), then a message-receive loop

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -107,6 +107,15 @@
     %% per-pass work is O(streams-with-pending-data); a fully-terminal stream
     %% leaves both this set and `streams` (pruned in `put_stream`).
     sendable = [] :: ordsets:ordset(non_neg_integer()),
+    %% Deferred send replies, one per stream id: a synchronous `send_data`
+    %% whose bytes did not fully flush this pass (closed flow / congestion
+    %% window) is parked here instead of replied, so the stream worker (and
+    %% the loop handler's Push) blocks until the buffer drains — the HTTP/3
+    %% analogue of h2's defer-ack backpressure. At most one entry per stream:
+    %% the worker blocks in `roadrunner_quic:await/3`, so it cannot have a
+    %% second `send_data` outstanding. Released by `release_drained/1` (drain
+    %% or abort) and `release_all/2` (connection teardown).
+    parked = #{} :: #{non_neg_integer() => {pid(), reference()}},
     %% Next server-initiated unidirectional stream id to hand out (RFC 9000
     %% §2.1: server uni ids are 3, 7, 11, ...); the owner opens its h3
     %% control stream this way.
@@ -334,18 +343,23 @@ finish_datagram(_Now, draining, #state{phase = draining} = State) ->
     %% timer set on entry keeps running in the shell.
     drain_emits(State);
 finish_datagram(Now, _Before, #state{phase = draining, pending_close = undefined} = State) ->
-    %% Just entered draining via a peer CONNECTION_CLOSE: deliver {closed, _} and
-    %% arm the drain timer; send nothing.
-    {State1, EmitEffects} = drain_emits(State),
-    {State1, [{arm_timer, drain, drain_deadline(Now, State1)} | EmitEffects]};
+    %% Just entered draining via a peer CONNECTION_CLOSE: release any parked
+    %% send replies (the send pass is skipped here, so a parked worker would
+    %% otherwise stall the whole drain window), deliver {closed, _}, and arm
+    %% the drain timer; send nothing.
+    {State1, Releases} = release_all({error, closed}, State),
+    {State2, EmitEffects} = drain_emits(State1),
+    {State2, [{arm_timer, drain, drain_deadline(Now, State2)} | Releases ++ EmitEffects]};
 finish_datagram(Now, _Before, #state{phase = draining} = State) ->
     %% Just entered draining via a locally-detected error: send our one
-    %% CONNECTION_CLOSE, deliver {closed, _}, and arm the drain timer. An
-    %% established connection's address is validated, so the close always fits the
-    %% §8.1 budget (send_close emits exactly one datagram).
+    %% CONNECTION_CLOSE, release any parked send replies, deliver {closed, _},
+    %% and arm the drain timer. An established connection's address is
+    %% validated, so the close always fits the §8.1 budget (send_close emits
+    %% exactly one datagram).
     {State1, [Close]} = send_close(State),
-    {State2, EmitEffects} = drain_emits(State1),
-    {State2, [Close, {arm_timer, drain, drain_deadline(Now, State2)} | EmitEffects]};
+    {State2, Releases} = release_all({error, closed}, State1),
+    {State3, EmitEffects} = drain_emits(State2),
+    {State3, [Close, {arm_timer, drain, drain_deadline(Now, State3)} | Releases ++ EmitEffects]};
 finish_datagram(_Now, _Before, #state{phase = closed, pending_close = undefined} = State) ->
     drain_emits(State);
 finish_datagram(_Now, _Before, #state{phase = closed} = State) ->
@@ -471,7 +485,10 @@ send_owner_close(ErrorCode, Reason, Keys, Now, #state{peer_scid = DCID, scid = S
     State1 = put_space(
         application, Space#space{next_pn = PN + 1}, State#state{phase = draining}
     ),
-    {State1, [{send, Datagram}, {arm_timer, drain, drain_deadline(Now, State1)}]}.
+    %% Release any parked send reply: a streaming worker can be mid-Push when
+    %% the owner closes, and this path skips the send pass.
+    {State2, Releases} = release_all({error, closed}, State1),
+    {State2, [{send, Datagram}, {arm_timer, drain, drain_deadline(Now, State2)} | Releases]}.
 
 %% Abandon the send side of a stream and tell the peer with a RESET_STREAM (RFC
 %% 9000 §19.4): discard the unsent buffer, record the bytes already sent as the
@@ -519,7 +536,46 @@ handle_send(From, Ref, _Sid, _IoData, _Fin, _Now, #state{phase = draining} = Sta
 handle_send(From, Ref, Sid, IoData, Fin, Now, State) ->
     State1 = enqueue_send(Sid, IoData, Fin, State),
     {State2, SendEffects} = send_pass(Now, State1),
-    {State2, [{reply, From, Ref, ok} | SendEffects]}.
+    case park_send(Sid, From, Ref, State2) of
+        {parked, State3} ->
+            %% Backpressure: the bytes did not fully flush, so withhold the
+            %% reply. The worker blocks in `await/3` until `release_drained/1`
+            %% (from a later send pass once the window opens, or on abort)
+            %% emits it. Bytes already went out in SendEffects.
+            {State3, SendEffects};
+        {reply, Result} ->
+            {State2, [{reply, From, Ref, Result} | SendEffects]}
+    end.
+
+%% Decide a send's reply: park (withhold) it iff this is a client-initiated
+%% bidi request stream (`Sid rem 4 =:= 0`, where response workers write) that
+%% is still present, not abandoned, and did not fully drain this pass —
+%% mirroring `release_result/2`. An abandoned stream (peer reset / STOP_SENDING)
+%% replies `{error, closed}` at once so the worker does not park on a dead
+%% stream. A fully-drained or pruned send, or a server-uni control send
+%% (`Sid rem 4 =/= 0`, which the conn-loop owner makes synchronously and must
+%% never block), replies `ok`.
+-spec park_send(non_neg_integer(), pid(), reference(), t()) ->
+    {parked, t()} | {reply, ok | {error, closed}}.
+park_send(Sid, From, Ref, #state{streams = Streams, parked = Parked} = State) when
+    Sid rem 4 =:= 0
+->
+    case Streams of
+        #{Sid := {Stream, _Flow}} ->
+            case roadrunner_quic_stream:send_abandoned(Stream) of
+                true ->
+                    {reply, {error, closed}};
+                false ->
+                    case roadrunner_quic_stream:send_pending(Stream) of
+                        true -> {parked, State#state{parked = Parked#{Sid => {From, Ref}}}};
+                        false -> {reply, ok}
+                    end
+            end;
+        #{} ->
+            {reply, ok}
+    end;
+park_send(_Sid, _From, _Ref, _State) ->
+    {reply, ok}.
 
 %% Append outbound bytes to a stream's send buffer (creating the stream on
 %% first reference) and flag the FIN when this is the final write.
@@ -648,6 +704,8 @@ process_frame(_Now, application, {max_data, Max}, #state{conn_flow = ConnFlow} =
     State#state{conn_flow = roadrunner_quic_flow:on_max_data_received(Max, ConnFlow)};
 process_frame(_Now, application, {max_stream_data, Sid, Max}, State) ->
     on_max_stream_data(Sid, Max, State);
+process_frame(_Now, application, {stop_sending, Sid, ErrorCode}, State) ->
+    process_stop_sending(Sid, ErrorCode, State);
 process_frame(_Now, _Level, _Frame, State) ->
     %% ping / padding are no-ops. MAX_STREAMS is accepted but not yet acted on
     %% (the server never opens enough streams to need the raised limit).
@@ -932,6 +990,25 @@ process_reset_stream(Sid, ErrorCode, FinalSize, State) ->
             end
     end.
 
+%% Peer STOP_SENDING (RFC 9000 §3.5): the peer will not read more of our
+%% response on this stream. Abandon our send side — `stop_sending/1` discards
+%% the unsent buffer and marks the stream send-stopped, so a parked send reply
+%% releases with `{error, closed}` (via `release_drained/1` at the end of this
+%% datagram) instead of `ok` — and surface it to the owner as a stream reset so
+%% a response worker stops (reusing the reset routing) rather than buffering more
+%% onto a stopped stream. A frame for a stream we hold no send state for is
+%% ignored, like a late RESET_STREAM.
+-spec process_stop_sending(non_neg_integer(), non_neg_integer(), t()) -> t().
+process_stop_sending(Sid, ErrorCode, #state{streams = Streams} = State) ->
+    case Streams of
+        #{Sid := {Stream0, Flow}} ->
+            Stream1 = roadrunner_quic_stream:stop_sending(Stream0),
+            State1 = put_stream(Sid, Stream1, Flow, State),
+            emit({stream_reset, Sid, ErrorCode}, State1);
+        #{} ->
+            State
+    end.
+
 %% A well-placed peer CONNECTION_CLOSE (transport at any level, or application
 %% at 1-RTT) ends the connection: surface it to the owner and move to the
 %% terminal phase so the send pass is skipped. An established connection lingers
@@ -1161,7 +1238,10 @@ put_stream(Sid, Stream, Flow, #state{streams = Streams, sendable = Sendable} = S
     %% finished) is pruned so the map stays bounded to live streams; the
     %% high-water keeps a late frame for its id from recreating it. Otherwise it
     %% is stored and the `sendable` working set kept in step (unsent data/FIN
-    %% joins it, a drained one leaves it).
+    %% joins it, a drained one leaves it). An abandoned send side (peer
+    %% RESET_STREAM left `aborted`, or STOP_SENDING / local reset set
+    %% `send_stopped`) leaves `sendable` even with buffered bytes, so the send
+    %% pass never emits STREAM frames on a stream the peer reset.
     case roadrunner_quic_stream:is_terminal(Stream) of
         true ->
             State#state{
@@ -1170,7 +1250,10 @@ put_stream(Sid, Stream, Flow, #state{streams = Streams, sendable = Sendable} = S
             };
         false ->
             Sendable1 =
-                case roadrunner_quic_stream:send_pending(Stream) of
+                case
+                    roadrunner_quic_stream:send_pending(Stream) andalso
+                        not roadrunner_quic_stream:send_abandoned(Stream)
+                of
                     true -> ordsets:add_element(Sid, Sendable);
                     false -> ordsets:del_element(Sid, Sendable)
                 end,
@@ -1192,10 +1275,68 @@ deliver_stream(_Sid, _Deliverable, _FinReached, State) ->
 -spec send_pass(integer(), t()) -> {t(), [effect()]}.
 send_pass(Now, State) ->
     {State1, RevSends} = drain_send(Now, State, []),
+    %% Release any parked send reply whose stream drained (or was aborted)
+    %% this pass. The release effects ride AFTER the reversed sends so the
+    %% bytes are on the wire before the worker is told it may send more
+    %% (`perform/3` folds effects left-to-right). This is the single choke
+    %% point: every flow / congestion relief (MAX_STREAM_DATA, MAX_DATA, an
+    %% ACK growing cwnd) runs in the datagram fold before `finish_datagram`
+    %% calls `send_pass`, so the scan here catches them all.
+    {State2, Releases} = release_drained(State1),
     %% `drain_send` returns the send effects newest-first; reverse them into
-    %% order and fold the (single) timer effect onto the end in the same pass,
-    %% rather than a second traversal to append it.
-    {State1, lists:reverse(RevSends, timer_effects(Now, State1))}.
+    %% order and fold the releases + the (single) timer effect onto the end in
+    %% the same pass, rather than a second traversal to append them.
+    {State2, lists:reverse(RevSends, Releases ++ timer_effects(Now, State2))}.
+
+%% Release each parked reply whose stream can no longer make progress toward
+%% draining: the stream is gone (pruned after its FIN flushed -> `ok`), its
+%% send side was abandoned by a reset / STOP_SENDING (`send_abandoned/1` ->
+%% `{error, closed}`, so a streaming worker does not treat the data as sent
+%% and re-send to a dead stream), or it fully drained (`ok`). A stream still
+%% holding unsent bytes stays parked. Each released entry is removed from
+%% `parked`, so a later scan in the same datagram cannot double-reply.
+-spec release_drained(t()) -> {t(), [effect()]}.
+release_drained(#state{parked = Parked, streams = Streams} = State) ->
+    {Parked1, Effects} = maps:fold(
+        fun(Sid, {From, Ref}, {Acc, Eff}) ->
+            case release_result(Sid, Streams) of
+                keep -> {Acc#{Sid => {From, Ref}}, Eff};
+                Result -> {Acc, [{reply, From, Ref, Result} | Eff]}
+            end
+        end,
+        {#{}, []},
+        Parked
+    ),
+    {State#state{parked = Parked1}, Effects}.
+
+%% The reply value for a parked stream id, or `keep` to leave it parked.
+-spec release_result(non_neg_integer(), #{non_neg_integer() => stream()}) ->
+    ok | {error, closed} | keep.
+release_result(Sid, Streams) ->
+    case Streams of
+        #{Sid := {Stream, _Flow}} ->
+            case roadrunner_quic_stream:send_abandoned(Stream) of
+                true ->
+                    {error, closed};
+                false ->
+                    case roadrunner_quic_stream:send_pending(Stream) of
+                        true -> keep;
+                        false -> ok
+                    end
+            end;
+        #{} ->
+            %% Pruned (terminal: its FIN flushed) — the send completed.
+            ok
+    end.
+
+%% Release every parked reply with `Result`, clearing the map. Used by the
+%% connection-teardown paths (draining / closed / owner close / idle) that
+%% skip `send_pass`, so a parked worker unblocks promptly instead of stalling
+%% until its conn monitor fires on the eventual process exit.
+-spec release_all(term(), t()) -> {t(), [effect()]}.
+release_all(Result, #state{parked = Parked} = State) ->
+    Effects = [{reply, From, Ref, Result} || {From, Ref} <- maps:values(Parked)],
+    {State#state{parked = #{}}, Effects}.
 
 %% Build and send one datagram per iteration until nothing is pending or
 %% the anti-amplification budget blocks; roll back the built state if the
@@ -1398,7 +1539,14 @@ handle_timeout(Now, pto, State) ->
     State1 = lists:foldl(fun(Level, S) -> on_pto(Now, Level, S) end, State, present_levels(State)),
     send_pass(Now, State1);
 handle_timeout(_Now, idle, State) ->
-    drain_emits(emit({closed, {local, idle_timeout}}, State#state{phase = closed}));
+    %% Release any parked send reply before the shell tears down, so a parked
+    %% worker unblocks and runs its disconnect path cleanly rather than only
+    %% crashing on the conn-process exit its monitor sees.
+    {State1, Releases} = release_all({error, closed}, State),
+    {State2, EmitEffects} = drain_emits(
+        emit({closed, {local, idle_timeout}}, State1#state{phase = closed})
+    ),
+    {State2, Releases ++ EmitEffects};
 handle_timeout(_Now, drain, State) ->
     %% The drain window elapsed (RFC 9000 §10.2): become closed so the shell
     %% tears the connection down. The owner already learned of the close on entry.

--- a/src/roadrunner_quic_stream.erl
+++ b/src/roadrunner_quic_stream.erl
@@ -32,7 +32,14 @@
 
 -export([new/0, receive_data/4, reset/2]).
 -export([
-    enqueue/2, finish/1, next_frame/2, stop_sending/1, send_pending/1, send_offset/1, is_terminal/1
+    enqueue/2,
+    finish/1,
+    next_frame/2,
+    stop_sending/1,
+    send_pending/1,
+    send_abandoned/1,
+    send_offset/1,
+    is_terminal/1
 ]).
 
 -export_type([t/0]).
@@ -60,7 +67,12 @@
     send_fin = false :: boolean(),
     %% Send side: whether a slice carrying the FIN has been produced, so it
     %% is not emitted twice (a retransmit replays the recorded frame).
-    fin_sent = false :: boolean()
+    fin_sent = false :: boolean(),
+    %% Send side: set by stop_sending/1 (a received STOP_SENDING or a local
+    %% reset abandoned the send side). Distinguishes an aborted send from a
+    %% naturally drained one, so a deferred backpressure reply releases with
+    %% an error rather than ok. See `send_abandoned/1`.
+    send_stopped = false :: boolean()
 }).
 
 -opaque t() :: #stream{}.
@@ -181,13 +193,24 @@ nothing more. The loop sends a RESET_STREAM separately.
 """.
 -spec stop_sending(t()) -> t().
 stop_sending(#stream{} = Stream) ->
-    Stream#stream{send_buf = <<>>, send_fin = false}.
+    Stream#stream{send_buf = <<>>, send_fin = false, send_stopped = true}.
 
 -doc "Whether the stream has unsent data or an unsent FIN to send.".
 -spec send_pending(t()) -> boolean().
 send_pending(#stream{fin_sent = true}) -> false;
 send_pending(#stream{send_buf = <<>>, send_fin = false}) -> false;
 send_pending(#stream{}) -> true.
+
+-doc """
+Whether the send side was abandoned rather than drained: the receive side
+was reset by the peer (`aborted`), or the send side was stopped via
+`stop_sending/1` (a received STOP_SENDING or a local reset). A deferred
+backpressure reply on such a stream releases with an error, not `ok`, so a
+streaming worker does not treat the data as delivered and re-send.
+""".
+-spec send_abandoned(t()) -> boolean().
+send_abandoned(#stream{aborted = Aborted, send_stopped = Stopped}) ->
+    Aborted orelse Stopped.
 
 -doc """
 Whether both directions are finished, so the stream can be pruned: the send FIN

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -31,6 +31,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     loop_conn_close_stops_worker/1,
     loop_stream_reset_delivers_disconnect/1,
     loop_push_flushes_per_event/1,
+    loop_backpressure_reset_while_parked/1,
     stream_response/1,
     stream_trailers/1,
     stream_autoclose/1,
@@ -99,6 +100,7 @@ all() ->
         loop_conn_close_stops_worker,
         loop_stream_reset_delivers_disconnect,
         loop_push_flushes_per_event,
+        loop_backpressure_reset_while_parked,
         stream_response,
         stream_trailers,
         stream_autoclose,
@@ -395,6 +397,32 @@ loop_push_flushes_per_event(Config) ->
     Worker ! {push, ~"e2"},
     _Acc2 = await_stream_bytes(Conn, StreamId, ~"data: e2\n\n", Acc1),
     Worker ! stop,
+    close(Conn).
+
+loop_backpressure_reset_while_parked(Config) ->
+    %% A loop worker blocked on a Push under a stalled per-stream send window
+    %% (the deferred-ack backpressure) is released and disconnected when the
+    %% client resets the stream — it does not hang in send_data forever.
+    Conn = connect(?config(port, Config), #{stream_window => 2000}),
+    {ok, StreamId} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
+    Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
+    true = register(roadrunner_h3_loop_observer, self()),
+    WorkerRef = monitor(process, Worker),
+    %% A push far larger than the 2000-byte per-stream window parks the worker
+    %% (the client withholds MAX_STREAM_DATA, so it cannot drain).
+    Worker ! {push, binary:copy(~"x", 16000)},
+    ok = roadrunner_quic_test_h3:cancel(Conn, StreamId),
+    receive
+        {handler_disconnect, Reason} -> ?assertEqual(reset, Reason)
+    after 5000 ->
+        ct:fail(disconnect_not_delivered)
+    end,
+    receive
+        {'DOWN', WorkerRef, process, Worker, _} -> ok
+    after 5000 ->
+        ct:fail(loop_worker_did_not_exit)
+    end,
+    true = unregister(roadrunner_h3_loop_observer),
     close(Conn).
 
 %% Accumulate the stream's raw bytes until they contain `Needle` (the SSE
@@ -1150,6 +1178,10 @@ udp_occupied_tcp_free_port() ->
 
 connect(Port) ->
     {ok, Conn} = roadrunner_quic_test_h3:connect({127, 0, 0, 1}, Port),
+    Conn.
+
+connect(Port, Opts) ->
+    {ok, Conn} = roadrunner_quic_test_h3:connect({127, 0, 0, 1}, Port, Opts),
     Conn.
 
 try_connect(Port) ->

--- a/test/roadrunner_http3_stream_worker_tests.erl
+++ b/test/roadrunner_http3_stream_worker_tests.erl
@@ -1,0 +1,61 @@
+-module(roadrunner_http3_stream_worker_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% sendfile_loop stops reading and sending the moment a chunk fails (the stream
+%% was reset / the connection closed), rather than looping over the rest of the
+%% file — which, on a dead stream under backpressure, would buffer the whole file
+%% onto a send buffer that can never drain.
+sendfile_loop_stops_on_send_error_test() ->
+    Path = "/tmp/rr_sendfile_loop_stop_test.bin",
+    %% Larger than ?SENDFILE_CHUNK_SIZE (64 KiB) so the loop takes the multi-chunk
+    %% (nofin) path where the stop-on-error branch lives.
+    ok = file:write_file(Path, binary:copy(~"x", 200000)),
+    {ok, IoDev} = file:open(Path, [read, raw, binary]),
+    Self = self(),
+    Send = fun(Data, nofin) ->
+        Self ! {sent, byte_size(Data)},
+        {error, closed}
+    end,
+    try
+        ?assertEqual(ok, roadrunner_http3_stream_worker:sendfile_loop(IoDev, 200000, Send))
+    after
+        _ = file:close(IoDev),
+        _ = file:delete(Path)
+    end,
+    %% Exactly one chunk was attempted; the {error, closed} stopped the loop
+    %% before reading or sending the rest of the file.
+    ?assertEqual(1, count_sent(0)).
+
+%% A successful loop sends every chunk and finishes with the FIN.
+sendfile_loop_sends_all_chunks_on_success_test() ->
+    Path = "/tmp/rr_sendfile_loop_ok_test.bin",
+    ok = file:write_file(Path, binary:copy(~"x", 200000)),
+    {ok, IoDev} = file:open(Path, [read, raw, binary]),
+    Self = self(),
+    Send = fun(Data, Flag) ->
+        Self ! {sent, byte_size(Data), Flag},
+        ok
+    end,
+    try
+        ?assertEqual(ok, roadrunner_http3_stream_worker:sendfile_loop(IoDev, 200000, Send))
+    after
+        _ = file:close(IoDev),
+        _ = file:delete(Path)
+    end,
+    Sends = collect_sends([]),
+    %% 200000 / 65536 = 3 full chunks + a 3392-byte remainder carrying the FIN.
+    ?assertEqual(200000, lists:sum([Size || {Size, _Flag} <- Sends])),
+    ?assertEqual([fin], [Flag || {_Size, Flag} <- Sends, Flag =:= fin]).
+
+count_sent(N) ->
+    receive
+        {sent, _} -> count_sent(N + 1)
+    after 0 -> N
+    end.
+
+collect_sends(Acc) ->
+    receive
+        {sent, Size, Flag} -> collect_sends([{Size, Flag} | Acc])
+    after 0 -> lists:reverse(Acc)
+    end.

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -931,6 +931,215 @@ reset_for_pruned_stream_ignored_test() ->
     {State3, _} = ?M:handle_datagram(?NOW, Rst, State2),
     ?assertEqual(connected, ?M:phase(State3)).
 
+%% --- deferred-ack backpressure (W3): park on a stalled stream, release on
+%% drain or on the stream/connection going away (so the worker never hangs) ---
+
+%% A payload larger than the initial congestion window cannot fully flush in one
+%% pass, so handle_send WITHHOLDS the reply (the worker blocks) while the
+%% credit-permitted bytes still go out. This is the primary backpressure branch.
+stalled_send_parks_reply_test() ->
+    {State, _ClientApSecret, ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {_State1, Effects} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(Effects, Ref)),
+    ?assertNotEqual([], sent_stream_frames(Effects, ServerApSecret)).
+
+%% A small send that fully drains in one pass is NOT parked: it replies ok
+%% immediately, exactly as before the fix (the healthy/common path).
+small_send_not_parked_test() ->
+    {State, _ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    {_State1, Effects} = ?M:handle_send(self(), Ref, 0, ~"hi", true, ?NOW, State),
+    ?assertEqual([ok], replies_for(Effects, Ref)).
+
+%% A control-stream send (server-uni, Sid 3) is NEVER parked even when it cannot
+%% fully flush — the conn-loop owner writes there synchronously and must not
+%% block.
+server_uni_send_not_parked_test() ->
+    {State, _ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {_State1, Effects} = ?M:handle_send(self(), Ref, 3, Payload, false, ?NOW, State),
+    ?assertEqual([ok], replies_for(Effects, Ref)).
+
+%% Growing the congestion window with a cumulative ACK drains the parked bytes
+%% and releases the deferred reply with ok — the release scan sits after
+%% process_ack in the same datagram fold, so the ACK-only credit path is covered.
+parked_reply_released_on_ack_credit_test() ->
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 13000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    Largest = largest_app_pn(E1, ServerApSecret),
+    Ack = app_datagram([{ack, Largest, 0, Largest, [], undefined}], 0, ClientApSecret),
+    {_State2, E2} = ?M:handle_datagram(?NOW, Ack, State1),
+    ?assertEqual([ok], replies_for(E2, Ref)).
+
+%% A peer RESET_STREAM while parked releases the reply with {error, closed} (not
+%% ok), so a streaming worker does not treat the data as sent and re-send.
+parked_reply_released_on_peer_reset_test() ->
+    {State, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    Reset = app_datagram([{reset_stream, 0, 7, 0}], 0, ClientApSecret),
+    {_State2, E2} = ?M:handle_datagram(?NOW, Reset, State1),
+    ?assertEqual([{error, closed}], replies_for(E2, Ref)).
+
+%% A peer STOP_SENDING while parked clears our send side and releases with
+%% {error, closed} (closing the pre-existing no-handler hang), and surfaces a
+%% stream reset to the owner so a response worker stops.
+parked_reply_released_on_peer_stop_sending_test() ->
+    {State, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    Stop = app_datagram([{stop_sending, 0, 7}], 0, ClientApSecret),
+    {_State2, E2} = ?M:handle_datagram(?NOW, Stop, State1),
+    ?assertEqual([{error, closed}], replies_for(E2, Ref)),
+    ?assert(lists:member({stream_reset, 0, 7}, [Ev || {emit, _Owner, Ev} <- E2])).
+
+%% A local reset (handle_call {reset_stream, _}) while a send on that stream is
+%% parked releases the parked reply with {error, closed}; it clears send_buf, so
+%% without the send_abandoned guard the generic drain scan would wrongly reply ok.
+parked_reply_released_on_local_reset_test() ->
+    {State, _ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    {_State2, E2} = ?M:handle_call(self(), make_ref(), {reset_stream, 0, 7}, ?NOW, State1),
+    ?assertEqual([{error, closed}], replies_for(E2, Ref)).
+
+%% A peer CONNECTION_CLOSE while parked drains every parked reply with
+%% {error, closed} (the draining transition skips the send pass), so the worker
+%% unblocks promptly instead of stalling the drain window.
+parked_reply_released_on_draining_test() ->
+    {State, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    Close = app_datagram(
+        [{connection_close, application, 9, undefined, <<>>}], 0, ClientApSecret
+    ),
+    {State2, E2} = ?M:handle_datagram(?NOW, Close, State1),
+    ?assertEqual(draining, ?M:phase(State2)),
+    ?assertEqual([{error, closed}], replies_for(E2, Ref)).
+
+%% An owner close while parked releases the parked reply with {error, closed}.
+parked_reply_released_on_owner_close_test() ->
+    {State, _ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    {State2, E2} = ?M:handle_call(self(), make_ref(), {close, 16#0100}, ?NOW, State1),
+    ?assertEqual(draining, ?M:phase(State2)),
+    ?assertEqual([{error, closed}], replies_for(E2, Ref)).
+
+%% An idle timeout while parked releases the parked reply with {error, closed}.
+parked_reply_released_on_idle_timeout_test() ->
+    {State, _ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    {State2, E2} = ?M:handle_timeout(?NOW, idle, State1),
+    ?assertEqual(closed, ?M:phase(State2)),
+    ?assertEqual([{error, closed}], replies_for(E2, Ref)).
+
+%% A parked reply stays parked across a send pass that drains some but not all
+%% of the buffer — backpressure holds until the buffer fully drains.
+parked_reply_kept_while_still_draining_test() ->
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    Largest = largest_app_pn(E1, ServerApSecret),
+    Ack = app_datagram([{ack, Largest, 0, Largest, [], undefined}], 0, ClientApSecret),
+    {_State2, E2} = ?M:handle_datagram(?NOW, Ack, State1),
+    %% One ACK grows the window by far less than the 100000-byte payload, so the
+    %% reply is still withheld.
+    ?assertEqual([], replies_for(E2, Ref)).
+
+%% A STOP_SENDING for a stream the server holds no send state for is ignored.
+stop_sending_for_untracked_stream_ignored_test() ->
+    {State, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Stop = app_datagram([{stop_sending, 8, 7}], 0, ClientApSecret),
+    {State1, _Effects} = ?M:handle_datagram(?NOW, Stop, State),
+    ?assertEqual(connected, ?M:phase(State1)).
+
+%% The final FIN-carrying push parks under the congestion window, then releases
+%% ok once the window opens; the FIN reaches the wire (loop termination does not
+%% deadlock).
+parked_fin_push_released_on_drain_test() ->
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 13000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, true, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    Largest = largest_app_pn(E1, ServerApSecret),
+    Ack = app_datagram([{ack, Largest, 0, Largest, [], undefined}], 0, ClientApSecret),
+    {_State2, E2} = ?M:handle_datagram(?NOW, Ack, State1),
+    ?assertEqual([ok], replies_for(E2, Ref)),
+    ?assert(
+        lists:any(
+            fun
+                ({stream, 0, _, _, true}) -> true;
+                (_) -> false
+            end,
+            sent_stream_frames(E2, ServerApSecret)
+        )
+    ).
+
+%% After a peer RESET_STREAM, the server must NOT re-send STREAM frames on the
+%% aborted stream even once the window opens (the aborted stream leaves the
+%% sendable set despite its buffered bytes).
+peer_reset_does_not_resend_test() ->
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    Largest = largest_app_pn(E1, ServerApSecret),
+    Reset = app_datagram([{reset_stream, 0, 7, 0}], 0, ClientApSecret),
+    {State2, _E2} = ?M:handle_datagram(?NOW, Reset, State1),
+    %% An ACK grows cwnd and frees the in-flight bytes; a non-aborted stream
+    %% would re-send here, but the aborted stream must stay silent.
+    Ack = app_datagram([{ack, Largest, 0, Largest, [], undefined}], 1, ClientApSecret),
+    {_State3, E3} = ?M:handle_datagram(?NOW, Ack, State2),
+    ?assertEqual([], sent_stream_frames(E3, ServerApSecret)).
+
+%% A send on an already-aborted stream replies {error, closed} at once (it does
+%% not park on a dead stream waiting for credit that will never come).
+send_on_aborted_stream_replies_error_test() ->
+    {State, ClientApSecret, _ServerApSecret} = connect_owned(),
+    {State1, _E1} = ?M:handle_send(self(), make_ref(), 0, ~"hi", false, ?NOW, State),
+    Reset = app_datagram([{reset_stream, 0, 7, 0}], 0, ClientApSecret),
+    {State2, _E2} = ?M:handle_datagram(?NOW, Reset, State1),
+    Ref = make_ref(),
+    {_State3, E3} = ?M:handle_send(self(), Ref, 0, ~"more", false, ?NOW, State2),
+    ?assertEqual([{error, closed}], replies_for(E3, Ref)).
+
+%% A parked reply is released exactly once: after the release, a later send pass
+%% does not emit a second {quic_reply} for the same Ref.
+parked_reply_not_double_released_test() ->
+    {State, ClientApSecret, _ServerApSecret} = connect_owned(),
+    Ref = make_ref(),
+    Payload = binary:copy(~"x", 100000),
+    {State1, E1} = ?M:handle_send(self(), Ref, 0, Payload, false, ?NOW, State),
+    ?assertEqual([], replies_for(E1, Ref)),
+    Reset = app_datagram([{reset_stream, 0, 7, 0}], 0, ClientApSecret),
+    {State2, E2} = ?M:handle_datagram(?NOW, Reset, State1),
+    ?assertEqual([{error, closed}], replies_for(E2, Ref)),
+    Ack = app_datagram([{ack, 0, 0, 0, [], undefined}], 1, ClientApSecret),
+    {_State3, E3} = ?M:handle_datagram(?NOW, Ack, State2),
+    ?assertEqual([], replies_for(E3, Ref)).
+
 %% As the peer opens bidi streams toward the advertised limit (test TP = 3), the
 %% server raises the limit and sends MAX_STREAMS so the peer can keep opening
 %% request streams (RFC 9000 §4.6). The first open is still within credit (no
@@ -1320,6 +1529,11 @@ sent_app_frames(Effects, ServerApSecret) ->
 
 emits(Effects) ->
     [Emit || {emit, _Owner, _Event} = Emit <- Effects].
+
+%% The reply results addressed to a given send Ref (a parked send emits none
+%% until released; a released one emits exactly one).
+replies_for(Effects, Ref) ->
+    [Result || {reply, _From, R, Result} <- Effects, R =:= Ref].
 
 %% The largest 1-RTT packet number among the server's sent datagrams, decoded
 %% with the server's application keys; used to acknowledge what is in flight.

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -13,7 +13,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -export([key_material/0, gen_keypair/0]).
--export([client_hello_framed/3]).
+-export([client_hello_framed/3, client_hello_framed/4]).
 -export([seal/6, seal_raw/6]).
 -export([crypto_bytes/4, frames/4]).
 -export([server_hello_key_share/1, deframe_all/1]).
@@ -80,12 +80,26 @@ first transcript element.
     Scheme :: non_neg_integer(), ClientPub :: binary(), ClientSCID :: binary() | none
 ) -> binary().
 client_hello_framed(Scheme, ClientPub, ClientSCID) ->
+    client_hello_framed(Scheme, ClientPub, ClientSCID, 800000).
+
+-doc """
+As `client_hello_framed/3` but advertising `StreamWindow` as the per-stream
+flow-control limit (initial_max_stream_data_*), so a test can pin a small
+per-stream send window on the server to exercise stream-level backpressure.
+""".
+-spec client_hello_framed(
+    Scheme :: non_neg_integer(),
+    ClientPub :: binary(),
+    ClientSCID :: binary() | none,
+    StreamWindow :: non_neg_integer()
+) -> binary().
+client_hello_framed(Scheme, ClientPub, ClientSCID, StreamWindow) ->
     Random = crypto:strong_rand_bytes(32),
     Extensions = iolist_to_binary([
         signature_algorithms_ext([Scheme]),
         alpn_ext(~"h3"),
         key_share_ext(ClientPub),
-        transport_params_ext(ClientSCID)
+        transport_params_ext(ClientSCID, StreamWindow)
     ]),
     CipherSuites = <<?CIPHER_AES_128_GCM_SHA256:16>>,
     Body =
@@ -111,16 +125,18 @@ key_share_ext(PubKey) ->
 %% windows are what the server seeds its send windows from (deliberately
 %% distinct from roadrunner_quic_flow's 786432 default, so a send test proves
 %% the window is the client's advertised value, not a hardcoded fallback).
-%% `none` emits no extension at all.
-transport_params_ext(none) ->
+%% `none` emits no extension at all. `StreamWindow` is the advertised
+%% per-stream limit (default 800000); a test pins a small value to make the
+%% server's per-stream send window the binding constraint.
+transport_params_ext(none, _StreamWindow) ->
     <<>>;
-transport_params_ext(ClientSCID) ->
+transport_params_ext(ClientSCID, StreamWindow) ->
     Body = iolist_to_binary(
         roadrunner_quic_transport_params:encode(#{
             initial_source_connection_id => ClientSCID,
             initial_max_data => 800000,
-            initial_max_stream_data_bidi_local => 800000,
-            initial_max_stream_data_uni => 800000
+            initial_max_stream_data_bidi_local => StreamWindow,
+            initial_max_stream_data_uni => StreamWindow
         })
     ),
     extension(?EXT_QUIC_TRANSPORT_PARAMS, Body).

--- a/test/roadrunner_quic_test_conn.erl
+++ b/test/roadrunner_quic_test_conn.erl
@@ -31,7 +31,17 @@
 
 -include_lib("public_key/include/public_key.hrl").
 
--export([connect/2, close/1, open_bidi/1, open_uni/1, send/4, reset_stream/3, stop_sending/3]).
+-export([
+    connect/2,
+    connect/3,
+    close/1,
+    open_bidi/1,
+    open_uni/1,
+    send/4,
+    reset_stream/3,
+    stop_sending/3,
+    grant_stream_credit/3
+]).
 
 %% v1 connection-id length and signature scheme (the test cert is RSA).
 -define(CID_LEN, 8).
@@ -105,9 +115,19 @@ HANDSHAKE_DONE arrives) or the handshake fails. Returns the connection pid.
 -spec connect(inet:ip_address() | inet:hostname(), inet:port_number()) ->
     {ok, pid()} | {error, term()}.
 connect(Host, Port) ->
+    connect(Host, Port, #{}).
+
+-doc """
+As `connect/2` but with `Opts`. `stream_window => N` advertises a small
+per-stream flow-control window so a test can exercise stream-level
+backpressure on the server (default 800000).
+""".
+-spec connect(inet:ip_address() | inet:hostname(), inet:port_number(), map()) ->
+    {ok, pid()} | {error, term()}.
+connect(Host, Port, Opts) ->
     Ref = make_ref(),
     Parent = self(),
-    {Pid, Mon} = spawn_monitor(fun() -> init(Parent, Ref, Host, Port) end),
+    {Pid, Mon} = spawn_monitor(fun() -> init(Parent, Ref, Host, Port, Opts) end),
     receive
         {Ref, connected} ->
             erlang:demonitor(Mon, [flush]),
@@ -169,6 +189,15 @@ reset_stream(Pid, StreamId, ErrorCode) ->
 stop_sending(Pid, StreamId, ErrorCode) ->
     cast_frame(Pid, {stop_sending, StreamId, ErrorCode}).
 
+-doc """
+Grant `StreamId` more send credit by sending a MAX_STREAM_DATA raising its
+limit to `MaxStreamData` (RFC 9000 §19.10), so a server stalled on a small
+per-stream window resumes sending.
+""".
+-spec grant_stream_credit(pid(), non_neg_integer(), non_neg_integer()) -> ok.
+grant_stream_credit(Pid, StreamId, MaxStreamData) ->
+    cast_frame(Pid, {max_stream_data, StreamId, MaxStreamData}).
+
 cast_frame(Pid, Frame) ->
     Ref = make_ref(),
     Pid ! {frame, self(), Ref, Frame},
@@ -191,13 +220,17 @@ call(Pid, Request) ->
 %% Handshake
 %% =============================================================================
 
--spec init(pid(), reference(), inet:ip_address() | inet:hostname(), inet:port_number()) -> ok.
-init(Parent, Ref, Host, Port) ->
+-spec init(pid(), reference(), inet:ip_address() | inet:hostname(), inet:port_number(), map()) ->
+    ok.
+init(Parent, Ref, Host, Port, Opts) ->
     {ok, Socket} = roadrunner_quic_socket:open(0),
     Dcid0 = crypto:strong_rand_bytes(?CID_LEN),
     Scid = crypto:strong_rand_bytes(?CID_LEN),
     {EphPub, EphPriv} = crypto:generate_key(ecdh, x25519),
-    ChFramed = roadrunner_quic_test_client:client_hello_framed(?SIG_SCHEME, EphPub, Scid),
+    StreamWindow = maps:get(stream_window, Opts, 800000),
+    ChFramed = roadrunner_quic_test_client:client_hello_framed(
+        ?SIG_SCHEME, EphPub, Scid, StreamWindow
+    ),
     %% Send the Initial carrying the ClientHello (padded to 1200 by seal/6).
     ClientInitialKeys = roadrunner_quic_keys:initial_client(Dcid0),
     Initial = roadrunner_quic_test_client:seal(

--- a/test/roadrunner_quic_test_h3.erl
+++ b/test/roadrunner_quic_test_h3.erl
@@ -15,9 +15,10 @@
 %% send_data, collect) are offered, so a test can interleave work between the
 %% request and the response.
 
--export([connect/2, close/1]).
+-export([connect/2, connect/3, close/1]).
 -export([get/2, post/3, request/3]).
 -export([open_request/2, open_request/3, send_data/4, collect/2, cancel/2, get_peer_settings/1]).
+-export([grant_stream_credit/3]).
 
 -define(COLLECT_TIMEOUT, 5000).
 %% RFC 9114 §8.1 H3_REQUEST_CANCELLED.
@@ -34,7 +35,16 @@ with a SETTINGS frame. Returns the underlying connection handle.
 -spec connect(inet:ip_address() | inet:hostname(), inet:port_number()) ->
     {ok, pid()} | {error, term()}.
 connect(Host, Port) ->
-    case roadrunner_quic_test_conn:connect(Host, Port) of
+    connect(Host, Port, #{}).
+
+-doc """
+As `connect/2` but with `Opts` passed to the underlying QUIC connection
+(e.g. `stream_window => N` to advertise a small per-stream window).
+""".
+-spec connect(inet:ip_address() | inet:hostname(), inet:port_number(), map()) ->
+    {ok, pid()} | {error, term()}.
+connect(Host, Port, Opts) ->
+    case roadrunner_quic_test_conn:connect(Host, Port, Opts) of
         {ok, Conn} ->
             Control = roadrunner_quic_test_conn:open_uni(Conn),
             ok = roadrunner_quic_test_conn:send(Conn, Control, control_with_settings(), false),
@@ -42,6 +52,11 @@ connect(Host, Port) ->
         {error, _} = Error ->
             Error
     end.
+
+-doc "Grant `StreamId` more send credit (MAX_STREAM_DATA) so a stalled server resumes.".
+-spec grant_stream_credit(pid(), non_neg_integer(), non_neg_integer()) -> ok.
+grant_stream_credit(Conn, StreamId, MaxStreamData) ->
+    roadrunner_quic_test_conn:grant_stream_credit(Conn, StreamId, MaxStreamData).
 
 -doc "Close the connection.".
 -spec close(pid()) -> ok.


### PR DESCRIPTION
# Description

On HTTP/3, `roadrunner_quic:send_data` is synchronous but the connection replied `ok` on enqueue, so a stalled client (closed flow / congestion window) let a stream's send buffer grow without bound. Defer the reply until the stream drains, so the loop handler's `Push` blocks under stall instead of buffering forever, mirroring HTTP/2's flow-window backpressure. The reply releases on drain, or with an error when the stream's send side is abandoned by a reset / STOP_SENDING.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)