### PR TITLE
Add a conditional-request ETag middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,9 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   opt-in HSTS and CSP; a header the handler already set wins.
 - **`roadrunner_cors`**: configurable CORS with an `OPTIONS` preflight
   short-circuit, deny-by-default origins, and a cache-correct `Vary: Origin`.
+- **`roadrunner_etag`**: conditional requests for dynamic `GET` / `HEAD`
+  responses; derives a weak `ETag` from the body (or honors one the handler
+  set) and answers a matching `If-None-Match` with `304 Not Modified`.
 
 ### Built-in handlers
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -476,22 +476,6 @@ concerns composable at the listener or per-route level. Each is
 boilerplate every public service rewrites today; shipping configurable,
 default-safe versions removes it.
 
-### Conditional requests for dynamic responses — small
-
-**What:** A `roadrunner_etag` middleware that derives a (strong or weak)
-`ETag` from the handler's response body, or honors one the handler
-already set, and turns a matching `If-None-Match` into a bodyless `304
-Not Modified`. The same ETag / `If-None-Match` logic the static handler
-already runs, lifted to apply to dynamic handler responses.
-
-**Why deferred:** static assets already get conditional requests via
-`roadrunner_static`; extending it to dynamic responses saves bandwidth on
-read-heavy JSON endpoints, but wants a real caller to confirm the hashing
-cost is worth it at their response sizes.
-
-**Scope:** small. Reuses the static handler's ETag and `If-None-Match`
-comparison; the new part is hashing the dynamic body and the 304 path.
-
 ### Rate-guard pre-body rejection — small, with a hazard
 
 **What:** The per-peer `rate_limit` check sits at handler dispatch (after the

--- a/src/roadrunner_etag.erl
+++ b/src/roadrunner_etag.erl
@@ -1,0 +1,139 @@
+-module(roadrunner_etag).
+-moduledoc false.
+
+%% Conditional-request middleware for dynamic responses (RFC 7232, RFC 9110
+%% §13.1.2). For a `GET` or `HEAD` answered with a buffered `200`, it derives
+%% a weak `ETag` from the response body (or honours one the handler already
+%% set) and turns a matching `If-None-Match` into a bodyless `304 Not
+%% Modified`, saving the body bytes on a cache revalidation.
+%%
+%% Add it to a listener's `middlewares` opt (or a map-shape route's
+%% `middlewares` key):
+%%
+%% ```erlang
+%% roadrunner_listener:start_link(my_api, #{
+%%     port => 8080,
+%%     routes => Routes,
+%%     middlewares => [roadrunner_etag]
+%% }).
+%% ```
+%%
+%% The ETag is WEAK (`W/"..."`). A weak validator is the correct kind here:
+%% a downstream transform may re-encode the body (e.g. `roadrunner_compress`
+%% gzipping it), so the strong-validator contract — byte-for-byte identity of
+%% the transferred representation — would no longer hold. `If-None-Match` is
+%% matched with the RFC 7232 §2.3.2 weak comparison: the opaque-tags are
+%% compared and the `W/` prefix is ignored on either side, so a client that
+%% echoes a strong or weak form of the tag still revalidates. `*` matches any
+%% current representation.
+%%
+%% Scope: only a buffered `200` for a `GET` / `HEAD` is handled; every other
+%% status, method, and response shape (`{stream, _}`, `{loop, _}`,
+%% `{sendfile, _}`, `{websocket, _}`) passes through untouched. Deriving the
+%% digest walks the whole body once per response, so this is opt-in: reach
+%% for it on read-heavy endpoints where saving the body on revalidation
+%% outweighs the hash.
+
+-behaviour(roadrunner_middleware).
+
+-export([call/3]).
+
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), term()) ->
+    roadrunner_handler:result().
+call(Req, Next, _State) ->
+    {Response, Req2} = Next(Req),
+    {transform(Req, Response), Req2}.
+
+%% Only a buffered 200 on a conditional-safe method is eligible; every other
+%% status / method and the streaming / loop / sendfile / websocket shapes
+%% pass through.
+-spec transform(roadrunner_req:request(), roadrunner_handler:response()) ->
+    roadrunner_handler:response().
+transform(Req, {200, Headers, Body} = Response) ->
+    case conditional_method(roadrunner_req:method(Req)) of
+        true -> conditional(Req, Headers, Body);
+        false -> Response
+    end;
+transform(_Req, Other) ->
+    Other.
+
+-spec conditional_method(binary()) -> boolean().
+conditional_method(~"GET") -> true;
+conditional_method(~"HEAD") -> true;
+conditional_method(_) -> false.
+
+%% Resolve the ETag, then either answer 304 when the client's If-None-Match
+%% validates it or attach it to the 200 so the client can revalidate next time.
+-spec conditional(roadrunner_req:request(), roadrunner_http:headers(), iodata()) ->
+    roadrunner_handler:response().
+conditional(Req, Headers, Body) ->
+    ETag = etag(Headers, Body),
+    case roadrunner_req:header(~"if-none-match", Req) of
+        undefined ->
+            {200, with_etag(Headers, ETag), Body};
+        IfNoneMatch ->
+            case if_none_match(IfNoneMatch, ETag) of
+                true -> not_modified(Headers, ETag);
+                false -> {200, with_etag(Headers, ETag), Body}
+            end
+    end.
+
+%% A handler-set ETag wins; otherwise a weak digest of the body.
+-spec etag(roadrunner_http:headers(), iodata()) -> binary().
+etag(Headers, Body) ->
+    case lists:keyfind(~"etag", 1, Headers) of
+        {_, ETag} -> ETag;
+        false -> weak_etag(Body)
+    end.
+
+-spec weak_etag(iodata()) -> binary().
+weak_etag(Body) ->
+    Hex = binary:encode_hex(crypto:hash(md5, Body), lowercase),
+    <<"W/", $", Hex/binary, $">>.
+
+-spec with_etag(roadrunner_http:headers(), binary()) -> roadrunner_http:headers().
+with_etag(Headers, ETag) ->
+    case lists:keymember(~"etag", 1, Headers) of
+        true -> Headers;
+        false -> [{~"etag", ETag} | Headers]
+    end.
+
+%% RFC 7232 §4.1: a 304 carries no body and echoes the cache-relevant header
+%% fields a 200 would have (Cache-Control, Vary, Expires, ...). Keep the
+%% handler's headers, drop the body's Content-Type, force Content-Length to 0,
+%% and ensure the validator is present.
+-spec not_modified(roadrunner_http:headers(), binary()) -> roadrunner_handler:response().
+not_modified(Headers, ETag) ->
+    Kept = lists:keydelete(~"content-type", 1, with_etag(Headers, ETag)),
+    {304, lists:keystore(~"content-length", 1, Kept, {~"content-length", ~"0"}), ~""}.
+
+%% RFC 7232 §3.2: If-None-Match is `*` (matches any current representation) or
+%% a comma-separated entity-tag list, matched with the weak comparison
+%% (§2.3.2) — opaque-tags compared, the `W/` prefix ignored on either side.
+-spec if_none_match(binary(), binary()) -> boolean().
+if_none_match(IfNoneMatch, ETag) ->
+    case roadrunner_bin:trim_ows(IfNoneMatch) of
+        ~"*" -> true;
+        _ -> lists:member(opaque_tag(ETag), entity_tags(IfNoneMatch))
+    end.
+
+%% Strip the weak prefix, leaving the quoted opaque-tag for comparison.
+-spec opaque_tag(binary()) -> binary().
+opaque_tag(<<"W/", Quoted/binary>>) -> Quoted;
+opaque_tag(Quoted) -> Quoted.
+
+%% Split an If-None-Match list into its opaque-tags (the quoted runs),
+%% quote-aware so a comma inside a tag does not split it. The `W/` prefixes
+%% and the inter-entry commas / whitespace fall outside the quotes.
+-spec entity_tags(binary()) -> [binary()].
+entity_tags(Bin) ->
+    case binary:split(Bin, ~"\"", [global]) of
+        [_NoQuotes] -> [];
+        [_Before | Quoted] -> quoted_runs(Quoted)
+    end.
+
+-spec quoted_runs([binary()]) -> [binary()].
+quoted_runs([Content, _Between | Rest]) ->
+    [<<$", Content/binary, $">> | quoted_runs(Rest)];
+quoted_runs(_) ->
+    [].

--- a/test/roadrunner_etag_tests.erl
+++ b/test/roadrunner_etag_tests.erl
@@ -1,0 +1,149 @@
+-module(roadrunner_etag_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% =============================================================================
+%% Pure unit tests against `call/3` — no listener, no socket.
+%% =============================================================================
+
+adds_weak_etag_when_absent_test() ->
+    Req = req(~"GET", []),
+    Next = fun(R) -> {{200, [{~"content-type", ~"application/json"}], ~"{}"}, R} end,
+    {{200, Headers, Body}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertMatch(<<"W/\"", _/binary>>, header(~"etag", Headers)),
+    %% Body is passed through unchanged.
+    ?assertEqual(~"{}", iolist_to_binary(Body)).
+
+matching_if_none_match_returns_304_test() ->
+    Body = ~"hello",
+    ETag = etag_of(Body),
+    Req = req(~"GET", [{~"if-none-match", ETag}]),
+    Next = fun(R) -> {{200, [{~"content-type", ~"text/plain"}], Body}, R} end,
+    {{Status, Headers, RespBody}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(304, Status),
+    ?assertEqual(ETag, header(~"etag", Headers)),
+    ?assertEqual(~"", iolist_to_binary(RespBody)),
+    ?assertEqual(~"0", header(~"content-length", Headers)),
+    %% A 304 has no body, so the body's Content-Type is dropped.
+    ?assertEqual(undefined, header(~"content-type", Headers)).
+
+%% RFC 7232 §2.3.2 weak comparison: a client echoing the tag without the
+%% `W/` prefix (strong form) still revalidates.
+strong_form_matches_weak_etag_test() ->
+    Body = ~"hello",
+    <<"W/", Quoted/binary>> = etag_of(Body),
+    Req = req(~"GET", [{~"if-none-match", Quoted}]),
+    Next = fun(R) -> {{200, [], Body}, R} end,
+    {{Status, _, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(304, Status).
+
+star_if_none_match_returns_304_test() ->
+    Req = req(~"GET", [{~"if-none-match", ~"*"}]),
+    Next = fun(R) -> {{200, [], ~"x"}, R} end,
+    {{Status, _, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(304, Status).
+
+if_none_match_list_returns_304_test() ->
+    %% A comma-separated list where the second entry matches.
+    Body = ~"hello",
+    ETag = etag_of(Body),
+    Req = req(~"GET", [{~"if-none-match", <<"\"other\", ", ETag/binary>>}]),
+    Next = fun(R) -> {{200, [], Body}, R} end,
+    {{Status, _, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(304, Status).
+
+non_matching_if_none_match_returns_200_test() ->
+    Req = req(~"GET", [{~"if-none-match", ~"\"nope\""}]),
+    Next = fun(R) -> {{200, [], ~"hello"}, R} end,
+    {{Status, Headers, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(200, Status),
+    ?assertMatch(<<"W/\"", _/binary>>, header(~"etag", Headers)).
+
+%% A malformed If-None-Match with no quoted entity-tag matches nothing.
+unquoted_if_none_match_returns_200_test() ->
+    Req = req(~"GET", [{~"if-none-match", ~"bogus"}]),
+    Next = fun(R) -> {{200, [], ~"hello"}, R} end,
+    {{Status, _, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(200, Status).
+
+handler_etag_is_honored_for_match_test() ->
+    Strong = ~"\"v1\"",
+    Req = req(~"GET", [{~"if-none-match", Strong}]),
+    Next = fun(R) -> {{200, [{~"etag", Strong}], ~"body"}, R} end,
+    {{Status, _, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(304, Status).
+
+handler_etag_not_overwritten_test() ->
+    Strong = ~"\"v1\"",
+    Req = req(~"GET", []),
+    Next = fun(R) -> {{200, [{~"etag", Strong}], ~"body"}, R} end,
+    {{200, Headers, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(Strong, header(~"etag", Headers)).
+
+head_request_matching_returns_304_test() ->
+    Body = ~"hello",
+    ETag = etag_of(Body),
+    Req = req(~"HEAD", [{~"if-none-match", ETag}]),
+    Next = fun(R) -> {{200, [], Body}, R} end,
+    {{Status, _, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(304, Status).
+
+%% A non-safe method gets no ETag and no 304: ETag/If-None-Match caching is
+%% for GET / HEAD.
+post_passes_through_test() ->
+    Req = req(~"POST", [{~"if-none-match", ~"\"x\""}]),
+    Next = fun(R) -> {{200, [], ~"created"}, R} end,
+    {{Status, Headers, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(200, Status),
+    ?assertEqual(undefined, header(~"etag", Headers)).
+
+non_200_passes_through_test() ->
+    Req = req(~"GET", []),
+    Next = fun(R) -> {{404, [{~"content-type", ~"text/plain"}], ~"nope"}, R} end,
+    {{Status, Headers, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(404, Status),
+    ?assertEqual(undefined, header(~"etag", Headers)).
+
+stream_response_passes_through_test() ->
+    Fun = fun(_Send) -> ok end,
+    Req = req(~"GET", []),
+    Next = fun(R) -> {{stream, 200, [], Fun}, R} end,
+    {Response, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertMatch({stream, 200, [], _}, Response).
+
+%% A 304 echoes cache-relevant headers (Cache-Control) while dropping the
+%% body's Content-Type and zeroing Content-Length (RFC 7232 §4.1).
+not_modified_keeps_cache_headers_test() ->
+    Body = ~"hello",
+    ETag = etag_of(Body),
+    Req = req(~"GET", [{~"if-none-match", ETag}]),
+    Next = fun(R) ->
+        {{200, [{~"content-type", ~"text/plain"}, {~"cache-control", ~"max-age=60"}], Body}, R}
+    end,
+    {{304, Headers, _}, _} = roadrunner_etag:call(Req, Next, undefined),
+    ?assertEqual(~"max-age=60", header(~"cache-control", Headers)),
+    ?assertEqual(undefined, header(~"content-type", Headers)),
+    ?assertEqual(~"0", header(~"content-length", Headers)).
+
+%% --- helpers ---
+
+req(Method, Headers) ->
+    #{
+        method => Method,
+        target => ~"/",
+        version => {1, 1},
+        headers => Headers
+    }.
+
+header(Name, Headers) ->
+    case lists:keyfind(Name, 1, Headers) of
+        {_, V} -> V;
+        false -> undefined
+    end.
+
+%% The ETag the middleware derives for `Body` (run it with no If-None-Match
+%% and read the header back), so match tests need not hardcode a digest.
+etag_of(Body) ->
+    Next = fun(R) -> {{200, [], Body}, R} end,
+    {{200, Headers, _}, _} = roadrunner_etag:call(req(~"GET", []), Next, undefined),
+    header(~"etag", Headers).


### PR DESCRIPTION
# Description

Adds `roadrunner_etag`, a conditional-request middleware for dynamic responses (RFC 7232). For a `GET` / `HEAD` answered with a buffered `200`, it derives a **weak** `ETag` from the body (or honors one the handler set) and turns a matching `If-None-Match` into a bodyless `304 Not Modified`, saving the body bytes on a cache revalidation. Matching uses the RFC 7232 §2.3.2 weak comparison (the `W/` prefix is ignored on both sides) and supports `*`. Other statuses, methods, and response shapes pass through untouched.

```erlang
roadrunner_listener:start_link(my_api, #{
    port => 8080,
    routes => Routes,
    middlewares => [roadrunner_etag]
}).
```

It is opt-in by design: it hashes the whole body per eligible response, so it trades a little server CPU for less egress on poll-heavy, mostly-unchanging read endpoints (it is not a server-throughput optimization). A weak validator is used so a downstream transform such as `roadrunner_compress` re-encoding the body does not invalidate it.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
