### PR TITLE
Add a security-headers middleware

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -524,19 +524,6 @@ the shape rather than a guess. The middleware slot is ready.
 **Scope:** small-medium. The preflight branch plus header echoing is the
 bulk; `Vary` correctness mirrors `roadrunner_compress`.
 
-### Security-headers middleware — small
-
-**What:** A `roadrunner_security_headers` middleware that applies a
-default-safe set on every response: `X-Content-Type-Options: nosniff`,
-frame options, referrer policy, `Strict-Transport-Security` on TLS
-listeners, and opt-in CSP. Every value overridable; a header the handler
-already set wins.
-
-**Why deferred:** trivial to hand-roll, but it is the same dozen lines in
-every service; a curated default earns its keep once one service asks.
-
-**Scope:** small.
-
 ### Conditional requests for dynamic responses — small
 
 **What:** A `roadrunner_etag` middleware that derives a (strong or weak)

--- a/src/roadrunner_security_headers.erl
+++ b/src/roadrunner_security_headers.erl
@@ -1,0 +1,186 @@
+-module(roadrunner_security_headers).
+-moduledoc """
+Security-headers middleware: a default-safe set of response headers, the
+same handful every browser-facing service hand-rolls, added to every HTTP
+response and leaving any header the handler already set untouched.
+
+Wire it into a listener's (or route's) `middlewares` opt, bare for the
+defaults or `{roadrunner_security_headers, Config}` to tune them:
+
+```erlang
+roadrunner_listener:start_link(my_app, #{
+    port => 8080,
+    routes => Routes,
+    middlewares => [roadrunner_security_headers]
+}).
+```
+
+## Default set
+
+| Header | Default value | Config key |
+|--------|---------------|------------|
+| `x-content-type-options` | `nosniff` | `content_type_options` |
+| `x-frame-options` | `SAMEORIGIN` | `frame_options` |
+| `referrer-policy` | `strict-origin-when-cross-origin` | `referrer_policy` |
+
+Each key takes a binary to override the value, or `false` to drop the header.
+
+## Opt-in headers
+
+Two headers carry consequences beyond the current response, so they stay off
+until enabled explicitly:
+
+- **`content-security-policy`** (`content_security_policy => <<"...">>`): a
+  default policy is too application-specific to be safe.
+- **`strict-transport-security`** (`hsts => true | Config`): once a browser
+  sees HSTS it refuses plain HTTP to the host for the whole `max-age`, even
+  after the header stops, and `include_subdomains` extends that to every
+  subdomain, so a wrong value is a durable outage rather than a one-response
+  mistake. It is emitted only over HTTPS (per `roadrunner_req:scheme/1`); a
+  browser ignores HSTS received over plain HTTP (RFC 6797 §8.1).
+
+`hsts => true` emits the recommended `max-age=31536000; includeSubDomains`.
+`hsts => Config` tunes it:
+
+- `max_age => non_neg_integer()` (default 31536000, one year)
+- `include_subdomains => boolean()` (default `true`)
+- `preload => boolean()` (default `false`): opt-in, it commits the host to
+  the browser preload lists, which is slow to reverse
+
+## Precedence and scope
+
+A header the handler already set wins: each default is added only when
+absent. Unlike `roadrunner_compress`, this middleware adds no `Vary` (its
+output conditions on no request header; HSTS keys off the connection scheme,
+not a header). It decorates every response shape that carries headers
+(buffered, stream, sendfile, and loop), so a file served via `sendfile` gets
+`nosniff` too; only a `{websocket, _, _}` upgrade, which has no response
+headers, passes through.
+""".
+
+-behaviour(roadrunner_middleware).
+
+-export([call/3]).
+
+-type config() :: #{
+    content_type_options => binary() | false,
+    frame_options => binary() | false,
+    referrer_policy => binary() | false,
+    hsts => boolean() | hsts_config(),
+    content_security_policy => binary() | false
+}.
+-type hsts_config() :: #{
+    max_age => non_neg_integer(),
+    include_subdomains => boolean(),
+    preload => boolean()
+}.
+
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), roadrunner_middleware:state()) ->
+    roadrunner_handler:result().
+call(Req, Next, State) ->
+    {Response, Req2} = Next(Req),
+    {transform(Req, config(State), Response), Req2}.
+
+%% A bare-callable entry hands `undefined` as the state, meaning "all defaults".
+-spec config(roadrunner_middleware:state()) -> config().
+config(undefined) -> #{};
+config(Config) when is_map(Config) -> Config.
+
+%% Decorate every header-bearing response shape; pass a `{websocket, _, _}`
+%% upgrade (no response headers) through. The `is_integer(Status)` guard on
+%% the buffered clause is load-bearing: it rejects the `{websocket, Mod, State}`
+%% triple, which shares the 3-tuple shape but carries an atom where the status
+%% would be.
+-spec transform(roadrunner_req:request(), config(), roadrunner_handler:response()) ->
+    roadrunner_handler:response().
+transform(Req, Config, {Status, Headers, Body}) when
+    is_integer(Status), Status >= 100, Status =< 599
+->
+    {Status, inject(Req, Config, Headers), Body};
+transform(Req, Config, {stream, Status, Headers, Fun}) when
+    is_integer(Status), Status >= 100, Status =< 599, is_function(Fun, 1)
+->
+    {stream, Status, inject(Req, Config, Headers), Fun};
+transform(Req, Config, {sendfile, Status, Headers, Spec}) when
+    is_integer(Status), Status >= 100, Status =< 599
+->
+    {sendfile, Status, inject(Req, Config, Headers), Spec};
+transform(Req, Config, {loop, Status, Headers, LoopState}) when
+    is_integer(Status), Status >= 100, Status =< 599
+->
+    {loop, Status, inject(Req, Config, Headers), LoopState};
+transform(_Req, _Config, Other) ->
+    Other.
+
+%% Prepend each enabled default the handler didn't already set. The full set
+%% is built once in emit order; `add_defaults/2` skips any whose value resolved
+%% to `false` (disabled by config, or HSTS off / over plain HTTP).
+-spec inject(roadrunner_req:request(), config(), roadrunner_http:headers()) ->
+    roadrunner_http:headers().
+inject(Req, Config, Headers) ->
+    Scheme = roadrunner_req:scheme(Req),
+    add_defaults(
+        [
+            {~"x-content-type-options", opt(content_type_options, Config, ~"nosniff")},
+            {~"x-frame-options", opt(frame_options, Config, ~"SAMEORIGIN")},
+            {~"referrer-policy", opt(referrer_policy, Config, ~"strict-origin-when-cross-origin")},
+            {~"strict-transport-security", hsts(Scheme, Config)},
+            {~"content-security-policy", opt(content_security_policy, Config, false)}
+        ],
+        Headers
+    ).
+
+-spec add_defaults([{binary(), binary() | false}], roadrunner_http:headers()) ->
+    roadrunner_http:headers().
+add_defaults([], Headers) ->
+    Headers;
+add_defaults([{_Name, false} | Rest], Headers) ->
+    add_defaults(Rest, Headers);
+add_defaults([{Name, Value} | Rest], Headers) ->
+    case has_header(Name, Headers) of
+        true -> add_defaults(Rest, Headers);
+        false -> [{Name, Value} | add_defaults(Rest, Headers)]
+    end.
+
+%% `strict-transport-security` is opt-in (its commitment outlives the header,
+%% see the moduledoc) and meaningful only over HTTPS (RFC 6797 §8.1: a browser
+%% ignores it on a plain-HTTP response), so it resolves to `false` (skipped)
+%% on a plain-HTTP connection, when unset, or when `hsts => false`. `true`
+%% emits the recommended settings; a map tunes them.
+-spec hsts(http | https, config()) -> binary() | false.
+hsts(https, Config) ->
+    case opt(hsts, Config, false) of
+        false -> false;
+        true -> hsts_value(#{});
+        HstsConfig when is_map(HstsConfig) -> hsts_value(HstsConfig)
+    end;
+hsts(http, _Config) ->
+    false.
+
+%% Build `max-age=N[; includeSubDomains][; preload]` from the HSTS sub-config.
+-spec hsts_value(hsts_config()) -> binary().
+hsts_value(Config) ->
+    MaxAge = integer_to_binary(opt(max_age, Config, 31536000)),
+    Base = <<"max-age=", MaxAge/binary>>,
+    WithSubdomains =
+        case opt(include_subdomains, Config, true) of
+            true -> <<Base/binary, "; includeSubDomains">>;
+            false -> Base
+        end,
+    case opt(preload, Config, false) of
+        true -> <<WithSubdomains/binary, "; preload">>;
+        false -> WithSubdomains
+    end.
+
+%% A config value: the override, or `Default` when the key is unset. A map
+%% pattern (not `maps:get`) so a present-but-`false` value still reads through.
+-spec opt(atom(), map(), term()) -> term().
+opt(Key, Config, Default) ->
+    case Config of
+        #{Key := Value} -> Value;
+        #{} -> Default
+    end.
+
+-spec has_header(binary(), roadrunner_http:headers()) -> boolean().
+has_header(Name, Headers) ->
+    lists:keymember(Name, 1, Headers).

--- a/test/roadrunner_security_headers_tests.erl
+++ b/test/roadrunner_security_headers_tests.erl
@@ -1,0 +1,233 @@
+-module(roadrunner_security_headers_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_security_headers).
+
+%% =============================================================================
+%% Pure unit tests against `call/3` — no listener, no socket.
+%% =============================================================================
+
+defaults_added_on_buffered_http_test() ->
+    Req = req(http, []),
+    Next = fun(R) -> {{200, [], ~"body"}, R} end,
+    {{200, Headers, ~"body"}, _Req2} = ?M:call(Req, Next, undefined),
+    ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)),
+    ?assertEqual(~"SAMEORIGIN", header(~"x-frame-options", Headers)),
+    ?assertEqual(~"strict-origin-when-cross-origin", header(~"referrer-policy", Headers)),
+    %% HSTS only on HTTPS; CSP is opt-in.
+    ?assertEqual(undefined, header(~"strict-transport-security", Headers)),
+    ?assertEqual(undefined, header(~"content-security-policy", Headers)).
+
+hsts_off_by_default_on_https_test() ->
+    %% HSTS is opt-in even over HTTPS: the bare middleware does not commit the
+    %% host to HTTPS-only. The reversible defaults are still applied.
+    Req = req(https, []),
+    Next = fun(R) -> {{200, [], ~"body"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, undefined),
+    ?assertEqual(undefined, header(~"strict-transport-security", Headers)),
+    ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
+
+hsts_enabled_with_true_on_https_test() ->
+    Req = req(https, []),
+    Next = fun(R) -> {{200, [], ~"body"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, #{hsts => true}),
+    ?assertEqual(
+        ~"max-age=31536000; includeSubDomains",
+        header(~"strict-transport-security", Headers)
+    ).
+
+hsts_not_emitted_over_http_even_when_enabled_test() ->
+    %% Enabled, but the connection is plain HTTP — no HSTS (RFC 6797 §8.1).
+    Req = req(http, []),
+    Next = fun(R) -> {{200, [], ~"body"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, #{hsts => true}),
+    ?assertEqual(undefined, header(~"strict-transport-security", Headers)).
+
+handler_header_wins_test() ->
+    %% Handler already set x-frame-options — the middleware must not override
+    %% or duplicate it.
+    Req = req(http, []),
+    Next = fun(R) -> {{200, [{~"x-frame-options", ~"DENY"}], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, undefined),
+    ?assertEqual([~"DENY"], [V || {~"x-frame-options", V} <- Headers]),
+    %% The other defaults still get added.
+    ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
+
+handler_hsts_wins_test() ->
+    Req = req(https, []),
+    Next = fun(R) -> {{200, [{~"strict-transport-security", ~"max-age=0"}], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, #{hsts => true}),
+    ?assertEqual([~"max-age=0"], [V || {~"strict-transport-security", V} <- Headers]).
+
+override_value_test() ->
+    Req = req(http, []),
+    Config = #{frame_options => ~"DENY", referrer_policy => ~"no-referrer"},
+    Next = fun(R) -> {{200, [], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    ?assertEqual(~"DENY", header(~"x-frame-options", Headers)),
+    ?assertEqual(~"no-referrer", header(~"referrer-policy", Headers)),
+    %% Unconfigured defaults are unchanged.
+    ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
+
+disable_header_test() ->
+    Req = req(http, []),
+    Config = #{content_type_options => false},
+    Next = fun(R) -> {{200, [], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    ?assertEqual(undefined, header(~"x-content-type-options", Headers)),
+    ?assertEqual(~"SAMEORIGIN", header(~"x-frame-options", Headers)).
+
+csp_opt_in_test() ->
+    Req = req(http, []),
+    Config = #{content_security_policy => ~"default-src 'self'"},
+    Next = fun(R) -> {{200, [], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    ?assertEqual(~"default-src 'self'", header(~"content-security-policy", Headers)).
+
+hsts_disable_test() ->
+    Req = req(https, []),
+    Config = #{hsts => false},
+    Next = fun(R) -> {{200, [], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    ?assertEqual(undefined, header(~"strict-transport-security", Headers)).
+
+hsts_sub_config_test() ->
+    %% max_age override, includeSubDomains off, preload on.
+    Req = req(https, []),
+    Config = #{hsts => #{max_age => 600, include_subdomains => false, preload => true}},
+    Next = fun(R) -> {{200, [], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    ?assertEqual(~"max-age=600; preload", header(~"strict-transport-security", Headers)).
+
+hsts_subdomains_without_preload_test() ->
+    Req = req(https, []),
+    Config = #{hsts => #{max_age => 100, include_subdomains => true, preload => false}},
+    Next = fun(R) -> {{200, [], ~"b"}, R} end,
+    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    ?assertEqual(
+        ~"max-age=100; includeSubDomains",
+        header(~"strict-transport-security", Headers)
+    ).
+
+stream_response_decorated_test() ->
+    Req = req(http, []),
+    Fun = fun(_Send) -> ok end,
+    Next = fun(R) -> {{stream, 200, [], Fun}, R} end,
+    {{stream, 200, Headers, OutFun}, _Req2} = ?M:call(Req, Next, undefined),
+    ?assertEqual(Fun, OutFun),
+    ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
+
+sendfile_response_decorated_test() ->
+    %% A file served via sendfile gets the headers too (nosniff matters most
+    %% here — MIME-sniffing of served files).
+    Req = req(http, []),
+    Spec = {~"/tmp/x", 0, 10},
+    Next = fun(R) -> {{sendfile, 200, [], Spec}, R} end,
+    {{sendfile, 200, Headers, OutSpec}, _Req2} = ?M:call(Req, Next, undefined),
+    ?assertEqual(Spec, OutSpec),
+    ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
+
+loop_response_decorated_test() ->
+    Req = req(http, []),
+    Next = fun(R) -> {{loop, 200, [], loop_state}, R} end,
+    {{loop, 200, Headers, OutState}, _Req2} = ?M:call(Req, Next, undefined),
+    ?assertEqual(loop_state, OutState),
+    ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
+
+websocket_passes_through_test() ->
+    Req = req(http, []),
+    Next = fun(R) -> {{websocket, some_mod, init_state}, R} end,
+    {Response, _Req2} = ?M:call(Req, Next, undefined),
+    ?assertMatch({websocket, some_mod, init_state}, Response).
+
+%% =============================================================================
+%% End-to-end through roadrunner_listener.
+%% =============================================================================
+
+plain_listener_sets_headers_test_() ->
+    {setup,
+        fun() ->
+            {ok, _} = roadrunner_listener:start_link(sec_headers_plain_e2e, #{
+                port => 0,
+                routes => roadrunner_hello_handler,
+                middlewares => [roadrunner_security_headers]
+            }),
+            roadrunner_listener:port(sec_headers_plain_e2e)
+        end,
+        fun(_) -> ok = roadrunner_listener:stop(sec_headers_plain_e2e) end, fun(Port) ->
+            {"plain HTTP response carries the default set, no HSTS", fun() ->
+                {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+                ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"),
+                Reply = recv_all(Sock, <<>>),
+                ok = gen_tcp:close(Sock),
+                {match, _} = re:run(Reply, ~"x-content-type-options: nosniff", [caseless]),
+                {match, _} = re:run(Reply, ~"x-frame-options: SAMEORIGIN", [caseless]),
+                {match, _} = re:run(
+                    Reply, ~"referrer-policy: strict-origin-when-cross-origin", [caseless]
+                ),
+                %% HSTS must be absent over plain HTTP.
+                nomatch = re:run(Reply, ~"strict-transport-security", [caseless])
+            end}
+        end}.
+
+tls_listener_sets_hsts_test_() ->
+    {setup,
+        fun() ->
+            {ok, _} = application:ensure_all_started(ssl),
+            {ok, _} = roadrunner_listener:start_link(sec_headers_tls_e2e, #{
+                port => 0,
+                tls => roadrunner_test_certs:server_opts(),
+                routes => roadrunner_hello_handler,
+                middlewares => [{roadrunner_security_headers, #{hsts => true}}]
+            }),
+            ClientOpts = [{verify, verify_none} | roadrunner_test_certs:client_opts()],
+            {roadrunner_listener:port(sec_headers_tls_e2e), ClientOpts}
+        end,
+        fun(_) -> ok = roadrunner_listener:stop(sec_headers_tls_e2e) end, fun({Port, ClientOpts}) ->
+            {"HTTPS response carries HSTS", fun() ->
+                {ok, Sock} = ssl:connect(
+                    {127, 0, 0, 1}, Port, ClientOpts ++ [binary, {active, false}], 5000
+                ),
+                ok = ssl:send(
+                    Sock, ~"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+                ),
+                Reply = recv_all_ssl(Sock, <<>>),
+                ok = ssl:close(Sock),
+                {match, _} = re:run(
+                    Reply,
+                    ~"strict-transport-security: max-age=31536000; includeSubDomains",
+                    [caseless]
+                ),
+                {match, _} = re:run(Reply, ~"x-content-type-options: nosniff", [caseless])
+            end}
+        end}.
+
+%% --- helpers ---
+
+req(Scheme, Headers) ->
+    #{
+        method => ~"GET",
+        target => ~"/",
+        version => {1, 1},
+        scheme => Scheme,
+        headers => Headers
+    }.
+
+header(Name, Headers) ->
+    case lists:keyfind(Name, 1, Headers) of
+        {_, V} -> V;
+        false -> undefined
+    end.
+
+recv_all(Sock, Acc) ->
+    case gen_tcp:recv(Sock, 0, 1000) of
+        {ok, Data} -> recv_all(Sock, <<Acc/binary, Data/binary>>);
+        {error, _} -> Acc
+    end.
+
+recv_all_ssl(Sock, Acc) ->
+    case ssl:recv(Sock, 0, 2000) of
+        {ok, Data} -> recv_all_ssl(Sock, <<Acc/binary, Data/binary>>);
+        {error, _} -> Acc
+    end.


### PR DESCRIPTION
# Description

Adds `roadrunner_security_headers`, a second built-in middleware. Bare, it adds a default-safe set to every header-bearing response (buffered, stream, sendfile, loop), skipping any header the handler already set: `x-content-type-options: nosniff`, `x-frame-options: SAMEORIGIN`, and `referrer-policy: strict-origin-when-cross-origin`. HSTS and CSP are opt-in, since both commit beyond the current response: `hsts => true` emits HTTPS-only `strict-transport-security` (`hsts => #{...}` to tune), and `content_security_policy => Policy` sets a CSP. No `Vary` (unlike compress, its output conditions on no request header).

```erlang
middlewares => [{roadrunner_security_headers, #{hsts => true}}]
%% every response gains nosniff/frame-options/referrer-policy; HTTPS also gets HSTS
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
