### PR TITLE
Add an opt-in per-peer request-rate guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,10 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
 
 - **DoS bounds**: `max_clients`, `max_concurrent_requests`,
   `socket_backlog`, `max_content_length`, `request_timeout`,
-  `keep_alive_timeout`, `min_bytes_per_second`, `max_keep_alive_requests`
+  `keep_alive_timeout`, `min_bytes_per_second`, `max_keep_alive_requests`,
+  `rate_limit` (opt-in per-peer request-rate guard)
+- **Real client IP**: `proxy_protocol` (read the PROXY-protocol header an
+  L4 balancer prepends, so `roadrunner_req:peer/1` is the real client)
 - **Middleware**: `middlewares`
 - **Body buffering**: `body_buffering`
 - **Graceful drain**: `graceful_drain`, `slot_reconciliation`
@@ -325,6 +328,16 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   `{Callable, State}` pair, where `Callable` is a module (`call/3`) or a
   `fun((Req, Next, State) -> {Response, Req2})`. Listener-level + per-route,
   first-in-list = outermost.
+
+### Built-in middleware
+
+- **`roadrunner_compress`**: gzip / deflate response compression negotiated
+  on `Accept-Encoding`, with `Vary: Accept-Encoding`.
+- **`roadrunner_security_headers`**: a default-safe response header set
+  (`x-content-type-options`, `x-frame-options`, `referrer-policy`), with
+  opt-in HSTS and CSP; a header the handler already set wins.
+- **`roadrunner_cors`**: configurable CORS with an `OPTIONS` preflight
+  short-circuit, deny-by-default origins, and a cache-correct `Vary: Origin`.
 
 ### Built-in handlers
 

--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -4,7 +4,7 @@ Roadrunner bounds how much memory and CPU a single connection or peer
 can pull in before any handler runs. The goal is that no client, by
 sending oversized, malformed, or slow input, can grow a connection's
 memory without bound or pin a worker. Every limit on this page is on by
-default.
+default, except the opt-in per-peer rate guard (`rate_limit`, below).
 
 This page is an operator reference. For the reporting policy, see
 `SECURITY.md`. For the exact option types, see
@@ -114,6 +114,7 @@ so there is no dynamic-table memory to bound yet.
 | `keep_alive_timeout` | 60 s | yes | idle timeout between requests |
 | `max_keep_alive_requests` | 1000 | yes | requests served per connection before close |
 | `min_bytes_per_second` | 100 | yes (0 disables) | slow-loris guard on the request-read phase |
+| `rate_limit` | off | opt-in | per-peer request-rate cap (`429` + `Retry-After`) |
 
 `max_clients` bounds connections and the HTTP/2 / HTTP/3
 `max_concurrent_streams` bounds streams per connection, but their product
@@ -128,6 +129,21 @@ handler runs, and the refusal emits `[roadrunner, request, throttled]` and
 increments the `throttled` count from `roadrunner_listener:info/1`. HTTP/1
 is unaffected: it serves one request per connection, so `max_clients`
 already bounds it.
+
+Where `max_clients` and `max_concurrent_requests` bound the listener's
+total load, `rate_limit` (off by default, the only opt-in guard here) caps
+a single **source**, so one peer cannot monopolize the server. It is a
+token bucket keyed on the client IP: `#{rate := N, period => Secs, burst
+=> B}` allows `N` requests per `period` seconds (default 1) with a burst
+of `B` (default `N`). A peer over its rate gets `429 Too Many Requests` +
+`Retry-After` before any handler runs (a real 429 on HTTP/2 and HTTP/3,
+not the retry-safe `REFUSED_STREAM` / `H3_REQUEST_REJECTED`, so clients
+back off instead of retrying at once), emitting `[roadrunner, request,
+throttled]` with `reason => rate_limit` and incrementing the
+`rate_limited` count from `roadrunner_listener:info/1`. Idle per-peer
+buckets are swept on a timer (`idle_ttl` / `sweep_interval`). It keys on
+the real client IP, so set `proxy_protocol` behind an L4 balancer for
+accurate per-client limiting.
 
 ## Configuring
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -526,24 +526,24 @@ cost is worth it at their response sizes.
 **Scope:** small. Reuses the static handler's ETag and `If-None-Match`
 comparison; the new part is hashing the dynamic body and the 304 path.
 
-### Per-peer request-rate guard — medium
+### Rate-guard pre-body rejection — small, with a hazard
 
-**What:** A token-bucket abuse guard keyed by peer (the real client IP,
-accurate behind a proxy once PROXY-protocol support lands), answering
-`429 Too Many Requests` with `Retry-After` when one peer exceeds a
-configured request rate. It belongs to the same DoS-protection family as
-the slowloris `min_bytes_per_second` guard and `max_clients`: it stops a
-single source monopolizing the server rather than enforcing application
-quotas.
+**What:** The per-peer `rate_limit` check sits at handler dispatch (after the
+request body is read), matching the `max_concurrent_requests` sibling. Rejecting
+right after the request headers on HTTP/1 would avoid reading a rate-limited
+request's body.
 
-**Why deferred:** the existing caps already bound total load; per-peer
-fairness matters once a deployment sees one source flooding it. The
-per-peer bucket state (an `atomics` / ETS store) wants a clean ownership
-and sweep story before it ships. Richer per-user or per-route quota
-policy is application logic, expressed above the server.
+**Why deferred:** the expensive handler work is already skipped at the dispatch
+point, so this only saves the (already `max_content_length`-bounded) body read,
+on h1 only. And it carries a real hazard: closing the connection on a 429 while
+the client is still sending its body triggers a TCP reset that can discard the
+429 before the client reads it. The post-body placement drains the body first
+and delivers the response cleanly (the reason nginx/Apache drain before
+erroring); a correct pre-body version needs a read-some-then-drain strategy that
+undercuts the saving. Wants a real large-body-flood driver before taking it on.
 
-**Scope:** medium. The bucket math is small; the per-peer store and its
-sweep are the bulk.
+**Scope:** small code, but the RST-delivery hazard makes the current post-body
+placement the safer default.
 
 ### Graceful load-shedding — small-medium
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -68,7 +68,7 @@
     rate_limit_check/6,
     resolve_rate_limit/2,
     rate_limited_telemetry/2,
-    rate_limit_evict_idle/4,
+    rate_limit_evict_idle/3,
     drain_oversized_body/3,
     send_internal_error/1,
     send_not_found/1,
@@ -414,25 +414,20 @@ rate_limited_telemetry(ListenerName, Counter) ->
     }).
 
 -doc """
-Evict per-peer buckets idle since before `NowMs - IdleTtl`, at most `MaxRows`
-per call so one listener sweep tick can't stall on a huge table (the rest wait
-for the next tick). Returns the number evicted. The bounded eviction is what
-keeps the bucket store from growing without limit at high `max_clients`.
+Evict every per-peer bucket idle since before `NowMs - IdleTtl`, in one
+`select_delete` pass, returning the number evicted. A single pass (rather than a
+per-tick row budget) is what actually bounds the store to the active-peer set: a
+budget would cap eviction below the rate new buckets are created under a
+high-cardinality scan, letting the table grow without limit. The pass runs on
+the listener gen_server (control plane, off the request path), so a full
+traversal every sweep tick is cheap.
 """.
--spec rate_limit_evict_idle(ets:table(), integer(), pos_integer(), pos_integer()) ->
-    non_neg_integer().
-rate_limit_evict_idle(Table, NowMs, IdleTtl, MaxRows) ->
+-spec rate_limit_evict_idle(ets:table(), integer(), pos_integer()) -> non_neg_integer().
+rate_limit_evict_idle(Table, NowMs, IdleTtl) ->
     Cutoff = NowMs - IdleTtl,
-    %% Row is `{IP, Tokens, LastMs}`; match those last touched before `Cutoff`
-    %% and return the `IP` key to delete.
-    Spec = [{{'$1', '_', '$2'}, [{'<', '$2', Cutoff}], ['$1']}],
-    case ets:select(Table, Spec, MaxRows) of
-        '$end_of_table' ->
-            0;
-        {Keys, _Cont} ->
-            lists:foreach(fun(Key) -> true = ets:delete(Table, Key) end, Keys),
-            length(Keys)
-    end.
+    %% Row is `{IP, Units, LastMs}`; delete those last touched before `Cutoff`.
+    Spec = [{{'_', '_', '$1'}, [{'<', '$1', Cutoff}], [true]}],
+    ets:select_delete(Table, Spec).
 
 -doc "Decrement the in-flight-request counter, paired with `try_acquire_request_slot/2`.".
 -spec release_request_slot(infinity | pos_integer(), counters:counters_ref() | undefined) -> ok.

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -200,8 +200,9 @@
 }.
 
 %% The per-connection rate-limit guard state cached on each conn loop's record:
-%% the `{Rate, Burst, Period, Table, Counter, IP}` resolved from `proto_opts` +
-%% the peer once at setup (see `resolve_rate_limit/2`), or `undefined` when the
+%% the `{Rate, Cap, Cost, Table, Counter, IP}` resolved from `proto_opts` + the
+%% peer once at setup (see `resolve_rate_limit/2`) — with `Cap`/`Cost` already
+%% derived so the per-request check does no arithmetic — or `undefined` when the
 %% guard is off or the peer IP is unknown. Checked by `rate_limit_check/6`.
 -type rate_limit_state() ::
     {
@@ -363,7 +364,12 @@ resolve_rate_limit(
     },
     {IP, _Port}
 ) ->
-    {Rate, Burst, Period, Table, Counter, IP};
+    %% Bake the derived `Cost` (units/request) and `Cap` (bucket capacity) here,
+    %% once per connection, so the per-request `rate_limit_check/6` does no
+    %% multiplication.
+    Cost = Period * 1000,
+    Cap = Burst * Cost,
+    {Rate, Cap, Cost, Table, Counter, IP};
 resolve_rate_limit(_ProtoOpts, _Peer) ->
     undefined.
 
@@ -383,25 +389,26 @@ deterministically testable).
     ets:table(), inet:ip_address(), pos_integer(), pos_integer(), pos_integer(), integer()
 ) ->
     allow | {deny, pos_integer()}.
-rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) ->
-    %% `Rate` requests per `Period` seconds: one request costs `Cost` units,
-    %% the bucket holds up to `Cap` (see `roadrunner_rate_limit`).
-    Cost = Period * 1000,
-    Cap = Burst * Cost,
-    {Units0, LastMs} =
+rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) ->
+    %% `Cap` (bucket capacity) and `Cost` (units per request) are resolved once
+    %% per connection (see `resolve_rate_limit/2`), not per request. A
+    %% never-seen peer starts at a full bucket (`Cap`) and needs no refill; an
+    %% existing one is refilled for the elapsed time in place (no intermediate
+    %% tuple).
+    Refilled =
         case ets:lookup(Table, IP) of
-            [{IP, U, L}] -> {U, L};
-            %% First request from this peer: a full bucket.
-            [] -> {Cap, NowMs}
+            [{IP, Units, LastMs}] ->
+                roadrunner_rate_limit:refill(Units, LastMs, NowMs, Rate, Cap);
+            [] ->
+                Cap
         end,
-    Refilled = roadrunner_rate_limit:refill(Units0, LastMs, NowMs, Rate, Cap),
     case roadrunner_rate_limit:spend(Refilled, Cost) of
-        {ok, Remaining} ->
-            true = ets:insert(Table, {IP, Remaining, NowMs}),
-            allow;
         denied ->
             true = ets:insert(Table, {IP, Refilled, NowMs}),
-            {deny, roadrunner_rate_limit:retry_after_secs(Refilled, Rate, Cost)}
+            {deny, roadrunner_rate_limit:retry_after_secs(Refilled, Rate, Cost)};
+        Remaining ->
+            true = ets:insert(Table, {IP, Remaining, NowMs}),
+            allow
     end.
 
 -doc "Record a rate-limit refusal: bump the cumulative counter and emit telemetry.".

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -64,6 +64,11 @@
     send_status/2,
     parse_error_status/1,
     send_payload_too_large/1,
+    send_rate_limited/2,
+    rate_limit_check/6,
+    resolve_rate_limit/2,
+    rate_limited_telemetry/2,
+    rate_limit_evict_idle/4,
     drain_oversized_body/3,
     send_internal_error/1,
     send_not_found/1,
@@ -73,7 +78,7 @@
     head_response/2
 ]).
 
--export_type([proto_opts/0, dispatch/0]).
+-export_type([proto_opts/0, dispatch/0, rate_limit/0, rate_limit_state/0]).
 
 -on_load(init_patterns/0).
 
@@ -112,6 +117,14 @@
     max_concurrent_requests := infinity | pos_integer(),
     inflight_counter := counters:counters_ref(),
     throttled_counter := atomics:atomics_ref(),
+    %% Per-peer request-rate guard (off by default). `rate_limit` carries the
+    %% resolved config + per-listener ETS bucket store when the `rate_limit`
+    %% opt is set, else `undefined`. `rate_limited_counter` is the cumulative
+    %% count of requests refused at the per-peer rate, mirroring
+    %% `throttled_counter`, surfaced in `roadrunner_listener:info/1` (always
+    %% present, stays 0 when the guard is off).
+    rate_limit := undefined | rate_limit(),
+    rate_limited_counter := atomics:atomics_ref(),
     min_bytes_per_second := non_neg_integer(),
     body_buffering := auto | manual,
     listener_name => atom(),
@@ -171,6 +184,35 @@
     handler_spawn_opts => [proc_lib:start_spawn_option()],
     handler_start_timeout => timeout()
 }.
+
+%% Resolved per-peer rate-limit config, built by `roadrunner_listener` when the
+%% `rate_limit` opt is set: `rate` requests per `period` seconds with a `burst`
+%% bucket capacity, and an `idle_ttl`/`sweep_interval` (ms) eviction policy for
+%% the ETS `table` holding each peer's bucket. The cumulative refusal count
+%% lives in the top-level `rate_limited_counter`.
+-type rate_limit() :: #{
+    rate := pos_integer(),
+    burst := pos_integer(),
+    period := pos_integer(),
+    idle_ttl := pos_integer(),
+    sweep_interval := pos_integer(),
+    table := ets:table()
+}.
+
+%% The per-connection rate-limit guard state cached on each conn loop's record:
+%% the `{Rate, Burst, Period, Table, Counter, IP}` resolved from `proto_opts` +
+%% the peer once at setup (see `resolve_rate_limit/2`), or `undefined` when the
+%% guard is off or the peer IP is unknown. Checked by `rate_limit_check/6`.
+-type rate_limit_state() ::
+    {
+        pos_integer(),
+        pos_integer(),
+        pos_integer(),
+        ets:table(),
+        atomics:atomics_ref(),
+        inet:ip_address()
+    }
+    | undefined.
 
 -doc """
 Spawn an unlinked connection process for the accepted `Socket` and the
@@ -302,6 +344,94 @@ try_acquire_request_slot(Max, Counter) ->
         _ ->
             ok = counters:sub(Counter, 1, 1),
             false
+    end.
+
+%% Resolve the per-connection rate-limit tuple `{Rate, Burst, Table, Counter,
+%% IP}` from `proto_opts` + the (constant-per-conn) peer once at setup, or
+%% `undefined` when the guard is off, so the per-request check is a single
+%% branch on a cached value. The peer IP is baked in here, so the catch-all
+%% also covers a missing peer (a 2-tuple `{IP, _}` is required) as well as
+%% `rate_limit => undefined` and the hand-built proto_opts in unit tests.
+-doc false.
+-spec resolve_rate_limit(
+    proto_opts(), {inet:ip_address(), inet:port_number()} | undefined
+) -> rate_limit_state().
+resolve_rate_limit(
+    #{
+        rate_limit := #{rate := Rate, burst := Burst, period := Period, table := Table},
+        rate_limited_counter := Counter
+    },
+    {IP, _Port}
+) ->
+    {Rate, Burst, Period, Table, Counter, IP};
+resolve_rate_limit(_ProtoOpts, _Peer) ->
+    undefined.
+
+-doc """
+Per-peer token-bucket check, the per-source sibling of
+`try_acquire_request_slot/2`. Reads the peer `IP`'s bucket from the listener's
+ETS `Table` (a never-seen peer starts full), refills it for the elapsed time,
+and tries to spend one request. `allow` on success, `{deny, RetryAfterSecs}`
+when the bucket is empty. The read-refill-write is last-write-wins: concurrent
+connections from one IP can overshoot the bucket by a bounded amount, the same
+contract `try_acquire_request_slot/2` documents.
+
+`NowMs` is `erlang:monotonic_time(millisecond)` (passed in so the bucket math is
+deterministically testable).
+""".
+-spec rate_limit_check(
+    ets:table(), inet:ip_address(), pos_integer(), pos_integer(), pos_integer(), integer()
+) ->
+    allow | {deny, pos_integer()}.
+rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) ->
+    %% `Rate` requests per `Period` seconds: one request costs `Cost` units,
+    %% the bucket holds up to `Cap` (see `roadrunner_rate_limit`).
+    Cost = Period * 1000,
+    Cap = Burst * Cost,
+    {Units0, LastMs} =
+        case ets:lookup(Table, IP) of
+            [{IP, U, L}] -> {U, L};
+            %% First request from this peer: a full bucket.
+            [] -> {Cap, NowMs}
+        end,
+    Refilled = roadrunner_rate_limit:refill(Units0, LastMs, NowMs, Rate, Cap),
+    case roadrunner_rate_limit:spend(Refilled, Cost) of
+        {ok, Remaining} ->
+            true = ets:insert(Table, {IP, Remaining, NowMs}),
+            allow;
+        denied ->
+            true = ets:insert(Table, {IP, Refilled, NowMs}),
+            {deny, roadrunner_rate_limit:retry_after_secs(Refilled, Rate, Cost)}
+    end.
+
+-doc "Record a rate-limit refusal: bump the cumulative counter and emit telemetry.".
+-spec rate_limited_telemetry(atom(), atomics:atomics_ref()) -> ok.
+rate_limited_telemetry(ListenerName, Counter) ->
+    ok = atomics:add(Counter, 1, 1),
+    roadrunner_telemetry:request_throttled(#{
+        listener_name => ListenerName,
+        reason => rate_limit
+    }).
+
+-doc """
+Evict per-peer buckets idle since before `NowMs - IdleTtl`, at most `MaxRows`
+per call so one listener sweep tick can't stall on a huge table (the rest wait
+for the next tick). Returns the number evicted. The bounded eviction is what
+keeps the bucket store from growing without limit at high `max_clients`.
+""".
+-spec rate_limit_evict_idle(ets:table(), integer(), pos_integer(), pos_integer()) ->
+    non_neg_integer().
+rate_limit_evict_idle(Table, NowMs, IdleTtl, MaxRows) ->
+    Cutoff = NowMs - IdleTtl,
+    %% Row is `{IP, Tokens, LastMs}`; match those last touched before `Cutoff`
+    %% and return the `IP` key to delete.
+    Spec = [{{'$1', '_', '$2'}, [{'<', '$2', Cutoff}], ['$1']}],
+    case ets:select(Table, Spec, MaxRows) of
+        '$end_of_table' ->
+            0;
+        {Keys, _Cont} ->
+            lists:foreach(fun(Key) -> true = ets:delete(Table, Key) end, Keys),
+            length(Keys)
     end.
 
 -doc "Decrement the in-flight-request counter, paired with `try_acquire_request_slot/2`.".
@@ -1122,6 +1252,19 @@ send_payload_too_large(Socket) ->
     Resp = roadrunner_http1:response(
         413,
         [{~"content-length", ~"0"}, {~"connection", ~"close"}],
+        ~""
+    ),
+    roadrunner_transport:send(Socket, Resp).
+
+-spec send_rate_limited(roadrunner_transport:socket(), pos_integer()) -> ok | {error, term()}.
+send_rate_limited(Socket, RetryAfterSecs) ->
+    Resp = roadrunner_http1:response(
+        429,
+        [
+            {~"content-length", ~"0"},
+            {~"connection", ~"close"},
+            {~"retry-after", integer_to_binary(RetryAfterSecs)}
+        ],
         ~""
     ),
     roadrunner_transport:send(Socket, Resp).

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -125,7 +125,11 @@
     %% each request gets its own grace + budget).
     min_rate = 0 :: non_neg_integer(),
     recv_phase_start = 0 :: integer(),
-    recv_phase_bytes = 0 :: non_neg_integer()
+    recv_phase_bytes = 0 :: non_neg_integer(),
+    %% Per-peer rate-limit guard resolved from `proto_opts` + peer once at
+    %% `shoot` (`undefined` when off — the common case, a single branch in
+    %% `dispatch_phase/2`).
+    rate_limit = undefined :: roadrunner_conn:rate_limit_state()
 }).
 
 -spec start(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) ->
@@ -247,7 +251,8 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
                     maps:get(http1_max_header_line, ProtoOpts, 8192),
                     maps:get(http1_max_header_block, ProtoOpts, 10240),
                     maps:get(http1_max_header_count, ProtoOpts, 100)
-                }
+                },
+                rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer)
             },
             read_request_phase(S)
     end.
@@ -673,16 +678,45 @@ read_body_phase(
 dispatch_phase(
     #loop_state{
         socket = Socket,
-        dispatch = Dispatch
+        dispatch = Dispatch,
+        listener_name = ListenerName,
+        rate_limit = RateLimit
     } = S,
     Req
 ) ->
-    case roadrunner_conn:resolve_handler(Dispatch, Req) of
-        {ok, Handler, Bindings, Pipeline, _State} ->
-            run_pipeline(S, Handler, Req#{bindings => Bindings}, Pipeline);
-        not_found ->
-            _ = roadrunner_conn:send_not_found(Socket),
+    case rate_limit_allows(RateLimit, Socket, ListenerName) of
+        true ->
+            case roadrunner_conn:resolve_handler(Dispatch, Req) of
+                {ok, Handler, Bindings, Pipeline, _State} ->
+                    run_pipeline(S, Handler, Req#{bindings => Bindings}, Pipeline);
+                not_found ->
+                    _ = roadrunner_conn:send_not_found(Socket),
+                    exit_normal(S)
+            end;
+        false ->
+            %% Rate exceeded: `rate_limit_allows/4` already sent 429 + close.
             exit_normal(S)
+    end.
+
+%% Per-peer rate-limit gate before handler dispatch. `true` to proceed; `false`
+%% after a 429 + `Retry-After` was sent. The guard being off (`undefined`, which
+%% also covers a connection with no peer IP) always proceeds.
+-spec rate_limit_allows(
+    roadrunner_conn:rate_limit_state(),
+    roadrunner_transport:socket(),
+    atom()
+) -> boolean().
+rate_limit_allows(undefined, _Socket, _ListenerName) ->
+    true;
+rate_limit_allows({Rate, Burst, Period, Table, Counter, IP}, Socket, ListenerName) ->
+    NowMs = erlang:monotonic_time(millisecond),
+    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) of
+        allow ->
+            true;
+        {deny, RetryAfter} ->
+            ok = roadrunner_conn:rate_limited_telemetry(ListenerName, Counter),
+            _ = roadrunner_conn:send_rate_limited(Socket, RetryAfter),
+            false
     end.
 
 -spec run_pipeline(

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -708,9 +708,9 @@ dispatch_phase(
 ) -> boolean().
 rate_limit_allows(undefined, _Socket, _ListenerName) ->
     true;
-rate_limit_allows({Rate, Burst, Period, Table, Counter, IP}, Socket, ListenerName) ->
+rate_limit_allows({Rate, Cap, Cost, Table, Counter, IP}, Socket, ListenerName) ->
     NowMs = erlang:monotonic_time(millisecond),
-    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) of
+    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
         allow ->
             true;
         {deny, RetryAfter} ->

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1785,13 +1785,13 @@ rate_limit_refused(#loop{rate_limit = undefined}, _StreamId) ->
     ok;
 rate_limit_refused(
     #loop{
-        rate_limit = {Rate, Burst, Period, Table, Counter, IP},
+        rate_limit = {Rate, Cap, Cost, Table, Counter, IP},
         listener_name = ListenerName
     } = State,
     StreamId
 ) ->
     NowMs = erlang:monotonic_time(millisecond),
-    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) of
+    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
         allow ->
             ok;
         {deny, RetryAfter} ->

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -244,6 +244,9 @@
     %% passes them to `roadrunner_conn` directly. See `dispatch_stream/2`.
     max_concurrent_requests = infinity :: infinity | pos_integer(),
     inflight_counter :: counters:counters_ref() | undefined,
+    %% Per-peer rate-limit guard resolved from proto_opts + peer at `enter/6`
+    %% (`undefined` when off). Checked in `dispatch_stream/2`.
+    rate_limit = undefined :: roadrunner_conn:rate_limit_state(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -333,6 +336,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered) ->
         alt_svc = AltSvc,
         max_concurrent_requests = MaxConcReq,
         inflight_counter = InflightCounter,
+        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
         handshake_timeout = HandshakeTimeout,
         idle_timeout = IdleTimeout
     },
@@ -1133,32 +1137,43 @@ dispatch_stream(
             },
             case roadrunner_http2_request:from_headers(Headers, BodyIolist, RequestContext) of
                 {ok, Req} ->
-                    case roadrunner_conn:try_acquire_request_slot(MaxConcReq, InflightCounter) of
-                        true ->
-                            {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
-                                self(), StreamId, Req, ProtoOpts
-                            ),
-                            Stream1 = Stream#{
-                                worker_pid := WorkerPid,
-                                worker_ref := MonRef,
-                                state := half_closed_remote,
-                                body := []
-                            },
-                            State1 = State#loop{
-                                streams = Streams#{StreamId := Stream1},
-                                worker_refs = (State#loop.worker_refs)#{MonRef => StreamId},
-                                req_id_buffer = NewBuf
-                            },
-                            frame_loop(State1);
-                        false ->
-                            %% Listener-wide in-flight ceiling reached — refuse
-                            %% the stream (retry-safe REFUSED_STREAM) without
-                            %% spawning a worker.
-                            ok = throttle_stream(State, ListenerName),
-                            _ = send_rst_stream(State, StreamId, refused_stream),
-                            frame_loop(
-                                remove_stream(State#loop{req_id_buffer = NewBuf}, StreamId)
-                            )
+                    StateBuf = State#loop{req_id_buffer = NewBuf},
+                    case rate_limit_refused(StateBuf, StreamId) of
+                        {refused, State1} ->
+                            %% Per-peer rate exceeded: 429 + RST(no_error) sent,
+                            %% no worker spawned. 429 (not REFUSED_STREAM) so the
+                            %% client backs off per Retry-After instead of
+                            %% retrying the stream immediately.
+                            frame_loop(remove_stream(State1, StreamId));
+                        ok ->
+                            case
+                                roadrunner_conn:try_acquire_request_slot(
+                                    MaxConcReq, InflightCounter
+                                )
+                            of
+                                true ->
+                                    {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
+                                        self(), StreamId, Req, ProtoOpts
+                                    ),
+                                    Stream1 = Stream#{
+                                        worker_pid := WorkerPid,
+                                        worker_ref := MonRef,
+                                        state := half_closed_remote,
+                                        body := []
+                                    },
+                                    frame_loop(StateBuf#loop{
+                                        streams = Streams#{StreamId := Stream1},
+                                        worker_refs =
+                                            (StateBuf#loop.worker_refs)#{MonRef => StreamId}
+                                    });
+                                false ->
+                                    %% Listener-wide in-flight ceiling reached —
+                                    %% refuse with retry-safe REFUSED_STREAM, no
+                                    %% worker spawned.
+                                    ok = throttle_stream(StateBuf, ListenerName),
+                                    _ = send_rst_stream(StateBuf, StreamId, refused_stream),
+                                    frame_loop(remove_stream(StateBuf, StreamId))
+                            end
                     end;
                 {error, _Reason} ->
                     _ = send_rst_stream(State, StreamId, protocol_error),
@@ -1758,6 +1773,35 @@ throttle_stream(#loop{proto_opts = #{throttled_counter := Counter}}, ListenerNam
         listener_name => ListenerName,
         reason => max_concurrent_requests
     }).
+
+%% Per-peer rate-limit gate before spawning a stream worker. `ok` to proceed;
+%% `{refused, State1}` after sending `429` + `Retry-After` and an
+%% `RST_STREAM(NO_ERROR)` on the request stream (the rate was exceeded). 429
+%% (not `REFUSED_STREAM`) so the client honors `Retry-After` instead of
+%% retrying the stream immediately. The guard being off (`undefined`) or a
+%% missing peer IP proceeds.
+-spec rate_limit_refused(#loop{}, stream_id()) -> ok | {refused, #loop{}}.
+rate_limit_refused(#loop{rate_limit = undefined}, _StreamId) ->
+    ok;
+rate_limit_refused(
+    #loop{
+        rate_limit = {Rate, Burst, Period, Table, Counter, IP},
+        listener_name = ListenerName
+    } = State,
+    StreamId
+) ->
+    NowMs = erlang:monotonic_time(millisecond),
+    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) of
+        allow ->
+            ok;
+        {deny, RetryAfter} ->
+            ok = roadrunner_conn:rate_limited_telemetry(ListenerName, Counter),
+            State1 = encode_and_send_response_atomic(
+                State, StreamId, 429, [{~"retry-after", integer_to_binary(RetryAfter)}], ~"", 0
+            ),
+            _ = send_rst_stream(State1, StreamId, no_error),
+            {refused, State1}
+    end.
 
 -spec exit_clean(#loop{}) -> no_return().
 exit_clean(#loop{

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -144,7 +144,10 @@
     %% from proto_opts at `init/2` so the per-stream acquire/release passes
     %% them to `roadrunner_conn` directly. See `dispatch_decoded/3`.
     max_concurrent_requests = infinity :: infinity | pos_integer(),
-    inflight_counter :: counters:counters_ref() | undefined
+    inflight_counter :: counters:counters_ref() | undefined,
+    %% Per-peer rate-limit guard resolved from proto_opts + peer at conn start
+    %% (`undefined` when off). Checked in `dispatch_decoded/4`.
+    rate_limit = undefined :: roadrunner_conn:rate_limit_state()
 }).
 
 -doc """
@@ -206,7 +209,8 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
             http3_max_field_section_size, ProtoOpts, 2 * MaxHeaderBlock
         ),
         max_concurrent_requests = maps:get(max_concurrent_requests, ProtoOpts, infinity),
-        inflight_counter = maps:get(inflight_counter, ProtoOpts, undefined)
+        inflight_counter = maps:get(inflight_counter, ProtoOpts, undefined),
+        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer)
     }).
 
 -spec loop(#h3{}) -> ok.
@@ -758,7 +762,7 @@ respond_field_section_too_large(#h3{conn = Conn} = State, StreamId) ->
 
 -spec dispatch_decoded(#h3{}, non_neg_integer(), roadrunner_http:headers(), iodata()) ->
     handle_result().
-dispatch_decoded(#h3{streams = Streams} = State, StreamId, Headers, Body) ->
+dispatch_decoded(State, StreamId, Headers, Body) ->
     {ReqId, NewBuf} = roadrunner_conn:generate_request_id(State#h3.req_id_buffer),
     RequestContext = #{
         peer => State#h3.peer,
@@ -774,31 +778,46 @@ dispatch_decoded(#h3{streams = Streams} = State, StreamId, Headers, Body) ->
             %% stream error H3_MESSAGE_ERROR.
             reset_and_drop(State1, StreamId, ?H3_MESSAGE_ERROR);
         {ok, Req} ->
-            case
-                roadrunner_conn:try_acquire_request_slot(
-                    State1#h3.max_concurrent_requests, State1#h3.inflight_counter
-                )
-            of
-                true ->
-                    {WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
-                        State1#h3.conn, StreamId, Req, State1#h3.proto_opts
-                    ),
-                    %% The worker owns the response now, tracked by its monitor
-                    %% ref; drop the (no-longer-needed) frame-accumulation entry
-                    %% so the streams map only ever holds in-progress requests.
-                    %% Record the pid too so a peer reset can reach the worker.
-                    State1#h3{
-                        streams = maps:remove(StreamId, Streams),
-                        worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId},
-                        worker_pids = (State1#h3.worker_pids)#{StreamId => WorkerPid}
-                    };
-                false ->
-                    %% Listener-wide in-flight ceiling reached — refuse the
-                    %% stream (retry-safe H3_REQUEST_REJECTED) without spawning
-                    %% a worker.
-                    ok = throttle_stream(State1),
-                    reset_and_drop(State1, StreamId, ?H3_REQUEST_REJECTED)
+            case rate_limit_refused(State1, StreamId) of
+                {refused, State2} ->
+                    %% Per-peer rate exceeded: 429 + Retry-After sent, stream
+                    %% dropped. 429 (not H3_REQUEST_REJECTED) so the client backs
+                    %% off per Retry-After instead of retrying immediately.
+                    State2;
+                ok ->
+                    dispatch_with_slot(State1, StreamId, Req)
             end
+    end.
+
+%% Acquire the listener-wide in-flight slot and spawn the stream worker, or
+%% refuse with retry-safe H3_REQUEST_REJECTED at the ceiling.
+-spec dispatch_with_slot(#h3{}, non_neg_integer(), roadrunner_req:request()) ->
+    handle_result().
+dispatch_with_slot(#h3{streams = Streams} = State1, StreamId, Req) ->
+    case
+        roadrunner_conn:try_acquire_request_slot(
+            State1#h3.max_concurrent_requests, State1#h3.inflight_counter
+        )
+    of
+        true ->
+            {WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
+                State1#h3.conn, StreamId, Req, State1#h3.proto_opts
+            ),
+            %% The worker owns the response now, tracked by its monitor
+            %% ref; drop the (no-longer-needed) frame-accumulation entry
+            %% so the streams map only ever holds in-progress requests.
+            %% Record the pid too so a peer reset can reach the worker.
+            State1#h3{
+                streams = maps:remove(StreamId, Streams),
+                worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId},
+                worker_pids = (State1#h3.worker_pids)#{StreamId => WorkerPid}
+            };
+        false ->
+            %% Listener-wide in-flight ceiling reached — refuse the
+            %% stream (retry-safe H3_REQUEST_REJECTED) without spawning
+            %% a worker.
+            ok = throttle_stream(State1),
+            reset_and_drop(State1, StreamId, ?H3_REQUEST_REJECTED)
     end.
 
 %% A worker exit: normal means it sent its response with the stream FIN
@@ -842,6 +861,35 @@ throttle_stream(#h3{proto_opts = #{throttled_counter := Counter}, listener_name 
         listener_name => ListenerName,
         reason => max_concurrent_requests
     }).
+
+%% Per-peer rate-limit gate before spawning a stream worker. `ok` to proceed;
+%% `{refused, State1}` after sending `429` + `Retry-After` as a buffered
+%% response and dropping the stream (the rate was exceeded). 429 (not
+%% H3_REQUEST_REJECTED) so the client honors `Retry-After` instead of retrying
+%% the request immediately. The guard being off (`undefined`) or a missing peer
+%% IP proceeds.
+-spec rate_limit_refused(#h3{}, non_neg_integer()) -> ok | {refused, #h3{}}.
+rate_limit_refused(#h3{rate_limit = undefined}, _StreamId) ->
+    ok;
+rate_limit_refused(
+    #h3{
+        rate_limit = {Rate, Burst, Period, Table, Counter, IP},
+        conn = Conn,
+        listener_name = ListenerName
+    } = State,
+    StreamId
+) ->
+    NowMs = erlang:monotonic_time(millisecond),
+    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) of
+        allow ->
+            ok;
+        {deny, RetryAfter} ->
+            ok = roadrunner_conn:rate_limited_telemetry(ListenerName, Counter),
+            ok = roadrunner_http3_stream_worker:send_buffered(
+                Conn, StreamId, 429, [{~"retry-after", integer_to_binary(RetryAfter)}], ~""
+            ),
+            {refused, drop_stream(State, StreamId)}
+    end.
 
 %% A connection error (RFC 9114 §8): close the QUIC connection with the
 %% h3 error code + reason, then run the normal teardown. The peer sees

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -873,14 +873,14 @@ rate_limit_refused(#h3{rate_limit = undefined}, _StreamId) ->
     ok;
 rate_limit_refused(
     #h3{
-        rate_limit = {Rate, Burst, Period, Table, Counter, IP},
+        rate_limit = {Rate, Cap, Cost, Table, Counter, IP},
         conn = Conn,
         listener_name = ListenerName
     } = State,
     StreamId
 ) ->
     NowMs = erlang:monotonic_time(millisecond),
-    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Burst, Period, NowMs) of
+    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
         allow ->
             ok;
         {deny, RetryAfter} ->

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -883,6 +883,7 @@ status_line(400) -> ~"HTTP/1.1 400 Bad Request\r\n";
 status_line(401) -> ~"HTTP/1.1 401 Unauthorized\r\n";
 status_line(403) -> ~"HTTP/1.1 403 Forbidden\r\n";
 status_line(404) -> ~"HTTP/1.1 404 Not Found\r\n";
+status_line(429) -> ~"HTTP/1.1 429 Too Many Requests\r\n";
 status_line(500) -> ~"HTTP/1.1 500 Internal Server Error\r\n";
 status_line(503) -> ~"HTTP/1.1 503 Service Unavailable\r\n";
 %% Uncommon status codes — emit `HTTP/1.1 NNN \r\n` with an empty

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -45,6 +45,9 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
 -define(DEFAULT_MAX_CLIENTS, 150).
 -define(DEFAULT_MAX_CONCURRENT_REQUESTS, infinity).
+%% Max per-peer rate-limit buckets evicted per sweep tick, so one tick can't
+%% stall the listener on a huge table (leftovers wait for the next tick).
+-define(RATE_LIMIT_SWEEP_BUDGET, 1000).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
 %% TCP listen backlog (kernel SYN/accept queue depth). OTP defaults to 5,
 %% which a burst of concurrent connects overflows; 1024 matches cowboy.
@@ -219,6 +222,22 @@ ops-tuning rationale.
     %% rejected on an HTTP/3-only listener. Trust it only behind a balancer that
     %% always prepends the header (otherwise a direct peer can spoof its IP).
     proxy_protocol => boolean(),
+    %% Opt in to a per-peer request-rate guard keyed on the client IP. A map
+    %% `#{rate := pos_integer()}` (requests allowed per `period`, required) with
+    %% optional `period` (window in seconds, default 1, so `rate` is per-second
+    %% unless set), `burst` (bucket capacity in requests, default = `rate`),
+    %% `idle_ttl` (ms a peer's bucket survives without traffic before eviction,
+    %% default 60000), and `sweep_interval` (ms between eviction passes, default
+    %% 10000). A peer exceeding the rate gets `429 Too Many Requests` +
+    %% `Retry-After` before the handler runs. Keyed on the real client IP, so
+    %% accurate behind a balancer when `proxy_protocol` is set.
+    rate_limit => #{
+        rate := pos_integer(),
+        period => pos_integer(),
+        burst => pos_integer(),
+        idle_ttl => pos_integer(),
+        sweep_interval => pos_integer()
+    },
     %% When set, the per-connection process auto-hibernates after
     %% `Ms` milliseconds of idle main-loop time. Most useful for
     %% long-lived keep-alive HTTP/1.1 connections that mostly sit
@@ -628,6 +647,7 @@ init(#{port := Port} = Opts) ->
             case start_quic(Port, Opts, Protocols, ProtoOpts) of
                 {ok, QuicListener} ->
                     Reconciliation = setup_reconciliation(Opts),
+                    ok = setup_rate_limit_sweep(ProtoOpts),
                     {ok, #state{
                         listen_socket = LSocket,
                         quic_listener = QuicListener,
@@ -834,6 +854,17 @@ setup_reconciliation(#{slot_reconciliation := #{interval := IntervalMs}}) when
 setup_reconciliation(_Opts) ->
     disabled.
 
+%% Arm the periodic per-peer rate-limit bucket sweep when the guard is on. Like
+%% `setup_reconciliation`, the `erlang:send_after` timer auto-cancels when the
+%% listener exits, so there is no `terminate/2` cleanup; the ETS table dies with
+%% its owner (this gen_server) for the same reason.
+-spec setup_rate_limit_sweep(roadrunner_conn:proto_opts()) -> ok.
+setup_rate_limit_sweep(#{rate_limit := #{sweep_interval := IntervalMs}}) ->
+    _ = erlang:send_after(IntervalMs, self(), rate_limit_sweep),
+    ok;
+setup_rate_limit_sweep(_ProtoOpts) ->
+    ok.
+
 %% Compile + publish to `persistent_term` once, at listener start. The
 %% conn reads via `persistent_term:get/1` on every request, so the
 %% lookup is O(1) and the table is shared across all conns of this
@@ -985,6 +1016,12 @@ build_proto_opts(Opts, ListenerName) ->
     %% `max_concurrent_requests` ceiling, mirroring `rejected_counter`.
     InflightCounter = counters:new(1, [write_concurrency]),
     ThrottledCounter = atomics:new(1, [{signed, false}]),
+    %% `rate_limited_counter` is the cumulative count of requests refused at the
+    %% per-peer `rate_limit`, mirroring `throttled_counter`. Always created (so
+    %% `info/1` surfaces it as 0 when the guard is off); the per-peer bucket
+    %% store is created only when `rate_limit` is configured.
+    RateLimitedCounter = atomics:new(1, [{signed, false}]),
+    RateLimit = build_rate_limit(maps:get(rate_limit, Opts, undefined)),
     %% Public `ws` opts are a nested map; flatten to the `ws_*`
     %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
     %% → `http2_*` flattening above.
@@ -1014,6 +1051,8 @@ build_proto_opts(Opts, ListenerName) ->
             rejected_counter => RejectedCounter,
             inflight_counter => InflightCounter,
             throttled_counter => ThrottledCounter,
+            rate_limited_counter => RateLimitedCounter,
+            rate_limit => RateLimit,
             min_bytes_per_second =>
                 maps:get(min_bytes_per_second, Opts, ?DEFAULT_MIN_BYTES_PER_SECOND),
             body_buffering => maps:get(body_buffering, Opts, auto),
@@ -1425,6 +1464,63 @@ validate_ws_opts(Opts) when is_map(Opts) ->
 validate_ws_opts(Other) ->
     error({invalid_listener_opt, ws, Other}).
 
+%% Validate the `rate_limit` opt and, when set, create its per-listener ETS
+%% bucket store. `undefined` (the default) skips the guard entirely.
+-spec build_rate_limit(term()) -> undefined | roadrunner_conn:rate_limit().
+build_rate_limit(RawOpt) ->
+    case validate_rate_limit(RawOpt) of
+        undefined ->
+            undefined;
+        Config ->
+            %% Anonymous public table, one per listener, owned by this
+            %% gen_server so it dies with the listener.
+            Config#{
+                table => ets:new(roadrunner_rate_limit, [public, {write_concurrency, true}])
+            }
+    end.
+
+-spec validate_rate_limit(term()) ->
+    undefined
+    | #{
+        rate := pos_integer(),
+        burst := pos_integer(),
+        period := pos_integer(),
+        idle_ttl := pos_integer(),
+        sweep_interval := pos_integer()
+    }.
+validate_rate_limit(undefined) ->
+    undefined;
+validate_rate_limit(Opts) when is_map(Opts) ->
+    %% Every supplied key must be a known positive integer.
+    Resolved = maps:fold(
+        fun(K, V, Acc) ->
+            case
+                lists:member(K, [rate, burst, period, idle_ttl, sweep_interval]) andalso
+                    is_integer(V) andalso V > 0
+            of
+                true -> Acc#{K => V};
+                false -> error({invalid_listener_opt, rate_limit, Opts})
+            end
+        end,
+        #{},
+        Opts
+    ),
+    case Resolved of
+        #{rate := Rate} ->
+            #{
+                rate => Rate,
+                burst => maps:get(burst, Resolved, Rate),
+                period => maps:get(period, Resolved, 1),
+                idle_ttl => maps:get(idle_ttl, Resolved, 60000),
+                sweep_interval => maps:get(sweep_interval, Resolved, 10000)
+            };
+        #{} ->
+            %% `rate` is required.
+            error({invalid_listener_opt, rate_limit, Opts})
+    end;
+validate_rate_limit(Other) ->
+    error({invalid_listener_opt, rate_limit, Other}).
+
 build_dispatch(#{routes := Module} = Opts, _ListenerName) when is_atom(Module) ->
     bake_dispatch(Module, Opts, [], no_state);
 build_dispatch(#{routes := {Module, State}} = Opts, _ListenerName) when is_atom(Module) ->
@@ -1494,6 +1590,7 @@ handle_call(info, _From, #state{proto_opts = ProtoOpts} = State) ->
         requests_counter := RequestsCounter,
         rejected_counter := RejectedCounter,
         throttled_counter := ThrottledCounter,
+        rate_limited_counter := RateLimitedCounter,
         max_clients := MaxClients,
         max_concurrent_requests := MaxConcurrentRequests
     } = ProtoOpts,
@@ -1503,7 +1600,8 @@ handle_call(info, _From, #state{proto_opts = ProtoOpts} = State) ->
         requests_served => atomics:get(RequestsCounter, 1),
         rejected => atomics:get(RejectedCounter, 1),
         max_concurrent_requests => MaxConcurrentRequests,
-        throttled => atomics:get(ThrottledCounter, 1)
+        throttled => atomics:get(ThrottledCounter, 1),
+        rate_limited => atomics:get(RateLimitedCounter, 1)
     },
     {reply, Reply, State}.
 
@@ -1640,6 +1738,22 @@ handle_info(
     {noreply, State#state{
         reconciliation = #{interval => Interval, prev_diff => NewDiff - Release}
     }};
+handle_info(
+    rate_limit_sweep,
+    #state{
+        proto_opts = #{
+            rate_limit := #{
+                table := Table, idle_ttl := IdleTtl, sweep_interval := Interval
+            }
+        }
+    } = State
+) ->
+    %% Evict per-peer buckets idle past `idle_ttl` (bounded per tick), then
+    %% reschedule. Keeps the store bounded by the active-peer working set.
+    NowMs = erlang:monotonic_time(millisecond),
+    _ = roadrunner_conn:rate_limit_evict_idle(Table, NowMs, IdleTtl, ?RATE_LIMIT_SWEEP_BUDGET),
+    _ = erlang:send_after(Interval, self(), rate_limit_sweep),
+    {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
 

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -45,9 +45,6 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
 -define(DEFAULT_MAX_CLIENTS, 150).
 -define(DEFAULT_MAX_CONCURRENT_REQUESTS, infinity).
-%% Max per-peer rate-limit buckets evicted per sweep tick, so one tick can't
-%% stall the listener on a huge table (leftovers wait for the next tick).
--define(RATE_LIMIT_SWEEP_BUDGET, 1000).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
 %% TCP listen backlog (kernel SYN/accept queue depth). OTP defaults to 5,
 %% which a burst of concurrent connects overflows; 1024 matches cowboy.
@@ -230,7 +227,10 @@ ops-tuning rationale.
     %% default 60000), and `sweep_interval` (ms between eviction passes, default
     %% 10000). A peer exceeding the rate gets `429 Too Many Requests` +
     %% `Retry-After` before the handler runs. Keyed on the real client IP, so
-    %% accurate behind a balancer when `proxy_protocol` is set.
+    %% accurate behind a balancer when `proxy_protocol` is set. The per-IP
+    %% bucket is lock-free (last-write-wins), so concurrent connections from one
+    %% IP can momentarily admit up to that many requests past `burst`; it bounds
+    %% the sustained per-source rate, not exact simultaneity.
     rate_limit => #{
         rate := pos_integer(),
         period => pos_integer(),
@@ -1751,7 +1751,7 @@ handle_info(
     %% Evict per-peer buckets idle past `idle_ttl` (bounded per tick), then
     %% reschedule. Keeps the store bounded by the active-peer working set.
     NowMs = erlang:monotonic_time(millisecond),
-    _ = roadrunner_conn:rate_limit_evict_idle(Table, NowMs, IdleTtl, ?RATE_LIMIT_SWEEP_BUDGET),
+    _ = roadrunner_conn:rate_limit_evict_idle(Table, NowMs, IdleTtl),
     _ = erlang:send_after(Interval, self(), rate_limit_sweep),
     {noreply, State};
 handle_info(_Msg, State) ->

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -588,7 +588,8 @@ Useful for ops dashboards / health endpoints.
         requests_served := non_neg_integer(),
         rejected := non_neg_integer(),
         max_concurrent_requests := infinity | pos_integer(),
-        throttled := non_neg_integer()
+        throttled := non_neg_integer(),
+        rate_limited := non_neg_integer()
     }.
 info(Name) ->
     gen_server:call(Name, info).

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -1473,9 +1473,14 @@ build_rate_limit(RawOpt) ->
             undefined;
         Config ->
             %% Anonymous public table, one per listener, owned by this
-            %% gen_server so it dies with the listener.
+            %% gen_server so it dies with the listener. `write_concurrency, auto`
+            %% adapts the lock count to load (matching the QUIC CID registry);
+            %% no `read_concurrency` — each request reads then writes the same
+            %% key (interleaved RMW), the one pattern it would slow down.
             Config#{
-                table => ets:new(roadrunner_rate_limit, [public, {write_concurrency, true}])
+                table => ets:new(roadrunner_rate_limit, [
+                    set, public, {write_concurrency, auto}
+                ])
             }
     end.
 

--- a/src/roadrunner_rate_limit.erl
+++ b/src/roadrunner_rate_limit.erl
@@ -25,11 +25,13 @@ refill(Units, LastMs, NowMs, Rate, Cap) ->
     Elapsed = max(0, NowMs - LastMs),
     min(Cap, Units + Elapsed * Rate).
 
-%% Spend one request (`Cost` units). `{ok, Remaining}` when the bucket can cover
-%% it, else `denied`.
+%% Spend one request (`Cost` units): the remaining units when the bucket can
+%% cover it, else `denied`. Returns the bare integer (not `{ok, _}`) so the
+%% per-request allow path allocates nothing — the remaining count is a 64-bit
+%% immediate, the `denied` atom needs no heap.
 -doc false.
--spec spend(integer(), pos_integer()) -> {ok, integer()} | denied.
-spend(Units, Cost) when Units >= Cost -> {ok, Units - Cost};
+-spec spend(integer(), pos_integer()) -> non_neg_integer() | denied.
+spend(Units, Cost) when Units >= Cost -> Units - Cost;
 spend(_Units, _Cost) -> denied.
 
 %% Seconds until a depleted bucket can cover one request again, rounded up,

--- a/src/roadrunner_rate_limit.erl
+++ b/src/roadrunner_rate_limit.erl
@@ -1,0 +1,45 @@
+-module(roadrunner_rate_limit).
+-moduledoc false.
+
+%% Pure token-bucket math for the per-peer request-rate guard (the
+%% `roadrunner_listener` `rate_limit` opt). The bucket is accounted in integer
+%% "units" so the arithmetic stays exact at any period: one request costs
+%% `Cost = Period * 1000` units, and the bucket accrues `Rate` units per
+%% millisecond, so a limit of `Rate` requests per `Period` seconds refills
+%% exactly one request's worth of units every `Period / Rate` seconds. Capacity
+%% is `Burst` requests, i.e. `Burst * Cost` units. The caller (the per-listener
+%% ETS bucket store in `roadrunner_conn`) derives `Cost` and the cap; this
+%% module is socket- and state-free so the bucket math is exhaustively testable.
+
+-export([refill/5, spend/2, retry_after_secs/3]).
+
+-define(MILLI, 1000).
+
+%% Refill a bucket holding `Units`, last touched at `LastMs`, to its level at
+%% `NowMs`: add `Elapsed * Rate` units (the refill rate is `Rate` units/ms),
+%% capped at `Cap` units. A monotonic clock can read backwards across
+%% schedulers, so the elapsed delta clamps to 0.
+-doc false.
+-spec refill(integer(), integer(), integer(), pos_integer(), pos_integer()) -> integer().
+refill(Units, LastMs, NowMs, Rate, Cap) ->
+    Elapsed = max(0, NowMs - LastMs),
+    min(Cap, Units + Elapsed * Rate).
+
+%% Spend one request (`Cost` units). `{ok, Remaining}` when the bucket can cover
+%% it, else `denied`.
+-doc false.
+-spec spend(integer(), pos_integer()) -> {ok, integer()} | denied.
+spend(Units, Cost) when Units >= Cost -> {ok, Units - Cost};
+spend(_Units, _Cost) -> denied.
+
+%% Seconds until a depleted bucket can cover one request again, rounded up,
+%% never below 1 so a throttled caller always gets a positive `Retry-After`.
+-doc false.
+-spec retry_after_secs(integer(), pos_integer(), pos_integer()) -> pos_integer().
+retry_after_secs(Units, Rate, Cost) ->
+    DeficitMs = ceil_div(Cost - Units, Rate),
+    max(1, ceil_div(DeficitMs, ?MILLI)).
+
+%% Integer ceiling division (non-negative numerator, positive divisor).
+-spec ceil_div(non_neg_integer(), pos_integer()) -> non_neg_integer().
+ceil_div(A, B) -> (A + B - 1) div B.

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -76,14 +76,19 @@
 %%   - **Measurements:** `system_time`.
 %%   - **Metadata:** `listener_name`, `reason` (`max_clients`).
 %%
-%% - `[roadrunner, request, throttled]` — fired when an HTTP/2 or HTTP/3
-%%   stream is refused because the listener is at its
-%%   `max_concurrent_requests` in-flight ceiling, before any handler runs.
-%%   The stream is reset (`REFUSED_STREAM` / `H3_REQUEST_REJECTED`); pair
-%%   with the cumulative `throttled` count from `roadrunner_listener:info/1`.
+%% - `[roadrunner, request, throttled]` — fired before any handler runs when a
+%%   request is refused at a listener limit, for one of two reasons:
+%%     - `max_concurrent_requests`: an HTTP/2 or HTTP/3 stream over the
+%%       listener's in-flight ceiling, reset with `REFUSED_STREAM` /
+%%       `H3_REQUEST_REJECTED`; pair with the cumulative `throttled` count from
+%%       `roadrunner_listener:info/1`.
+%%     - `rate_limit`: a peer over its per-peer `rate_limit`, answered with
+%%       `429` + `Retry-After` (HTTP/1, HTTP/2, and HTTP/3); pair with the
+%%       cumulative `rate_limited` count from `roadrunner_listener:info/1`.
 %%
 %%   - **Measurements:** `system_time`.
-%%   - **Metadata:** `listener_name`, `reason` (`max_concurrent_requests`).
+%%   - **Metadata:** `listener_name`, `reason`
+%%     (`max_concurrent_requests` | `rate_limit`).
 %%
 %% - `[roadrunner, ws, upgrade]` — fired in the conn process once the
 %%   WebSocket handshake response has been written. Marks the

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -23,6 +23,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     large_post/1,
     not_found/1,
     crash_500/1,
+    rate_limited/1,
     forbidden_response_header_stripped/1,
     unsafe_response_header_500/1,
     unsupported_shapes_501/1,
@@ -92,6 +93,7 @@ all() ->
         large_post,
         not_found,
         crash_500,
+        rate_limited,
         forbidden_response_header_stripped,
         unsafe_response_header_500,
         unsupported_shapes_501,
@@ -181,6 +183,7 @@ end_per_suite(_Config) ->
 %% max_clients, no TLS) start their own and skip this one.
 init_per_testcase(Case, Config) when
     Case =:= not_found;
+    Case =:= rate_limited;
     Case =:= oversized_413;
     Case =:= protocols_tuple_form;
     Case =:= certfile_keyfile;
@@ -281,6 +284,22 @@ crash_500(Config) ->
     Conn = connect(?config(port, Config)),
     ?assertMatch({500, _}, status_body(get(Conn, ~"/crash"))),
     close(Conn).
+
+rate_limited(_Config) ->
+    %% Per-peer rate guard over h3: the first request (full bucket) reaches the
+    %% handler; the second from the same peer is refused with 429 + Retry-After
+    %% (a real response, not H3_REQUEST_REJECTED).
+    Name = listener_name(rate_limited),
+    {ok, _} = start_h3(Name, #{rate_limit => #{rate => 1, burst => 1}}),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        ?assertMatch({200, _}, status_body(get(Conn, ~"/"))),
+        {429, Headers, _} = get(Conn, ~"/"),
+        ?assertEqual(~"1", proplists:get_value(~"retry-after", Headers))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
 
 forbidden_response_header_stripped(Config) ->
     %% A handler returning any connection-specific header has it stripped

--- a/test/roadrunner_rate_limit_listener_tests.erl
+++ b/test/roadrunner_rate_limit_listener_tests.erl
@@ -1,0 +1,197 @@
+-module(roadrunner_rate_limit_listener_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% =============================================================================
+%% Opt validation (trap_exit so the bad start surfaces as `{error, _}`).
+%% =============================================================================
+
+valid_rate_limit_starts_test() ->
+    with_listener([http1], #{rate => 5}, fun(_Port, Name) ->
+        ?assert(is_integer(roadrunner_listener:port(Name)))
+    end).
+
+valid_full_rate_limit_starts_test() ->
+    Cfg = #{rate => 5, period => 60, burst => 10, idle_ttl => 1000, sweep_interval => 500},
+    with_listener([http1], Cfg, fun(_Port, Name) ->
+        ?assert(is_integer(roadrunner_listener:port(Name)))
+    end).
+
+rejects_missing_rate_test() ->
+    ?assertMatch(
+        {error, {{invalid_listener_opt, rate_limit, #{burst := 5}}, _}},
+        start(rl_missing_rate, [http1], #{burst => 5})
+    ).
+
+rejects_unknown_key_test() ->
+    ?assertMatch(
+        {error, {{invalid_listener_opt, rate_limit, _}, _}},
+        start(rl_unknown_key, [http1], #{rate => 5, bogus => 1})
+    ).
+
+rejects_non_positive_test() ->
+    ?assertMatch(
+        {error, {{invalid_listener_opt, rate_limit, _}, _}},
+        start(rl_non_positive, [http1], #{rate => 0})
+    ).
+
+rejects_non_integer_test() ->
+    ?assertMatch(
+        {error, {{invalid_listener_opt, rate_limit, _}, _}},
+        start(rl_non_integer, [http1], #{rate => fast})
+    ).
+
+rejects_non_map_test() ->
+    process_flag(trap_exit, true),
+    R = roadrunner_listener:start_link(rl_non_map, #{
+        port => 0, protocols => [http1], rate_limit => true, routes => roadrunner_hello_handler
+    }),
+    ?assertMatch({error, {{invalid_listener_opt, rate_limit, true}, _}}, R).
+
+%% =============================================================================
+%% info/1 surfaces the counter; the sweep tick runs without crashing.
+%% =============================================================================
+
+info_surfaces_rate_limited_test() ->
+    with_listener([http1], #{rate => 5}, fun(_Port, Name) ->
+        ?assertEqual(0, maps:get(rate_limited, roadrunner_listener:info(Name)))
+    end).
+
+sweep_tick_runs_test() ->
+    %% Drive the `rate_limit_sweep` handle_info directly; the listener keeps
+    %% running (reschedules) and stays answerable.
+    Name = unique(rl_sweep),
+    {ok, Pid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => [http1],
+        rate_limit => #{rate => 5, sweep_interval => 50, idle_ttl => 1},
+        routes => roadrunner_hello_handler
+    }),
+    try
+        Pid ! rate_limit_sweep,
+        ?assertEqual(0, maps:get(rate_limited, roadrunner_listener:info(Name)))
+    after
+        ok = roadrunner_listener:stop(Name)
+    end.
+
+%% =============================================================================
+%% End-to-end 429 over HTTP/1.
+%% =============================================================================
+
+h1_second_request_is_rate_limited_test() ->
+    with_listener([http1], #{rate => 1, burst => 1}, fun(Port, _Name) ->
+        %% First request (full bucket) reaches the handler.
+        R1 = h1_request(Port),
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, R1),
+        %% Second request from the same IP (bucket now empty) is refused.
+        R2 = h1_request(Port),
+        ?assertMatch(<<"HTTP/1.1 429 Too Many Requests", _/binary>>, R2),
+        {match, _} = re:run(R2, ~"retry-after: 1", [caseless])
+    end).
+
+h1_period_sets_longer_retry_after_test() ->
+    %% `period => 60` (1 request/minute): the refused request's Retry-After
+    %% reflects the window, not a flat 1 second.
+    with_listener([http1], #{rate => 1, burst => 1, period => 60}, fun(Port, _Name) ->
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_request(Port)),
+        R2 = h1_request(Port),
+        ?assertMatch(<<"HTTP/1.1 429 Too Many Requests", _/binary>>, R2),
+        {match, _} = re:run(R2, ~"retry-after: 60", [caseless])
+    end).
+
+%% =============================================================================
+%% End-to-end 429 over HTTP/2 (h2c) — proves the multiplexed deny path emits a
+%% 429 response (not REFUSED_STREAM).
+%% =============================================================================
+
+h2c_second_stream_is_rate_limited_test() ->
+    with_listener([http2], #{rate => 1, burst => 1}, fun(Port, _Name) ->
+        {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        Preface = ~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+        EmptySettings = <<0:24, 4, 0, 0:32>>,
+        ok = gen_tcp:send(Sock, [Preface, EmptySettings | h2_request_frames()]),
+        Reply = recv_for(Sock, <<>>, 800),
+        ok = gen_tcp:close(Sock),
+        Statuses = collect_statuses(Reply, roadrunner_http2_hpack:new_decoder(4096)),
+        %% One stream served (200), the other refused with 429.
+        ?assert(lists:member(~"200", Statuses)),
+        ?assert(lists:member(~"429", Statuses))
+    end).
+
+%% --- helpers ---
+
+start(Name, Protocols, RateLimit) ->
+    process_flag(trap_exit, true),
+    roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => Protocols,
+        rate_limit => RateLimit,
+        routes => roadrunner_hello_handler
+    }).
+
+with_listener(Protocols, RateLimit, Fun) ->
+    Name = unique(rl_it),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => Protocols,
+        rate_limit => RateLimit,
+        routes => roadrunner_hello_handler
+    }),
+    Port = roadrunner_listener:port(Name),
+    try
+        Fun(Port, Name)
+    after
+        ok = roadrunner_listener:stop(Name)
+    end.
+
+unique(Prefix) ->
+    list_to_atom(atom_to_list(Prefix) ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
+
+h1_request(Port) ->
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"),
+    Reply = recv_for(Sock, <<>>, 1000),
+    ok = gen_tcp:close(Sock),
+    Reply.
+
+recv_for(Sock, Acc, Timeout) ->
+    case gen_tcp:recv(Sock, 0, Timeout) of
+        {ok, Data} -> recv_for(Sock, <<Acc/binary, Data/binary>>, Timeout);
+        {error, _} -> Acc
+    end.
+
+h2_request_frames() ->
+    Enc0 = roadrunner_http2_hpack:new_encoder(4096),
+    {Block1, Enc1} = encode_req(Enc0),
+    {Block3, _Enc2} = encode_req(Enc1),
+    [
+        roadrunner_http2_frame:encode({headers, 1, 16#04 bor 16#01, undefined, Block1}),
+        roadrunner_http2_frame:encode({headers, 3, 16#04 bor 16#01, undefined, Block3})
+    ].
+
+encode_req(Enc) ->
+    {Block, Enc1} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"http"},
+            {~":authority", ~"x"},
+            {~":path", ~"/"}
+        ],
+        Enc
+    ),
+    {iolist_to_binary(Block), Enc1}.
+
+%% Walk the response frames in order, decoding each HEADERS block (the HPACK
+%% decoder is per-connection, so it must be threaded), collecting `:status`.
+collect_statuses(<<>>, _Dec) ->
+    [];
+collect_statuses(Bin, Dec) ->
+    case roadrunner_http2_frame:parse(Bin, 16384) of
+        {ok, {headers, _Stream, _Flags, _Priority, Hpack}, Rest} ->
+            {ok, Headers, Dec1} = roadrunner_http2_hpack:decode(Hpack, Dec),
+            [proplists:get_value(~":status", Headers) | collect_statuses(Rest, Dec1)];
+        {ok, _Other, Rest} ->
+            collect_statuses(Rest, Dec);
+        _ ->
+            []
+    end.

--- a/test/roadrunner_rate_limit_store_tests.erl
+++ b/test/roadrunner_rate_limit_store_tests.erl
@@ -8,37 +8,40 @@
 %% --- rate_limit_check/6 (real ETS bucket store, injected clock; Period 1 =
 %% per-second unless noted) ---
 
+%% `rate_limit_check` takes the resolved `Cap`/`Cost` (not burst/period); the
+%% `cap/2` and `cost/1` helpers keep the burst/period intent visible.
+
 first_request_allowed_test() ->
     Table = new_table(),
-    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)).
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, cap(2, 1), cost(1), 1000)).
 
 burst_then_denied_test() ->
     Table = new_table(),
     %% Burst of 2: two requests pass, the third is denied (Retry-After 1s).
-    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)),
-    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)),
-    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)).
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, cap(2, 1), cost(1), 1000)),
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, cap(2, 1), cost(1), 1000)),
+    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 2, cap(2, 1), cost(1), 1000)).
 
 refills_after_time_test() ->
     Table = new_table(),
     %% Drain the burst of 1, then a request 500ms later (2/sec → one back) passes.
-    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 1, 1, 1000)),
-    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 2, 1, 1, 1000)),
-    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 1, 1, 1500)).
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, cap(1, 1), cost(1), 1000)),
+    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 2, cap(1, 1), cost(1), 1000)),
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, cap(1, 1), cost(1), 1500)).
 
 different_ips_are_independent_test() ->
     Table = new_table(),
     IP2 = {10, 0, 0, 9},
-    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 1, 1, 1, 1000)),
-    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 1, 1, 1, 1000)),
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 1, cap(1, 1), cost(1), 1000)),
+    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 1, cap(1, 1), cost(1), 1000)),
     %% A different peer has its own full bucket.
-    ?assertEqual(allow, ?M:rate_limit_check(Table, IP2, 1, 1, 1, 1000)).
+    ?assertEqual(allow, ?M:rate_limit_check(Table, IP2, 1, cap(1, 1), cost(1), 1000)).
 
 per_minute_rate_test() ->
     Table = new_table(),
     %% 1 request per 60s: the second is denied with a 60s Retry-After.
-    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 1, 1, 60, 1000)),
-    ?assertEqual({deny, 60}, ?M:rate_limit_check(Table, ?IP, 1, 1, 60, 1000)).
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 1, cap(1, 60), cost(60), 1000)),
+    ?assertEqual({deny, 60}, ?M:rate_limit_check(Table, ?IP, 1, cap(1, 60), cost(60), 1000)).
 
 %% --- resolve_rate_limit/2 ---
 
@@ -52,7 +55,10 @@ resolve_off_without_peer_test() ->
 resolve_on_test() ->
     Table = new_table(),
     {Counter, Opts} = proto_opts_with_counter(Table),
-    ?assertEqual({10, 20, 30, Table, Counter, ?IP}, ?M:resolve_rate_limit(Opts, {?IP, 5000})).
+    %% rate 10, burst 20, period 30 → Cost 30000, Cap 600000 baked in.
+    ?assertEqual(
+        {10, 600000, 30000, Table, Counter, ?IP}, ?M:resolve_rate_limit(Opts, {?IP, 5000})
+    ).
 
 %% --- rate_limited_telemetry/2 ---
 
@@ -90,6 +96,11 @@ evict_clears_all_idle_in_one_pass_test() ->
 
 new_table() ->
     ets:new(rate_limit_test, [public, {write_concurrency, true}]).
+
+%% Mirror the runtime derivation: one request costs `Period * 1000` units; a
+%% bucket holds `Burst` requests.
+cost(Period) -> Period * 1000.
+cap(Burst, Period) -> Burst * cost(Period).
 
 proto_opts(RateLimit) ->
     Cfg =

--- a/test/roadrunner_rate_limit_store_tests.erl
+++ b/test/roadrunner_rate_limit_store_tests.erl
@@ -69,22 +69,22 @@ evicts_only_idle_rows_test() ->
     true = ets:insert(Table, {{1, 1, 1, 1}, 5000, 0}),
     true = ets:insert(Table, {{2, 2, 2, 2}, 5000, 1000}),
     %% Now=2000, ttl=1500 → cutoff 500. Only the row last touched at 0 is idle.
-    ?assertEqual(1, ?M:rate_limit_evict_idle(Table, 2000, 1500, 100)),
+    ?assertEqual(1, ?M:rate_limit_evict_idle(Table, 2000, 1500)),
     ?assertEqual([], ets:lookup(Table, {1, 1, 1, 1})),
     ?assertMatch([{{2, 2, 2, 2}, _, _}], ets:lookup(Table, {2, 2, 2, 2})).
 
 evict_empty_table_test() ->
     Table = new_table(),
-    ?assertEqual(0, ?M:rate_limit_evict_idle(Table, 2000, 1500, 100)).
+    ?assertEqual(0, ?M:rate_limit_evict_idle(Table, 2000, 1500)).
 
-evict_respects_budget_test() ->
+evict_clears_all_idle_in_one_pass_test() ->
     Table = new_table(),
     true = ets:insert(Table, {{1, 1, 1, 1}, 0, 0}),
     true = ets:insert(Table, {{2, 2, 2, 2}, 0, 0}),
     true = ets:insert(Table, {{3, 3, 3, 3}, 0, 0}),
-    %% Three idle rows, budget of 2: only two evicted this pass.
-    ?assertEqual(2, ?M:rate_limit_evict_idle(Table, 1000000, 1, 2)),
-    ?assertEqual(1, ets:info(Table, size)).
+    %% All three idle rows are evicted in a single pass (no per-tick budget).
+    ?assertEqual(3, ?M:rate_limit_evict_idle(Table, 1000000, 1)),
+    ?assertEqual(0, ets:info(Table, size)).
 
 %% --- helpers ---
 

--- a/test/roadrunner_rate_limit_store_tests.erl
+++ b/test/roadrunner_rate_limit_store_tests.erl
@@ -1,0 +1,126 @@
+-module(roadrunner_rate_limit_store_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_conn).
+-define(IP, {127, 0, 0, 1}).
+
+%% --- rate_limit_check/6 (real ETS bucket store, injected clock; Period 1 =
+%% per-second unless noted) ---
+
+first_request_allowed_test() ->
+    Table = new_table(),
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)).
+
+burst_then_denied_test() ->
+    Table = new_table(),
+    %% Burst of 2: two requests pass, the third is denied (Retry-After 1s).
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)),
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)),
+    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 2, 2, 1, 1000)).
+
+refills_after_time_test() ->
+    Table = new_table(),
+    %% Drain the burst of 1, then a request 500ms later (2/sec → one back) passes.
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 1, 1, 1000)),
+    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 2, 1, 1, 1000)),
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 2, 1, 1, 1500)).
+
+different_ips_are_independent_test() ->
+    Table = new_table(),
+    IP2 = {10, 0, 0, 9},
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 1, 1, 1, 1000)),
+    ?assertEqual({deny, 1}, ?M:rate_limit_check(Table, ?IP, 1, 1, 1, 1000)),
+    %% A different peer has its own full bucket.
+    ?assertEqual(allow, ?M:rate_limit_check(Table, IP2, 1, 1, 1, 1000)).
+
+per_minute_rate_test() ->
+    Table = new_table(),
+    %% 1 request per 60s: the second is denied with a 60s Retry-After.
+    ?assertEqual(allow, ?M:rate_limit_check(Table, ?IP, 1, 1, 60, 1000)),
+    ?assertEqual({deny, 60}, ?M:rate_limit_check(Table, ?IP, 1, 1, 60, 1000)).
+
+%% --- resolve_rate_limit/2 ---
+
+resolve_off_without_config_test() ->
+    ?assertEqual(undefined, ?M:resolve_rate_limit(proto_opts(undefined), {?IP, 5000})).
+
+resolve_off_without_peer_test() ->
+    Table = new_table(),
+    ?assertEqual(undefined, ?M:resolve_rate_limit(proto_opts(Table), undefined)).
+
+resolve_on_test() ->
+    Table = new_table(),
+    {Counter, Opts} = proto_opts_with_counter(Table),
+    ?assertEqual({10, 20, 30, Table, Counter, ?IP}, ?M:resolve_rate_limit(Opts, {?IP, 5000})).
+
+%% --- rate_limited_telemetry/2 ---
+
+telemetry_bumps_counter_test() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Counter = atomics:new(1, [{signed, false}]),
+    ok = ?M:rate_limited_telemetry(some_listener, Counter),
+    ?assertEqual(1, atomics:get(Counter, 1)).
+
+%% --- rate_limit_evict_idle/4 ---
+
+evicts_only_idle_rows_test() ->
+    Table = new_table(),
+    true = ets:insert(Table, {{1, 1, 1, 1}, 5000, 0}),
+    true = ets:insert(Table, {{2, 2, 2, 2}, 5000, 1000}),
+    %% Now=2000, ttl=1500 → cutoff 500. Only the row last touched at 0 is idle.
+    ?assertEqual(1, ?M:rate_limit_evict_idle(Table, 2000, 1500, 100)),
+    ?assertEqual([], ets:lookup(Table, {1, 1, 1, 1})),
+    ?assertMatch([{{2, 2, 2, 2}, _, _}], ets:lookup(Table, {2, 2, 2, 2})).
+
+evict_empty_table_test() ->
+    Table = new_table(),
+    ?assertEqual(0, ?M:rate_limit_evict_idle(Table, 2000, 1500, 100)).
+
+evict_respects_budget_test() ->
+    Table = new_table(),
+    true = ets:insert(Table, {{1, 1, 1, 1}, 0, 0}),
+    true = ets:insert(Table, {{2, 2, 2, 2}, 0, 0}),
+    true = ets:insert(Table, {{3, 3, 3, 3}, 0, 0}),
+    %% Three idle rows, budget of 2: only two evicted this pass.
+    ?assertEqual(2, ?M:rate_limit_evict_idle(Table, 1000000, 1, 2)),
+    ?assertEqual(1, ets:info(Table, size)).
+
+%% --- helpers ---
+
+new_table() ->
+    ets:new(rate_limit_test, [public, {write_concurrency, true}]).
+
+proto_opts(RateLimit) ->
+    Cfg =
+        case RateLimit of
+            undefined ->
+                undefined;
+            Table ->
+                #{
+                    rate => 10,
+                    burst => 20,
+                    period => 30,
+                    idle_ttl => 60000,
+                    sweep_interval => 10000,
+                    table => Table
+                }
+        end,
+    #{
+        rate_limit => Cfg,
+        rate_limited_counter => atomics:new(1, [{signed, false}])
+    }.
+
+proto_opts_with_counter(Table) ->
+    Counter = atomics:new(1, [{signed, false}]),
+    {Counter, #{
+        rate_limit => #{
+            rate => 10,
+            burst => 20,
+            period => 30,
+            idle_ttl => 60000,
+            sweep_interval => 10000,
+            table => Table
+        },
+        rate_limited_counter => Counter
+    }}.

--- a/test/roadrunner_rate_limit_tests.erl
+++ b/test/roadrunner_rate_limit_tests.erl
@@ -1,0 +1,59 @@
+-module(roadrunner_rate_limit_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_rate_limit).
+
+%% Units: one request costs `Period * 1000`. The cases below use the per-second
+%% default (Cost = 1000, Cap = Burst * 1000) unless a period is called out.
+
+%% --- refill/5 ---
+
+refill_from_empty_accrues_test() ->
+    %% 100ms at Rate 10 units/ms = 1000 units = one request, under a 5-request cap.
+    ?assertEqual(1000, ?M:refill(0, 0, 100, 10, 5000)).
+
+refill_partial_adds_to_existing_test() ->
+    ?assertEqual(2500, ?M:refill(2000, 0, 50, 10, 5000)).
+
+refill_caps_at_capacity_test() ->
+    ?assertEqual(5000, ?M:refill(0, 0, 100000, 10, 5000)).
+
+refill_already_full_stays_capped_test() ->
+    ?assertEqual(5000, ?M:refill(5000, 0, 1000, 10, 5000)).
+
+refill_backwards_clock_clamps_to_zero_test() ->
+    ?assertEqual(2000, ?M:refill(2000, 100, 50, 10, 5000)).
+
+%% --- spend/2 ---
+
+spend_ok_deducts_one_request_test() ->
+    ?assertEqual({ok, 1500}, ?M:spend(2500, 1000)).
+
+spend_exactly_one_request_test() ->
+    ?assertEqual({ok, 0}, ?M:spend(1000, 1000)).
+
+spend_denied_below_one_request_test() ->
+    ?assertEqual(denied, ?M:spend(999, 1000)).
+
+spend_denied_when_empty_test() ->
+    ?assertEqual(denied, ?M:spend(0, 1000)).
+
+%% --- retry_after_secs/3 ---
+
+retry_after_per_second_is_one_test() ->
+    %% Cost 1000 (period 1s): one request always refills within a second.
+    ?assertEqual(1, ?M:retry_after_secs(0, 10, 1000)).
+
+retry_after_per_minute_is_longer_test() ->
+    %% 1 request per 60s → Cost 60000, Rate 1 unit/ms: an empty bucket takes
+    %% 60s to refill one request.
+    ?assertEqual(60, ?M:retry_after_secs(0, 1, 60000)).
+
+retry_after_partial_deficit_test() ->
+    %% 10 per 60s → Cost 60000, Rate 10 units/ms. Half a request short (30000
+    %% units) → 3000ms → 3s.
+    ?assertEqual(3, ?M:retry_after_secs(30000, 10, 60000)).
+
+retry_after_never_below_one_test() ->
+    ?assertEqual(1, ?M:retry_after_secs(999, 1000, 1000)).

--- a/test/roadrunner_rate_limit_tests.erl
+++ b/test/roadrunner_rate_limit_tests.erl
@@ -27,11 +27,11 @@ refill_backwards_clock_clamps_to_zero_test() ->
 
 %% --- spend/2 ---
 
-spend_ok_deducts_one_request_test() ->
-    ?assertEqual({ok, 1500}, ?M:spend(2500, 1000)).
+spend_ok_returns_remaining_test() ->
+    ?assertEqual(1500, ?M:spend(2500, 1000)).
 
 spend_exactly_one_request_test() ->
-    ?assertEqual({ok, 0}, ?M:spend(1000, 1000)).
+    ?assertEqual(0, ?M:spend(1000, 1000)).
 
 spend_denied_below_one_request_test() ->
     ?assertEqual(denied, ?M:spend(999, 1000)).


### PR DESCRIPTION
# Description

Adds an opt-in per-peer request-rate guard. Every existing load control is global or per-connection (`max_clients`, `max_concurrent_requests`, `min_bytes_per_second`); none caps a single source, so one abusive IP can monopolize the request budget while staying under every limit. This is a token bucket keyed on the real client IP that answers `429 Too Many Requests` + `Retry-After` before any handler runs, across HTTP/1, HTTP/2, and HTTP/3. Off by default; when off the hot path adds one cached branch per dispatch.

```erlang
roadrunner:start_listener(my_api, #{
    port => 8080,
    routes => my_handler,
    rate_limit => #{rate => 100, period => 1, burst => 200}
}).
```

A peer over its rate is rejected with a real `429` (not the retry-safe `REFUSED_STREAM` / `H3_REQUEST_REJECTED`), so clients back off instead of retrying at once. Idle buckets are swept on a timer to keep the per-IP store bounded.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
