### PR TITLE
Add an NDJSON streaming response builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
 ### Handlers
 
 - **Buffered responses**: `{Status, Headers, Body}` via `roadrunner_resp:text/2`,
-  `:html/2`, `:json/2`, `:redirect/2`, plus empty-status shortcuts.
+  `:html/2`, `:json/2`, `:ndjson/2`, `:redirect/2`, plus empty-status shortcuts.
 - **Streaming**: `{stream, Status, Headers, Fun}`, chunked transfer with a
   `Send/2` callback; supports trailer headers per RFC 9112 §7.1.2.
   `roadrunner_ndjson:item/1` frames newline-delimited JSON lines for a

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Roadrunner is the HTTP backbone of the
 [arizona-framework](https://github.com/arizona-framework/arizona), and works
 standalone too. The API is small: a handler behaviour, request and response
 accessors, listener controls, and opt-in helpers (cookies, query strings,
-multipart, SSE, WebSocket).
+multipart, SSE, NDJSON, WebSocket).
 
 ## Why Roadrunner?
 
@@ -32,8 +32,8 @@ A small, fast HTTP core you can trust on the hot path.
   no C NIFs, and Roadrunner owns its own h1/h2/h3 codecs and its own QUIC
   transport: easy to read and audit.
 - **Pleasant to build on**: Plain-Erlang request and response values, composable
-  middleware, and opt-in helpers for cookies, query strings, multipart, SSE, and
-  WebSocket.
+  middleware, and opt-in helpers for cookies, query strings, multipart, SSE,
+  NDJSON, and WebSocket.
 - **Production lifecycle in the box**: Graceful drain with a deadline, telemetry
   events, per-request `request_id` log correlation, and configurable DoS bounds.
 
@@ -137,6 +137,7 @@ means out of scope for that server.
 | Streaming request bodies                  |     ✓      |   ✓    |  —   |
 | Native qs / cookie / multipart            |     ✓      |   ✓    |  —   |
 | Server-Sent Events helper                 |     ✓      |   —    |  —   |
+| NDJSON streaming helper                   |     ✓      |   —    |  —   |
 | Sendfile                                  |     ✓      |   ✓    |  ✓   |
 | Static handler (ETag / Range / IMS)       |     ✓      |   ✓    |  —   |
 | Graceful drain with deadline + broadcast  |     ✓      |   —    |  ✗   |
@@ -308,6 +309,8 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   `:html/2`, `:json/2`, `:redirect/2`, plus empty-status shortcuts.
 - **Streaming**: `{stream, Status, Headers, Fun}`, chunked transfer with a
   `Send/2` callback; supports trailer headers per RFC 9112 §7.1.2.
+  `roadrunner_ndjson:item/1` frames newline-delimited JSON lines for a
+  streamed or buffered response.
 - **Loop / SSE**: `{loop, Status, Headers, State}` plus an optional
   `handle_info/3` callback for message-driven push.
 - **WebSocket**: `{websocket, Module, State}` upgrade with a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -397,21 +397,6 @@ grammar enforcement is callers-write-bugs ergonomics, not security.
 
 **Scope:** small per attribute. Add when a real caller hits the gap.
 
-### NDJSON streaming response builder — small
-
-**What:** A first-class newline-delimited-JSON response, the JSON
-sibling of `roadrunner_sse`: a builder that frames each item as one
-`<json>\n` chunk over the existing chunked-streaming path, for streaming
-list endpoints and token-by-token responses.
-
-**Why deferred:** the chunked-streaming primitive already lets a handler
-emit NDJSON by hand; a named builder is ergonomics, worth adding once a
-handler wants the framing (and the `application/x-ndjson` content type)
-for free.
-
-**Scope:** small. A thin wrapper over the streaming response shape plus
-the content-type default.
-
 ### Cap outbound response header size — small
 
 **What:** h1/h2/h3 all cap INBOUND headers (the security-relevant direction,

--- a/rebar.config
+++ b/rebar.config
@@ -165,7 +165,7 @@
     %% etc.) are implementation detail; their docstrings are
     %% dev-reader narrative, not API contract.
     {filter_modules,
-        "^roadrunner(_(handler|req|resp|router|listener|static|ws|ws_handler|middleware|http|cookie|qs|uri|sse|multipart))?$"}
+        "^roadrunner(_(handler|req|resp|router|listener|static|ws|ws_handler|middleware|http|cookie|qs|uri|sse|ndjson|multipart))?$"}
 ]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.

--- a/src/roadrunner_ndjson.erl
+++ b/src/roadrunner_ndjson.erl
@@ -1,0 +1,60 @@
+-module(roadrunner_ndjson).
+-moduledoc """
+Newline-delimited JSON (NDJSON) encoding helper.
+
+The JSON sibling of `roadrunner_sse`. `item/1` frames one value as a
+compact JSON document followed by a single `\\n` delimiter and returns
+iodata, so it drops into every response shape unchanged. Set the
+response content-type to `content_type/0` (`application/x-ndjson`).
+
+A bounded result set as a buffered body (a list comprehension of items
+is itself valid iodata):
+
+```erlang
+handle(Req) ->
+    Rows = my_db:recent_orders(),
+    Body = [roadrunner_ndjson:item(Row) || Row <- Rows],
+    {{200, [{~"content-type", roadrunner_ndjson:content_type()}], Body}, Req}.
+```
+
+A large or lazy result set, streamed one line per chunk without
+buffering the whole body (the `{stream, ...}` shape):
+
+```erlang
+handle(Req) ->
+    Fun = fun(Send) ->
+        my_db:fold_orders(fun(Row, _Acc) ->
+            Send(roadrunner_ndjson:item(Row), nofin)
+        end, ok),
+        Send(~"", fin)
+    end,
+    {{stream, 200, [{~"content-type", roadrunner_ndjson:content_type()}], Fun}, Req}.
+```
+
+A message-driven feed (token-by-token output, pub/sub): use the
+`{loop, ...}` shape and push each item from `handle_info/3`, exactly as
+the `roadrunner_sse` example does, with `item/1` in place of
+`roadrunner_sse:event/1`.
+
+`json:encode/1` emits compact, single-line JSON (control characters in
+strings are escaped), so an item never carries a raw newline that would
+break the framing.
+""".
+
+-export([
+    item/1,
+    content_type/0
+]).
+
+-doc """
+Encode one term as a compact JSON document followed by the `\\n`
+delimiter, ready to hand to the streaming `Push` fun.
+""".
+-spec item(Term :: term()) -> iodata().
+item(Term) ->
+    [json:encode(Term), $\n].
+
+-doc "The NDJSON media type, for the response `content-type` header.".
+-spec content_type() -> binary().
+content_type() ->
+    ~"application/x-ndjson".

--- a/src/roadrunner_ndjson.erl
+++ b/src/roadrunner_ndjson.erl
@@ -7,14 +7,13 @@ compact JSON document followed by a single `\\n` delimiter and returns
 iodata, so it drops into every response shape unchanged. Set the
 response content-type to `content_type/0` (`application/x-ndjson`).
 
-A bounded result set as a buffered body (a list comprehension of items
-is itself valid iodata):
+A bounded result set as a buffered body — `roadrunner_resp:ndjson/2`
+frames the whole list and sets the headers (it calls `item/1` per row):
 
 ```erlang
 handle(Req) ->
     Rows = my_db:recent_orders(),
-    Body = [roadrunner_ndjson:item(Row) || Row <- Rows],
-    {{200, [{~"content-type", roadrunner_ndjson:content_type()}], Body}, Req}.
+    {roadrunner_resp:ndjson(200, Rows), Req}.
 ```
 
 A large or lazy result set, streamed one line per chunk without

--- a/src/roadrunner_resp.erl
+++ b/src/roadrunner_resp.erl
@@ -18,6 +18,7 @@ WebSocket-upgrade handlers build their own tuple directly; see
     text/2,
     html/2,
     json/2,
+    ndjson/2,
     redirect/2,
     add_header/3,
     set_cookie/4,
@@ -68,6 +69,18 @@ JSON response — the term is encoded via the stdlib `json` module
 json(Status, Term) ->
     Body = json:encode(Term),
     with_length(Status, ~"application/json", Body).
+
+-doc """
+NDJSON response — each item in `Items` is framed as one compact JSON
+document on its own line via `roadrunner_ndjson:item/1`, and
+`Content-Type` is set to `application/x-ndjson`. The buffered companion
+to a `{stream, ...}` handler that pushes `roadrunner_ndjson:item/1` per
+line; reach for this when the whole list fits in memory.
+""".
+-spec ndjson(StatusCode :: roadrunner_http:status(), Items :: [term()]) -> buffered_response().
+ndjson(Status, Items) when is_list(Items) ->
+    Body = [roadrunner_ndjson:item(Item) || Item <- Items],
+    with_length(Status, roadrunner_ndjson:content_type(), Body).
 
 -doc """
 Redirect response — sets the `Location` header and an empty body.

--- a/test/roadrunner_ndjson_tests.erl
+++ b/test/roadrunner_ndjson_tests.erl
@@ -1,0 +1,70 @@
+-module(roadrunner_ndjson_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% --- basic shapes ---
+
+item_object_test() ->
+    ?assertEqual(
+        ~"{\"a\":1}\n",
+        iolist_to_binary(roadrunner_ndjson:item(#{a => 1}))
+    ).
+
+item_string_test() ->
+    ?assertEqual(
+        ~"\"hello\"\n",
+        iolist_to_binary(roadrunner_ndjson:item(~"hello"))
+    ).
+
+item_list_test() ->
+    ?assertEqual(
+        ~"[1,2,3]\n",
+        iolist_to_binary(roadrunner_ndjson:item([1, 2, 3]))
+    ).
+
+item_empty_container_test() ->
+    ?assertEqual(~"{}\n", iolist_to_binary(roadrunner_ndjson:item(#{}))),
+    ?assertEqual(~"[]\n", iolist_to_binary(roadrunner_ndjson:item([]))).
+
+%% Output is stable across runs: the encoder sorts object keys, so a
+%% multi-key map frames deterministically (matters for line-by-line
+%% clients and golden tests).
+item_sorts_map_keys_test() ->
+    ?assertEqual(
+        ~"{\"a\":2,\"b\":1}\n",
+        iolist_to_binary(roadrunner_ndjson:item(#{b => 1, a => 2}))
+    ).
+
+%% --- framing safety: the line delimiter is the ONLY raw newline ---
+
+%% The whole point of NDJSON is that each item is exactly one line. A
+%% string value carrying LF / CR / TAB / NUL must stay on its line: the
+%% encoder escapes every control byte, so the only raw `\n` in the output
+%% is the trailing delimiter. Decoding the line back yields the original
+%% value (lossless), proving the escaping didn't corrupt the payload.
+item_escapes_control_chars_single_delimiter_test() ->
+    Hostile = <<"a\nb\rc\td", 0, "e">>,
+    Out = iolist_to_binary(roadrunner_ndjson:item(#{msg => Hostile})),
+    [Line, <<>>] = binary:split(Out, ~"\n", [global]),
+    ?assertEqual(#{~"msg" => Hostile}, json:decode(Line)).
+
+%% U+2028 (LINE SEPARATOR) and U+2029 are line terminators in JavaScript
+%% but NOT in NDJSON, whose framing is LF-only. The encoder passes them
+%% through as raw UTF-8 (it does not escape them); since neither contains
+%% a `0x0A` byte, the item still holds exactly one delimiter.
+item_unicode_line_separator_not_a_delimiter_test() ->
+    Sep = <<16#E2, 16#80, 16#A8, 16#E2, 16#80, 16#A9>>,
+    Out = iolist_to_binary(roadrunner_ndjson:item(Sep)),
+    ?assertEqual(2, length(binary:split(Out, ~"\n", [global]))),
+    [Line, <<>>] = binary:split(Out, ~"\n", [global]),
+    ?assertEqual(Sep, json:decode(Line)).
+
+%% A term the JSON encoder cannot represent (tuple, pid, ref, fun) is a
+%% handler bug: `item/1` lets it crash rather than emit garbage, so the
+%% streaming response fails loudly instead of putting an unparseable line
+%% on the wire.
+item_non_encodable_term_crashes_test() ->
+    ?assertError({unsupported_type, _}, roadrunner_ndjson:item({1, 2})).
+
+content_type_test() ->
+    ?assertEqual(~"application/x-ndjson", roadrunner_ndjson:content_type()).

--- a/test/roadrunner_resp_tests.erl
+++ b/test/roadrunner_resp_tests.erl
@@ -47,6 +47,37 @@ json_test() ->
     Decoded = json:decode(iolist_to_binary(Body)),
     ?assertEqual(Term, Decoded).
 
+ndjson_test() ->
+    Items = [#{~"id" => 1}, #{~"id" => 2}],
+    {200, Headers, Body} = roadrunner_resp:ndjson(200, Items),
+    ?assertEqual(
+        ~"application/x-ndjson",
+        proplists:get_value(~"content-type", Headers)
+    ),
+    Bin = iolist_to_binary(Body),
+    ?assertEqual(~"{\"id\":1}\n{\"id\":2}\n", Bin),
+    %% Content-Length is the byte count of the framed lines.
+    ?assertEqual(
+        integer_to_binary(byte_size(Bin)),
+        proplists:get_value(~"content-length", Headers)
+    ),
+    %% Each line round-trips as one JSON document.
+    [L1, L2, <<>>] = binary:split(Bin, ~"\n", [global]),
+    ?assertEqual(#{~"id" => 1}, json:decode(L1)),
+    ?assertEqual(#{~"id" => 2}, json:decode(L2)).
+
+ndjson_empty_list_test() ->
+    %% No items → empty body, Content-Length 0.
+    ?assertEqual(
+        {200,
+            [
+                {~"content-type", ~"application/x-ndjson"},
+                {~"content-length", ~"0"}
+            ],
+            []},
+        roadrunner_resp:ndjson(200, [])
+    ).
+
 redirect_test() ->
     ?assertEqual(
         {302,


### PR DESCRIPTION
# Description

Adds NDJSON (newline-delimited JSON) helpers, the JSON sibling of `roadrunner_sse`. `roadrunner_ndjson:item/1` frames one value as a compact JSON document plus a single `\n` delimiter and returns iodata, so it drops into a `{stream, ...}` response (one line per chunk) or a `{loop, ...}` feed unchanged. `roadrunner_resp:ndjson/2` is the buffered companion, parallel to `roadrunner_resp:json/2`: it frames a whole list and sets `application/x-ndjson` + `Content-Length`. `json:encode/1` emits compact, single-line JSON (control characters in strings are escaped), so an item never carries a raw newline that would break the line framing.

```erlang
handle(Req) ->
    {roadrunner_resp:ndjson(200, my_db:recent_orders()), Req}.
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
