### PR TITLE
Reject non-zero QUIC packet reserved bits

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,8 +88,11 @@ advisory or malformed cases the server currently tolerates or omits.
   TLS 1.3 / x25519, aborting on no overlap (RFC 8446 §4.1.1) — medium
 - Honor the peer's `SETTINGS_MAX_FIELD_SECTION_SIZE` when sizing response
   headers (RFC 9114 §4.2.2) — small-medium
-- Reject non-zero packet reserved bits as PROTOCOL_VIOLATION after
-  header-protection removal (RFC 9000 §17.2 / §17.3.1) — small
+- Close on a malformed authenticated frame instead of absorbing it: the recv
+  pipeline already reports `{frame_error, _, Reason}`, but the loop only acts
+  on the packet-header reserved-bits case (PROTOCOL_VIOLATION); map a frame
+  decode reason to FRAME_ENCODING_ERROR / the frame-specific code (RFC 9000
+  §12.4) and close — small
 
 ### Transport completeness — bites large transfers / advanced cases
 

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -638,7 +638,14 @@ process_outcome(
     end;
 process_outcome(_Now, {drop, _Reason}, State) ->
     State;
+process_outcome(_Now, {frame_error, Level, protocol_violation}, State) ->
+    %% A packet-header protocol violation the recv pipeline flagged after the
+    %% packet authenticated (non-zero reserved bits, RFC 9000 §17.2/§17.3.1):
+    %% close with PROTOCOL_VIOLATION.
+    connection_fatal(Level, protocol_violation, State);
 process_outcome(_Now, {frame_error, _Level, _Reason}, State) ->
+    %% Other recv-flagged frame errors (a malformed authenticated frame) are
+    %% absorbed for now rather than closing — see docs/roadmap.md.
     State.
 
 %% A decrypted Handshake packet proves the client received the server's

--- a/src/roadrunner_quic_recv.erl
+++ b/src/roadrunner_quic_recv.erl
@@ -24,10 +24,11 @@
 %% Per packet it yields `{ok, Decoded}` (decrypted, frames decoded),
 %% `{drop, Reason}` for an undecryptable or unsupported packet (silently
 %% dropped, never the whole datagram, RFC 9001 §5.4.2), or
-%% `{frame_error, Level, Reason}` when an authenticated payload holds a
-%% malformed frame (a connection error the loop must act on, kept distinct
-%% from a drop). A decrypt failure drops only that packet and the loop
-%% continues with the rest of the datagram.
+%% `{frame_error, Level, Reason}` when an authenticated packet holds a
+%% malformed frame, or sets the header reserved bits (RFC 9000
+%% §17.2/§17.3.1, `Reason = protocol_violation`) — a connection error the
+%% loop must act on, kept distinct from a drop. A decrypt failure drops
+%% only that packet and the loop continues with the rest of the datagram.
 
 -export([datagram/4]).
 %% Exported for direct unit coverage of the RFC 9000 §A.3 windows; the
@@ -93,7 +94,14 @@ packet(Packet, DCIDLen, Keys, Largest) ->
             roadrunner_quic_aead:unprotect_header(HP, Packet, PNOffset),
         PN = reconstruct_pn(level_largest(Level, Largest), PNLen, TruncPN),
         {ok, Plaintext} ?= open(Key, IV, PN, Header, Ciphertext),
-        decode_frames(Level, PN, Header, Plaintext)
+        %% RFC 9000 §17.2 / §17.3.1: the header's reserved bits MUST be 0.
+        %% Checked only after the packet authenticates (open/5 above) so a
+        %% forged packet cannot spuriously close the connection; a non-zero
+        %% value is a PROTOCOL_VIOLATION the loop acts on, not a silent drop.
+        case reserved_bits_zero(Level, Header) of
+            true -> decode_frames(Level, PN, Header, Plaintext);
+            false -> {frame_error, Level, protocol_violation}
+        end
     else
         {drop, _} = Drop -> Drop;
         {error, Reason} -> {drop, Reason}
@@ -169,3 +177,16 @@ decoded(application, PN, <<FirstByte, _/binary>>, Frames) ->
     };
 decoded(Level, PN, _Header, Frames) ->
     #{level => Level, pn => PN, frames => Frames}.
+
+%% RFC 9000 §17.2 (long header) / §17.3.1 (short header): the reserved
+%% bits of the unprotected first byte are 0 in a conformant packet.
+-spec reserved_bits_zero(level(), binary()) -> boolean().
+reserved_bits_zero(Level, <<FirstByte, _/binary>>) ->
+    FirstByte band reserved_mask(Level) =:= 0.
+
+%% Reserved-bit mask: 0x18 in a 1-RTT short header, 0x0c in a long header
+%% (the two bits between the type / key-phase fields and the
+%% packet-number length).
+-spec reserved_mask(level()) -> non_neg_integer().
+reserved_mask(application) -> 16#18;
+reserved_mask(_Long) -> 16#0c.

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -176,6 +176,33 @@ malformed_frame_ignored_test() ->
     ?assertEqual(handshaking, ?M:phase(State1)),
     ?assertEqual([], sends(Effects)).
 
+reserved_bits_close_with_protocol_violation_test() ->
+    %% RFC 9000 §17.2: a long-header packet whose reserved bits are non-zero
+    %% (detected only after the packet authenticates) is a PROTOCOL_VIOLATION;
+    %% the decision core closes rather than processing the packet.
+    {State0, _Ctx} = new_conn([~"leaf-cert-der"]),
+    %% Pad like a real client Initial (RFC 9000 §14.1) so the server's 3x
+    %% anti-amplification budget covers the 1200-byte Initial CONNECTION_CLOSE.
+    Datagram = ?TC:seal_raw_reserved(
+        initial,
+        0,
+        roadrunner_quic_keys:initial_client(?DCID),
+        binary:copy(<<0>>, 400),
+        ?DCID,
+        ?SCID
+    ),
+    {State1, Effects} = ?M:handle_datagram(?NOW, Datagram, with_owner(State0)),
+    ?assertEqual(closed, ?M:phase(State1)),
+    ?assertEqual([{emit, self(), {closed, {local, protocol_violation}}}], emits(Effects)),
+    Frames = ?TC:frames(
+        sends(Effects),
+        initial,
+        #{initial => roadrunner_quic_keys:initial_server(?DCID)},
+        byte_size(?DCID)
+    ),
+    Code = roadrunner_quic_error:code_int(protocol_violation),
+    ?assertEqual([{connection_close, transport, Code, 0, <<>>}], Frames).
+
 packet_for_discarded_space_ignored_test() ->
     %% One datagram coalescing the client Finished (which confirms the
     %% handshake and discards the Handshake space) with a trailing handshake

--- a/test/roadrunner_quic_recv_tests.erl
+++ b/test/roadrunner_quic_recv_tests.erl
@@ -157,6 +157,17 @@ frame_error_reported_test() ->
         ?M:datagram(Wire, ?DCID_LEN, #{handshake => handshake_keys()}, #{})
     ).
 
+%% RFC 9000 §17.3.1: a 1-RTT packet whose reserved bits are non-zero (after
+%% header protection is removed and the packet authenticates) is a
+%% PROTOCOL_VIOLATION, kept distinct from a silent drop.
+short_header_reserved_bits_protocol_violation_test() ->
+    {Plaintext, _Frames} = frames_for([{stream, 0, 0, <<"x">>, true}]),
+    Wire = seal_short_reserved(7, application_keys(), Plaintext),
+    ?assertEqual(
+        [{frame_error, application, protocol_violation}],
+        ?M:datagram(Wire, ?DCID_LEN, #{application => application_keys()}, #{})
+    ).
+
 %% =============================================================================
 %% Packet-number reconstruction (RFC 9000 §A.3) — direct, all windows.
 %% =============================================================================
@@ -228,4 +239,14 @@ seal_short_pn(FullPN, WirePNLen, #{key := Key, iv := IV, hp := HP}, KeyPhase, Pl
     Protected = roadrunner_quic_aead:protect_header(
         HP, Header, Sealed, byte_size(Header) - WirePNLen
     ),
+    <<Protected/binary, Sealed/binary>>.
+
+%% A short-header packet with the reserved bits (mask 0x18) set; a
+%% conformant 1-RTT packet leaves them 0 (RFC 9000 §17.3.1).
+seal_short_reserved(PN, #{key := Key, iv := IV, hp := HP}, Plaintext) ->
+    PNLen = roadrunner_quic_packet:pn_length(PN),
+    FirstByte = 2#01000000 bor 16#18 bor (PNLen - 1),
+    Header = <<FirstByte, ?DCID/binary, (roadrunner_quic_packet:encode_pn(PN, PNLen))/binary>>,
+    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
     <<Protected/binary, Sealed/binary>>.

--- a/test/roadrunner_quic_test_client.erl
+++ b/test/roadrunner_quic_test_client.erl
@@ -14,7 +14,7 @@
 
 -export([key_material/0, gen_keypair/0]).
 -export([client_hello_framed/3, client_hello_framed/4]).
--export([seal/6, seal_raw/6]).
+-export([seal/6, seal_raw/6, seal_raw_reserved/6]).
 -export([crypto_bytes/4, frames/4]).
 -export([server_hello_key_share/1, deframe_all/1]).
 -export([
@@ -183,6 +183,30 @@ seal_raw(Level, PN, #{key := Key, iv := IV, hp := HP}, Plaintext, DCID, SCID) ->
     [Header, _Payload] = roadrunner_quic_packet:encode_long(
         Level, 1, DCID, SCID, #{pn => PN, payload => <<0:(SealedSize * 8)>>}
     ),
+    Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
+    Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
+    <<Protected/binary, Sealed/binary>>.
+
+-doc """
+Like `seal_raw/6`, but sets the long-header reserved bits (mask 0x0c) — a
+conformant packet leaves them 0, so the server MUST close with
+PROTOCOL_VIOLATION once it authenticates (RFC 9000 §17.2).
+""".
+-spec seal_raw_reserved(
+    roadrunner_quic_packet:long_type(),
+    non_neg_integer(),
+    roadrunner_quic_keys:keys(),
+    binary(),
+    binary(),
+    binary()
+) -> binary().
+seal_raw_reserved(Level, PN, #{key := Key, iv := IV, hp := HP}, Plaintext, DCID, SCID) ->
+    PNLen = roadrunner_quic_packet:pn_length(PN),
+    SealedSize = byte_size(Plaintext) + 16,
+    [<<FirstByte, HeaderRest/binary>>, _Payload] = roadrunner_quic_packet:encode_long(
+        Level, 1, DCID, SCID, #{pn => PN, payload => <<0:(SealedSize * 8)>>}
+    ),
+    Header = <<(FirstByte bor 16#0c), HeaderRest/binary>>,
     Sealed = roadrunner_quic_aead:seal(Key, IV, PN, Header, Plaintext),
     Protected = roadrunner_quic_aead:protect_header(HP, Header, Sealed, byte_size(Header) - PNLen),
     <<Protected/binary, Sealed/binary>>.


### PR DESCRIPTION
# Description

RFC 9000 §17.2 / §17.3.1: a packet whose header reserved bits are non-zero, **after both header protection and packet protection are removed**, is a `PROTOCOL_VIOLATION`. The recv pipeline now checks them right after the packet authenticates (so a forged packet cannot spuriously close the connection) and reports `{frame_error, Level, protocol_violation}`; the connection loop acts on that and closes with `PROTOCOL_VIOLATION` (`0x0A`). Other recv-flagged frame errors (a malformed authenticated frame) stay absorbed for now, tracked in `docs/roadmap.md`.

Reserved-bit masks: `0x18` in a 1-RTT short header, `0x0c` in a long header.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
