### PR TITLE
Run the Autobahn conformance suite on every CI run

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -241,14 +241,14 @@ jobs:
         run: ./scripts/h2spec.sh
 
   # WebSocket conformance — backs the README "Autobahn fuzzingclient
-  # strict 100 %" claim, on every supported OTP. Slow (~5 min/version) —
-  # runs only on push to main, merge_group, and manual dispatch, not every
-  # PR. Use `workflow_dispatch` to trigger on a feature branch when WS code
-  # is touched. Self-contained per matrix version like Test / h2spec.
+  # strict 100 %" claim, on every supported OTP. Slow (~5 min/version) but
+  # runs on every push + PR + merge_group, in parallel with the other jobs,
+  # exactly like h2spec — so a WebSocket regression is caught before merge
+  # rather than only after landing on main. Needs Docker (the
+  # crossbario/autobahn-testsuite image), which the ubuntu runner provides.
+  # Self-contained per matrix version like Test / h2spec.
   autobahn:
     name: autobahn (OTP ${{ matrix.otp }})
-
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
# Description

Removes the `if:` gate on the `autobahn` job so the WebSocket Autobahn fuzzingclient conformance suite runs on every push, pull request, and merge_group across the full OTP matrix, matching how the `h2spec` conformance job already runs. The job was already complete (it compiles the test profile and runs `scripts/autobahn.escript`, which drives the `crossbario/autobahn-testsuite` Docker image the ubuntu runner provides and exits non-zero on any failure), so dropping the gate is enough to make it a real per-PR gate that catches a WebSocket regression before merge instead of only after it lands on main. Trade-off: about 5 minutes per OTP version on each PR, run in parallel with the other jobs, same as h2spec.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
