### PR TITLE
Add opt-in PROXY protocol for the real client peer

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -412,26 +412,6 @@ for free.
 **Scope:** small. A thin wrapper over the streaming response shape plus
 the content-type default.
 
-### PROXY protocol for the real client address — medium
-
-**What:** Parse the PROXY protocol header (v1 text and v2 binary) that a
-TCP load balancer (haproxy, AWS NLB, and friends) prepends before the
-first request byte, and populate `roadrunner_req:peer/1` with the real
-client address instead of the balancer's. Opt-in per listener, since
-trusting that header from an untrusted peer would let a client spoof its
-own address.
-
-**Why deferred:** direct-to-internet and TLS-terminating-proxy
-deployments do not need it (the socket peer is already the client, or the
-proxy speaks HTTP and can set `Forwarded`). It matters specifically
-behind an L4 balancer, where today the peer address is the balancer's.
-Real-IP-aware logging, the per-peer rate guard, and any geo or authz
-keyed on client IP all depend on it.
-
-**Scope:** medium. A pre-request parse stage on accept (gated by a
-listener opt), plus threading the parsed address into the request's peer
-field across h1, h2, and h3.
-
 ### Decide handler 1xx response handling uniformly — small
 
 **What:** A handler that returns a status of 100..199 has it sent as the

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -122,6 +122,11 @@
     %% SSE / WebSocket handlers depend on it. Short-lived h1
     %% workloads can opt out for ~10% lower per-conn overhead.
     graceful_drain => boolean(),
+    %% When `true`, `roadrunner_conn_loop:awaiting_shoot/3` reads and strips a
+    %% PROXY-protocol header (an L4 balancer prepends it) before serving, and
+    %% the request peer is the real client. TCP-only; the listener rejects it on
+    %% an HTTP/3-only listener.
+    proxy_protocol => boolean(),
     %% Enabled protocols as a flat atom list in user-supplied (ALPN
     %% preference) order. On plain TCP with `[http2]`,
     %% `roadrunner_conn_loop:awaiting_shoot/3` routes straight to the

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -156,63 +156,21 @@ init_loop(Parent, Socket, ProtoOpts) ->
 awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
     receive
         shoot ->
-            %% Socket ownership has just transferred from the acceptor —
-            %% refine the proc_lib label with the peer (which we couldn't
-            %% know on init/1 because the OS-level socket wasn't ours yet).
-            Peer = roadrunner_conn:peer(Socket),
-            ok = roadrunner_conn:refine_conn_label(ProtoOpts, Peer),
-            Scheme = roadrunner_conn:scheme(Socket),
-            StartMono = roadrunner_telemetry:listener_accept(#{
-                listener_name => ListenerName, peer => Peer
-            }),
-            case http2_negotiated(Socket) orelse h2c_only(ProtoOpts) of
-                true ->
-                    %% Either ALPN landed on `h2` (TLS listener) or the
-                    %% listener is in prior-knowledge h2c mode (plain TCP
-                    %% with `protocols => [http2]`). The HTTP/2 path takes
-                    %% over; slot release and `listener_conn_close` happen
-                    %% inside the h2 module.
-                    roadrunner_conn_loop_http2:enter(
-                        Socket, ProtoOpts, ListenerName, Peer, StartMono
-                    );
-                false ->
-                    #{
-                        requests_counter := RequestsCounter,
-                        dispatch := Dispatch,
-                        middlewares := Middlewares,
-                        max_content_length := MaxContentLength,
-                        max_keep_alive_requests := MaxKeepAliveRequests,
-                        min_bytes_per_second := MinRate,
-                        request_timeout := RequestTimeout,
-                        keep_alive_timeout := KeepAliveTimeout,
-                        body_buffering := BodyBuffering
-                    } = ProtoOpts,
-                    S = #loop_state{
-                        socket = Socket,
-                        proto_opts = ProtoOpts,
-                        listener_name = ListenerName,
-                        start_mono = StartMono,
-                        peer = Peer,
-                        scheme = Scheme,
-                        requests_counter = RequestsCounter,
-                        dispatch = Dispatch,
-                        middlewares = Middlewares,
-                        max_content_length = MaxContentLength,
-                        max_keep_alive_requests = MaxKeepAliveRequests,
-                        min_rate = MinRate,
-                        request_timeout = RequestTimeout,
-                        keep_alive_timeout = KeepAliveTimeout,
-                        body_buffering = BodyBuffering,
-                        hibernate_after = maps:get(hibernate_after, ProtoOpts, 0),
-                        alt_svc = maps:get(alt_svc, ProtoOpts, undefined),
-                        http1_limits = {
-                            maps:get(http1_max_request_line, ProtoOpts, 8192),
-                            maps:get(http1_max_header_line, ProtoOpts, 8192),
-                            maps:get(http1_max_header_block, ProtoOpts, 10240),
-                            maps:get(http1_max_header_count, ProtoOpts, 100)
-                        }
-                    },
-                    read_request_phase(S)
+            %% Socket ownership has just transferred from the acceptor. If the
+            %% listener enabled the PROXY protocol, read and strip the header an
+            %% L4 balancer prepended so we serve the real client peer; otherwise
+            %% the OS peer passes through unchanged.
+            OsPeer = roadrunner_conn:peer(Socket),
+            case proxy_protocol_stage(Socket, ProtoOpts, OsPeer) of
+                {ok, Peer, Buffered} ->
+                    serve(Socket, ProtoOpts, ListenerName, Peer, Buffered);
+                close ->
+                    %% Malformed/absent PROXY header on a proxy_protocol
+                    %% listener (a misconfigured upstream). No accept telemetry
+                    %% has fired yet (it pairs with the real peer in serve/5),
+                    %% so release the slot and close silently, like the
+                    %% pre-`shoot` drain path below.
+                    exit_clean(Socket, ProtoOpts, undefined, undefined, ListenerName, 0, normal)
             end;
         {roadrunner_drain, _Deadline} ->
             %% Drain before `shoot` — no telemetry was fired yet (accept
@@ -224,6 +182,114 @@ awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
             %% silently; we do the same so a buggy library can't crash the
             %% conn with a typo'd message.
             awaiting_shoot(Socket, ProtoOpts, ListenerName)
+    end.
+
+%% Begin serving a connection once the peer is settled (the real client when
+%% the PROXY protocol is on). Fires the accept telemetry, refines the proc_lib
+%% label, then forks to HTTP/2 (ALPN `h2` or prior-knowledge h2c) or HTTP/1.
+%% `Buffered` seeds the read buffer with any bytes a coalesced segment carried
+%% after a stripped PROXY header (empty on the normal path).
+-spec serve(
+    roadrunner_transport:socket(),
+    roadrunner_conn:proto_opts(),
+    atom(),
+    {inet:ip_address(), inet:port_number()} | undefined,
+    binary()
+) -> no_return().
+serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
+    ok = roadrunner_conn:refine_conn_label(ProtoOpts, Peer),
+    Scheme = roadrunner_conn:scheme(Socket),
+    StartMono = roadrunner_telemetry:listener_accept(#{
+        listener_name => ListenerName, peer => Peer
+    }),
+    case http2_negotiated(Socket) orelse h2c_only(ProtoOpts) of
+        true ->
+            %% Either ALPN landed on `h2` (TLS listener) or the listener is in
+            %% prior-knowledge h2c mode (plain TCP with `protocols => [http2]`).
+            %% The HTTP/2 path takes over; slot release and `listener_conn_close`
+            %% happen inside the h2 module.
+            roadrunner_conn_loop_http2:enter(
+                Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered
+            );
+        false ->
+            #{
+                requests_counter := RequestsCounter,
+                dispatch := Dispatch,
+                middlewares := Middlewares,
+                max_content_length := MaxContentLength,
+                max_keep_alive_requests := MaxKeepAliveRequests,
+                min_bytes_per_second := MinRate,
+                request_timeout := RequestTimeout,
+                keep_alive_timeout := KeepAliveTimeout,
+                body_buffering := BodyBuffering
+            } = ProtoOpts,
+            S = #loop_state{
+                socket = Socket,
+                proto_opts = ProtoOpts,
+                listener_name = ListenerName,
+                start_mono = StartMono,
+                peer = Peer,
+                scheme = Scheme,
+                buffered = Buffered,
+                requests_counter = RequestsCounter,
+                dispatch = Dispatch,
+                middlewares = Middlewares,
+                max_content_length = MaxContentLength,
+                max_keep_alive_requests = MaxKeepAliveRequests,
+                min_rate = MinRate,
+                request_timeout = RequestTimeout,
+                keep_alive_timeout = KeepAliveTimeout,
+                body_buffering = BodyBuffering,
+                hibernate_after = maps:get(hibernate_after, ProtoOpts, 0),
+                alt_svc = maps:get(alt_svc, ProtoOpts, undefined),
+                http1_limits = {
+                    maps:get(http1_max_request_line, ProtoOpts, 8192),
+                    maps:get(http1_max_header_line, ProtoOpts, 8192),
+                    maps:get(http1_max_header_block, ProtoOpts, 10240),
+                    maps:get(http1_max_header_count, ProtoOpts, 100)
+                }
+            },
+            read_request_phase(S)
+    end.
+
+%% Read and strip a PROXY-protocol header when the listener enabled it. Returns
+%% `{ok, Peer, Leftover}` — the real client peer on a PROXY command, the OS peer
+%% on a LOCAL/UNKNOWN one — or `close` on a malformed header or read error. With
+%% the opt off the OS peer passes straight through and no bytes are read.
+-spec proxy_protocol_stage(
+    roadrunner_transport:socket(),
+    roadrunner_conn:proto_opts(),
+    {inet:ip_address(), inet:port_number()} | undefined
+) -> {ok, {inet:ip_address(), inet:port_number()} | undefined, binary()} | close.
+proxy_protocol_stage(Socket, #{proxy_protocol := ProxyProto} = ProtoOpts, OsPeer) ->
+    case ProxyProto of
+        false -> {ok, OsPeer, <<>>};
+        true -> read_proxy_header(Socket, ProtoOpts, OsPeer, <<>>)
+    end.
+
+%% The socket is passive at this phase, so read synchronously, accumulating
+%% until `roadrunner_proxy_protocol:parse/1` decides. The parser bounds the
+%% header size (v1 107 bytes, v2 by its declared length), so `Acc` cannot grow
+%% without bound, and each recv carries the per-request timeout against a
+%% dribbling sender.
+-spec read_proxy_header(
+    roadrunner_transport:socket(),
+    roadrunner_conn:proto_opts(),
+    {inet:ip_address(), inet:port_number()} | undefined,
+    binary()
+) -> {ok, {inet:ip_address(), inet:port_number()} | undefined, binary()} | close.
+read_proxy_header(Socket, #{request_timeout := Timeout} = ProtoOpts, OsPeer, Acc) ->
+    case roadrunner_transport:recv(Socket, 0, Timeout) of
+        {ok, Bytes} ->
+            Buf = <<Acc/binary, Bytes/binary>>,
+            case roadrunner_proxy_protocol:parse(Buf) of
+                {ok, Peer, Rest} -> {ok, Peer, Rest};
+                {local, Rest} -> {ok, OsPeer, Rest};
+                more -> read_proxy_header(Socket, ProtoOpts, OsPeer, Buf);
+                {error, _Reason} -> close
+            end;
+        {error, _} ->
+            close
     end.
 
 %% True iff the TLS handshake negotiated `h2`. Plain TCP and TLS

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -52,7 +52,7 @@
 %% | `{sendfile, _}` | yes (chunked DATA via the stream-response engine) |
 %% | `{websocket, _, _}` | 501 (Phase H13) |
 
--export([enter/5]).
+-export([enter/6]).
 
 %% Hibernate continuation — invoked via `erlang:hibernate/3` when an
 %% idle conn parks past `hibernate_after`. Must stay exported so the
@@ -205,42 +205,42 @@
     conn_send_window = 65535 :: integer(),
     conn_recv_window = 65535 :: non_neg_integer(),
     %% Configured peaks + refill threshold. Read from proto_opts at
-    %% `enter/5`. See the `?DEFAULT_*` macros above for the policy
+    %% `enter/6`. See the `?DEFAULT_*` macros above for the policy
     %% baseline + the listener moduledoc for the override knobs.
     recv_window_peak = ?DEFAULT_CONN_RECV_WINDOW :: pos_integer(),
     stream_recv_window_peak = ?DEFAULT_STREAM_RECV_WINDOW :: pos_integer(),
     recv_window_threshold = ?DEFAULT_WINDOW_REFILL_THRESHOLD :: pos_integer(),
     %% Max concurrent client-initiated streams: advertised in our SETTINGS
-    %% and enforced in `on_headers/5`. Read from proto_opts at `enter/5`.
+    %% and enforced in `on_headers/5`. Read from proto_opts at `enter/6`.
     max_concurrent_streams = ?MAX_CONCURRENT_STREAMS :: pos_integer(),
     %% Cumulative HEADERS+CONTINUATION block cap (CONTINUATION-flood guard).
-    %% Read from proto_opts at `enter/5`.
+    %% Read from proto_opts at `enter/6`.
     max_header_block = ?MAX_HEADER_BLOCK :: pos_integer(),
     %% Request-body cap (`max_content_length` listener opt); an over-cap
     %% body answers 413 + RST_STREAM(NO_ERROR). Read from proto_opts at
-    %% `enter/5`.
+    %% `enter/6`.
     max_content_length = ?DEFAULT_MAX_CONTENT_LENGTH :: non_neg_integer(),
     %% Decoded header-list cap (RFC 9113 §6.5.2 SETTINGS_MAX_HEADER_LIST_SIZE):
     %% advertised in our SETTINGS and enforced after HPACK decode in
-    %% `finalize_headers/2`. Read from proto_opts at `enter/5`.
+    %% `finalize_headers/2`. Read from proto_opts at `enter/6`.
     max_header_list_size = ?DEFAULT_MAX_HEADER_LIST_SIZE :: pos_integer(),
     %% `proto_opts.hibernate_after`, or 0 when unset (the common case).
     %% When > 0 and no streams are in flight, the idle-wait path parks
-    %% for this window and hibernates. Read from proto_opts at `enter/5`.
+    %% for this window and hibernates. Read from proto_opts at `enter/6`.
     hibernate_after = 0 :: non_neg_integer(),
-    %% Read-deadline caps, cached once at `enter/5` so the per-iteration
+    %% Read-deadline caps, cached once at `enter/6` so the per-iteration
     %% handshake/idle waits read a record field instead of re-reading
     %% persistent_term every loop. The persistent_term override (a test
-    %% hook) is captured at `enter/5`, so it must be set before connect.
+    %% hook) is captured at `enter/6`, so it must be set before connect.
     handshake_timeout = ?HANDSHAKE_TIMEOUT_DEFAULT :: non_neg_integer(),
     idle_timeout = ?IDLE_TIMEOUT_DEFAULT :: non_neg_integer(),
     %% Precomputed `Alt-Svc` value (h3 co-serving), or `undefined`.
     %% Prepended to every response by `roadrunner_http:auto_headers/2`.
-    %% Read from proto_opts at `enter/5`.
+    %% Read from proto_opts at `enter/6`.
     alt_svc = undefined :: binary() | undefined,
     %% In-flight-request slot accounting (cross-listener cap). `infinity`
     %% (default) disables it; `inflight_counter` is the shared gauge.
-    %% Read from proto_opts at `enter/5` so the per-stream acquire/release
+    %% Read from proto_opts at `enter/6` so the per-stream acquire/release
     %% passes them to `roadrunner_conn` directly. See `dispatch_stream/2`.
     max_concurrent_requests = infinity :: infinity | pos_integer(),
     inflight_counter :: counters:counters_ref() | undefined,
@@ -270,15 +270,20 @@
 Top-level entry from the HTTP/1.1 dispatch fork. Owns the socket
 from this point on; takes responsibility for releasing the listener
 slot and firing `[roadrunner, listener, conn_close]` telemetry.
+
+`Buffered` seeds the connection's initial read buffer — the bytes a
+coalesced TCP segment carried after a stripped PROXY-protocol header
+(which may be the start of the client preface). Empty for the normal path.
 """.
 -spec enter(
     roadrunner_transport:socket(),
     roadrunner_conn:proto_opts(),
     atom(),
     {inet:ip_address(), inet:port_number()} | undefined,
-    integer()
+    integer(),
+    binary()
 ) -> no_return().
-enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
+enter(Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered) ->
     proc_lib:set_label({roadrunner_conn_loop_http2, ListenerName, Peer}),
     Scheme = roadrunner_conn:scheme(Socket),
     {Data, Closed, Error} = roadrunner_transport:messages(Socket),
@@ -316,6 +321,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono) ->
         msg_error = Error,
         hpack_dec = roadrunner_http2_hpack:new_decoder(?HPACK_TABLE_SIZE),
         hpack_enc = roadrunner_http2_hpack:new_encoder(?HPACK_TABLE_SIZE),
+        buffer = Buffered,
         recv_window_peak = ConnPeak,
         stream_recv_window_peak = StreamPeak,
         recv_window_threshold = Threshold,

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -213,6 +213,12 @@ ops-tuning rationale.
     %% WebSocket) still rely on this — keep `true` if your handlers
     %% have those.
     graceful_drain => boolean(),
+    %% Opt in to the PROXY protocol (HAProxy v1 text / v2 binary). When `true`,
+    %% the connection reads and strips the header an L4 balancer prepends before
+    %% the first byte, so `roadrunner_req:peer/1` is the real client. TCP-only:
+    %% rejected on an HTTP/3-only listener. Trust it only behind a balancer that
+    %% always prepends the header (otherwise a direct peer can spoof its IP).
+    proxy_protocol => boolean(),
     %% When set, the per-connection process auto-hibernates after
     %% `Ms` milliseconds of idle main-loop time. Most useful for
     %% long-lived keep-alive HTTP/1.1 connections that mostly sit
@@ -937,6 +943,20 @@ spawn_acceptors_loop(LSocket, ProtoOpts, I, N) ->
     {ok, _Pid} = roadrunner_acceptor:start_link(LSocket, ProtoOpts, I),
     spawn_acceptors_loop(LSocket, ProtoOpts, I + 1, N).
 
+%% Validate the opt-in `proxy_protocol` listener opt. It is a TCP-stream
+%% feature (an L4 balancer prepends the header before the first byte), so it
+%% conflicts with an HTTP/3-only (UDP) listener; on a mixed `[http1, http3]`
+%% listener the TCP side honors it and h3 ignores it.
+-spec validate_proxy_protocol(term(), [http1 | http2 | http3, ...]) -> boolean().
+validate_proxy_protocol(false, _Protocols) ->
+    false;
+validate_proxy_protocol(true, [http3]) ->
+    error({listener_opt_conflict, proxy_protocol, true, no_tcp_listener});
+validate_proxy_protocol(true, _Protocols) ->
+    true;
+validate_proxy_protocol(Other, _Protocols) ->
+    error({invalid_listener_opt, proxy_protocol, Other}).
+
 -spec build_proto_opts(opts(), atom()) -> roadrunner_conn:proto_opts().
 build_proto_opts(Opts, ListenerName) ->
     %% Validate + normalize the `protocols` list. Public input may
@@ -1001,6 +1021,9 @@ build_proto_opts(Opts, ListenerName) ->
             graceful_drain => maps:get(graceful_drain, Opts, true),
             handler_spawn_opts => HandlerSpawnOpts,
             handler_start_timeout => HandlerStartTimeout,
+            proxy_protocol => validate_proxy_protocol(
+                maps:get(proxy_protocol, Opts, false), Protocols
+            ),
             protocols => Protocols
         }),
         ProtoFlats

--- a/src/roadrunner_proxy_protocol.erl
+++ b/src/roadrunner_proxy_protocol.erl
@@ -1,0 +1,196 @@
+-module(roadrunner_proxy_protocol).
+-moduledoc false.
+
+%% The HAProxy PROXY protocol header parser (v1 text and v2 binary), used by
+%% the connection loop when a listener sets `proxy_protocol => true`. An L4
+%% (TCP) load balancer prepends this header before the first application byte
+%% so the server learns the real client address instead of the balancer's.
+%%
+%% Pure and socket-free: the conn loop reads bytes off the (passive) socket
+%% and feeds them here; `parse/1` returns one of
+%%
+%% - `{ok, {Ip, Port}, Rest}` — a PROXY command carrying the real client
+%%   address; `Rest` is the bytes after the header (the start of the first
+%%   request / the h2 preface, which a coalesced segment can carry).
+%% - `{local, Rest}` — a LOCAL command (v2) or `UNKNOWN` transport (v1): the
+%%   sender is the balancer's own health check, so keep the OS peer.
+%% - `more` — the buffer holds a valid prefix of a header but not the whole
+%%   thing yet; read more bytes and call again with the accumulated buffer.
+%% - `{error, Reason}` — not a PROXY header, or a malformed one. The caller
+%%   closes the connection (the opt is only set behind a trusted balancer
+%%   that ALWAYS prepends the header, so a missing/bad one is a hard error).
+%%
+%% v1: RFC-less HAProxy spec §2.1 — `PROXY TCP4 <src> <dst> <sport> <dport>\r\n`
+%% (or `TCP6`, or `UNKNOWN`), at most 107 bytes including the CRLF.
+%% v2: spec §2.2 — a 12-byte signature, a version/command byte, an
+%% address-family/transport byte, a 16-bit address-block length, then the
+%% addresses (and optional TLVs, which we skip).
+
+-export([parse/1]).
+
+-on_load(init_patterns/0).
+
+%% Compiled binary:split patterns, stashed in persistent_term at load (the
+%% project convention — never inline-compile on the path).
+-define(CRLF_CP_KEY, {?MODULE, crlf_cp}).
+-define(SPACE_CP_KEY, {?MODULE, space_cp}).
+
+%% v2 signature: the fixed 12 bytes that open every binary header (spec §2.2).
+-define(V2_SIG, 16#0D, 16#0A, 16#0D, 16#0A, 16#00, 16#0D, 16#0A, 16#51, 16#55, 16#49, 16#54, 16#0A).
+-define(V2_SIG_BIN, <<?V2_SIG>>).
+%% A v1 header (including the CRLF) never exceeds 107 bytes.
+-define(V1_MAX, 107).
+
+-type peer() :: {inet:ip_address(), inet:port_number()}.
+
+-doc """
+Parse a leading PROXY header from `Bin`. See the moduledoc for the result
+shapes. `Bin` is the bytes accumulated so far; on `more`, accumulate more and
+call again.
+""".
+-spec parse(binary()) ->
+    {ok, peer(), binary()} | {local, binary()} | more | {error, term()}.
+parse(<<?V2_SIG, Rest/binary>>) ->
+    parse_v2(Rest);
+parse(<<"PROXY ", Rest/binary>>) ->
+    parse_v1(Rest);
+parse(Bin) ->
+    %% Not yet a recognizable header. If the bytes are still a prefix of a v1
+    %% or v2 signature, more may complete it; otherwise it is not a PROXY
+    %% header at all.
+    case is_prefix(Bin, ?V2_SIG_BIN) orelse is_prefix(Bin, <<"PROXY ">>) of
+        true -> more;
+        false -> {error, not_proxy_header}
+    end.
+
+%% =============================================================================
+%% v1 (text)
+%% =============================================================================
+
+%% `Rest` is everything after the `PROXY ` prefix. The line ends at the first
+%% CRLF; the whole header (prefix included) must fit in 107 bytes.
+-spec parse_v1(binary()) -> {ok, peer(), binary()} | {local, binary()} | more | {error, term()}.
+parse_v1(Rest) ->
+    case binary:split(Rest, persistent_term:get(?CRLF_CP_KEY)) of
+        [Line, After] when byte_size(Line) =< ?V1_MAX - 8 ->
+            %% 8 = byte_size("PROXY ") + byte_size("\r\n").
+            parse_v1_fields(
+                binary:split(Line, persistent_term:get(?SPACE_CP_KEY), [global]), After
+            );
+        [Line, _After] when byte_size(Line) > ?V1_MAX - 8 ->
+            {error, v1_too_long};
+        [Partial] when byte_size(Partial) =< ?V1_MAX - 8 ->
+            %% No CRLF yet, still within the size budget — wait for more.
+            more;
+        [_Partial] ->
+            {error, v1_too_long}
+    end.
+
+-spec parse_v1_fields([binary()], binary()) ->
+    {ok, peer(), binary()} | {local, binary()} | {error, term()}.
+parse_v1_fields([Proto, SrcIp, _DstIp, SrcPort, _DstPort], After) when
+    Proto =:= ~"TCP4"; Proto =:= ~"TCP6"
+->
+    maybe
+        {ok, Ip} ?= parse_ip(SrcIp, Proto),
+        {ok, Port} ?= parse_port(SrcPort),
+        {ok, {Ip, Port}, After}
+    end;
+parse_v1_fields([~"UNKNOWN" | _], After) ->
+    %% `UNKNOWN`: the sender could not determine the addresses (e.g. a health
+    %% check). Keep the OS peer; the remaining fields, if any, are ignored.
+    {local, After};
+parse_v1_fields(_, _After) ->
+    {error, v1_malformed}.
+
+-spec parse_ip(binary(), binary()) -> {ok, inet:ip_address()} | {error, term()}.
+parse_ip(Bin, Proto) ->
+    case inet:parse_address(binary_to_list(Bin)) of
+        {ok, Ip} when Proto =:= ~"TCP4", tuple_size(Ip) =:= 4 -> {ok, Ip};
+        {ok, Ip} when Proto =:= ~"TCP6", tuple_size(Ip) =:= 8 -> {ok, Ip};
+        _ -> {error, v1_bad_address}
+    end.
+
+-spec parse_port(binary()) -> {ok, inet:port_number()} | {error, term()}.
+parse_port(Bin) ->
+    case string:to_integer(Bin) of
+        {Port, <<>>} when is_integer(Port), Port >= 0, Port =< 65535 -> {ok, Port};
+        _ -> {error, v1_bad_port}
+    end.
+
+%% =============================================================================
+%% v2 (binary)
+%% =============================================================================
+
+%% `Rest` is everything after the 12-byte signature: the version/command byte,
+%% the family/transport byte, a 16-bit address-block length, then that many
+%% bytes of address block (and optional TLVs we skip), then the leftover.
+-spec parse_v2(binary()) -> {ok, peer(), binary()} | {local, binary()} | more | {error, term()}.
+parse_v2(<<Ver:4, Cmd:4, Fam:4, Trans:4, Len:16, Body:Len/binary, After/binary>>) when
+    Ver =:= 2
+->
+    parse_v2_command(Cmd, Fam, Trans, Body, After);
+parse_v2(<<Ver:4, _Cmd:4, _/binary>>) when Ver =/= 2 ->
+    {error, v2_bad_version};
+parse_v2(_Partial) ->
+    %% The signature matched but the header (length-declared body included) is
+    %% not all here yet.
+    more.
+
+-spec parse_v2_command(0..15, 0..15, 0..15, binary(), binary()) ->
+    {ok, peer(), binary()} | {local, binary()} | {error, term()}.
+parse_v2_command(16#1, Fam, Trans, Body, After) ->
+    %% PROXY command (0x1): a real connection. Parse the source address for an
+    %% INET/INET6 stream; anything else (AF_UNIX, UNSPEC) keeps the OS peer.
+    parse_v2_addr(Fam, Trans, Body, After);
+parse_v2_command(16#0, _Fam, _Trans, _Body, After) ->
+    %% LOCAL command (0x0): the sender's own connection (a health check). Keep
+    %% the OS peer; the address block is present but ignored.
+    {local, After};
+parse_v2_command(_Cmd, _Fam, _Trans, _Body, _After) ->
+    {error, v2_bad_command}.
+
+-spec parse_v2_addr(0..15, 0..15, binary(), binary()) ->
+    {ok, peer(), binary()} | {local, binary()} | {error, term()}.
+parse_v2_addr(
+    16#1, 16#1, <<A, B, C, D, _Dst:4/binary, SrcPort:16, _DstPort:16, _Tlv/binary>>, After
+) ->
+    %% AF_INET (0x1) + STREAM (0x1).
+    {ok, {{A, B, C, D}, SrcPort}, After};
+parse_v2_addr(
+    16#2,
+    16#1,
+    <<S1:16, S2:16, S3:16, S4:16, S5:16, S6:16, S7:16, S8:16, _Dst:16/binary, SrcPort:16,
+        _DstPort:16, _Tlv/binary>>,
+    After
+) ->
+    %% AF_INET6 (0x2) + STREAM (0x1).
+    {ok, {{S1, S2, S3, S4, S5, S6, S7, S8}, SrcPort}, After};
+parse_v2_addr(Fam, _Trans, _Body, After) when Fam =:= 16#0; Fam =:= 16#3 ->
+    %% AF_UNSPEC (0x0) or AF_UNIX (0x3): no IP peer to report; keep the OS peer.
+    {local, After};
+parse_v2_addr(_Fam, _Trans, _Body, _After) ->
+    {error, v2_bad_address}.
+
+%% =============================================================================
+%% Internal
+%% =============================================================================
+
+%% Whether `Bin` is a (proper or full) prefix of `Full` — i.e. reading more
+%% bytes could still complete `Full`.
+-spec is_prefix(binary(), binary()) -> boolean().
+is_prefix(Bin, Full) when byte_size(Bin) =< byte_size(Full) ->
+    Len = byte_size(Bin),
+    case Full of
+        <<Bin:Len/binary, _/binary>> -> true;
+        _ -> false
+    end;
+is_prefix(_Bin, _Full) ->
+    false.
+
+%% `-on_load` callback: compile the v1 line/field split patterns once.
+-spec init_patterns() -> ok.
+init_patterns() ->
+    persistent_term:put(?CRLF_CP_KEY, binary:compile_pattern(~"\r\n")),
+    persistent_term:put(?SPACE_CP_KEY, binary:compile_pattern(~" ")),
+    ok.

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -461,6 +461,13 @@ delivered this request.
 connection. Returns `undefined` when the request map has no peer
 field (e.g. constructed manually outside the connection pipeline) or
 when the OS call failed at accept time.
+
+On a listener with `proxy_protocol => true` this is the client address
+the upstream balancer reported in its PROXY-protocol header, not the
+balancer's socket address. **Trust it only behind a balancer that always
+prepends the header** — the inverse of the `forwarded_for/1` warning: the
+opt is opt-in precisely because trusting a PROXY header from a peer that
+can reach the listener directly would let that peer spoof its own address.
 """.
 -spec peer(request()) ->
     {inet:ip_address(), inet:port_number()} | undefined.

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -186,6 +186,7 @@ proto_opts(ListenerName, Counter) ->
         rejected_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
+        proxy_protocol => false,
         listener_name => ListenerName,
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -454,7 +454,7 @@ concurrent_streams_both_dispatch() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_concurrent_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_concurrent_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -521,6 +521,7 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
         max_clients => 100,
         min_bytes_per_second => 0,
         body_buffering => auto,
+        proxy_protocol => false,
         graceful_drain => false,
         protocols => [http2],
         http2_conn_window => 65535,
@@ -575,6 +576,7 @@ plaintext_listener_without_h2c_stays_h1() ->
         max_clients => 100,
         min_bytes_per_second => 0,
         body_buffering => auto,
+        proxy_protocol => false,
         graceful_drain => false,
         protocols => [http1]
     },
@@ -1202,7 +1204,7 @@ middleware_chain_runs() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_mw_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_mw_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -1265,7 +1267,7 @@ router_404_returns_not_found() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_404_listener, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_404_listener, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -2124,7 +2126,7 @@ rst_during_stream_response_unwinds_worker() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_rst_during_stream, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_rst_during_stream, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -2205,7 +2207,7 @@ drain_refuses_new_streams() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_drain_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_drain_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -2261,7 +2263,7 @@ drain_with_in_flight_stream_waits() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_drain_inflight_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_drain_inflight_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -2324,7 +2326,7 @@ drain_message_is_idempotent() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_drain_dup_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_drain_dup_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -2377,7 +2379,7 @@ drain_then_peer_rst_exits_via_frame_loop() ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_drain_rst_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_drain_rst_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -2471,7 +2473,7 @@ telemetry_request_stop_fires_for_router_404() ->
                 ready -> ok
             end,
             roadrunner_conn_loop_http2:enter(
-                Sock, ProtoOpts, h2_telem_404, undefined, erlang:monotonic_time()
+                Sock, ProtoOpts, h2_telem_404, undefined, erlang:monotonic_time(), <<>>
             )
         end),
         Ref = monitor(process, Pid),
@@ -2560,7 +2562,7 @@ run_h2_with_compress_middleware(Path, ExtraHeaders) ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_compress_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_compress_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -3533,7 +3535,7 @@ post_handshake_handler(Handler) ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_strict_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_strict_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -3669,7 +3671,7 @@ start_http2_conn(Extra) ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, http2_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, http2_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -3789,7 +3791,7 @@ run_h2_request_with_handler(Handler, Path) ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_handler_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_handler_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),
@@ -3850,7 +3852,7 @@ run_stream_request(Path, PrefaceSettings) ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_stream_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_stream_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1328,6 +1328,7 @@ fake_opts(ListenerName) ->
         rejected_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
+        proxy_protocol => false,
         listener_name => ListenerName,
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -261,7 +261,7 @@ start_conn(H2Opts) ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_window_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_window_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -428,7 +428,7 @@ start_conn(Handler, Extra) ->
             ready -> ok
         end,
         roadrunner_conn_loop_http2:enter(
-            Sock, ProtoOpts, h2_flow_test, undefined, erlang:monotonic_time()
+            Sock, ProtoOpts, h2_flow_test, undefined, erlang:monotonic_time(), <<>>
         )
     end),
     Ref = monitor(process, Pid),

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -453,6 +453,33 @@ listener_rejects_h1_and_h2_on_plain_tcp_test() ->
         [[http1, http2], [http2, http1]]
     ).
 
+listener_rejects_invalid_proxy_protocol_test() ->
+    %% `proxy_protocol` must be a boolean.
+    process_flag(trap_exit, true),
+    R = roadrunner_listener:start_link(listener_test_proxy_invalid, #{
+        port => 0,
+        protocols => [http1],
+        proxy_protocol => yes_please,
+        routes => roadrunner_hello_handler
+    }),
+    ?assertMatch({error, {{invalid_listener_opt, proxy_protocol, yes_please}, _Stack}}, R).
+
+listener_rejects_proxy_protocol_on_http3_only_test() ->
+    %% PROXY protocol is a TCP-stream feature (an L4 balancer prepends it before
+    %% the first byte); enabling it on an HTTP/3-only (UDP) listener conflicts.
+    %% h3 requires TLS, so supply a cert to get past that check to this one.
+    process_flag(trap_exit, true),
+    R = roadrunner_listener:start_link(listener_test_proxy_h3_only, #{
+        port => 0,
+        protocols => [http3],
+        proxy_protocol => true,
+        tls => roadrunner_test_certs:server_opts(),
+        routes => roadrunner_hello_handler
+    }),
+    ?assertMatch(
+        {error, {{listener_opt_conflict, proxy_protocol, true, no_tcp_listener}, _Stack}}, R
+    ).
+
 listener_rejects_invalid_protocols_value_test() ->
     %% Empty list, unknown atom, duplicates, and non-list shapes all
     %% reject with `{invalid_listener_opt, protocols, _}`.

--- a/test/roadrunner_proxy_peer_handler.erl
+++ b/test/roadrunner_proxy_peer_handler.erl
@@ -1,0 +1,27 @@
+-module(roadrunner_proxy_peer_handler).
+-moduledoc false.
+
+%% Test fixture: echoes the request's peer IP literal (e.g. `192.168.0.1`) so a
+%% PROXY-protocol test can assert the override produced the real client address,
+%% not just that some peer is present.
+
+-behaviour(roadrunner_handler).
+
+-export([handle/1]).
+
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
+handle(Req) ->
+    Body =
+        case roadrunner_req:peer(Req) of
+            {Ip, _Port} -> list_to_binary(inet:ntoa(Ip));
+            undefined -> ~"undefined"
+        end,
+    Resp =
+        {200,
+            [
+                {~"content-type", ~"text/plain"},
+                {~"content-length", integer_to_binary(byte_size(Body))},
+                {~"connection", ~"close"}
+            ],
+            Body},
+    {Resp, Req}.

--- a/test/roadrunner_proxy_protocol_tests.erl
+++ b/test/roadrunner_proxy_protocol_tests.erl
@@ -1,0 +1,242 @@
+-module(roadrunner_proxy_protocol_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_proxy_protocol).
+-define(V2_SIG, 16#0D, 16#0A, 16#0D, 16#0A, 16#00, 16#0D, 16#0A, 16#51, 16#55, 16#49, 16#54, 16#0A).
+
+%% --- v1 text ---
+
+v1_tcp4_ok_test() ->
+    Bin = <<"PROXY TCP4 192.168.0.1 10.0.0.5 56324 443\r\nGET / HTTP/1.1\r\n">>,
+    ?assertEqual(
+        {ok, {{192, 168, 0, 1}, 56324}, <<"GET / HTTP/1.1\r\n">>},
+        ?M:parse(Bin)
+    ).
+
+v1_tcp6_ok_test() ->
+    Bin = <<"PROXY TCP6 2001:db8::1 2001:db8::2 4711 443\r\nrest">>,
+    ?assertEqual(
+        {ok, {{16#2001, 16#db8, 0, 0, 0, 0, 0, 1}, 4711}, <<"rest">>},
+        ?M:parse(Bin)
+    ).
+
+v1_unknown_is_local_test() ->
+    Bin = <<"PROXY UNKNOWN\r\nrest">>,
+    ?assertEqual({local, <<"rest">>}, ?M:parse(Bin)).
+
+v1_unknown_with_addrs_is_local_test() ->
+    %% A balancer MAY still send addresses with UNKNOWN; they are ignored.
+    Bin = <<"PROXY UNKNOWN 1.1.1.1 2.2.2.2 1 2\r\nrest">>,
+    ?assertEqual({local, <<"rest">>}, ?M:parse(Bin)).
+
+v1_missing_crlf_is_more_test() ->
+    ?assertEqual(more, ?M:parse(<<"PROXY TCP4 192.168.0.1 10.0.0.5 56324 44">>)).
+
+v1_too_long_no_crlf_test() ->
+    %% A line that exceeds the 107-byte budget without a CRLF is rejected.
+    Long = list_to_binary(lists:duplicate(110, $x)),
+    ?assertEqual({error, v1_too_long}, ?M:parse(<<"PROXY ", Long/binary>>)).
+
+v1_too_long_with_crlf_test() ->
+    Long = list_to_binary(lists:duplicate(110, $x)),
+    ?assertEqual({error, v1_too_long}, ?M:parse(<<"PROXY ", Long/binary, "\r\n">>)).
+
+v1_bad_address_test() ->
+    ?assertEqual(
+        {error, v1_bad_address},
+        ?M:parse(<<"PROXY TCP4 999.1.1.1 10.0.0.5 1 2\r\n">>)
+    ).
+
+v1_tcp4_with_ipv6_address_test() ->
+    %% Family/address mismatch: TCP4 carrying an IPv6 literal.
+    ?assertEqual(
+        {error, v1_bad_address},
+        ?M:parse(<<"PROXY TCP4 2001:db8::1 10.0.0.5 1 2\r\n">>)
+    ).
+
+v1_bad_port_too_high_test() ->
+    ?assertEqual(
+        {error, v1_bad_port},
+        ?M:parse(<<"PROXY TCP4 192.168.0.1 10.0.0.5 70000 443\r\n">>)
+    ).
+
+v1_bad_port_non_numeric_test() ->
+    ?assertEqual(
+        {error, v1_bad_port},
+        ?M:parse(<<"PROXY TCP4 192.168.0.1 10.0.0.5 abc 443\r\n">>)
+    ).
+
+v1_malformed_field_count_test() ->
+    ?assertEqual({error, v1_malformed}, ?M:parse(<<"PROXY TCP4 192.168.0.1\r\n">>)).
+
+%% --- v2 binary ---
+
+v2_inet_ok_test() ->
+    Hdr = v2(2, 1, 1, 1, <<192, 168, 0, 1, 10, 0, 0, 5, 56324:16, 443:16>>),
+    ?assertEqual(
+        {ok, {{192, 168, 0, 1}, 56324}, <<"rest">>},
+        ?M:parse(<<Hdr/binary, "rest">>)
+    ).
+
+v2_inet6_ok_test() ->
+    Addr = <<16#2001:16, 16#db8:16, 0:16, 0:16, 0:16, 0:16, 0:16, 1:16>>,
+    Body = <<Addr/binary, 0:128, 4711:16, 443:16>>,
+    Hdr = v2(2, 1, 2, 1, Body),
+    ?assertEqual(
+        {ok, {{16#2001, 16#db8, 0, 0, 0, 0, 0, 1}, 4711}, <<"rest">>},
+        ?M:parse(<<Hdr/binary, "rest">>)
+    ).
+
+v2_inet_with_tlv_skipped_test() ->
+    %% Trailing TLV bytes are inside the declared length, so they are consumed
+    %% (not part of the leftover) and the source address still parses.
+    Body = <<192, 168, 0, 1, 10, 0, 0, 5, 56324:16, 443:16, 16#03, 0:16>>,
+    Hdr = v2(2, 1, 1, 1, Body),
+    ?assertEqual(
+        {ok, {{192, 168, 0, 1}, 56324}, <<"rest">>},
+        ?M:parse(<<Hdr/binary, "rest">>)
+    ).
+
+v2_local_is_local_test() ->
+    Hdr = v2(2, 0, 1, 1, <<192, 168, 0, 1, 10, 0, 0, 5, 1:16, 2:16>>),
+    ?assertEqual({local, <<"rest">>}, ?M:parse(<<Hdr/binary, "rest">>)).
+
+v2_af_unix_is_local_test() ->
+    Hdr = v2(2, 1, 3, 1, binary:copy(<<0>>, 216)),
+    ?assertEqual({local, <<"rest">>}, ?M:parse(<<Hdr/binary, "rest">>)).
+
+v2_af_unspec_is_local_test() ->
+    Hdr = v2(2, 1, 0, 0, <<>>),
+    ?assertEqual({local, <<"rest">>}, ?M:parse(<<Hdr/binary, "rest">>)).
+
+v2_short_body_is_more_test() ->
+    %% Signature + header byte present, but the declared body has not all
+    %% arrived yet.
+    Partial = <<?V2_SIG, (16#21), (16#11), 12:16, 192, 168>>,
+    ?assertEqual(more, ?M:parse(Partial)).
+
+v2_bad_version_test() ->
+    Hdr = v2(3, 1, 1, 1, <<192, 168, 0, 1, 10, 0, 0, 5, 1:16, 2:16>>),
+    ?assertEqual({error, v2_bad_version}, ?M:parse(Hdr)).
+
+v2_bad_command_test() ->
+    Hdr = v2(2, 2, 1, 1, <<192, 168, 0, 1, 10, 0, 0, 5, 1:16, 2:16>>),
+    ?assertEqual({error, v2_bad_command}, ?M:parse(Hdr)).
+
+v2_bad_address_short_for_inet_test() ->
+    %% PROXY + INET but the body is too short to hold the address block.
+    Hdr = v2(2, 1, 1, 1, <<1, 2, 3>>),
+    ?assertEqual({error, v2_bad_address}, ?M:parse(Hdr)).
+
+%% --- parse/1 dispatch / partial signatures ---
+
+empty_is_more_test() ->
+    ?assertEqual(more, ?M:parse(<<>>)).
+
+partial_v1_signature_is_more_test() ->
+    ?assertEqual(more, ?M:parse(<<"PROX">>)).
+
+partial_v2_signature_is_more_test() ->
+    ?assertEqual(more, ?M:parse(<<16#0D, 16#0A, 16#0D>>)).
+
+not_a_proxy_header_test() ->
+    ?assertEqual({error, not_proxy_header}, ?M:parse(<<"GET / HTTP/1.1\r\n">>)).
+
+%% --- end-to-end: a real listener with proxy_protocol => true overrides the
+%% request peer with the address the PROXY header reports ---
+
+v1_override_test() ->
+    Body = proxy_request(
+        <<"PROXY TCP4 192.168.0.7 10.0.0.1 5000 443\r\n">>,
+        <<"GET / HTTP/1.1\r\nHost: x\r\n\r\n">>
+    ),
+    ?assertEqual(~"192.168.0.7", Body).
+
+v2_override_test() ->
+    Hdr = v2(2, 1, 1, 1, <<203, 0, 113, 9, 10, 0, 0, 1, 5000:16, 443:16>>),
+    Body = proxy_request(Hdr, <<"GET / HTTP/1.1\r\nHost: x\r\n\r\n">>),
+    ?assertEqual(~"203.0.113.9", Body).
+
+unknown_keeps_os_peer_test() ->
+    Body = proxy_request(<<"PROXY UNKNOWN\r\n">>, <<"GET / HTTP/1.1\r\nHost: x\r\n\r\n">>),
+    ?assertEqual(~"127.0.0.1", Body).
+
+split_header_test() ->
+    with_listener(fun(Port) ->
+        {ok, S} = connect(Port),
+        ok = gen_tcp:send(S, <<"PROXY TCP4 192.168.0.7 10.0.0.1 50">>),
+        timer:sleep(20),
+        ok = gen_tcp:send(S, <<"00 443\r\nGET / HTTP/1.1\r\nHost: x\r\n\r\n">>),
+        ?assertEqual(~"192.168.0.7", body_of(recv_response(S, <<>>))),
+        gen_tcp:close(S)
+    end).
+
+malformed_closes_test() ->
+    with_listener(fun(Port) ->
+        {ok, S} = connect(Port),
+        %% A raw request (no PROXY header) on a proxy_protocol listener is a
+        %% misconfigured upstream — the connection closes with no response.
+        ok = gen_tcp:send(S, <<"GET / HTTP/1.1\r\nHost: x\r\n\r\n">>),
+        ?assertEqual(<<>>, recv_response(S, <<>>)),
+        gen_tcp:close(S)
+    end).
+
+recv_error_closes_test() ->
+    with_listener(fun(Port) ->
+        {ok, S} = connect(Port),
+        %% Half-close (FIN) before sending any PROXY header: the server's first
+        %% recv returns {error, closed}, so the connection closes with no reply.
+        ok = gen_tcp:shutdown(S, write),
+        ?assertEqual(<<>>, recv_response(S, <<>>)),
+        gen_tcp:close(S)
+    end).
+
+%% --- helpers ---
+
+proxy_request(Header, Request) ->
+    with_listener(fun(Port) ->
+        {ok, S} = connect(Port),
+        ok = gen_tcp:send(S, <<Header/binary, Request/binary>>),
+        Body = body_of(recv_response(S, <<>>)),
+        gen_tcp:close(S),
+        Body
+    end).
+
+%% Stand up a real listener directly (no app start/stop, mirroring
+%% roadrunner_compress_tests) so concurrent test modules don't race on the
+%% shared `pg` scope.
+with_listener(Fun) ->
+    Name = list_to_atom("proxy_it_" ++ integer_to_list(erlang:unique_integer([positive]))),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        proxy_protocol => true,
+        protocols => [http1],
+        routes => roadrunner_proxy_peer_handler
+    }),
+    Port = roadrunner_listener:port(Name),
+    try
+        Fun(Port)
+    after
+        ok = roadrunner_listener:stop(Name)
+    end.
+
+connect(Port) ->
+    gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000).
+
+recv_response(Sock, Acc) ->
+    case gen_tcp:recv(Sock, 0, 2000) of
+        {ok, Data} -> recv_response(Sock, <<Acc/binary, Data/binary>>);
+        {error, _} -> Acc
+    end.
+
+body_of(Resp) ->
+    case binary:split(Resp, <<"\r\n\r\n">>) of
+        [_Headers, Body] -> Body;
+        [_] -> <<>>
+    end.
+
+%% Build a v2 header: signature, version+command, family+transport, the 16-bit
+%% body length, then the body.
+v2(Ver, Cmd, Fam, Trans, Body) ->
+    <<?V2_SIG, Ver:4, Cmd:4, Fam:4, Trans:4, (byte_size(Body)):16, Body/binary>>.

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -134,6 +134,7 @@ request_rejected_event_fires_on_bad_request_line_test() ->
             rejected_counter => atomics:new(1, [{signed, false}]),
             min_bytes_per_second => 0,
             body_buffering => auto,
+            proxy_protocol => false,
             listener_name => probe_listener_rej,
             handler_spawn_opts => [{fullsweep_after, 0}],
             handler_start_timeout => infinity

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -570,6 +570,7 @@ fake_proto_opts(Handler) ->
         rejected_counter => atomics:new(1, [{signed, false}]),
         min_bytes_per_second => 0,
         body_buffering => auto,
+        proxy_protocol => false,
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity
     }.


### PR DESCRIPTION
# Description

Adds an opt-in `proxy_protocol => true` listener flag. When set, the connection reads and strips the HAProxy PROXY header (v1 text and v2 binary) on accept, before the first application byte, so `roadrunner_req:peer/1` returns the real client behind an L4 balancer (haproxy, AWS NLB) instead of the balancer's socket address, across HTTP/1 and HTTP/2 (incl. prior-knowledge h2c). Bytes a coalesced TCP segment carries after the header seed the connection read buffer. TCP-only: rejected on an HTTP/3-only listener. It is opt-in because trusting the header from a peer that can reach the listener directly would let it spoof its address, so enable it only behind a balancer that always prepends it.

```erlang
%% behind `PROXY TCP4 203.0.113.9 10.0.0.1 56324 443\r\n`:
roadrunner_req:peer(Req) =:= {{203, 0, 113, 9}, 56324}
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
