### PR TITLE
Add a CORS middleware

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -508,21 +508,7 @@ The continuation-middleware model (`call(Req, Next, State)`, configured
 per entry via `{Module, State}`) makes browser-facing and abuse-control
 concerns composable at the listener or per-route level. Each is
 boilerplate every public service rewrites today; shipping configurable,
-default-safe versions removes it. None is wired yet.
-
-### CORS middleware — small-medium
-
-**What:** A configurable `roadrunner_cors` middleware: origin allowlist
-or predicate, allowed methods and headers, credentials, exposed headers,
-max-age, an `OPTIONS` preflight short-circuit with the right
-`Access-Control-*` headers, and a cache-correct `Vary: Origin`.
-
-**Why deferred:** every browser-facing service needs it, but the exact
-policy is app-specific, so it stays unwired until a real caller drives
-the shape rather than a guess. The middleware slot is ready.
-
-**Scope:** small-medium. The preflight branch plus header echoing is the
-bulk; `Vary` correctness mirrors `roadrunner_compress`.
+default-safe versions removes it.
 
 ### Conditional requests for dynamic responses — small
 

--- a/src/roadrunner_cors.erl
+++ b/src/roadrunner_cors.erl
@@ -1,0 +1,325 @@
+-module(roadrunner_cors).
+-moduledoc """
+Cross-Origin Resource Sharing (CORS) middleware.
+
+Answers the browser's preflight `OPTIONS` request and decorates cross-origin
+responses with the right `Access-Control-*` headers, driven by a per-instance
+policy. Deny-by-default: a request whose `Origin` is not allowed gets no
+`Access-Control-Allow-Origin`, so the browser blocks it.
+
+Wire it with its config (there is no useful bare form, `origins` is required):
+
+```erlang
+middlewares => [
+    {roadrunner_cors, #{
+        origins => [~"https://app.example.com"],
+        methods => [~"GET", ~"POST"],
+        credentials => true
+    }}
+]
+```
+
+## Config
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `origins` | (required) | `[binary()]` allowlist, `fun((binary()) -> boolean())` predicate, or `any` |
+| `methods` | `[~"GET", ~"HEAD", ~"POST"]` | methods echoed in a preflight's `Access-Control-Allow-Methods` |
+| `headers` | `[]` | `[binary()]` echoed in `Access-Control-Allow-Headers`, or `reflect` to mirror the request's `Access-Control-Request-Headers` |
+| `expose` | `[]` | `[binary()]` for `Access-Control-Expose-Headers` |
+| `credentials` | `false` | when `true`, emit `Access-Control-Allow-Credentials: true` |
+| `max_age` | (omitted) | preflight cache lifetime in seconds (`Access-Control-Max-Age`) |
+
+A bad value crashes the request with `{invalid_cors_opt, Key, Value}` rather
+than failing silently.
+
+## Behaviour
+
+- **No `Origin` header**: not a CORS request, passed through untouched.
+- **Preflight** (`OPTIONS` with `Access-Control-Request-Method`): short-circuited
+  with a `204` carrying the `Access-Control-*` set, without calling the handler.
+- **Simple / actual request**: the handler runs, then `Access-Control-Allow-Origin`
+  (plus credentials / exposed headers when configured) is added to its response.
+
+`Vary: Origin` is added to every CORS response, allowed or not, so a shared
+cache never serves one origin's response to another; an existing `Vary` (e.g.
+`Accept-Encoding` from `roadrunner_compress`) is appended to rather than
+replaced.
+
+## Credentials and the wildcard
+
+With `credentials => true` the response echoes the concrete request `Origin`
+rather than `*`, because a browser rejects `Access-Control-Allow-Origin: *`
+together with `Access-Control-Allow-Credentials: true`. `origins => any`
+without credentials emits the literal `*`.
+""".
+
+-behaviour(roadrunner_middleware).
+
+-export([call/3]).
+
+-type origins() :: any | [binary()] | fun((binary()) -> boolean()).
+-type config() :: #{
+    origins := origins(),
+    methods => [binary()],
+    headers => [binary()] | reflect,
+    expose => [binary()],
+    credentials => boolean(),
+    max_age => non_neg_integer()
+}.
+
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), roadrunner_middleware:state()) ->
+    roadrunner_handler:result().
+call(Req, Next, Config) ->
+    case roadrunner_req:header(~"origin", Req) of
+        undefined ->
+            %% Not a CORS request — nothing to do.
+            Next(Req);
+        Origin ->
+            case is_preflight(Req) of
+                true ->
+                    %% Preflight: answer 204 ourselves, never reaching the handler.
+                    {preflight_response(Config, Origin, Req), Req};
+                false ->
+                    {Response, Req2} = Next(Req),
+                    {add_actual_headers(Response, Config, Origin), Req2}
+            end
+    end.
+
+%% A preflight is an `OPTIONS` carrying `Access-Control-Request-Method`. The
+%% header lookup is inlined so it only runs once the method check passes.
+-spec is_preflight(roadrunner_req:request()) -> boolean().
+is_preflight(Req) ->
+    roadrunner_req:method(Req) =:= ~"OPTIONS" andalso
+        roadrunner_req:header(~"access-control-request-method", Req) =/= undefined.
+
+%% =============================================================================
+%% Preflight (204)
+%% =============================================================================
+
+-spec preflight_response(config(), binary(), roadrunner_req:request()) ->
+    roadrunner_handler:response().
+preflight_response(Config, Origin, Req) ->
+    %% Vary: Origin even on a disallowed preflight, so a cache keys correctly.
+    Base = add_vary_origin([]),
+    Origins = origins(Config),
+    case allowed(Origin, Origins) of
+        false ->
+            {204, Base, ~""};
+        true ->
+            Creds = credentials(Config),
+            ok = roadrunner_http:check_header_safe(Origin, value),
+            Headers = add_cors(
+                [
+                    {~"access-control-allow-origin", allow_origin_value(Origin, Origins, Creds)},
+                    {~"access-control-allow-methods", join(methods(Config))},
+                    {~"access-control-allow-headers", allow_headers_value(Config, Req)},
+                    {~"access-control-allow-credentials", credentials_value(Creds)},
+                    {~"access-control-max-age", max_age_value(Config)}
+                ],
+                Base
+            ),
+            {204, Headers, ~""}
+    end.
+
+%% The `Access-Control-Allow-Headers` value: mirror the request's requested
+%% headers (`reflect`), join a configured list, or omit when neither applies.
+-spec allow_headers_value(config(), roadrunner_req:request()) -> binary() | false.
+allow_headers_value(Config, Req) ->
+    case headers(Config) of
+        reflect ->
+            case roadrunner_req:header(~"access-control-request-headers", Req) of
+                undefined ->
+                    false;
+                Requested ->
+                    ok = roadrunner_http:check_header_safe(Requested, value),
+                    Requested
+            end;
+        [] ->
+            false;
+        List ->
+            join(List)
+    end.
+
+-spec max_age_value(config()) -> binary() | false.
+max_age_value(Config) ->
+    case max_age(Config) of
+        undefined -> false;
+        Seconds -> integer_to_binary(Seconds)
+    end.
+
+%% =============================================================================
+%% Simple / actual request
+%% =============================================================================
+
+%% Decorate every header-bearing response shape; a `{websocket, _, _}` upgrade
+%% (no response headers) passes through. The `is_integer(Status)` guard on the
+%% buffered clause keeps the websocket triple out of it.
+-spec add_actual_headers(roadrunner_handler:response(), config(), binary()) ->
+    roadrunner_handler:response().
+add_actual_headers({Status, Headers, Body}, Config, Origin) when
+    is_integer(Status), Status >= 100, Status =< 599
+->
+    {Status, actual_headers(Headers, Config, Origin), Body};
+add_actual_headers({stream, Status, Headers, Fun}, Config, Origin) when
+    is_integer(Status), Status >= 100, Status =< 599, is_function(Fun, 1)
+->
+    {stream, Status, actual_headers(Headers, Config, Origin), Fun};
+add_actual_headers({sendfile, Status, Headers, Spec}, Config, Origin) when
+    is_integer(Status), Status >= 100, Status =< 599
+->
+    {sendfile, Status, actual_headers(Headers, Config, Origin), Spec};
+add_actual_headers({loop, Status, Headers, LoopState}, Config, Origin) when
+    is_integer(Status), Status >= 100, Status =< 599
+->
+    {loop, Status, actual_headers(Headers, Config, Origin), LoopState};
+add_actual_headers(Other, _Config, _Origin) ->
+    Other.
+
+-spec actual_headers(roadrunner_http:headers(), config(), binary()) ->
+    roadrunner_http:headers().
+actual_headers(Headers, Config, Origin) ->
+    WithVary = add_vary_origin(Headers),
+    Origins = origins(Config),
+    case allowed(Origin, Origins) of
+        false ->
+            %% Disallowed: only Vary: Origin, no Access-Control-Allow-Origin.
+            WithVary;
+        true ->
+            Creds = credentials(Config),
+            ok = roadrunner_http:check_header_safe(Origin, value),
+            add_cors(
+                [
+                    {~"access-control-allow-origin", allow_origin_value(Origin, Origins, Creds)},
+                    {~"access-control-allow-credentials", credentials_value(Creds)},
+                    {~"access-control-expose-headers", expose_value(Config)}
+                ],
+                WithVary
+            )
+    end.
+
+-spec expose_value(config()) -> binary() | false.
+expose_value(Config) ->
+    case expose(Config) of
+        [] -> false;
+        List -> join(List)
+    end.
+
+%% =============================================================================
+%% Shared header building
+%% =============================================================================
+
+%% Whether the request `Origin` is allowed by the policy.
+-spec allowed(binary(), origins()) -> boolean().
+allowed(_Origin, any) -> true;
+allowed(Origin, List) when is_list(List) -> lists:member(Origin, List);
+allowed(Origin, Fun) when is_function(Fun, 1) -> Fun(Origin) =:= true.
+
+%% The `Access-Control-Allow-Origin` value: the literal `*` only for the public
+%% `origins => any` case without credentials; otherwise the concrete origin (a
+%% browser rejects `*` with credentials, and an allowlist always echoes).
+-spec allow_origin_value(binary(), origins(), boolean()) -> binary().
+allow_origin_value(_Origin, any, false) -> ~"*";
+allow_origin_value(Origin, _Origins, _Creds) -> Origin.
+
+-spec credentials_value(boolean()) -> binary() | false.
+credentials_value(true) -> ~"true";
+credentials_value(false) -> false.
+
+%% Add `Vary: Origin`, appending to an existing `Vary` rather than replacing it
+%% (e.g. `Accept-Encoding` set by `roadrunner_compress`).
+-spec add_vary_origin(roadrunner_http:headers()) -> roadrunner_http:headers().
+add_vary_origin(Headers) ->
+    case lists:keyfind(~"vary", 1, Headers) of
+        false ->
+            [{~"vary", ~"Origin"} | Headers];
+        {_, Existing} ->
+            lists:keystore(~"vary", 1, Headers, {~"vary", <<Existing/binary, ", Origin">>})
+    end.
+
+%% Prepend each candidate the handler didn't already set, skipping any whose
+%% value resolved to `false` (the header doesn't apply under this policy).
+-spec add_cors([{binary(), binary() | false}], roadrunner_http:headers()) ->
+    roadrunner_http:headers().
+add_cors([], Headers) ->
+    Headers;
+add_cors([{_Name, false} | Rest], Headers) ->
+    add_cors(Rest, Headers);
+add_cors([{Name, Value} | Rest], Headers) ->
+    case lists:keymember(Name, 1, Headers) of
+        true -> add_cors(Rest, Headers);
+        false -> [{Name, Value} | add_cors(Rest, Headers)]
+    end.
+
+%% Join binaries with ", " into one binary (header values must be binary).
+-spec join([binary()]) -> binary().
+join([]) -> ~"";
+join([Value]) -> Value;
+join([Value | Rest]) -> <<Value/binary, ", ", (join(Rest))/binary>>.
+
+%% =============================================================================
+%% Config readers (validated lazily; a bad value crashes the request with a
+%% clear `{invalid_cors_opt, Key, Value}` rather than denying silently)
+%% =============================================================================
+
+-spec origins(map()) -> origins().
+origins(#{origins := Origins}) ->
+    case Origins of
+        any -> any;
+        Fun when is_function(Fun, 1) -> Fun;
+        List when is_list(List) -> require_binaries(origins, List);
+        _ -> error({invalid_cors_opt, origins, Origins})
+    end;
+origins(_Config) ->
+    error({invalid_cors_opt, origins, undefined}).
+
+-spec methods(map()) -> [binary()].
+methods(Config) ->
+    case Config of
+        #{methods := Methods} when is_list(Methods) -> require_binaries(methods, Methods);
+        #{methods := Methods} -> error({invalid_cors_opt, methods, Methods});
+        #{} -> [~"GET", ~"HEAD", ~"POST"]
+    end.
+
+-spec headers(map()) -> [binary()] | reflect.
+headers(Config) ->
+    case Config of
+        #{headers := reflect} -> reflect;
+        #{headers := Headers} when is_list(Headers) -> require_binaries(headers, Headers);
+        #{headers := Headers} -> error({invalid_cors_opt, headers, Headers});
+        #{} -> []
+    end.
+
+-spec expose(map()) -> [binary()].
+expose(Config) ->
+    case Config of
+        #{expose := Expose} when is_list(Expose) -> require_binaries(expose, Expose);
+        #{expose := Expose} -> error({invalid_cors_opt, expose, Expose});
+        #{} -> []
+    end.
+
+-spec credentials(map()) -> boolean().
+credentials(Config) ->
+    case Config of
+        #{credentials := Creds} when is_boolean(Creds) -> Creds;
+        #{credentials := Creds} -> error({invalid_cors_opt, credentials, Creds});
+        #{} -> false
+    end.
+
+-spec max_age(map()) -> non_neg_integer() | undefined.
+max_age(Config) ->
+    case Config of
+        #{max_age := Age} when is_integer(Age), Age >= 0 -> Age;
+        #{max_age := Age} -> error({invalid_cors_opt, max_age, Age});
+        #{} -> undefined
+    end.
+
+%% Every element of a configured list must be a binary header/method/origin
+%% name; a charlist (`"x"`, a common slip for `[~"x"]`) is rejected loudly
+%% rather than silently matching nothing.
+-spec require_binaries(atom(), [term()]) -> [binary()].
+require_binaries(Key, List) ->
+    case lists:all(fun is_binary/1, List) of
+        true -> List;
+        false -> error({invalid_cors_opt, Key, List})
+    end.

--- a/test/roadrunner_cors_tests.erl
+++ b/test/roadrunner_cors_tests.erl
@@ -1,0 +1,319 @@
+-module(roadrunner_cors_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_cors).
+-define(ALLOWLIST, #{origins => [~"https://app.example.com"]}).
+-define(ORIGIN, ~"https://app.example.com").
+
+%% =============================================================================
+%% Pure unit tests against `call/3` — no listener, no socket.
+%% =============================================================================
+
+%% --- not a CORS request ---
+
+no_origin_passes_through_test() ->
+    Req = req(~"GET", []),
+    Next = fun(R) -> {{200, [{~"x", ~"y"}], ~"body"}, R} end,
+    {{200, Headers, ~"body"}, _Req2} = ?M:call(Req, Next, ?ALLOWLIST),
+    %% Untouched: no Access-Control / Vary headers added.
+    ?assertEqual(undefined, header(~"access-control-allow-origin", Headers)),
+    ?assertEqual(undefined, header(~"vary", Headers)).
+
+%% --- simple / actual request ---
+
+allowed_origin_echoes_origin_test() ->
+    {Headers, _} = simple(?ORIGIN, ?ALLOWLIST),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)),
+    ?assertEqual(~"Origin", header(~"vary", Headers)).
+
+disallowed_origin_has_no_acao_but_vary_test() ->
+    {Headers, _} = simple(~"https://evil.example.com", ?ALLOWLIST),
+    ?assertEqual(undefined, header(~"access-control-allow-origin", Headers)),
+    %% Vary: Origin even when disallowed, so a cache never cross-serves.
+    ?assertEqual(~"Origin", header(~"vary", Headers)).
+
+origins_any_without_credentials_is_wildcard_test() ->
+    {Headers, _} = simple(?ORIGIN, #{origins => any}),
+    ?assertEqual(~"*", header(~"access-control-allow-origin", Headers)).
+
+origins_any_with_credentials_echoes_concrete_test() ->
+    {Headers, _} = simple(?ORIGIN, #{origins => any, credentials => true}),
+    %% `*` is invalid with credentials — echo the concrete origin instead.
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)),
+    ?assertEqual(~"true", header(~"access-control-allow-credentials", Headers)).
+
+origins_predicate_allows_test() ->
+    Pred = fun(O) -> O =:= ?ORIGIN end,
+    {Headers, _} = simple(?ORIGIN, #{origins => Pred}),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
+
+origins_predicate_denies_test() ->
+    Pred = fun(_) -> false end,
+    {Headers, _} = simple(?ORIGIN, #{origins => Pred}),
+    ?assertEqual(undefined, header(~"access-control-allow-origin", Headers)),
+    ?assertEqual(~"Origin", header(~"vary", Headers)).
+
+expose_headers_test() ->
+    {Headers, _} = simple(?ORIGIN, cfg(#{expose => [~"x-total-count", ~"x-page"]})),
+    ?assertEqual(~"x-total-count, x-page", header(~"access-control-expose-headers", Headers)).
+
+expose_empty_omits_header_test() ->
+    {Headers, _} = simple(?ORIGIN, ?ALLOWLIST),
+    ?assertEqual(undefined, header(~"access-control-expose-headers", Headers)).
+
+vary_appended_to_existing_test() ->
+    Req = req(~"GET", [{~"origin", ?ORIGIN}]),
+    Next = fun(R) -> {{200, [{~"vary", ~"Accept-Encoding"}], ~"b"}, R} end,
+    {{200, Headers, _}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    ?assertEqual(~"Accept-Encoding, Origin", header(~"vary", Headers)).
+
+handler_acao_wins_test() ->
+    Req = req(~"GET", [{~"origin", ?ORIGIN}]),
+    Next = fun(R) -> {{200, [{~"access-control-allow-origin", ~"https://other"}], ~"b"}, R} end,
+    {{200, Headers, _}, _} = ?M:call(Req, Next, #{origins => any}),
+    ?assertEqual([~"https://other"], [V || {~"access-control-allow-origin", V} <- Headers]).
+
+%% --- response shapes ---
+
+stream_response_decorated_test() ->
+    Req = req(~"GET", [{~"origin", ?ORIGIN}]),
+    Fun = fun(_Send) -> ok end,
+    Next = fun(R) -> {{stream, 200, [], Fun}, R} end,
+    {{stream, 200, Headers, OutFun}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    ?assertEqual(Fun, OutFun),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
+
+sendfile_response_decorated_test() ->
+    Req = req(~"GET", [{~"origin", ?ORIGIN}]),
+    Spec = {~"/tmp/x", 0, 10},
+    Next = fun(R) -> {{sendfile, 200, [], Spec}, R} end,
+    {{sendfile, 200, Headers, OutSpec}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    ?assertEqual(Spec, OutSpec),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
+
+loop_response_decorated_test() ->
+    Req = req(~"GET", [{~"origin", ?ORIGIN}]),
+    Next = fun(R) -> {{loop, 200, [], loop_state}, R} end,
+    {{loop, 200, Headers, OutState}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    ?assertEqual(loop_state, OutState),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
+
+websocket_passes_through_test() ->
+    Req = req(~"GET", [{~"origin", ?ORIGIN}]),
+    Next = fun(R) -> {{websocket, some_mod, init_state}, R} end,
+    {Response, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    ?assertMatch({websocket, some_mod, init_state}, Response).
+
+%% --- preflight ---
+
+preflight_allowed_test() ->
+    {Status, Headers} = preflight(?ORIGIN, ~"POST", [], ?ALLOWLIST),
+    ?assertEqual(204, Status),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)),
+    ?assertEqual(~"GET, HEAD, POST", header(~"access-control-allow-methods", Headers)),
+    ?assertEqual(~"Origin", header(~"vary", Headers)).
+
+preflight_short_circuits_without_calling_next_test() ->
+    %% A Next that crashes if called proves the handler is never reached.
+    Req = req(~"OPTIONS", [
+        {~"origin", ?ORIGIN}, {~"access-control-request-method", ~"POST"}
+    ]),
+    Next = fun(_R) -> error(next_must_not_run) end,
+    {{204, _Headers, ~""}, _} = ?M:call(Req, Next, ?ALLOWLIST).
+
+preflight_disallowed_has_only_vary_test() ->
+    {Status, Headers} = preflight(~"https://evil.example.com", ~"POST", [], ?ALLOWLIST),
+    ?assertEqual(204, Status),
+    ?assertEqual(undefined, header(~"access-control-allow-origin", Headers)),
+    ?assertEqual(~"Origin", header(~"vary", Headers)).
+
+preflight_reflects_requested_headers_test() ->
+    {204, Headers} = preflight(
+        ?ORIGIN,
+        ~"POST",
+        [{~"access-control-request-headers", ~"content-type, authorization"}],
+        cfg(#{headers => reflect})
+    ),
+    ?assertEqual(
+        ~"content-type, authorization", header(~"access-control-allow-headers", Headers)
+    ).
+
+preflight_reflect_without_request_headers_omits_test() ->
+    {204, Headers} = preflight(?ORIGIN, ~"POST", [], cfg(#{headers => reflect})),
+    ?assertEqual(undefined, header(~"access-control-allow-headers", Headers)).
+
+preflight_headers_list_test() ->
+    {204, Headers} = preflight(
+        ?ORIGIN, ~"POST", [], cfg(#{headers => [~"content-type", ~"x-api-key"]})
+    ),
+    ?assertEqual(~"content-type, x-api-key", header(~"access-control-allow-headers", Headers)).
+
+preflight_max_age_test() ->
+    {204, Headers} = preflight(?ORIGIN, ~"POST", [], cfg(#{max_age => 600})),
+    ?assertEqual(~"600", header(~"access-control-max-age", Headers)).
+
+preflight_credentials_test() ->
+    {204, Headers} = preflight(?ORIGIN, ~"POST", [], #{origins => any, credentials => true}),
+    ?assertEqual(~"true", header(~"access-control-allow-credentials", Headers)),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
+
+preflight_empty_methods_test() ->
+    {204, Headers} = preflight(?ORIGIN, ~"POST", [], cfg(#{methods => []})),
+    ?assertEqual(~"", header(~"access-control-allow-methods", Headers)).
+
+options_without_request_method_is_not_preflight_test() ->
+    %% An `OPTIONS` lacking `Access-Control-Request-Method` is a normal request,
+    %% not a preflight: the handler runs and gets the actual-request headers.
+    Req = req(~"OPTIONS", [{~"origin", ?ORIGIN}]),
+    Next = fun(R) -> {{200, [], ~"handled"}, R} end,
+    {{200, Headers, ~"handled"}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
+
+%% --- header injection guard ---
+
+unsafe_origin_crashes_test() ->
+    %% An attacker-controlled origin carrying CR/LF must not reach the wire.
+    Req = req(~"GET", [{~"origin", <<"https://evil\r\nx-injected: 1">>}]),
+    Next = fun(R) -> {{200, [], ~"b"}, R} end,
+    ?assertError({header_injection, value, _}, ?M:call(Req, Next, #{origins => any})).
+
+%% --- config validation ---
+
+missing_origins_crashes_test() ->
+    ?assertError({invalid_cors_opt, origins, undefined}, simple(?ORIGIN, #{})).
+
+bad_origins_type_crashes_test() ->
+    ?assertError({invalid_cors_opt, origins, not_valid}, simple(?ORIGIN, #{origins => not_valid})).
+
+bad_origins_charlist_crashes_test() ->
+    %% A charlist is a common slip for `[~"..."]`; reject it loudly.
+    ?assertError(
+        {invalid_cors_opt, origins, "https://app.example.com"},
+        simple(?ORIGIN, #{origins => "https://app.example.com"})
+    ).
+
+bad_methods_crashes_test() ->
+    ?assertError(
+        {invalid_cors_opt, methods, get},
+        preflight(?ORIGIN, ~"POST", [], cfg(#{methods => get}))
+    ).
+
+bad_headers_crashes_test() ->
+    ?assertError(
+        {invalid_cors_opt, headers, 123},
+        preflight(?ORIGIN, ~"POST", [], cfg(#{headers => 123}))
+    ).
+
+bad_expose_crashes_test() ->
+    ?assertError(
+        {invalid_cors_opt, expose, all}, simple(?ORIGIN, cfg(#{expose => all}))
+    ).
+
+bad_credentials_crashes_test() ->
+    ?assertError(
+        {invalid_cors_opt, credentials, yes}, simple(?ORIGIN, cfg(#{credentials => yes}))
+    ).
+
+bad_max_age_crashes_test() ->
+    ?assertError(
+        {invalid_cors_opt, max_age, -1},
+        preflight(?ORIGIN, ~"POST", [], cfg(#{max_age => -1}))
+    ).
+
+%% =============================================================================
+%% End-to-end through roadrunner_listener.
+%% =============================================================================
+
+end_to_end_test_() ->
+    {setup,
+        fun() ->
+            {ok, _} = roadrunner_listener:start_link(cors_e2e, #{
+                port => 0,
+                routes => roadrunner_hello_handler,
+                middlewares => [{roadrunner_cors, #{origins => [~"https://app.example.com"]}}]
+            }),
+            roadrunner_listener:port(cors_e2e)
+        end,
+        fun(_) -> ok = roadrunner_listener:stop(cors_e2e) end, fun(Port) ->
+            [
+                {"cross-origin GET echoes the allowed origin and varies on it", fun() ->
+                    Reply = request(Port, [
+                        ~"GET / HTTP/1.1\r\n",
+                        ~"Host: x\r\n",
+                        ~"Origin: https://app.example.com\r\n",
+                        ~"Connection: close\r\n\r\n"
+                    ]),
+                    {match, _} = re:run(
+                        Reply, ~"access-control-allow-origin: https://app.example.com", [caseless]
+                    ),
+                    {match, _} = re:run(Reply, ~"vary: Origin", [caseless])
+                end},
+                {"OPTIONS preflight short-circuits with 204 and the allow set", fun() ->
+                    Reply = request(Port, [
+                        ~"OPTIONS / HTTP/1.1\r\n",
+                        ~"Host: x\r\n",
+                        ~"Origin: https://app.example.com\r\n",
+                        ~"Access-Control-Request-Method: POST\r\n",
+                        ~"Connection: close\r\n\r\n"
+                    ]),
+                    ?assertMatch(<<"HTTP/1.1 204", _/binary>>, Reply),
+                    {match, _} = re:run(
+                        Reply, ~"access-control-allow-origin: https://app.example.com", [caseless]
+                    ),
+                    {match, _} = re:run(Reply, ~"access-control-allow-methods:", [caseless])
+                end}
+            ]
+        end}.
+
+%% --- helpers ---
+
+%% Allowlist config with `Extra` merged in. Updates the `Extra` variable (not a
+%% literal map) so the compiler's update-literal warning doesn't fire.
+cfg(Extra) ->
+    Extra#{origins => [?ORIGIN]}.
+
+%% Run a simple (non-preflight) GET with the given origin and config; returns
+%% the response headers and request.
+simple(Origin, Config) ->
+    Req = req(~"GET", [{~"origin", Origin}]),
+    Next = fun(R) -> {{200, [], ~"body"}, R} end,
+    {{200, Headers, ~"body"}, Req2} = ?M:call(Req, Next, Config),
+    {Headers, Req2}.
+
+%% Run a preflight OPTIONS; returns the response status and headers. The Next
+%% crashes if called, asserting the short-circuit.
+preflight(Origin, RequestMethod, ExtraHeaders, Config) ->
+    Req = req(~"OPTIONS", [
+        {~"origin", Origin}, {~"access-control-request-method", RequestMethod} | ExtraHeaders
+    ]),
+    Next = fun(_R) -> error(next_must_not_run) end,
+    {{Status, Headers, ~""}, _} = ?M:call(Req, Next, Config),
+    {Status, Headers}.
+
+req(Method, Headers) ->
+    #{
+        method => Method,
+        target => ~"/",
+        version => {1, 1},
+        headers => Headers
+    }.
+
+header(Name, Headers) ->
+    case lists:keyfind(Name, 1, Headers) of
+        {_, V} -> V;
+        false -> undefined
+    end.
+
+request(Port, IoData) ->
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Sock, IoData),
+    Reply = recv_all(Sock, <<>>),
+    ok = gen_tcp:close(Sock),
+    Reply.
+
+recv_all(Sock, Acc) ->
+    case gen_tcp:recv(Sock, 0, 1000) of
+        {ok, Data} -> recv_all(Sock, <<Acc/binary, Data/binary>>);
+        {error, _} -> Acc
+    end.


### PR DESCRIPTION
# Description

Adds `roadrunner_cors`, a configurable CORS middleware. It answers the browser's `OPTIONS` preflight with a `204` carrying the `Access-Control-*` set (without calling the handler), and decorates cross-origin responses with `Access-Control-Allow-Origin` plus credentials / exposed headers. The origin policy is an allowlist, a predicate fun, or `any`, deny-by-default. `Vary: Origin` goes on every CORS response (allowed or not), appended to an existing `Vary` rather than replaced. With credentials it echoes the concrete origin instead of `*`. A bad config option crashes the request with `{invalid_cors_opt, Key, Value}`.

```erlang
middlewares => [{roadrunner_cors, #{origins => [~"https://app.example.com"], credentials => true}}]
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
