### PR TITLE
Reject a handler-returned 1xx status as a final response

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -412,26 +412,6 @@ for free.
 **Scope:** small. A thin wrapper over the streaming response shape plus
 the content-type default.
 
-### Decide handler 1xx response handling uniformly — small
-
-**What:** A handler that returns a status of 100..199 has it sent as the
-FINAL response (headers + end-of-stream) on h1, h2, and h3 alike, via three
-identical `Status >= 100, Status =< 599` guards (`roadrunner_http1:865`,
-`roadrunner_http2_stream_worker`, `roadrunner_http3_stream_worker`). A 1xx is
-interim (RFC 9110 §15.2): it cannot carry content or terminate the response,
-and a final response must follow. The single-response handler API cannot
-express "interim 1xx then final", so a returned 1xx is always a misuse. Pick
-ONE cross-protocol behavior: reject it (answer 500, log) or add a real
-interim-response mechanism.
-
-**Why deferred:** legitimate interim 1xx is already automatic where it matters
-(h1 `Expect: 100-continue` via `roadrunner_conn:maybe_send_continue`); a
-handler returning a 1xx is rare, and the current uniform behavior is at least
-consistent. It is a deliberate framework-wide decision, not an h3-only patch
-(which would diverge from h1/h2). Surfaced by the post-merge HTTP/3 review.
-
-**Scope:** small, but touches the three response paths together.
-
 ### Cap outbound response header size — small
 
 **What:** h1/h2/h3 all cap INBOUND headers (the security-relevant direction,

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -838,6 +838,31 @@ dispatch_response(
                 end
         end,
     ok;
+%% RFC 9110 §15.2: a 1xx is interim and cannot be a final response. The
+%% single-response handler API cannot express "interim 1xx then final", so
+%% a returned 1xx is always a misuse; answer 500 rather than put an invalid
+%% final 1xx on the wire. Legitimate interim 100-continue is handled by
+%% `roadrunner_conn:maybe_send_continue/3`, not this path. Placed before the
+%% buffered clauses so it intercepts a 1xx for any method (HEAD included).
+dispatch_response(
+    #loop_state{socket = Socket, alt_svc = AltSvc},
+    Handler,
+    _Req,
+    {Status, _Headers, _Body}
+) when
+    is_integer(Status), Status >= 100, Status =< 199
+->
+    logger:error(#{
+        msg => "roadrunner h1 handler returned an interim 1xx status as a final response",
+        handler => Handler,
+        status => Status
+    }),
+    Headers = roadrunner_http:auto_headers([{~"content-type", ~"text/plain"}], AltSvc),
+    Resp = roadrunner_http1:response(500, Headers, ~"Internal Server Error"),
+    _ = roadrunner_telemetry:response_send(
+        roadrunner_transport:send(Socket, Resp), buffered_response
+    ),
+    ok;
 %% Buffered (3-tuple) response shape. RFC 9110 §9.3.2: HEAD must NOT
 %% include a message body — match on `method := ~"HEAD"` in the
 %% function head and emit the response with an empty body. Free

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -166,9 +166,13 @@ telemetry_metadata(#{
     }.
 
 emit_handler_response(ConnPid, StreamId, _Handler, {Status, Headers, Body}) when
-    is_integer(Status), Status >= 100, Status =< 599
+    is_integer(Status), Status >= 200, Status =< 599
 ->
     send_buffered(ConnPid, StreamId, Status, Headers, Body);
+emit_handler_response(ConnPid, StreamId, Handler, {Status, _Headers, _Body}) when
+    is_integer(Status), Status >= 100, Status =< 199
+->
+    reject_interim(ConnPid, StreamId, Handler, Status);
 emit_handler_response(ConnPid, StreamId, _Handler, {stream, Status, Headers, Fun}) when
     is_integer(Status), Status >= 100, Status =< 599, is_function(Fun, 1)
 ->
@@ -236,6 +240,21 @@ emit_501(ConnPid, StreamId) ->
         501,
         [{~"content-type", ~"text/plain"}],
         ~"HTTP/2 does not yet support this response shape"
+    ).
+
+%% RFC 9110 §15.2: a 1xx is interim and cannot be a final response. The
+%% single-response handler API cannot express "interim 1xx then final", so
+%% a returned 1xx is always a misuse; answer 500 rather than put an invalid
+%% final 1xx on the wire. Legitimate interim 100-continue is handled out of
+%% band; this only fires for a handler-returned buffered 1xx.
+reject_interim(ConnPid, StreamId, Handler, Status) ->
+    logger:error(#{
+        msg => "roadrunner h2 handler returned an interim 1xx status as a final response",
+        handler => Handler,
+        status => Status
+    }),
+    send_buffered(
+        ConnPid, StreamId, 500, [{~"content-type", ~"text/plain"}], ~"Internal Server Error"
     ).
 
 %% Buffered response: a single conn-side message that emits

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -154,12 +154,16 @@ telemetry_metadata(#{
 -spec emit_handler_response(pid(), non_neg_integer(), module(), roadrunner_handler:response()) ->
     roadrunner_http:status().
 emit_handler_response(Conn, StreamId, _Handler, {Status, Headers, Body}) when
-    is_integer(Status), Status >= 100, Status =< 599
+    is_integer(Status), Status >= 200, Status =< 599
 ->
     emit_checked(Conn, StreamId, Headers, fun() ->
         send_buffered(Conn, StreamId, Status, Headers, Body),
         Status
     end);
+emit_handler_response(Conn, StreamId, Handler, {Status, _Headers, _Body}) when
+    is_integer(Status), Status >= 100, Status =< 199
+->
+    reject_interim(Conn, StreamId, Handler, Status);
 emit_handler_response(Conn, StreamId, _Handler, {stream, Status, Headers, Fun}) ->
     emit_checked(Conn, StreamId, Headers, fun() ->
         send_stream(Conn, StreamId, Status, Headers, Fun),
@@ -228,6 +232,23 @@ reject_unsafe(Conn, StreamId, Kind) ->
     logger:error(#{
         msg => "roadrunner h3 handler returned a header with CR/LF/NUL",
         kind => Kind
+    }),
+    send_buffered(
+        Conn, StreamId, 500, [{~"content-type", ~"text/plain"}], ~"Internal Server Error"
+    ),
+    500.
+
+%% RFC 9110 §15.2: a 1xx is interim and cannot be a final response. The
+%% single-response handler API cannot express "interim 1xx then final", so
+%% a returned 1xx is always a misuse; answer 500 rather than put an invalid
+%% final 1xx on the wire. Legitimate interim 100-continue is handled out of
+%% band; this only fires for a handler-returned buffered 1xx.
+-spec reject_interim(pid(), non_neg_integer(), module(), 100..199) -> 500.
+reject_interim(Conn, StreamId, Handler, Status) ->
+    logger:error(#{
+        msg => "roadrunner h3 handler returned an interim 1xx status as a final response",
+        handler => Handler,
+        status => Status
     }),
     send_buffered(
         Conn, StreamId, 500, [{~"content-type", ~"text/plain"}], ~"Internal Server Error"

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -60,6 +60,7 @@ all_test_() ->
         fun sendfile_missing_file_resets_stream/0,
         fun websocket_response_returns_501/0,
         fun handler_crash_returns_500/0,
+        fun interim_buffered_response_returns_500/0,
         fun middleware_chain_runs/0,
         fun rst_stream_cancels_active_stream/0,
         fun router_404_returns_not_found/0,
@@ -1177,6 +1178,12 @@ websocket_response_returns_501() ->
 
 handler_crash_returns_500() ->
     {Pid, Ref} = run_h2_request_with_handler(roadrunner_h2_test_handler, ~"/crash"),
+    cleanup(Pid, Ref).
+
+interim_buffered_response_returns_500() ->
+    %% A handler returning a buffered 1xx status is a misuse (RFC 9110
+    %% §15.2): the worker rejects it with 500 and the conn survives.
+    {Pid, Ref} = run_h2_request_with_handler(roadrunner_h2_test_handler, ~"/interim"),
     cleanup(Pid, Ref).
 
 middleware_chain_runs() ->

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -510,6 +510,32 @@ handler_crash_writes_500_and_fires_request_exception_test() ->
     detach_telemetry(Tag),
     Sink ! stop.
 
+interim_buffered_response_writes_500_test() ->
+    %% A handler returning a buffered 1xx status is a misuse (RFC 9110
+    %% §15.2): the conn loop rejects it with 500 rather than put an invalid
+    %% interim status on the wire as the final response.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_active_sink_with_send_log(
+        Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
+    ),
+    Opts = (fake_opts(interim))#{
+        dispatch :=
+            {handler, roadrunner_interim_handler, fun roadrunner_interim_handler:handle/1,
+                undefined}
+    },
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertMatch(<<"HTTP/1.1 500", _/binary>>, Sent),
+    Sink ! stop.
+
 post_body_echoes_via_auto_mode_test() ->
     ensure_pg(),
     Self = self(),

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -147,6 +147,10 @@ handle(#{target := ~"/sendfile/large"} = Req) ->
     {{sendfile, 200, [], {"/tmp/rr_h2_sf_large.bin", 0, 100_000}}, Req};
 handle(#{target := ~"/websocket"} = Req) ->
     {{websocket, some_module, state}, Req};
+handle(#{target := ~"/interim"} = Req) ->
+    %% A buffered 1xx (interim) status returned as a final response is a
+    %% misuse (RFC 9110 §15.2); the worker rejects it with 500.
+    {{103, [], ~""}, Req};
 handle(#{target := ~"/crash"} = _Req) ->
     error(boom);
 handle(#{target := ~"/badshape"} = Req) ->

--- a/test/roadrunner_h3_test_handler.erl
+++ b/test/roadrunner_h3_test_handler.erl
@@ -39,6 +39,10 @@ handle(#{target := ~"/inject-name"} = Req) ->
 handle(#{target := ~"/stream-inject"} = Req) ->
     %% Same defect on a streaming response's headers → 500.
     {{stream, 200, [{~"x-evil", ~"a\r\nb"}], fun(Send) -> ok = Send(~"x", fin) end}, Req};
+handle(#{target := ~"/interim"} = Req) ->
+    %% A buffered 1xx (interim) status returned as a final response is a
+    %% misuse (RFC 9110 §15.2); the worker rejects it with 500.
+    {{103, [], ~""}, Req};
 handle(#{target := ~"/crash"} = _Req) ->
     error(boom);
 handle(#{target := ~"/badheaders"} = Req) ->

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -23,6 +23,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     large_post/1,
     not_found/1,
     crash_500/1,
+    interim_response_500/1,
     rate_limited/1,
     forbidden_response_header_stripped/1,
     unsafe_response_header_500/1,
@@ -93,6 +94,7 @@ all() ->
         large_post,
         not_found,
         crash_500,
+        interim_response_500,
         rate_limited,
         forbidden_response_header_stripped,
         unsafe_response_header_500,
@@ -283,6 +285,14 @@ not_found(_Config) ->
 crash_500(Config) ->
     Conn = connect(?config(port, Config)),
     ?assertMatch({500, _}, status_body(get(Conn, ~"/crash"))),
+    close(Conn).
+
+interim_response_500(Config) ->
+    %% A handler returning a buffered 1xx status is a misuse (RFC 9110
+    %% §15.2): the worker rejects it with 500 rather than send an invalid
+    %% interim status as the final response.
+    Conn = connect(?config(port, Config)),
+    ?assertMatch({500, _}, status_body(get(Conn, ~"/interim"))),
     close(Conn).
 
 rate_limited(_Config) ->

--- a/test/roadrunner_interim_handler.erl
+++ b/test/roadrunner_interim_handler.erl
@@ -1,0 +1,15 @@
+-module(roadrunner_interim_handler).
+-moduledoc """
+Test-fixture `roadrunner_handler` — returns a buffered `103` (interim)
+status as its final response. A 1xx cannot be a final response (RFC 9110
+§15.2), so the conn loop / stream worker rejects it with `500`. Used to
+cover that rejection on the h1 dispatch path.
+""".
+
+-behaviour(roadrunner_handler).
+
+-export([handle/1]).
+
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
+handle(Req) ->
+    {{103, [], ~""}, Req}.


### PR DESCRIPTION
# Description

A handler that returns a `100..199` status as a buffered response has it sent as the final response today (h1 puts an invalid interim status on the wire; h2/h3 turn it into a 500 only via an ungraceful crash). A 1xx is interim (RFC 9110 §15.2) and cannot be a final response, so a returned 1xx is always a misuse. This rejects it cleanly with a `500` + log on all three protocols, matching the existing `reject_unsafe` 500-override pattern. Legitimate interim `100-continue` (handled out of band by `roadrunner_conn:maybe_send_continue/3`) and the WebSocket `101` shape are untouched.

```erlang
handle(Req) -> {{103, [], ~""}, Req}.   %% misuse → 500, logged
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
