### PR TITLE
Fix flaky tests surfaced in CI

### DIFF
--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -25,7 +25,6 @@ reuse / scheduling races.
     inbound_data_over_stream_window_triggers_rst_stream/1,
     inbound_data_over_conn_window_triggers_goaway/1,
     inbound_padded_data_counts_padding_against_window/1,
-    window_update_for_unknown_stream_ignored/1,
     stream_window_update_grows_send_window/1,
     large_response_chunks_through_send_window/1,
     large_response_blocked_resumes_on_window_update/1,
@@ -56,7 +55,6 @@ all() ->
         inbound_data_over_stream_window_triggers_rst_stream,
         inbound_data_over_conn_window_triggers_goaway,
         inbound_padded_data_counts_padding_against_window,
-        window_update_for_unknown_stream_ignored,
         stream_window_update_grows_send_window,
         large_response_chunks_through_send_window,
         large_response_blocked_resumes_on_window_update,
@@ -161,16 +159,6 @@ inbound_padded_data_counts_padding_against_window(_Config) ->
     Rst = expect_send_type(3),
     {ok, {rst_stream, 1, flow_control_error}, <<>>} =
         roadrunner_http2_frame:parse(Rst, 16384),
-    true = is_process_alive(Pid),
-    cleanup(Pid, Ref).
-
-window_update_for_unknown_stream_ignored(_Config) ->
-    %% WINDOW_UPDATE for a stream that's not currently open is
-    %% silently dropped (closed-stream legality per RFC 9113 §6.9).
-    {Pid, Ref, ConnPid} = start_conn(roadrunner_hello_handler),
-    handshake(ConnPid),
-    Wu = encode_frame({window_update, 99, 1024}),
-    serve_recv(ConnPid, Wu),
     true = is_process_alive(Pid),
     cleanup(Pid, Ref).
 

--- a/test/roadrunner_loop_response_tests.erl
+++ b/test/roadrunner_loop_response_tests.erl
@@ -87,7 +87,7 @@ loop_discards_inbound_data_and_continues_test_() ->
         await_worker_done(Worker),
         Sink ! stop,
         ?assertEqual([user_msg_1], collect_handler_msgs([], 100)),
-        ?assert(lists:member(~"0\r\n\r\n", collect_sent([], Tag, 100)))
+        ?assert(await_sent(~"0\r\n\r\n", Tag, 2000))
     end}.
 
 %% If arming `{active, once}` fails (socket already gone), the loop
@@ -184,6 +184,23 @@ collect_sent(Acc, Tag, Timeout) ->
         {sent, Tag, Data} -> collect_sent([iolist_to_binary(Data) | Acc], Tag, 0)
     after Timeout ->
         lists:reverse(Acc)
+    end.
+
+%% Wait up to TimeoutMs for a specific chunk to be sent, returning as soon
+%% as it arrives. The loop process flushes through the fake sink
+%% asynchronously, so a chunk can land shortly after the worker signals
+%% done; polling for the exact chunk is reliable where reading a fixed
+%% time window races the flush under load (collecting on a 0-timeout drain
+%% misses a chunk that arrives a moment later).
+await_sent(Target, Tag, TimeoutMs) ->
+    receive
+        {sent, Tag, Data} ->
+            case iolist_to_binary(Data) of
+                Target -> true;
+                _ -> await_sent(Target, Tag, TimeoutMs)
+            end
+    after TimeoutMs ->
+        false
     end.
 
 %% --- helpers ---

--- a/test/roadrunner_ndjson_tests.erl
+++ b/test/roadrunner_ndjson_tests.erl
@@ -26,14 +26,14 @@ item_empty_container_test() ->
     ?assertEqual(~"{}\n", iolist_to_binary(roadrunner_ndjson:item(#{}))),
     ?assertEqual(~"[]\n", iolist_to_binary(roadrunner_ndjson:item([]))).
 
-%% Output is stable across runs: the encoder sorts object keys, so a
-%% multi-key map frames deterministically (matters for line-by-line
-%% clients and golden tests).
-item_sorts_map_keys_test() ->
-    ?assertEqual(
-        ~"{\"a\":2,\"b\":1}\n",
-        iolist_to_binary(roadrunner_ndjson:item(#{b => 1, a => 2}))
-    ).
+%% A multi-key object: the key ORDER in the output is not guaranteed (it
+%% follows the map's iteration order, which varies across terms and OTP
+%% versions), so assert via decode rather than byte-equality. The framing
+%% is still exactly one line.
+item_multikey_map_roundtrips_test() ->
+    Map = #{~"a" => 1, ~"b" => 2},
+    [Line, <<>>] = binary:split(iolist_to_binary(roadrunner_ndjson:item(Map)), ~"\n", [global]),
+    ?assertEqual(Map, json:decode(Line)).
 
 %% --- framing safety: the line delimiter is the ONLY raw newline ---
 


### PR DESCRIPTION
# Description

Eliminates three tests that failed intermittently in CI (the failures clustered in the `eunit + ct` step across branches and OTP 27/28, the signature of flakiness rather than a real break).

- **`roadrunner_ndjson_tests`** asserted `json:encode/1` emits sorted object keys. Map key order is unspecified and varies by OTP version (it passed locally, failed on CI), so the multi-key test now asserts via a decode roundtrip instead of byte-equality.
- **`roadrunner_loop_response_tests`** read a fixed time window for the chunked terminator and drained the rest on a 0ms timeout, so a chunk that landed a moment later under load was missed. It now polls for the exact chunk with a generous deadline, returning as soon as it arrives.
- **`roadrunner_http2_flow_control_SUITE`** had a `window_update_for_unknown_stream_ignored` case whose premise was wrong: a WINDOW_UPDATE for an idle stream is correctly a `PROTOCOL_ERROR` (GOAWAY + close, RFC 9113 §5.1), so the test raced `is_process_alive/1` against the connection's exit. Both the idle (GOAWAY) and closed (ignored) branches are already covered deterministically by `roadrunner_conn_loop_http2_tests`, so the redundant case is removed.

Verified by looping eunit 12× and the flow-control CT suite 20× locally (all green) plus `make precommit` (100% coverage).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
