### PR TITLE
Emit a reserved GREASE setting in the h3 SETTINGS frame

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -86,8 +86,6 @@ advisory or malformed cases the server currently tolerates or omits.
 - Intersect the client's offered cipher / TLS version (`supported_versions`) /
   group (`supported_groups`) against the hardcoded `TLS_AES_128_GCM_SHA256` /
   TLS 1.3 / x25519, aborting on no overlap (RFC 8446 §4.1.1) — medium
-- Emit a reserved "GREASE" setting in the h3 SETTINGS frame (RFC 9114
-  §7.2.4.1) — small
 - Honor the peer's `SETTINGS_MAX_FIELD_SECTION_SIZE` when sizing response
   headers (RFC 9114 §4.2.2) — small-medium
 - Reject non-zero packet reserved bits as PROTOCOL_VIOLATION after

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -278,7 +278,13 @@ send_control_stream(#h3{conn = Conn, max_field_section_size = MaxFieldSection} =
     Settings = roadrunner_quic_h3_frame:encode_settings(#{
         qpack_max_table_capacity => 0,
         qpack_blocked_streams => 0,
-        max_field_section_size => MaxFieldSection
+        max_field_section_size => MaxFieldSection,
+        %% A reserved "GREASE" setting (RFC 9114 §7.2.4.1): an identifier of
+        %% the form 0x1f*N+0x21 a conformant peer MUST ignore, sent so peers
+        %% that mishandle unknown settings are shaken out early rather than
+        %% letting the wire format ossify. The identifier and value are
+        %% otherwise arbitrary.
+        16#1f21 => 0
     }),
     _ = roadrunner_quic:send_data(Conn, CtrlStreamId, [Prefix, Settings], false),
     State#h3{control_stream_id = CtrlStreamId}.

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -48,6 +48,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     oversized_413/1,
     oversized_headers_431/1,
     advertises_max_field_section_size/1,
+    advertises_grease_setting/1,
     field_section_too_large_431/1,
     protocols_tuple_form/1,
     certfile_keyfile/1,
@@ -119,6 +120,7 @@ all() ->
         oversized_413,
         oversized_headers_431,
         advertises_max_field_section_size,
+        advertises_grease_setting,
         field_section_too_large_431,
         protocols_tuple_form,
         certfile_keyfile,
@@ -623,6 +625,16 @@ advertises_max_field_section_size(_Config) ->
         close(Conn),
         roadrunner_listener:stop(Name)
     end.
+
+advertises_grease_setting(Config) ->
+    %% RFC 9114 §7.2.4.1: the server includes a reserved "GREASE" setting
+    %% (id 0x1f*N+0x21) in its control-stream SETTINGS so peers that
+    %% mishandle unknown settings are caught early. A conformant client
+    %% keeps the unknown id under its integer key and otherwise ignores it.
+    Conn = connect(?config(port, Config)),
+    Settings = roadrunner_quic_test_h3:get_peer_settings(Conn),
+    ?assertMatch(#{16#1f21 := 0}, Settings),
+    close(Conn).
 
 field_section_too_large_431(_Config) ->
     %% RFC 9114 §4.2.2: a request whose DECODED field section exceeds the


### PR DESCRIPTION
# Description

The server's HTTP/3 control-stream SETTINGS frame now includes a reserved "GREASE" setting (RFC 9114 §7.2.4.1) — an identifier of the form `0x1f*N+0x21` that a conformant peer MUST ignore. Sending one exercises peers' "ignore unknown settings" path so the wire format doesn't ossify. `setting_to_id/1` already passes integer identifiers through, and the decoder already keeps unknown identifiers under their integer key, so it is safe in both directions.

A common-test case drives a real QUIC client against a live listener and asserts the server's advertised SETTINGS carry the reserved identifier.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
