### PR TITLE
Speed up the WebSocket hot path

### DIFF
--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -706,22 +706,31 @@ parse_payload(Len, 1, Bin, Fin, Rsv1, Op, Pre) ->
     end.
 
 %% Unmask a client→server payload (RFC 6455 §5.3) by XOR'ing
-%% against the 32-bit `MaskKey` repeatedly. Processes 16 bytes
-%% per recursion (4 × 32-bit words) so the BEAM JIT can emit
-%% straight-line code for the common case — same shape as
-%% cowlib's `cow_ws:mask/3`. For 1 KB payloads this is ~10×
-%% faster than the byte-at-a-time iolist version.
+%% against the 32-bit `MaskKey`. Processes 64 bytes per recursion
+%% (16 × 32-bit words) so the per-pass cost (match-context setup,
+%% the call, append bookkeeping) is amortised over more bytes —
+%% measured ~15-27% faster than a 16-byte (4-word) pass across
+%% 64 B–1 KB payloads. 32-bit words stay inside a 60-bit fixnum;
+%% 64-bit words would spill to heap bignums and lose.
 -spec unmask(binary(), binary()) -> binary().
 unmask(Payload, <<MaskKey:32>>) ->
     unmask_chunks(Payload, MaskKey, <<>>).
 
 -spec unmask_chunks(binary(), non_neg_integer(), binary()) -> binary().
-unmask_chunks(<<O1:32, O2:32, O3:32, O4:32, Rest/binary>>, MK, Acc) ->
-    T1 = O1 bxor MK,
-    T2 = O2 bxor MK,
-    T3 = O3 bxor MK,
-    T4 = O4 bxor MK,
-    unmask_chunks(Rest, MK, <<Acc/binary, T1:32, T2:32, T3:32, T4:32>>);
+unmask_chunks(
+    <<O1:32, O2:32, O3:32, O4:32, O5:32, O6:32, O7:32, O8:32, O9:32, O10:32, O11:32, O12:32, O13:32,
+        O14:32, O15:32, O16:32, Rest/binary>>,
+    MK,
+    Acc
+) ->
+    unmask_chunks(
+        Rest,
+        MK,
+        <<Acc/binary, (O1 bxor MK):32, (O2 bxor MK):32, (O3 bxor MK):32, (O4 bxor MK):32,
+            (O5 bxor MK):32, (O6 bxor MK):32, (O7 bxor MK):32, (O8 bxor MK):32, (O9 bxor MK):32,
+            (O10 bxor MK):32, (O11 bxor MK):32, (O12 bxor MK):32, (O13 bxor MK):32,
+            (O14 bxor MK):32, (O15 bxor MK):32, (O16 bxor MK):32>>
+    );
 unmask_chunks(<<O:32, Rest/binary>>, MK, Acc) ->
     T = O bxor MK,
     unmask_chunks(Rest, MK, <<Acc/binary, T:32>>);

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -18,6 +18,7 @@ frames.
 
 -export([accept_key/1, handshake_response/1]).
 -export([parse_frame/1, parse_frame/2]).
+-export([parse_frame_known/3]).
 -export([peek_frame_header/2]).
 -export([encode_frame/3, encode_frame/4]).
 -export([parse_extensions/1, negotiate_extensions/1]).
@@ -528,6 +529,53 @@ parse_frame(Bin, Opts) ->
         maps:get(allow_rsv1, Opts, false),
         maps:get(pre_unmasked, Opts, undefined)
     ).
+
+%% Parse a frame whose header `roadrunner_ws_session` already decoded via
+%% `peek_frame_header/2`, skipping the redundant second header decode and
+%% re-validation. `Header` is the peek map; `Pre` is the caller's
+%% already-unmasked payload (when the whole payload was unmasked during
+%% incremental UTF-8 validation) or `undefined`. Returns `{more,
+%% undefined}` when the body isn't fully buffered yet. Header-level
+%% protocol errors (bad opcode/RSV/length, unmasked, oversized or
+%% fragmented control) were already surfaced by the peek, so this never
+%% returns `{error, _}`. `parse_frame/2` stays the standalone (test
+%% oracle) entry that decodes from scratch.
+-doc false.
+-spec parse_frame_known(binary(), map(), binary() | undefined) ->
+    {ok, frame(), Rest :: binary()} | {more, undefined}.
+parse_frame_known(
+    Buf,
+    #{
+        payload_offset := Off,
+        total_payload_len := Len,
+        mask_key := MaskKey,
+        fin := Fin,
+        rsv1 := Rsv1,
+        opcode := Op
+    },
+    Pre
+) ->
+    case Buf of
+        <<_Header:Off/binary, Payload:Len/binary, Rest/binary>> ->
+            {ok,
+                #{
+                    fin => Fin,
+                    rsv1 => Rsv1,
+                    opcode => Op,
+                    payload => known_payload(Pre, Payload, MaskKey)
+                },
+                Rest};
+        _ ->
+            {more, undefined}
+    end.
+
+%% Use the caller's already-unmasked payload when supplied, else unmask
+%% the masked bytes now. The session supplies `Pre` only when it unmasked
+%% the full payload during `early_validate_text/3`, so it always matches
+%% the frame length.
+-spec known_payload(binary() | undefined, binary(), binary()) -> binary().
+known_payload(undefined, Payload, MaskKey) -> unmask(Payload, MaskKey);
+known_payload(Pre, _Payload, _MaskKey) -> Pre.
 
 -spec do_parse_frame(binary(), boolean(), binary() | undefined) -> parse_result().
 do_parse_frame(<<_Fin:1, _Rsv1:1, Rsv23:2, _:4, _/bitstring>>, _AllowRsv1, _Pre) when

--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -763,10 +763,9 @@ encode_frame(Opcode, Payload, Fin, Opts) ->
     Op = encode_opcode(Opcode),
     FinBit = fin_bit(Fin),
     Rsv1Bit = rsv_bit(maps:get(rsv1, Opts, false)),
-    PayloadBin = iolist_to_binary(Payload),
-    Len = byte_size(PayloadBin),
+    Len = iolist_size(Payload),
     Header = encode_header(FinBit, Rsv1Bit, Op, Len),
-    [Header, PayloadBin].
+    [Header, Payload].
 
 -spec encode_header(0 | 1, 0 | 1, 0..15, non_neg_integer()) -> binary().
 encode_header(FinBit, Rsv1Bit, Op, Len) when Len =< 125 ->

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -828,8 +828,7 @@ validate_fin_fragment(binary, _Compressed, _Pending, _Bytes) ->
 validate_fin_fragment(text, true, _Pending, _Bytes) ->
     ok;
 validate_fin_fragment(text, false, Pending, Bytes) ->
-    Combined = <<Pending/binary, Bytes/binary>>,
-    case unicode:characters_to_binary(Combined, utf8, utf8) of
+    case unicode:characters_to_binary(append_bin(Pending, Bytes), utf8, utf8) of
         Bin when is_binary(Bin) -> ok;
         %% Trailing bytes that didn't form a complete sequence are
         %% invalid at FIN time per RFC 6455 §8.1.
@@ -904,8 +903,10 @@ validate_incremental(binary, _Compressed, _Pending, _Bytes) ->
 validate_incremental(text, true, _Pending, _Bytes) ->
     {ok, <<>>};
 validate_incremental(text, false, Pending, Bytes) ->
-    Combined = <<Pending/binary, Bytes/binary>>,
-    case unicode:characters_to_binary(Combined, utf8, utf8) of
+    %% Empty `Pending` (the common case) hands the validator the payload
+    %% binary as-is — the BIF's fast binary path beats a pre-concat copy
+    %% and an iodata list alike.
+    case unicode:characters_to_binary(append_bin(Pending, Bytes), utf8, utf8) of
         Bin when is_binary(Bin) ->
             %% Fully-valid (no trailing incomplete sequence).
             {ok, <<>>};

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -680,6 +680,28 @@ handle_frame(#{opcode := ping, payload := P}, Data, Hibernate) ->
 handle_frame(#{opcode := pong}, Data, Hibernate) ->
     %% Server is not pinging clients yet — pong from client is dropped.
     process_buffer(Data, Hibernate);
+handle_frame(
+    #{fin := true, rsv1 := false, opcode := Op, payload := P} = Frame,
+    #data{msg_acc = undefined, utf8_pending = Pending, max_message_size = MaxMsg} = Data,
+    Hibernate
+) when
+    (Op =:= text orelse Op =:= binary), byte_size(P) =< MaxMsg
+->
+    %% Fast path for the dominant case: a complete, unfragmented,
+    %% uncompressed data message delivered in one frame, with no message
+    %% already in progress. The parsed `Frame` is already byte-identical
+    %% to what the reassembly path would synthesize, so dispatch it
+    %% directly and skip the fragment machinery (classify, the `[P]`
+    %% cons, `finalize_message`, and the synthesized map). Wire-level
+    %% UTF-8 ran incrementally; FIN only adds "no trailing incomplete
+    %% sequence". Oversized (> `max_message_size`), compressed (RSV1) and
+    %% mid-fragmentation frames fall through to the reassembly path below.
+    case fragment_validate_fin(Op, false, Pending, P, Data) of
+        ok ->
+            dispatch_data_frame(Frame, reset_msg(Data), Hibernate);
+        invalid_utf8 ->
+            close_with(close_invalid_payload(), reset_msg(Data))
+    end;
 handle_frame(Frame, Data, Hibernate) ->
     %% Data frames (text / binary / continuation). Per RFC 6455 §5.4 a
     %% message MAY be fragmented across multiple frames at the wire

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -435,27 +435,38 @@ process_buffer(#data{buffer = Buf, pmd_params = Pmd} = Data, HibernateAcc) ->
             _ -> #{allow_rsv1 => true}
         end,
     case early_validate_text(Data, Buf, Opts) of
-        {ok, Data1, MaybeTotalLen} ->
-            case frame_within_cap(MaybeTotalLen, Data1) of
+        {frame, #{total_payload_len := TotalLen} = Header, Data1} ->
+            case frame_within_cap(TotalLen, Data1) of
                 false ->
                     %% Declared frame payload exceeds `max_frame_size`.
                     %% The header is in hand but the body isn't buffered
                     %% yet — close now (RFC 6455 §7.4 code 1009) instead
                     %% of letting the `{more, _}` re-arm keep reading.
-                    close_oversize(max_frame_size, MaybeTotalLen, Data1);
+                    close_oversize(max_frame_size, TotalLen, Data1);
                 true ->
-                    process_parsed_frame(Data1, Buf, Opts, MaybeTotalLen, HibernateAcc)
+                    process_parsed_frame(Data1, Buf, Header, HibernateAcc)
             end;
+        {more, Data1} ->
+            arm_or_stop(Data1#data.socket, Data1, hibernate_actions(HibernateAcc));
+        {error, _} ->
+            %% RFC 6455 §5.5.1 / §7.4.1: a header-level framing violation
+            %% (bad opcode, RSV, unmasked client frame, fragmented or
+            %% oversize control, or a 64-bit length with the high bit set)
+            %% the header peek already rejected — send a 1002 Close rather
+            %% than dropping the TCP connection silently.
+            close_with(close_protocol_error(), Data);
         invalid_utf8 ->
             close_with(close_invalid_payload(), reset_msg(Data))
     end.
 
--spec process_parsed_frame(
-    #data{}, binary(), roadrunner_ws:parse_opts(), non_neg_integer() | undefined, boolean()
-) -> gen_statem:event_handler_result(atom()).
-process_parsed_frame(#data{socket = Socket} = Data1, Buf, Opts, MaybeTotalLen, HibernateAcc) ->
-    ParseOpts = parse_opts_with_pre_unmasked(Opts, Data1, MaybeTotalLen),
-    case roadrunner_ws:parse_frame(Buf, ParseOpts) of
+-spec process_parsed_frame(#data{}, binary(), map(), boolean()) ->
+    gen_statem:event_handler_result(atom()).
+process_parsed_frame(#data{socket = Socket} = Data1, Buf, Header, HibernateAcc) ->
+    %% `Header` was decoded by the peek in `early_validate_text/3`;
+    %% `parse_frame_known` reuses it (no second decode) and only needs to
+    %% confirm the body is fully buffered. Header-level protocol errors
+    %% were already surfaced upstream, so there's no `{error, _}` here.
+    case roadrunner_ws:parse_frame_known(Buf, Header, pre_unmasked(Data1, Header)) of
         {ok, #{opcode := Opcode} = Frame, NewBuffer} ->
             ok = roadrunner_telemetry:ws_frame_in(
                 (Data1#data.ctx)#{opcode => Opcode},
@@ -472,39 +483,28 @@ process_parsed_frame(#data{socket = Socket} = Data1, Buf, Opts, MaybeTotalLen, H
                 HibernateAcc
             );
         {more, _} ->
-            arm_or_stop(Socket, Data1, hibernate_actions(HibernateAcc));
-        {error, _} ->
-            %% RFC 6455 §5.5.1 / §7.4.1: a framing violation (bad opcode,
-            %% RSV, unmasked client frame, fragmented control, oversize
-            %% control, or a 64-bit length with the high bit set) is a
-            %% protocol error — send a 1002 Close before closing rather
-            %% than dropping the TCP connection silently.
-            close_with(close_protocol_error(), Data1)
+            arm_or_stop(Socket, Data1, hibernate_actions(HibernateAcc))
     end.
 
-%% Hand the cached unmasked payload to `parse_frame` when (and only
+%% Hand the cached unmasked payload to `parse_frame_known` when (and only
 %% when) `early_validate_text/3` has unmasked the entire payload as a
-%% side-effect of UTF-8 validation. Keeps `parse_frame` from
-%% redundantly unmasking the same bytes a second time — saved ~40% of
-%% own time on the WS hot path.
-parse_opts_with_pre_unmasked(Opts, _Data, undefined) ->
-    Opts;
-parse_opts_with_pre_unmasked(Opts, #data{unmasked_buf = Buf}, TotalLen) when
+%% side-effect of UTF-8 validation. Keeps the parse from redundantly
+%% unmasking the same bytes a second time — saved ~40% of own time on the
+%% WS text hot path.
+-spec pre_unmasked(#data{}, map()) -> binary() | undefined.
+pre_unmasked(#data{unmasked_buf = Buf}, #{total_payload_len := TotalLen}) when
     byte_size(Buf) =:= TotalLen, TotalLen > 0
 ->
-    Opts#{pre_unmasked => Buf};
-parse_opts_with_pre_unmasked(Opts, _Data, _TotalLen) ->
-    Opts.
+    Buf;
+pre_unmasked(_Data, _Header) ->
+    undefined.
 
 %% Per-frame size cap. The peeked header reveals the frame's declared
 %% payload length before the body is buffered, so an oversized frame is
 %% rejected on the header alone (≤14 bytes seen) rather than after the
-%% `{more, _}` re-arm reads the whole payload. `undefined` means the
-%% length isn't known yet — let parsing continue and re-check on the
-%% next pass.
--spec frame_within_cap(non_neg_integer() | undefined, #data{}) -> boolean().
-frame_within_cap(undefined, _Data) ->
-    true;
+%% `{more, _}` re-arm reads the whole payload. Only reached once the peek
+%% has a full header, so the length is always known here.
+-spec frame_within_cap(non_neg_integer(), #data{}) -> boolean().
 frame_within_cap(TotalLen, #data{max_frame_size = Max}) ->
     TotalLen =< Max.
 
@@ -517,14 +517,17 @@ frame_within_cap(TotalLen, #data{max_frame_size = Max}) ->
 %% Skipped when the in-progress frame isn't a fresh text data frame
 %% (binary, control, continuation, or compressed all bypass — they
 %% have their own validation paths or no encoding constraint).
-%% Returns `{ok, Data, MaybeTotalLen}` — the third element carries
-%% the in-progress frame's total payload length when a header was
-%% peekable, or `undefined` when there isn't enough buffer to know
-%% yet (or the frame isn't a fresh uncompressed text frame). The
-%% caller (`process_buffer/2`) uses it to decide whether to hand the
-%% accumulated `unmasked_buf` to `parse_frame` via `pre_unmasked`.
+%% Returns the decoded peek header so the caller hands it straight to
+%% `roadrunner_ws:parse_frame_known/3` (no second header decode):
+%% - `{frame, Header, Data}` — full header peeked (text payload bytes
+%%   so far validated + unmasked into `Data`'s `unmasked_buf`);
+%% - `{more, Data}` — header not fully buffered yet, re-arm for the rest;
+%% - `{error, Reason}` — a header-level protocol violation the peek
+%%   already rejects (bad opcode/RSV/length, unmasked, oversized or
+%%   fragmented control), surfaced here so we don't re-decode to find it;
+%% - `invalid_utf8` — a text payload byte broke UTF-8 (close 1007).
 -spec early_validate_text(#data{}, binary(), roadrunner_ws:parse_opts()) ->
-    {ok, #data{}, non_neg_integer() | undefined} | invalid_utf8.
+    {frame, map(), #data{}} | {more, #data{}} | {error, term()} | invalid_utf8.
 early_validate_text(Data, Buf, Opts) ->
     case roadrunner_ws:peek_frame_header(Buf, Opts) of
         {ok,
@@ -534,7 +537,7 @@ early_validate_text(Data, Buf, Opts) ->
                 mask_key := MaskKey,
                 payload_offset := Off,
                 total_payload_len := TotalLen
-            },
+            } = Header,
             Available} ->
             #data{
                 frame_validated = AlreadyValidated,
@@ -544,36 +547,33 @@ early_validate_text(Data, Buf, Opts) ->
             ToValidate = min(Available, TotalLen) - AlreadyValidated,
             case ToValidate > 0 of
                 false ->
-                    {ok, Data, TotalLen};
+                    {frame, Header, Data};
                 true ->
                     Slice = binary:part(Buf, Off + AlreadyValidated, ToValidate),
                     Unmasked = unmask_slice(Slice, MaskKey, AlreadyValidated),
                     case validate_incremental(text, false, Pending, Unmasked) of
                         {ok, NewPending} ->
-                            {ok,
-                                Data#data{
-                                    utf8_pending = NewPending,
-                                    frame_validated = AlreadyValidated + ToValidate,
-                                    unmasked_buf = append_bin(UnmaskedBuf, Unmasked)
-                                },
-                                TotalLen};
+                            {frame, Header, Data#data{
+                                utf8_pending = NewPending,
+                                frame_validated = AlreadyValidated + ToValidate,
+                                unmasked_buf = append_bin(UnmaskedBuf, Unmasked)
+                            }};
                         invalid_utf8 ->
                             invalid_utf8
                     end
             end;
-        {ok, #{total_payload_len := TotalLen}, _Available} ->
+        {ok, Header, _Available} ->
             %% Header is peekable but the in-progress frame isn't a
             %% fresh uncompressed text frame (binary / control /
             %% continuation / compressed). No incremental UTF-8
-            %% validation applies, but surface the declared length so
-            %% `process_buffer/2` can apply the per-frame size cap
-            %% before the body is buffered.
-            {ok, Data, TotalLen};
-        _ ->
-            %% Header isn't peekable yet — not enough buffered bytes to
-            %% know the declared length. parse_frame will catch protocol
-            %% errors; UTF-8 validation happens at fragment / FIN time.
-            {ok, Data, undefined}
+            %% validation applies; hand the decoded header straight on so
+            %% the parse reuses it and the size cap still sees the length.
+            {frame, Header, Data};
+        {more, undefined} ->
+            %% Header isn't fully buffered yet — re-arm for the rest.
+            {more, Data};
+        {error, _} = Err ->
+            Err
     end.
 
 %% Unmask `Slice` where its first byte sits at `Offset` into the

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -554,7 +554,7 @@ early_validate_text(Data, Buf, Opts) ->
                                 Data#data{
                                     utf8_pending = NewPending,
                                     frame_validated = AlreadyValidated + ToValidate,
-                                    unmasked_buf = <<UnmaskedBuf/binary, Unmasked/binary>>
+                                    unmasked_buf = append_bin(UnmaskedBuf, Unmasked)
                                 },
                                 TotalLen};
                         invalid_utf8 ->
@@ -623,7 +623,18 @@ unmask_slice_chunks(<<>>, _MK, Acc) ->
 
 -spec append_buffer(#data{}, binary()) -> #data{}.
 append_buffer(#data{buffer = Buf} = Data, Bytes) ->
-    Data#data{buffer = <<Buf/binary, Bytes/binary>>}.
+    Data#data{buffer = append_bin(Buf, Bytes)}.
+
+%% Append `New` onto `Acc`, returning `New` untouched when `Acc` is empty.
+%% The single-chunk hot path (a whole frame in one TCP read, the buffer
+%% and unmasked accumulator drained, no partial UTF-8 carried over) hits
+%% the empty case every time, skipping a full payload-sized copy per
+%% inbound frame. Returning the bare binary also lets the UTF-8 BIF take
+%% its fast binary path, which is measured well ahead of both a pre-concat
+%% copy and an iodata list (the BIF walks a list far slower).
+-spec append_bin(binary(), binary()) -> binary().
+append_bin(<<>>, New) -> New;
+append_bin(Acc, New) -> <<Acc/binary, New/binary>>.
 
 -spec hibernate_actions(boolean()) -> [hibernate].
 hibernate_actions(true) -> [hibernate];

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -584,9 +584,9 @@ early_validate_text(Data, Buf, Opts) ->
 unmask_slice(Slice, <<MaskKey:32>>, Offset) ->
     %% Rotate the 32-bit mask so its byte at the slice's logical
     %% start lines up with bit position 0 — same trick as cowlib's
-    %% `cow_ws:unmask/3`. After rotation we can XOR 4 bytes at a
-    %% time (16 per recursion) instead of byte-at-a-time, which
-    %% on 1 KB payloads is ~10× faster than the old iolist version.
+    %% `cow_ws:unmask/3`. After rotation we XOR 4 bytes at a time,
+    %% 64 per recursion (16 × 32-bit words), which beats both the
+    %% byte-at-a-time iolist version and a narrower 4-word pass.
     Left = (Offset rem 4) * 8,
     Right = 32 - Left,
     Rotated = (MaskKey bsl Left) + (MaskKey bsr Right),
@@ -597,12 +597,20 @@ unmask_slice(Slice, <<MaskKey:32>>, Offset) ->
     unmask_slice_chunks(Slice, Rotated32, <<>>).
 
 -spec unmask_slice_chunks(binary(), non_neg_integer(), binary()) -> binary().
-unmask_slice_chunks(<<O1:32, O2:32, O3:32, O4:32, Rest/binary>>, MK, Acc) ->
-    T1 = O1 bxor MK,
-    T2 = O2 bxor MK,
-    T3 = O3 bxor MK,
-    T4 = O4 bxor MK,
-    unmask_slice_chunks(Rest, MK, <<Acc/binary, T1:32, T2:32, T3:32, T4:32>>);
+unmask_slice_chunks(
+    <<O1:32, O2:32, O3:32, O4:32, O5:32, O6:32, O7:32, O8:32, O9:32, O10:32, O11:32, O12:32, O13:32,
+        O14:32, O15:32, O16:32, Rest/binary>>,
+    MK,
+    Acc
+) ->
+    unmask_slice_chunks(
+        Rest,
+        MK,
+        <<Acc/binary, (O1 bxor MK):32, (O2 bxor MK):32, (O3 bxor MK):32, (O4 bxor MK):32,
+            (O5 bxor MK):32, (O6 bxor MK):32, (O7 bxor MK):32, (O8 bxor MK):32, (O9 bxor MK):32,
+            (O10 bxor MK):32, (O11 bxor MK):32, (O12 bxor MK):32, (O13 bxor MK):32,
+            (O14 bxor MK):32, (O15 bxor MK):32, (O16 bxor MK):32>>
+    );
 unmask_slice_chunks(<<O:32, Rest/binary>>, MK, Acc) ->
     T = O bxor MK,
     unmask_slice_chunks(Rest, MK, <<Acc/binary, T:32>>);

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -106,6 +106,35 @@ coalesced_split_first_frame_completes_from_socket_test() ->
     Sink ! stop,
     ok = gen_statem:stop(Pid).
 
+coalesced_split_after_header_completes_test() ->
+    %% Full header buffered but the body split across reads. Exercises the
+    %% `parse_frame_known {more}` re-arm in `process_parsed_frame/4` (the
+    %% header is decoded once by the peek; the body just isn't all here yet).
+    Self = self(),
+    Tag = make_ref(),
+    Full = frame(text, ~"hello"),
+    %% 6-byte header+mask for the 5-byte payload; split mid-body at byte 8.
+    <<First:8/binary, Second/binary>> = Full,
+    Sink = spawn_active_sink(Self, Tag, [{recv, Second}]),
+    {ok, Pid} = gen_statem:start(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            First,
+            ws_proto_opts()
+        },
+        []
+    ),
+    Pid ! socket_ready,
+    Sent = iolist_to_binary(collect_sends(Tag, 200)),
+    ?assertNotEqual(nomatch, binary:match(Sent, ~"hello")),
+    Sink ! stop,
+    ok = gen_statem:stop(Pid).
+
 %% =============================================================================
 %% Active-mode frame_loop — hibernate, transport error, and stray-info
 %% paths. Drives the gen_statem directly (skipping the run/5 launcher)

--- a/test/roadrunner_ws_tests.erl
+++ b/test/roadrunner_ws_tests.erl
@@ -456,6 +456,20 @@ parse_frame_bad_rsv_test() ->
     Frame = <<16#c1, 16#80, 1, 2, 3, 4>>,
     ?assertEqual({error, bad_rsv}, roadrunner_ws:parse_frame(Frame)).
 
+parse_frame_64bit_length_high_bit_rejected_test() ->
+    %% RFC 6455 §5.2: the 64-bit extended length's MSB must be 0.
+    Frame = <<16#81, 16#ff, (1 bsl 63):64, 1, 2, 3, 4>>,
+    ?assertEqual({error, bad_length}, roadrunner_ws:parse_frame(Frame)).
+
+parse_frame_pre_unmasked_skips_unmask_test() ->
+    %% The session supplies already-unmasked bytes via `pre_unmasked`;
+    %% parse_frame/2 uses them verbatim instead of unmasking a second time.
+    Payload = ~"hello",
+    Mask = <<1, 2, 3, 4>>,
+    Frame = <<16#81, 16#85, Mask/binary, (mask(Payload, Mask))/binary>>,
+    {ok, F, ~""} = roadrunner_ws:parse_frame(Frame, #{pre_unmasked => Payload}),
+    ?assertEqual(Payload, maps:get(payload, F)).
+
 %% peek_frame_header/2 — sneak-peek for the wire-level UTF-8
 %% validation path in roadrunner_ws_session.
 peek_frame_header_text_short_payload_test() ->
@@ -709,6 +723,65 @@ handshake_accepts_mixed_case_websocket_test() ->
         {~"sec-websocket-version", ~"13"}
     ],
     ?assertMatch({ok, 101, _, _, _}, roadrunner_ws:handshake_response(Headers)).
+
+%% =============================================================================
+%% parse_frame_known/3 — the session's fast path reuses the peeked header
+%% instead of decoding it a second time. It MUST agree byte-for-byte with
+%% the from-scratch parse_frame/2 oracle across every frame shape.
+%% =============================================================================
+
+parse_frame_known_matches_oracle_test() ->
+    Mask = <<16#aa, 16#bb, 16#cc, 16#dd>>,
+    P200 = binary:copy(~"a", 200),
+    Frames = [
+        %% text "Hello" (7-bit length)
+        {<<16#81, 16#85, 16#37, 16#fa, 16#21, 16#3d, 16#7f, 16#9f, 16#4d, 16#51, 16#58>>, #{}},
+        %% binary
+        {<<16#82, 16#85, Mask/binary, (mask(<<1, 2, 3, 4, 5>>, Mask))/binary>>, #{}},
+        %% continuation (FIN=0)
+        {<<16#00, 16#80, 1, 2, 3, 4>>, #{}},
+        %% control frames
+        {<<16#88, 16#80, 1, 2, 3, 4>>, #{}},
+        {<<16#89, 16#80, 1, 2, 3, 4>>, #{}},
+        {<<16#8a, 16#80, 1, 2, 3, 4>>, #{}},
+        %% 16-bit extended length
+        {<<16#82, 16#fe, 200:16, Mask/binary, (mask(P200, Mask))/binary>>, #{}},
+        %% 64-bit extended length
+        {<<16#82, 16#ff, 2:64, Mask/binary, (mask(~"hi", Mask))/binary>>, #{}},
+        %% trailing bytes after the frame must be preserved as Rest
+        {
+            <<16#81, 16#85, 16#37, 16#fa, 16#21, 16#3d, 16#7f, 16#9f, 16#4d, 16#51, 16#58, "TAIL">>,
+            #{}
+        },
+        %% RSV1 set with permessage-deflate negotiated
+        {<<16#c2, 16#85, Mask/binary, (mask(<<9, 8, 7, 6, 5>>, Mask))/binary>>, #{
+            allow_rsv1 => true
+        }}
+    ],
+    [assert_known_matches_oracle(Buf, Opts) || {Buf, Opts} <- Frames],
+    ok.
+
+parse_frame_known_uses_pre_unmasked_test() ->
+    %% Supplying the already-unmasked payload yields the same frame as the
+    %% oracle, without re-unmasking.
+    Buf = <<16#81, 16#85, 16#37, 16#fa, 16#21, 16#3d, 16#7f, 16#9f, 16#4d, 16#51, 16#58>>,
+    {ok, Header, _Available} = roadrunner_ws:peek_frame_header(Buf, #{}),
+    {ok, Oracle, ~""} = roadrunner_ws:parse_frame(Buf, #{}),
+    Pre = maps:get(payload, Oracle),
+    ?assertEqual({ok, Oracle, ~""}, roadrunner_ws:parse_frame_known(Buf, Header, Pre)).
+
+parse_frame_known_incomplete_body_returns_more_test() ->
+    %% Full header peekable, only 3 of 5 declared payload bytes present.
+    Buf = <<16#81, 16#85, 1, 2, 3, 4, 99, 99, 99>>,
+    {ok, Header, 3} = roadrunner_ws:peek_frame_header(Buf, #{}),
+    ?assertEqual({more, undefined}, roadrunner_ws:parse_frame_known(Buf, Header, undefined)).
+
+assert_known_matches_oracle(Buf, Opts) ->
+    {ok, Header, _Available} = roadrunner_ws:peek_frame_header(Buf, Opts),
+    ?assertEqual(
+        roadrunner_ws:parse_frame(Buf, Opts),
+        roadrunner_ws:parse_frame_known(Buf, Header, undefined)
+    ).
 
 %% --- helpers ---
 


### PR DESCRIPTION
# Description

Speeds up the WebSocket hot path with a set of per-frame work and copy eliminations, no API or behavior change. Outbound frames are emitted as an iolist (no payload materialization); the inbound path skips the empty-prefix buffer/unmask copies, validates UTF-8 from the payload binary directly, decodes the frame header once (the peek result is reused by the parser instead of re-decoded), unmasks 64 bytes per pass, and dispatches a complete single-frame message without the fragment-reassembly machinery. Autobahn conformance and 100% line and branch coverage are preserved.

On the 1 KB text echo, an interleaved A/B showed about +10% throughput (p99 545 -> 431 us); the remaining parse and dispatch changes remove constant per-frame work proven by microbench and fprof (for example, unmask drops from 65 to 17 recursions per frame).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
