### PR TITLE
Emit DATA_BLOCKED / STREAM_DATA_BLOCKED when the send window fills

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -96,11 +96,12 @@ advisory or malformed cases the server currently tolerates or omits.
 
 ### Transport completeness — bites large transfers / advanced cases
 
-- Send-side flow control: emit `DATA_BLOCKED` / `STREAM_DATA_BLOCKED` when a
-  transfer is held at the current limit (RFC 9000 §4) so the peer knows to grant
-  more. Seeding the windows from the peer's transport params, raising them on
-  inbound `MAX_DATA` / `MAX_STREAM_DATA`, and granting outbound credit are done;
-  the blocked-frame signal is the advisory remainder — small
+- Send-side flow control edge: signal `DATA_BLOCKED` / `STREAM_DATA_BLOCKED` when
+  the send window is zero *before any data is sent* (a peer that advertised
+  `initial_max_data` / `initial_max_stream_data` of 0). The common case — a
+  transfer that fills a non-zero window — already emits the frame on the
+  flow's blocked transition; this remainder is the never-sent-a-byte case a
+  conformant peer never produces — small
 - Stream-count self-limiting (RFC 9000 §4.6): honor an inbound `MAX_STREAMS`, and
   check the peer's `initial_max_streams_uni` before opening the server's own
   control / QPACK uni streams (it opens ~3, always within a sane client's limit).

--- a/src/roadrunner_quic_conn_state.erl
+++ b/src/roadrunner_quic_conn_state.erl
@@ -1479,11 +1479,45 @@ take_stream(
             take_stream(Rest, AckFrames, PN, State);
         {Offset, Data, Fin, Stream1} ->
             Size = byte_size(Data),
-            {_, ConnFlow1} = roadrunner_quic_flow:on_data_sent(Size, ConnFlow),
-            {_, StreamFlow1} = roadrunner_quic_flow:on_data_sent(Size, StreamFlow0),
+            {ConnResult, ConnFlow1} = roadrunner_quic_flow:on_data_sent(Size, ConnFlow),
+            {StreamResult, StreamFlow1} = roadrunner_quic_flow:on_data_sent(Size, StreamFlow0),
             State1 = put_stream(Sid, Stream1, StreamFlow1, State#state{conn_flow = ConnFlow1}),
-            {[{stream, Sid, Offset, Data, Fin}], State1}
+            Frames = [
+                {stream, Sid, Offset, Data, Fin}
+                | blocked_frames(Sid, ConnResult, ConnFlow1, StreamResult, StreamFlow1)
+            ],
+            {Frames, State1}
     end.
+
+%% RFC 9000 §4.1 / §19.12-13: when a send exhausts the connection- or
+%% stream-level limit, ride a DATA_BLOCKED / STREAM_DATA_BLOCKED along in the
+%% same packet (the stream frame was capped by the window, so the datagram has
+%% room) so the peer learns to grant more credit; the Limit is the value we
+%% hit. The flow reports the blocked transition once per limit (it clears on
+%% the matching MAX_DATA / MAX_STREAM_DATA), so this never repeats for a limit.
+-spec blocked_frames(
+    non_neg_integer(),
+    ok | blocked,
+    roadrunner_quic_flow:t(),
+    ok | blocked,
+    roadrunner_quic_flow:t()
+) -> [roadrunner_quic_frame:frame()].
+blocked_frames(Sid, ConnResult, ConnFlow, StreamResult, StreamFlow) ->
+    conn_blocked_frame(ConnResult, ConnFlow, stream_blocked_frame(Sid, StreamResult, StreamFlow)).
+
+-spec conn_blocked_frame(ok | blocked, roadrunner_quic_flow:t(), [roadrunner_quic_frame:frame()]) ->
+    [roadrunner_quic_frame:frame()].
+conn_blocked_frame(blocked, ConnFlow, Tail) ->
+    [{data_blocked, roadrunner_quic_flow:bytes_sent(ConnFlow)} | Tail];
+conn_blocked_frame(ok, _ConnFlow, Tail) ->
+    Tail.
+
+-spec stream_blocked_frame(non_neg_integer(), ok | blocked, roadrunner_quic_flow:t()) ->
+    [roadrunner_quic_frame:frame()].
+stream_blocked_frame(Sid, blocked, StreamFlow) ->
+    [{stream_data_blocked, Sid, roadrunner_quic_flow:bytes_sent(StreamFlow)}];
+stream_blocked_frame(_Sid, ok, _StreamFlow) ->
+    [].
 
 -spec build_entry(level(), [roadrunner_quic_frame:frame()], #space{}, t()) -> {map(), t()}.
 build_entry(Level, Frames, #space{next_pn = PN} = Space, #state{send_keys = SendKeys} = State) ->

--- a/test/roadrunner_quic_conn_state_tests.erl
+++ b/test/roadrunner_quic_conn_state_tests.erl
@@ -862,6 +862,21 @@ send_resumes_after_max_data_and_max_stream_data_test() ->
     ?assert(byte_size(Sent2) > 0),
     ?assertEqual(byte_size(Payload), byte_size(Sent1) + byte_size(Sent2)).
 
+send_window_exhaustion_emits_blocked_frames_test() ->
+    %% RFC 9000 §4.1 / §19.12-13: when a send fills the connection and
+    %% per-stream limits, the server signals each once with DATA_BLOCKED /
+    %% STREAM_DATA_BLOCKED carrying the limit it hit, so the peer knows to
+    %% grant more credit.
+    {State, ClientApSecret, ServerApSecret} = connect_owned(),
+    Window = 800000,
+    Payload = binary:copy(~"x", Window + 1000),
+    {State1, Effects} = ?M:handle_send(self(), make_ref(), 0, Payload, false, ?NOW, State),
+    Frames = flush_app_frames(State1, Effects, ServerApSecret, ClientApSecret, 0),
+    ?assertEqual([{data_blocked, Window}], [F || {data_blocked, _} = F <- Frames]),
+    ?assertEqual(
+        [{stream_data_blocked, 0, Window}], [F || {stream_data_blocked, _, _} = F <- Frames]
+    ).
+
 congestion_window_caps_first_burst_test() ->
     %% A payload far larger than the initial congestion window is capped at about
     %% one window on the first pass, with no ACKs yet to grow it (RFC 9002 §7).
@@ -1594,6 +1609,26 @@ flush_with_acks(State, Effects, ServerApSecret, ClientApSecret, AckPN) ->
                 State1, Effects1, ServerApSecret, ClientApSecret, AckPN + 1
             ),
             {<<Sent/binary, Rest/binary>>, Final, FinalAckPN}
+    end.
+
+%% Like flush_with_acks/5 but accumulates every application frame across the
+%% ACK-paced rounds, so a test can find frames other than STREAM (e.g.
+%% DATA_BLOCKED). Stops once a round carries no more stream data; the
+%% accumulator order is irrelevant to the membership assertions.
+flush_app_frames(State, Effects, ServerApSecret, ClientApSecret, AckPN) ->
+    flush_app_frames(State, Effects, ServerApSecret, ClientApSecret, AckPN, []).
+
+flush_app_frames(State, Effects, ServerApSecret, ClientApSecret, AckPN, Acc) ->
+    Frames = sent_app_frames(Effects, ServerApSecret),
+    Acc1 = lists:foldl(fun(Frame, A) -> [Frame | A] end, Acc, Frames),
+    case [D || {stream, 0, _, D, _} <- Frames] of
+        [] ->
+            Acc1;
+        _ ->
+            Largest = largest_app_pn(Effects, ServerApSecret),
+            Ack = app_datagram([{ack, Largest, 0, Largest, [], undefined}], AckPN, ClientApSecret),
+            {State1, Effects1} = ?M:handle_datagram(?NOW, Ack, State),
+            flush_app_frames(State1, Effects1, ServerApSecret, ClientApSecret, AckPN + 1, Acc1)
     end.
 
 arm_deadline(Effects) ->


### PR DESCRIPTION
# Description

Send-side flow control (RFC 9000 §4.1 / §19.12-13): when a send exhausts the connection- or stream-level limit, the server now emits a `DATA_BLOCKED` / `STREAM_DATA_BLOCKED` frame carrying the limit it hit, so the peer knows to grant more credit. The frame rides in the same packet as the window-filling stream frame (the stream frame was window-capped, so the datagram has room, and it avoids stranding a separately-queued frame behind the congestion window). The flow reports the blocked transition once per limit (it clears on the matching `MAX_DATA` / `MAX_STREAM_DATA`), so a limit is never re-signalled.

Window-seeding, raising limits on inbound `MAX_DATA` / `MAX_STREAM_DATA`, and granting outbound credit were already in place; this is the advisory blocked-signal that was missing. The remaining edge (a peer advertising a zero window, so no byte is ever sent) is noted in `docs/roadmap.md`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
