### PR TITLE
Add a required init/1 middleware callback

### DIFF
--- a/src/roadrunner_compress.erl
+++ b/src/roadrunner_compress.erl
@@ -63,7 +63,7 @@
 
 -on_load(init_patterns/0).
 
--export([call/3]).
+-export([init/1, call/3]).
 
 -define(THRESHOLD, 860).
 -define(COMMA_CP_KEY, {?MODULE, comma_cp}).
@@ -71,7 +71,16 @@
 
 -type encoding() :: gzip | deflate | none.
 
--spec call(roadrunner_req:request(), roadrunner_middleware:next(), term()) ->
+%% No per-instance config — encoding is negotiated per request from
+%% `Accept-Encoding`, and the match patterns are compiled at load, so the
+%% compiled state is just the empty map.
+-type state() :: #{}.
+
+-spec init(roadrunner_middleware:config()) -> state().
+init(_Config) ->
+    #{}.
+
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
     roadrunner_handler:result().
 call(Req, Next, _State) ->
     {Response, Req2} = Next(Req),

--- a/src/roadrunner_cors.erl
+++ b/src/roadrunner_cors.erl
@@ -30,8 +30,9 @@ middlewares => [
 | `credentials` | `false` | when `true`, emit `Access-Control-Allow-Credentials: true` |
 | `max_age` | (omitted) | preflight cache lifetime in seconds (`Access-Control-Max-Age`) |
 
-A bad value crashes the request with `{invalid_cors_opt, Key, Value}` rather
-than failing silently.
+The policy is validated and compiled once when the listener starts (and on
+`reload_routes/2`), so a bad value crashes at startup with
+`{invalid_cors_opt, Key, Value}` rather than failing silently on a request.
 
 ## Behaviour
 
@@ -56,7 +57,7 @@ without credentials emits the literal `*`.
 
 -behaviour(roadrunner_middleware).
 
--export([call/3]).
+-export([init/1, call/3]).
 
 -type origins() :: any | [binary()] | fun((binary()) -> boolean()).
 -type config() :: #{
@@ -68,9 +69,72 @@ without credentials emits the literal `*`.
     max_age => non_neg_integer()
 }.
 
--spec call(roadrunner_req:request(), roadrunner_middleware:next(), roadrunner_middleware:state()) ->
+-export_type([config/0, state/0]).
+
+%% The compiled policy `init/1` produces. `origins` and `credentials` drive
+%% the per-request `Access-Control-Allow-Origin` decision; `reflect_headers`
+%% says whether `Access-Control-Allow-Headers` mirrors the request. The two
+%% header lists are fully built and false-filtered at compile time, so a
+%% request only prepends the origin-dependent header onto them.
+-record(cors, {
+    origins :: origins(),
+    credentials :: boolean(),
+    reflect_headers :: boolean(),
+    preflight_static :: roadrunner_http:headers(),
+    actual_static :: roadrunner_http:headers()
+}).
+
+-doc "The compiled policy produced by `init/1` and consumed by `call/3`.".
+-type state() :: #cors{}.
+
+%% Validate the policy and pre-build every static header once, at
+%% pipeline-compile time. A bad value crashes here (listener start) with a
+%% clear `{invalid_cors_opt, Key, Value}`, not on a request.
+-spec init(config()) -> state().
+init(Config) ->
+    Origins = origins(Config),
+    Credentials = credentials(Config),
+    AllowCredentials = credentials_value(Credentials),
+    {ReflectHeaders, AllowHeaders} = compile_allow_headers(Config),
+    PreflightStatic = drop_unset([
+        {~"access-control-allow-methods", join(methods(Config))},
+        {~"access-control-allow-headers", AllowHeaders},
+        {~"access-control-allow-credentials", AllowCredentials},
+        {~"access-control-max-age", max_age_value(Config)}
+    ]),
+    ActualStatic = drop_unset([
+        {~"access-control-allow-credentials", AllowCredentials},
+        {~"access-control-expose-headers", expose_value(Config)}
+    ]),
+    #cors{
+        origins = Origins,
+        credentials = Credentials,
+        reflect_headers = ReflectHeaders,
+        preflight_static = PreflightStatic,
+        actual_static = ActualStatic
+    }.
+
+%% The static `Access-Control-Allow-Headers` value, plus whether the policy
+%% reflects the request's headers. `reflect` is resolved per request (its value
+%% depends on `Access-Control-Request-Headers`), so the static value is `false`
+%% there; a configured list is pre-joined; `[]` emits nothing.
+-spec compile_allow_headers(map()) -> {boolean(), binary() | false}.
+compile_allow_headers(Config) ->
+    case headers(Config) of
+        reflect -> {true, false};
+        [] -> {false, false};
+        List -> {false, join(List)}
+    end.
+
+%% Drop the entries whose value didn't apply under the policy (`false`), so the
+%% per-request path only ever prepends real headers.
+-spec drop_unset([{binary(), binary() | false}]) -> roadrunner_http:headers().
+drop_unset(Headers) ->
+    [Header || {_Name, Value} = Header <- Headers, Value =/= false].
+
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
     roadrunner_handler:result().
-call(Req, Next, Config) ->
+call(Req, Next, #cors{} = State) ->
     case roadrunner_req:header(~"origin", Req) of
         undefined ->
             %% Not a CORS request — nothing to do.
@@ -79,10 +143,10 @@ call(Req, Next, Config) ->
             case is_preflight(Req) of
                 true ->
                     %% Preflight: answer 204 ourselves, never reaching the handler.
-                    {preflight_response(Config, Origin, Req), Req};
+                    {preflight_response(State, Origin, Req), Req};
                 false ->
                     {Response, Req2} = Next(Req),
-                    {add_actual_headers(Response, Config, Origin), Req2}
+                    {add_actual_headers(Response, State, Origin), Req2}
             end
     end.
 
@@ -97,51 +161,41 @@ is_preflight(Req) ->
 %% Preflight (204)
 %% =============================================================================
 
--spec preflight_response(config(), binary(), roadrunner_req:request()) ->
+-spec preflight_response(state(), binary(), roadrunner_req:request()) ->
     roadrunner_handler:response().
-preflight_response(Config, Origin, Req) ->
+preflight_response(#cors{origins = Origins} = State, Origin, Req) ->
     %% Vary: Origin even on a disallowed preflight, so a cache keys correctly.
     Base = add_vary_origin([]),
-    Origins = origins(Config),
     case allowed(Origin, Origins) of
         false ->
             {204, Base, ~""};
         true ->
-            Creds = credentials(Config),
             ok = roadrunner_http:check_header_safe(Origin, value),
-            Headers = add_cors(
-                [
-                    {~"access-control-allow-origin", allow_origin_value(Origin, Origins, Creds)},
-                    {~"access-control-allow-methods", join(methods(Config))},
-                    {~"access-control-allow-headers", allow_headers_value(Config, Req)},
-                    {~"access-control-allow-credentials", credentials_value(Creds)},
-                    {~"access-control-max-age", max_age_value(Config)}
-                ],
-                Base
-            ),
+            AllowOrigin =
+                {
+                    ~"access-control-allow-origin",
+                    allow_origin_value(Origin, Origins, State#cors.credentials)
+                },
+            Headers = add_headers([AllowOrigin | preflight_headers(State, Req)], Base),
             {204, Headers, ~""}
     end.
 
-%% The `Access-Control-Allow-Headers` value: mirror the request's requested
-%% headers (`reflect`), join a configured list, or omit when neither applies.
--spec allow_headers_value(config(), roadrunner_req:request()) -> binary() | false.
-allow_headers_value(Config, Req) ->
-    case headers(Config) of
-        reflect ->
-            case roadrunner_req:header(~"access-control-request-headers", Req) of
-                undefined ->
-                    false;
-                Requested ->
-                    ok = roadrunner_http:check_header_safe(Requested, value),
-                    Requested
-            end;
-        [] ->
-            false;
-        List ->
-            join(List)
+%% The pre-built preflight set, with the reflected `Access-Control-Allow-Headers`
+%% prepended when the policy mirrors the request (the only part that depends on
+%% the request, so the only part resolved here).
+-spec preflight_headers(state(), roadrunner_req:request()) -> roadrunner_http:headers().
+preflight_headers(#cors{reflect_headers = false, preflight_static = Static}, _Req) ->
+    Static;
+preflight_headers(#cors{reflect_headers = true, preflight_static = Static}, Req) ->
+    case roadrunner_req:header(~"access-control-request-headers", Req) of
+        undefined ->
+            Static;
+        Requested ->
+            ok = roadrunner_http:check_header_safe(Requested, value),
+            [{~"access-control-allow-headers", Requested} | Static]
     end.
 
--spec max_age_value(config()) -> binary() | false.
+-spec max_age_value(map()) -> binary() | false.
 max_age_value(Config) ->
     case max_age(Config) of
         undefined -> false;
@@ -155,50 +209,46 @@ max_age_value(Config) ->
 %% Decorate every header-bearing response shape; a `{websocket, _, _}` upgrade
 %% (no response headers) passes through. The `is_integer(Status)` guard on the
 %% buffered clause keeps the websocket triple out of it.
--spec add_actual_headers(roadrunner_handler:response(), config(), binary()) ->
+-spec add_actual_headers(roadrunner_handler:response(), state(), binary()) ->
     roadrunner_handler:response().
-add_actual_headers({Status, Headers, Body}, Config, Origin) when
+add_actual_headers({Status, Headers, Body}, State, Origin) when
     is_integer(Status), Status >= 100, Status =< 599
 ->
-    {Status, actual_headers(Headers, Config, Origin), Body};
-add_actual_headers({stream, Status, Headers, Fun}, Config, Origin) when
+    {Status, actual_headers(Headers, State, Origin), Body};
+add_actual_headers({stream, Status, Headers, Fun}, State, Origin) when
     is_integer(Status), Status >= 100, Status =< 599, is_function(Fun, 1)
 ->
-    {stream, Status, actual_headers(Headers, Config, Origin), Fun};
-add_actual_headers({sendfile, Status, Headers, Spec}, Config, Origin) when
+    {stream, Status, actual_headers(Headers, State, Origin), Fun};
+add_actual_headers({sendfile, Status, Headers, Spec}, State, Origin) when
     is_integer(Status), Status >= 100, Status =< 599
 ->
-    {sendfile, Status, actual_headers(Headers, Config, Origin), Spec};
-add_actual_headers({loop, Status, Headers, LoopState}, Config, Origin) when
+    {sendfile, Status, actual_headers(Headers, State, Origin), Spec};
+add_actual_headers({loop, Status, Headers, LoopState}, State, Origin) when
     is_integer(Status), Status >= 100, Status =< 599
 ->
-    {loop, Status, actual_headers(Headers, Config, Origin), LoopState};
-add_actual_headers(Other, _Config, _Origin) ->
+    {loop, Status, actual_headers(Headers, State, Origin), LoopState};
+add_actual_headers(Other, _State, _Origin) ->
     Other.
 
--spec actual_headers(roadrunner_http:headers(), config(), binary()) ->
+-spec actual_headers(roadrunner_http:headers(), state(), binary()) ->
     roadrunner_http:headers().
-actual_headers(Headers, Config, Origin) ->
+actual_headers(Headers, #cors{origins = Origins} = State, Origin) ->
     WithVary = add_vary_origin(Headers),
-    Origins = origins(Config),
     case allowed(Origin, Origins) of
         false ->
             %% Disallowed: only Vary: Origin, no Access-Control-Allow-Origin.
             WithVary;
         true ->
-            Creds = credentials(Config),
             ok = roadrunner_http:check_header_safe(Origin, value),
-            add_cors(
-                [
-                    {~"access-control-allow-origin", allow_origin_value(Origin, Origins, Creds)},
-                    {~"access-control-allow-credentials", credentials_value(Creds)},
-                    {~"access-control-expose-headers", expose_value(Config)}
-                ],
-                WithVary
-            )
+            AllowOrigin =
+                {
+                    ~"access-control-allow-origin",
+                    allow_origin_value(Origin, Origins, State#cors.credentials)
+                },
+            add_headers([AllowOrigin | State#cors.actual_static], WithVary)
     end.
 
--spec expose_value(config()) -> binary() | false.
+-spec expose_value(map()) -> binary() | false.
 expose_value(Config) ->
     case expose(Config) of
         [] -> false;
@@ -237,18 +287,17 @@ add_vary_origin(Headers) ->
             lists:keystore(~"vary", 1, Headers, {~"vary", <<Existing/binary, ", Origin">>})
     end.
 
-%% Prepend each candidate the handler didn't already set, skipping any whose
-%% value resolved to `false` (the header doesn't apply under this policy).
--spec add_cors([{binary(), binary() | false}], roadrunner_http:headers()) ->
+%% Prepend each pre-built candidate the handler didn't already set. The
+%% `false`-valued entries were dropped at compile time by `drop_unset/1`, so
+%% the only check left here is whether the handler already owns the header.
+-spec add_headers(roadrunner_http:headers(), roadrunner_http:headers()) ->
     roadrunner_http:headers().
-add_cors([], Headers) ->
+add_headers([], Headers) ->
     Headers;
-add_cors([{_Name, false} | Rest], Headers) ->
-    add_cors(Rest, Headers);
-add_cors([{Name, Value} | Rest], Headers) ->
+add_headers([{Name, _} = Header | Rest], Headers) ->
     case lists:keymember(Name, 1, Headers) of
-        true -> add_cors(Rest, Headers);
-        false -> [{Name, Value} | add_cors(Rest, Headers)]
+        true -> add_headers(Rest, Headers);
+        false -> [Header | add_headers(Rest, Headers)]
     end.
 
 %% Join binaries with ", " into one binary (header values must be binary).
@@ -258,8 +307,9 @@ join([Value]) -> Value;
 join([Value | Rest]) -> <<Value/binary, ", ", (join(Rest))/binary>>.
 
 %% =============================================================================
-%% Config readers (validated lazily; a bad value crashes the request with a
-%% clear `{invalid_cors_opt, Key, Value}` rather than denying silently)
+%% Config readers, run once by `init/1` at compile time; a bad value crashes
+%% at listener start with a clear `{invalid_cors_opt, Key, Value}` rather than
+%% denying silently
 %% =============================================================================
 
 -spec origins(map()) -> origins().

--- a/src/roadrunner_cors.erl
+++ b/src/roadrunner_cors.erl
@@ -171,7 +171,7 @@ preflight_response(#cors{origins = Origins} = State, Origin, Req) ->
                     allow_origin_value(Origin, Origins, State#cors.credentials)
                 },
             Headers = roadrunner_http:with_defaults(
-                [AllowOrigin | preflight_headers(State, Req)], Base
+                Base, [AllowOrigin | preflight_headers(State, Req)]
             ),
             {204, Headers, ~""}
     end.
@@ -241,7 +241,7 @@ actual_headers(Headers, #cors{origins = Origins} = State, Origin) ->
                     ~"access-control-allow-origin",
                     allow_origin_value(Origin, Origins, State#cors.credentials)
                 },
-            roadrunner_http:with_defaults([AllowOrigin | State#cors.actual_static], WithVary)
+            roadrunner_http:with_defaults(WithVary, [AllowOrigin | State#cors.actual_static])
     end.
 
 -spec expose_value(map()) -> binary() | false.

--- a/src/roadrunner_cors.erl
+++ b/src/roadrunner_cors.erl
@@ -96,13 +96,13 @@ init(Config) ->
     Credentials = credentials(Config),
     AllowCredentials = credentials_value(Credentials),
     {ReflectHeaders, AllowHeaders} = compile_allow_headers(Config),
-    PreflightStatic = drop_unset([
+    PreflightStatic = roadrunner_http:drop_unset([
         {~"access-control-allow-methods", join(methods(Config))},
         {~"access-control-allow-headers", AllowHeaders},
         {~"access-control-allow-credentials", AllowCredentials},
         {~"access-control-max-age", max_age_value(Config)}
     ]),
-    ActualStatic = drop_unset([
+    ActualStatic = roadrunner_http:drop_unset([
         {~"access-control-allow-credentials", AllowCredentials},
         {~"access-control-expose-headers", expose_value(Config)}
     ]),
@@ -125,12 +125,6 @@ compile_allow_headers(Config) ->
         [] -> {false, false};
         List -> {false, join(List)}
     end.
-
-%% Drop the entries whose value didn't apply under the policy (`false`), so the
-%% per-request path only ever prepends real headers.
--spec drop_unset([{binary(), binary() | false}]) -> roadrunner_http:headers().
-drop_unset(Headers) ->
-    [Header || {_Name, Value} = Header <- Headers, Value =/= false].
 
 -spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
     roadrunner_handler:result().
@@ -176,7 +170,9 @@ preflight_response(#cors{origins = Origins} = State, Origin, Req) ->
                     ~"access-control-allow-origin",
                     allow_origin_value(Origin, Origins, State#cors.credentials)
                 },
-            Headers = add_headers([AllowOrigin | preflight_headers(State, Req)], Base),
+            Headers = roadrunner_http:with_defaults(
+                [AllowOrigin | preflight_headers(State, Req)], Base
+            ),
             {204, Headers, ~""}
     end.
 
@@ -245,7 +241,7 @@ actual_headers(Headers, #cors{origins = Origins} = State, Origin) ->
                     ~"access-control-allow-origin",
                     allow_origin_value(Origin, Origins, State#cors.credentials)
                 },
-            add_headers([AllowOrigin | State#cors.actual_static], WithVary)
+            roadrunner_http:with_defaults([AllowOrigin | State#cors.actual_static], WithVary)
     end.
 
 -spec expose_value(map()) -> binary() | false.
@@ -285,19 +281,6 @@ add_vary_origin(Headers) ->
             [{~"vary", ~"Origin"} | Headers];
         {_, Existing} ->
             lists:keystore(~"vary", 1, Headers, {~"vary", <<Existing/binary, ", Origin">>})
-    end.
-
-%% Prepend each pre-built candidate the handler didn't already set. The
-%% `false`-valued entries were dropped at compile time by `drop_unset/1`, so
-%% the only check left here is whether the handler already owns the header.
--spec add_headers(roadrunner_http:headers(), roadrunner_http:headers()) ->
-    roadrunner_http:headers().
-add_headers([], Headers) ->
-    Headers;
-add_headers([{Name, _} = Header | Rest], Headers) ->
-    case lists:keymember(Name, 1, Headers) of
-        true -> add_headers(Rest, Headers);
-        false -> [Header | add_headers(Rest, Headers)]
     end.
 
 %% Join binaries with ", " into one binary (header values must be binary).

--- a/src/roadrunner_etag.erl
+++ b/src/roadrunner_etag.erl
@@ -36,9 +36,18 @@
 
 -behaviour(roadrunner_middleware).
 
--export([call/3]).
+-export([init/1, call/3]).
 
--spec call(roadrunner_req:request(), roadrunner_middleware:next(), term()) ->
+%% No per-instance config — the validator is derived from the response body
+%% and the request's `If-None-Match` per request, so the compiled state is
+%% just the empty map.
+-type state() :: #{}.
+
+-spec init(roadrunner_middleware:config()) -> state().
+init(_Config) ->
+    #{}.
+
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
     roadrunner_handler:result().
 call(Req, Next, _State) ->
     {Response, Req2} = Next(Req),

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -131,18 +131,19 @@ with_alt_svc(Headers, undefined) ->
 with_alt_svc(Headers, AltSvc) ->
     [{~"alt-svc", AltSvc} | Headers].
 
-%% Prepend each candidate the existing list doesn't already carry, so a
-%% handler-set value always wins. Body recursion preserves candidate order.
-%% Used by middlewares (`roadrunner_cors`, `roadrunner_security_headers`) to
-%% merge their pre-built header set onto the handler's response.
+%% Prepend each default the headers don't already carry, so a handler-set
+%% value always wins. Body recursion preserves the default order. Used by
+%% middlewares (`roadrunner_cors`, `roadrunner_security_headers`) to merge
+%% their pre-built header set onto the handler's response. Headers-first,
+%% matching `with_date/1` / `with_alt_svc/2`.
 -doc false.
--spec with_defaults(Defaults :: headers(), headers()) -> headers().
-with_defaults([], Headers) ->
+-spec with_defaults(headers(), Defaults :: headers()) -> headers().
+with_defaults(Headers, []) ->
     Headers;
-with_defaults([{Name, _} = Default | Rest], Headers) ->
+with_defaults(Headers, [{Name, _} = Default | Rest]) ->
     case lists:keymember(Name, 1, Headers) of
-        true -> with_defaults(Rest, Headers);
-        false -> [Default | with_defaults(Rest, Headers)]
+        true -> with_defaults(Headers, Rest);
+        false -> [Default | with_defaults(Headers, Rest)]
     end.
 
 %% Drop the candidates whose value resolved to `false` (the header doesn't

--- a/src/roadrunner_http.erl
+++ b/src/roadrunner_http.erl
@@ -37,6 +37,7 @@ accessors that operate on it.
 """.
 
 -export([http_date_now/0, format_http_date/1, with_date/1, auto_headers/2]).
+-export([with_defaults/2, drop_unset/1]).
 -export([header_list_size/1]).
 -export([check_header_safe/2, check_header_safe/3]).
 -export([unsafe_bytes_pattern/0]).
@@ -129,6 +130,28 @@ with_alt_svc(Headers, undefined) ->
     Headers;
 with_alt_svc(Headers, AltSvc) ->
     [{~"alt-svc", AltSvc} | Headers].
+
+%% Prepend each candidate the existing list doesn't already carry, so a
+%% handler-set value always wins. Body recursion preserves candidate order.
+%% Used by middlewares (`roadrunner_cors`, `roadrunner_security_headers`) to
+%% merge their pre-built header set onto the handler's response.
+-doc false.
+-spec with_defaults(Defaults :: headers(), headers()) -> headers().
+with_defaults([], Headers) ->
+    Headers;
+with_defaults([{Name, _} = Default | Rest], Headers) ->
+    case lists:keymember(Name, 1, Headers) of
+        true -> with_defaults(Rest, Headers);
+        false -> [Default | with_defaults(Rest, Headers)]
+    end.
+
+%% Drop the candidates whose value resolved to `false` (the header doesn't
+%% apply), leaving a plain header list. Middlewares call this once, at compile
+%% time, so the per-request `with_defaults/2` only ever prepends real headers.
+-doc false.
+-spec drop_unset([{binary(), binary() | false}]) -> headers().
+drop_unset(Candidates) ->
+    [Header || {_Name, Value} = Header <- Candidates, Value =/= false].
 
 %% RFC 7541 §4.1: the uncompressed size of a header list is the sum over
 %% its fields of `byte_size(Name) + byte_size(Value) + 32`. This is the

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -79,25 +79,50 @@ which wrap the handler — first in each list runs outermost.
 ## Middleware shape
 
 Each entry in a middlewares list is a `Callable`, optionally paired with
-its `State` as `{Callable, State}`. `State` is the middleware's own
-configuration, handed to the third argument of the call. A bare
-`Callable` is shorthand for `{Callable, undefined}`, the same way a
-`{Path, Handler}` route omits the state a `{Path, Handler, State}` route
-carries.
+its config as `{Callable, Config}`. A bare `Callable` is shorthand for
+`{Callable, #{}}` (empty config), the same way a `{Path, Handler}` route
+omits the state a `{Path, Handler, State}` route carries.
 
-- `module()` / `{module(), State}` — the module's `call/3` behaviour
-  callback is invoked as `Mod:call(Req, Next, State)`.
-- `fun((Request, Next, State) -> Result)` / `{Fun, State}` — the fun is
-  invoked directly as `Fun(Req, Next, State)`.
+- `module()` / `{module(), Config}` — a module implementing this
+  behaviour. Its `init(Config)` callback runs **once**, at
+  pipeline-compile time, and the value it returns becomes the `State`
+  handed to every `Mod:call(Req, Next, State)`. See "init/1" below.
+- `fun((Request, Next, State) -> Result)` / `{Fun, State}` — a fun has no
+  init step, so its paired `State` is threaded verbatim as the third
+  argument: `Fun(Req, Next, State)`. Reach for a fun for lightweight
+  inline middleware, a module when you want compile-time setup.
 
-`State` defaults to `undefined` for the bare forms. The same callable can
-appear more than once with different `State`, e.g.
+Config (module) and `State` (fun) default to `#{}` for the bare forms.
+The same callable can appear more than once with different config, e.g.
 `[{rate_limit, #{rps => 10}}, {rate_limit, #{rps => 100}}]`.
 
 Middleware `State` is **not** the request's `state` field. Route state
 (`{Path, Handler, State}`) is injected onto the request map and read
 with `roadrunner_req:state/1`; middleware `State` is handed to `call/3`
 as an argument and never touches the request.
+
+## init/1: compile-time setup (modules only)
+
+A module middleware **must** implement `init/1`. It runs once when the
+pipeline is compiled (listener boot and every `reload_routes/2`), never
+per request, and turns the user's raw config into the runtime state
+`call/3` receives:
+
+```erlang
+init(Config) -> State.            %% once, at compile time
+call(Req, Next, State) -> Result. %% per request, the same State reused
+```
+
+Do config validation and any precompute (compile patterns, pre-join
+binaries, build lookup tables) in `init/1`: a bad config then fails
+loudly at listener start rather than on a request, and the work is paid
+once instead of per request. A bare `module()` entry is initialised with
+`#{}`, so an `init/1` that reads an all-defaults config should accept the
+empty map.
+
+A fun-form middleware has no `init/1` (there's no module to host the
+callback); its paired `State` is used as-is, so precompute it yourself or
+pass a module if you want the compile-time hook.
 
 ## Examples
 
@@ -126,7 +151,7 @@ server_header(Req, Next, Server) ->
 """.
 
 -export([compose/2, build_pipeline/2, compile_pipeline/3]).
--export_type([middleware/0, middleware_fun/0, middleware_list/0, next/0, state/0]).
+-export_type([middleware/0, middleware_fun/0, middleware_list/0, next/0, config/0, state/0]).
 
 -doc """
 The continuation passed to a middleware's `call/3`: a fun that runs
@@ -137,10 +162,20 @@ middleware returns.
 -type next() :: fun((roadrunner_req:request()) -> roadrunner_handler:result()).
 
 -doc """
-A middleware entry's per-instance state, passed as the third argument
-of `call/3`. `undefined` is the default for a bare `Callable` entry.
+A middleware entry's raw per-instance config: the second element of a
+`{Callable, Config}` entry, and the `#{}` default for a bare `Callable`.
+For a module it is the argument handed to `init/1`; a fun has no init, so
+its config is threaded straight through as the `call/3` state. Typically a
+map.
 """.
--type state() :: undefined | term().
+-type config() :: term().
+
+-doc """
+A middleware entry's runtime state, passed as the third argument of
+`call/3`. For a module entry it is whatever `init/1` returned at compile
+time; for a fun entry it is the entry's `t:config/0` used verbatim.
+""".
+-type state() :: term().
 
 -doc """
 The function shape of a fun-form middleware: it receives the request,
@@ -151,28 +186,40 @@ the continuation, and the entry's `t:state/0`.
 
 -doc """
 A single entry in a `middlewares` list: a `Callable`, or a
-`{Callable, State}` pair. `Callable` is either a module implementing
-`-behaviour(roadrunner_middleware)` (its `call/3` is invoked) or a
-`t:middleware_fun/0` invoked directly. `State` is the middleware's own
-configuration, passed through as the third argument; a bare `Callable`
-defaults it to `undefined`.
+`{Callable, Config}` pair. `Callable` is either a module
+implementing `-behaviour(roadrunner_middleware)` (its `init/1` runs at
+compile time, its `call/3` per request) or a `t:middleware_fun/0` invoked
+directly. The pair's second element is the entry's `t:config/0` — fed to
+`init/1` for a module, used verbatim as the `call/3` state for a fun; a
+bare `Callable` defaults it to `#{}`.
 """.
 -type middleware() ::
     module()
     | middleware_fun()
-    | {module(), state()}
-    | {middleware_fun(), state()}.
+    | {module(), config()}
+    | {middleware_fun(), config()}.
 
 -doc "An ordered list of `t:middleware/0` entries.".
 -type middleware_list() :: [middleware()].
+
+-doc """
+Compile-time setup. Runs **once** when the pipeline is built (listener
+boot and every `roadrunner_listener:reload_routes/2`), never per request,
+and turns the entry's raw `t:config/0` into the `t:state/0` handed to
+every `call/3`. A bare `module()` entry is initialised with `#{}`.
+
+This is the place for config validation and precompute (compile patterns,
+pre-join binaries, build lookup tables): a bad config fails loudly at
+listener start, and the work is paid once rather than per request.
+""".
+-callback init(Config :: config()) -> state().
 
 -doc """
 The middleware contract. `Request` is the current request map;
 `Next` is a continuation that runs the rest of the pipeline (other
 middlewares + the inner handler) and returns the same
 `t:roadrunner_handler:result/0` shape every middleware returns. `State`
-is the entry's configuration (the second element of a `{module(),
-State}` entry, or `undefined` for a bare `module()` entry).
+is what this entry's `init/1` returned at compile time.
 
 The middleware decides whether to:
 - pass through unchanged (`Next(Req)`),
@@ -193,17 +240,35 @@ The middleware decides whether to:
 Compose a middleware list around a handler call, returning a single
 `next()` fun that runs the full pipeline.
 
-The first middleware in the list runs **outermost** — it gets the
-first crack at the request and the last crack at the response. The
-handler is the innermost call; an empty list returns the handler fun
-unchanged.
+Each module entry's `init/1` is run **here**, once, as the pipeline is
+built; the resulting `t:state/0` is captured in the entry's closure and
+reused on every request. The first middleware in the list runs
+**outermost** — it gets the first crack at the request and the last crack
+at the response. The handler is the innermost call; an empty list returns
+the handler fun unchanged.
 """.
 -spec compose(middleware_list(), next()) -> next().
 compose([], Handler) ->
     Handler;
 compose([Mw | Rest], Handler) ->
     Inner = compose(Rest, Handler),
-    fun(Req) -> apply_one(Mw, Req, Inner) end.
+    {Callable, State} = resolve(Mw),
+    fun(Req) -> apply_one(Callable, State, Req, Inner) end.
+
+%% Resolve a middleware entry to its `{Callable, State}` runtime pair at
+%% pipeline-bake time. A module entry runs its required `init/1` callback
+%% once here, so the per-request closure reuses the returned state; a fun
+%% entry has no init, so its config is the state verbatim. A bare entry
+%% defaults its config to `#{}`.
+-spec resolve(middleware()) -> {module() | middleware_fun(), state()}.
+resolve({Mod, Config}) when is_atom(Mod) ->
+    {Mod, Mod:init(Config)};
+resolve({Fun, Config}) when is_function(Fun, 3) ->
+    {Fun, Config};
+resolve(Mod) when is_atom(Mod) ->
+    {Mod, Mod:init(#{})};
+resolve(Fun) when is_function(Fun, 3) ->
+    {Fun, #{}}.
 
 %% Build the handler pipeline from a combined middleware list
 %% (listener-level ++ per-route) and a target handler module. The
@@ -244,13 +309,13 @@ compile_pipeline(Mws, Handler, {state, State}) ->
     Inner = build_pipeline(Mws, Handler),
     fun(Req) -> Inner(Req#{state => State}) end.
 
--spec apply_one(middleware(), roadrunner_req:request(), next()) ->
+%% Invoke a resolved entry with the request and continuation. `Callable`
+%% and `State` are threaded individually (no per-request tuple rebuild);
+%% the `{Callable, State}` pair was already split by `resolve/1` at bake
+%% time.
+-spec apply_one(module() | middleware_fun(), state(), roadrunner_req:request(), next()) ->
     roadrunner_handler:result().
-apply_one({Mod, State}, Req, Next) when is_atom(Mod) ->
+apply_one(Mod, State, Req, Next) when is_atom(Mod) ->
     Mod:call(Req, Next, State);
-apply_one({Fun, State}, Req, Next) when is_function(Fun, 3) ->
-    Fun(Req, Next, State);
-apply_one(Mod, Req, Next) when is_atom(Mod) ->
-    Mod:call(Req, Next, undefined);
-apply_one(Fun, Req, Next) when is_function(Fun, 3) ->
-    Fun(Req, Next, undefined).
+apply_one(Fun, State, Req, Next) when is_function(Fun, 3) ->
+    Fun(Req, Next, State).

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -150,8 +150,10 @@ server_header(Req, Next, Server) ->
 ```
 """.
 
--export([compose/2, build_pipeline/2, compile_pipeline/3]).
--export_type([middleware/0, middleware_fun/0, middleware_list/0, next/0, config/0, state/0]).
+-export([compose/2, build_pipeline/2, compile_pipeline/3, compile_pipeline/4, resolve/1]).
+-export_type([
+    middleware/0, middleware_fun/0, middleware_list/0, next/0, config/0, state/0, resolved/0
+]).
 
 -doc """
 The continuation passed to a middleware's `call/3`: a fun that runs
@@ -176,6 +178,13 @@ A middleware entry's runtime state, passed as the third argument of
 time; for a fun entry it is the entry's `t:config/0` used verbatim.
 """.
 -type state() :: term().
+
+-doc """
+A middleware entry after resolution: the `{Callable, State}` pair produced
+by running `resolve/1` (which calls each module's `init/1` once). Opaque —
+callers thread it back into `compile_pipeline/4` without inspecting it.
+""".
+-opaque resolved() :: {module() | middleware_fun(), state()}.
 
 -doc """
 The function shape of a fun-form middleware: it receives the request,
@@ -237,38 +246,54 @@ The middleware decides whether to:
     roadrunner_handler:result().
 
 -doc """
+Resolve a middleware list to its runtime `t:resolved/0` pairs, running each
+module's `init/1` **once**. Use this to resolve listener-wide middlewares a
+single time and reuse the result across every route (via
+`compile_pipeline/4`) instead of re-running their init per route.
+""".
+-spec resolve(middleware_list()) -> [resolved()].
+resolve(Mws) ->
+    [resolve_entry(Mw) || Mw <- Mws].
+
+%% Resolve one entry to its `{Callable, State}` runtime pair. A module entry
+%% runs its required `init/1` callback here, so the per-request closure reuses
+%% the returned state; a fun entry has no init, so its config is the state
+%% verbatim. A bare entry defaults its config to `#{}`.
+-spec resolve_entry(middleware()) -> resolved().
+resolve_entry({Mod, Config}) when is_atom(Mod) ->
+    {Mod, Mod:init(Config)};
+resolve_entry({Fun, Config}) when is_function(Fun, 3) ->
+    {Fun, Config};
+resolve_entry(Mod) when is_atom(Mod) ->
+    {Mod, Mod:init(#{})};
+resolve_entry(Fun) when is_function(Fun, 3) ->
+    {Fun, #{}}.
+
+-doc """
 Compose a middleware list around a handler call, returning a single
 `next()` fun that runs the full pipeline.
 
 Each module entry's `init/1` is run **here**, once, as the pipeline is
-built; the resulting `t:state/0` is captured in the entry's closure and
-reused on every request. The first middleware in the list runs
-**outermost** — it gets the first crack at the request and the last crack
-at the response. The handler is the innermost call; an empty list returns
-the handler fun unchanged.
+built (via `resolve/1`); the resulting `t:state/0` is captured in the
+entry's closure and reused on every request. The first middleware in the
+list runs **outermost** — it gets the first crack at the request and the
+last crack at the response. The handler is the innermost call; an empty
+list returns the handler fun unchanged.
 """.
 -spec compose(middleware_list(), next()) -> next().
-compose([], Handler) ->
-    Handler;
-compose([Mw | Rest], Handler) ->
-    Inner = compose(Rest, Handler),
-    {Callable, State} = resolve(Mw),
-    fun(Req) -> apply_one(Callable, State, Req, Inner) end.
+compose(Mws, Handler) ->
+    compose_resolved(resolve(Mws), Handler).
 
-%% Resolve a middleware entry to its `{Callable, State}` runtime pair at
-%% pipeline-bake time. A module entry runs its required `init/1` callback
-%% once here, so the per-request closure reuses the returned state; a fun
-%% entry has no init, so its config is the state verbatim. A bare entry
-%% defaults its config to `#{}`.
--spec resolve(middleware()) -> {module() | middleware_fun(), state()}.
-resolve({Mod, Config}) when is_atom(Mod) ->
-    {Mod, Mod:init(Config)};
-resolve({Fun, Config}) when is_function(Fun, 3) ->
-    {Fun, Config};
-resolve(Mod) when is_atom(Mod) ->
-    {Mod, Mod:init(#{})};
-resolve(Fun) when is_function(Fun, 3) ->
-    {Fun, #{}}.
+%% Compose already-resolved entries around a handler. No `init/1` runs here
+%% (it ran in `resolve/1`); the captured state is reused per request. Split
+%% from `compose/2` so pre-resolved listener middlewares can be composed
+%% without re-resolving them.
+-spec compose_resolved([resolved()], next()) -> next().
+compose_resolved([], Handler) ->
+    Handler;
+compose_resolved([{Callable, State} | Rest], Handler) ->
+    Inner = compose_resolved(Rest, Handler),
+    fun(Req) -> apply_one(Callable, State, Req, Inner) end.
 
 %% Build the handler pipeline from a combined middleware list
 %% (listener-level ++ per-route) and a target handler module. The
@@ -294,13 +319,12 @@ build_pipeline([], Handler) ->
 build_pipeline(Mws, Handler) ->
     compose(Mws, fun Handler:handle/1).
 
-%% Compile a per-request pipeline `next()` fun: composes the mws
-%% ending in `fun Handler:handle/1`, optionally wrapped in an
-%% outermost closure that injects `state` onto the request before
-%% middlewares run. Used by `roadrunner_router:compile/2` and
-%% `roadrunner_listener:build_dispatch/2` to pre-bake the full
-%% pipeline at compile / `reload_routes/2` time so the conn loops
-%% don't allocate closures per request.
+%% Compile a per-request pipeline `next()` fun from one combined middleware
+%% list: composes the mws ending in `fun Handler:handle/1`, optionally wrapped
+%% in an outermost closure that injects `state` onto the request before
+%% middlewares run. Used by `roadrunner_listener:build_dispatch/2` for
+%% single-handler dispatch (one pipeline, so no listener/route split). Routes
+%% use `compile_pipeline/4`.
 -doc false.
 -spec compile_pipeline(middleware_list(), module(), no_state | {state, term()}) -> next().
 compile_pipeline(Mws, Handler, no_state) ->
@@ -308,6 +332,29 @@ compile_pipeline(Mws, Handler, no_state) ->
 compile_pipeline(Mws, Handler, {state, State}) ->
     Inner = build_pipeline(Mws, Handler),
     fun(Req) -> Inner(Req#{state => State}) end.
+
+%% Compile a route's pipeline from listener middlewares already resolved once
+%% (shared across all routes) and the route's own raw middlewares. Only the
+%% route's mws are resolved here; the listener entries wrap them (and the
+%% handler), staying outermost. Used by `roadrunner_router:compile/2` so a
+%% listener-wide middleware's `init/1` runs once, not once per route.
+-doc false.
+-spec compile_pipeline([resolved()], middleware_list(), module(), no_state | {state, term()}) ->
+    next().
+compile_pipeline(ResolvedListener, RouteMws, Handler, no_state) ->
+    build_resolved_pipeline(ResolvedListener, RouteMws, Handler);
+compile_pipeline(ResolvedListener, RouteMws, Handler, {state, State}) ->
+    Inner = build_resolved_pipeline(ResolvedListener, RouteMws, Handler),
+    fun(Req) -> Inner(Req#{state => State}) end.
+
+%% Wrap the resolved listener middlewares (outermost) around the route's own
+%% middlewares (resolved here) around the handler. An empty listener + route
+%% list collapses to `fun Handler:handle/1` (no closures) via the
+%% `compose_resolved/2` empty-list clause.
+-spec build_resolved_pipeline([resolved()], middleware_list(), module()) -> next().
+build_resolved_pipeline(ResolvedListener, RouteMws, Handler) ->
+    Inner = compose_resolved(resolve(RouteMws), fun Handler:handle/1),
+    compose_resolved(ResolvedListener, Inner).
 
 %% Invoke a resolved entry with the request and continuation. `Callable`
 %% and `State` are threaded individually (no per-request tuple rebuild);

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -95,38 +95,39 @@ Compile a list of routes into the lookup form `match/2` expects.
 Each path is split on `/` (empty leading/trailing segments dropped),
 and segments starting with `:` are recorded as named captures.
 
-`ListenerMws` is the listener-wide middleware list; it is prepended
-to each route's own `middlewares` and composed once into a single
-`next()` fun (with any per-route `state` injected before middlewares
-run). The conn loop calls that fun straight with the request —
+`ListenerMws` is the listener-wide middleware list; it is resolved
+**once** (running each module's `init/1` a single time) and reused
+across every route, composed outermost around each route's own
+`middlewares` (with any per-route `state` injected before middlewares
+run). The conn loop calls the composed fun straight with the request —
 zero closure allocations per request. Pass `[]` for `ListenerMws`
 when compiling routes outside a listener (typically only in tests).
 """.
 -spec compile(routes(), roadrunner_middleware:middleware_list()) -> compiled().
 compile(Routes, ListenerMws) when is_list(Routes), is_list(ListenerMws) ->
-    [compile_route(R, ListenerMws) || R <- Routes].
+    ResolvedListener = roadrunner_middleware:resolve(ListenerMws),
+    [compile_route(R, ResolvedListener) || R <- Routes].
 
--spec compile_route(route(), roadrunner_middleware:middleware_list()) ->
+-spec compile_route(route(), [roadrunner_middleware:resolved()]) ->
     {[segment()], module(), roadrunner_middleware:next(), term()}.
-compile_route({Path, Handler}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
+compile_route({Path, Handler}, ResolvedListener) when is_binary(Path), is_atom(Handler) ->
     {
         compile_path(Path),
         Handler,
-        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, no_state),
+        roadrunner_middleware:compile_pipeline(ResolvedListener, [], Handler, no_state),
         undefined
     };
-compile_route({Path, Handler, State}, ListenerMws) when is_binary(Path), is_atom(Handler) ->
+compile_route({Path, Handler, State}, ResolvedListener) when is_binary(Path), is_atom(Handler) ->
     {
         compile_path(Path),
         Handler,
-        roadrunner_middleware:compile_pipeline(ListenerMws, Handler, {state, State}),
+        roadrunner_middleware:compile_pipeline(ResolvedListener, [], Handler, {state, State}),
         State
     };
-compile_route(#{path := Path, handler := Handler} = Route, ListenerMws) when
+compile_route(#{path := Path, handler := Handler} = Route, ResolvedListener) when
     is_binary(Path), is_atom(Handler)
 ->
     RouteMws = maps:get(middlewares, Route, []),
-    Mws = ListenerMws ++ RouteMws,
     {StateArg, StateValue} =
         case Route of
             #{state := S} -> {{state, S}, S};
@@ -135,7 +136,7 @@ compile_route(#{path := Path, handler := Handler} = Route, ListenerMws) when
     {
         compile_path(Path),
         Handler,
-        roadrunner_middleware:compile_pipeline(Mws, Handler, StateArg),
+        roadrunner_middleware:compile_pipeline(ResolvedListener, RouteMws, Handler, StateArg),
         StateValue
     }.
 

--- a/src/roadrunner_security_headers.erl
+++ b/src/roadrunner_security_headers.erl
@@ -60,7 +60,7 @@ headers, passes through.
 
 -behaviour(roadrunner_middleware).
 
--export([call/3]).
+-export([init/1, call/3]).
 
 -type config() :: #{
     content_type_options => binary() | false,
@@ -75,87 +75,110 @@ headers, passes through.
     preload => boolean()
 }.
 
--spec call(roadrunner_req:request(), roadrunner_middleware:next(), roadrunner_middleware:state()) ->
-    roadrunner_handler:result().
-call(Req, Next, State) ->
-    {Response, Req2} = Next(Req),
-    {transform(Req, config(State), Response), Req2}.
+-export_type([state/0]).
 
-%% A bare-callable entry hands `undefined` as the state, meaning "all defaults".
--spec config(roadrunner_middleware:state()) -> config().
-config(undefined) -> #{};
-config(Config) when is_map(Config) -> Config.
+%% The compiled header set `init/1` produces: `static` is the pre-built,
+%% false-filtered list of the scheme-independent defaults, prepended onto the
+%% handler's headers as-is per request. `hsts` is the pre-built
+%% `strict-transport-security` value (or `false` when off); it still emits only
+%% over HTTPS, gated per request on the scheme.
+-record(sec, {
+    static :: roadrunner_http:headers(),
+    hsts :: binary() | false
+}).
+
+-doc "The compiled header set produced by `init/1` and consumed by `call/3`.".
+-type state() :: #sec{}.
+
+%% Resolve every default and the HSTS value once, at pipeline-compile time, and
+%% pre-build the scheme-independent set so a request only prepends HSTS.
+-spec init(roadrunner_middleware:config()) -> state().
+init(Config) ->
+    Static = drop_unset([
+        {~"x-content-type-options", opt(content_type_options, Config, ~"nosniff")},
+        {~"x-frame-options", opt(frame_options, Config, ~"SAMEORIGIN")},
+        {~"referrer-policy", opt(referrer_policy, Config, ~"strict-origin-when-cross-origin")},
+        {~"content-security-policy", opt(content_security_policy, Config, false)}
+    ]),
+    #sec{static = Static, hsts = compile_hsts(Config)}.
+
+%% Drop entries whose value didn't apply under the config (`false`), so the
+%% per-request path only ever prepends real headers.
+-spec drop_unset([{binary(), binary() | false}]) -> roadrunner_http:headers().
+drop_unset(Headers) ->
+    [Header || {_Name, Value} = Header <- Headers, Value =/= false].
+
+%% Pre-build the `strict-transport-security` value (or `false` when off). It is
+%% still emitted only over HTTPS — see `hsts_candidates/3`.
+-spec compile_hsts(config()) -> binary() | false.
+compile_hsts(Config) ->
+    case opt(hsts, Config, false) of
+        false -> false;
+        true -> hsts_value(#{});
+        HstsConfig when is_map(HstsConfig) -> hsts_value(HstsConfig)
+    end.
+
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
+    roadrunner_handler:result().
+call(Req, Next, #sec{} = State) ->
+    {Response, Req2} = Next(Req),
+    {transform(Req, State, Response), Req2}.
 
 %% Decorate every header-bearing response shape; pass a `{websocket, _, _}`
 %% upgrade (no response headers) through. The `is_integer(Status)` guard on
 %% the buffered clause is load-bearing: it rejects the `{websocket, Mod, State}`
 %% triple, which shares the 3-tuple shape but carries an atom where the status
 %% would be.
--spec transform(roadrunner_req:request(), config(), roadrunner_handler:response()) ->
+-spec transform(roadrunner_req:request(), state(), roadrunner_handler:response()) ->
     roadrunner_handler:response().
-transform(Req, Config, {Status, Headers, Body}) when
+transform(Req, State, {Status, Headers, Body}) when
     is_integer(Status), Status >= 100, Status =< 599
 ->
-    {Status, inject(Req, Config, Headers), Body};
-transform(Req, Config, {stream, Status, Headers, Fun}) when
+    {Status, inject(Req, State, Headers), Body};
+transform(Req, State, {stream, Status, Headers, Fun}) when
     is_integer(Status), Status >= 100, Status =< 599, is_function(Fun, 1)
 ->
-    {stream, Status, inject(Req, Config, Headers), Fun};
-transform(Req, Config, {sendfile, Status, Headers, Spec}) when
+    {stream, Status, inject(Req, State, Headers), Fun};
+transform(Req, State, {sendfile, Status, Headers, Spec}) when
     is_integer(Status), Status >= 100, Status =< 599
 ->
-    {sendfile, Status, inject(Req, Config, Headers), Spec};
-transform(Req, Config, {loop, Status, Headers, LoopState}) when
+    {sendfile, Status, inject(Req, State, Headers), Spec};
+transform(Req, State, {loop, Status, Headers, LoopState}) when
     is_integer(Status), Status >= 100, Status =< 599
 ->
-    {loop, Status, inject(Req, Config, Headers), LoopState};
-transform(_Req, _Config, Other) ->
+    {loop, Status, inject(Req, State, Headers), LoopState};
+transform(_Req, _State, Other) ->
     Other.
 
-%% Prepend each enabled default the handler didn't already set. The full set
-%% is built once in emit order; `add_defaults/2` skips any whose value resolved
-%% to `false` (disabled by config, or HSTS off / over plain HTTP).
--spec inject(roadrunner_req:request(), config(), roadrunner_http:headers()) ->
+%% Prepend HSTS (over HTTPS, when configured) onto the pre-built static set,
+%% then prepend the lot onto the handler's headers, skipping any the handler
+%% already set.
+-spec inject(roadrunner_req:request(), state(), roadrunner_http:headers()) ->
     roadrunner_http:headers().
-inject(Req, Config, Headers) ->
-    Scheme = roadrunner_req:scheme(Req),
-    add_defaults(
-        [
-            {~"x-content-type-options", opt(content_type_options, Config, ~"nosniff")},
-            {~"x-frame-options", opt(frame_options, Config, ~"SAMEORIGIN")},
-            {~"referrer-policy", opt(referrer_policy, Config, ~"strict-origin-when-cross-origin")},
-            {~"strict-transport-security", hsts(Scheme, Config)},
-            {~"content-security-policy", opt(content_security_policy, Config, false)}
-        ],
-        Headers
-    ).
+inject(Req, #sec{static = Static} = State, Headers) ->
+    add_defaults(hsts_candidates(roadrunner_req:scheme(Req), State, Static), Headers).
 
--spec add_defaults([{binary(), binary() | false}], roadrunner_http:headers()) ->
+%% HSTS is meaningful only over HTTPS (RFC 6797 §8.1: a browser ignores it on a
+%% plain-HTTP response) and only when configured; the value itself was pre-built
+%% by `compile_hsts/1`. On plain HTTP, or when off, nothing is added.
+-spec hsts_candidates(http | https, state(), roadrunner_http:headers()) ->
+    roadrunner_http:headers().
+hsts_candidates(https, #sec{hsts = Hsts}, Static) when is_binary(Hsts) ->
+    [{~"strict-transport-security", Hsts} | Static];
+hsts_candidates(_Scheme, _State, Static) ->
+    Static.
+
+%% Prepend each pre-built default the handler didn't already set. The
+%% `false`-valued defaults were dropped at compile time by `drop_unset/1`.
+-spec add_defaults(roadrunner_http:headers(), roadrunner_http:headers()) ->
     roadrunner_http:headers().
 add_defaults([], Headers) ->
     Headers;
-add_defaults([{_Name, false} | Rest], Headers) ->
-    add_defaults(Rest, Headers);
-add_defaults([{Name, Value} | Rest], Headers) ->
+add_defaults([{Name, _} = Header | Rest], Headers) ->
     case has_header(Name, Headers) of
         true -> add_defaults(Rest, Headers);
-        false -> [{Name, Value} | add_defaults(Rest, Headers)]
+        false -> [Header | add_defaults(Rest, Headers)]
     end.
-
-%% `strict-transport-security` is opt-in (its commitment outlives the header,
-%% see the moduledoc) and meaningful only over HTTPS (RFC 6797 §8.1: a browser
-%% ignores it on a plain-HTTP response), so it resolves to `false` (skipped)
-%% on a plain-HTTP connection, when unset, or when `hsts => false`. `true`
-%% emits the recommended settings; a map tunes them.
--spec hsts(http | https, config()) -> binary() | false.
-hsts(https, Config) ->
-    case opt(hsts, Config, false) of
-        false -> false;
-        true -> hsts_value(#{});
-        HstsConfig when is_map(HstsConfig) -> hsts_value(HstsConfig)
-    end;
-hsts(http, _Config) ->
-    false.
 
 %% Build `max-age=N[; includeSubDomains][; preload]` from the HSTS sub-config.
 -spec hsts_value(hsts_config()) -> binary().

--- a/src/roadrunner_security_headers.erl
+++ b/src/roadrunner_security_headers.erl
@@ -151,7 +151,7 @@ transform(_Req, _State, Other) ->
     roadrunner_http:headers().
 inject(Req, #sec{static = Static} = State, Headers) ->
     roadrunner_http:with_defaults(
-        hsts_candidates(roadrunner_req:scheme(Req), State, Static), Headers
+        Headers, hsts_candidates(roadrunner_req:scheme(Req), State, Static)
     ).
 
 %% HSTS is meaningful only over HTTPS (RFC 6797 §8.1: a browser ignores it on a

--- a/src/roadrunner_security_headers.erl
+++ b/src/roadrunner_security_headers.erl
@@ -75,7 +75,7 @@ headers, passes through.
     preload => boolean()
 }.
 
--export_type([state/0]).
+-export_type([config/0, state/0]).
 
 %% The compiled header set `init/1` produces: `static` is the pre-built,
 %% false-filtered list of the scheme-independent defaults, prepended onto the
@@ -92,21 +92,15 @@ headers, passes through.
 
 %% Resolve every default and the HSTS value once, at pipeline-compile time, and
 %% pre-build the scheme-independent set so a request only prepends HSTS.
--spec init(roadrunner_middleware:config()) -> state().
+-spec init(config()) -> state().
 init(Config) ->
-    Static = drop_unset([
+    Static = roadrunner_http:drop_unset([
         {~"x-content-type-options", opt(content_type_options, Config, ~"nosniff")},
         {~"x-frame-options", opt(frame_options, Config, ~"SAMEORIGIN")},
         {~"referrer-policy", opt(referrer_policy, Config, ~"strict-origin-when-cross-origin")},
         {~"content-security-policy", opt(content_security_policy, Config, false)}
     ]),
     #sec{static = Static, hsts = compile_hsts(Config)}.
-
-%% Drop entries whose value didn't apply under the config (`false`), so the
-%% per-request path only ever prepends real headers.
--spec drop_unset([{binary(), binary() | false}]) -> roadrunner_http:headers().
-drop_unset(Headers) ->
-    [Header || {_Name, Value} = Header <- Headers, Value =/= false].
 
 %% Pre-build the `strict-transport-security` value (or `false` when off). It is
 %% still emitted only over HTTPS — see `hsts_candidates/3`.
@@ -156,7 +150,9 @@ transform(_Req, _State, Other) ->
 -spec inject(roadrunner_req:request(), state(), roadrunner_http:headers()) ->
     roadrunner_http:headers().
 inject(Req, #sec{static = Static} = State, Headers) ->
-    add_defaults(hsts_candidates(roadrunner_req:scheme(Req), State, Static), Headers).
+    roadrunner_http:with_defaults(
+        hsts_candidates(roadrunner_req:scheme(Req), State, Static), Headers
+    ).
 
 %% HSTS is meaningful only over HTTPS (RFC 6797 §8.1: a browser ignores it on a
 %% plain-HTTP response) and only when configured; the value itself was pre-built
@@ -167,18 +163,6 @@ hsts_candidates(https, #sec{hsts = Hsts}, Static) when is_binary(Hsts) ->
     [{~"strict-transport-security", Hsts} | Static];
 hsts_candidates(_Scheme, _State, Static) ->
     Static.
-
-%% Prepend each pre-built default the handler didn't already set. The
-%% `false`-valued defaults were dropped at compile time by `drop_unset/1`.
--spec add_defaults(roadrunner_http:headers(), roadrunner_http:headers()) ->
-    roadrunner_http:headers().
-add_defaults([], Headers) ->
-    Headers;
-add_defaults([{Name, _} = Header | Rest], Headers) ->
-    case has_header(Name, Headers) of
-        true -> add_defaults(Rest, Headers);
-        false -> [Header | add_defaults(Rest, Headers)]
-    end.
 
 %% Build `max-age=N[; includeSubDomains][; preload]` from the HSTS sub-config.
 -spec hsts_value(hsts_config()) -> binary().
@@ -203,7 +187,3 @@ opt(Key, Config, Default) ->
         #{Key := Value} -> Value;
         #{} -> Default
     end.
-
--spec has_header(binary(), roadrunner_http:headers()) -> boolean().
-has_header(Name, Headers) ->
-    lists:keymember(Name, 1, Headers).

--- a/test/roadrunner_cors_tests.erl
+++ b/test/roadrunner_cors_tests.erl
@@ -221,6 +221,22 @@ bad_max_age_crashes_test() ->
         preflight(?ORIGIN, ~"POST", [], cfg(#{max_age => -1}))
     ).
 
+bad_config_crashes_at_compile_test() ->
+    %% Routes are compiled (running each middleware's `init/1`) when the
+    %% listener starts or reloads, so an invalid policy crashes there with a
+    %% clear `{invalid_cors_opt, ...}` rather than surfacing on a request.
+    Routes = [
+        #{
+            path => ~"/",
+            handler => roadrunner_hello_handler,
+            middlewares => [{roadrunner_cors, #{origins => not_valid}}]
+        }
+    ],
+    ?assertError(
+        {invalid_cors_opt, origins, not_valid},
+        roadrunner_router:compile(Routes, [])
+    ).
+
 %% =============================================================================
 %% End-to-end through roadrunner_listener.
 %% =============================================================================

--- a/test/roadrunner_cors_tests.erl
+++ b/test/roadrunner_cors_tests.erl
@@ -237,6 +237,49 @@ bad_config_crashes_at_compile_test() ->
         roadrunner_router:compile(Routes, [])
     ).
 
+per_route_config_is_isolated_test_() ->
+    {setup,
+        fun() ->
+            {ok, _} = roadrunner_listener:start_link(cors_per_route, #{
+                port => 0,
+                routes => [
+                    #{
+                        path => ~"/a",
+                        handler => roadrunner_hello_handler,
+                        middlewares => [{roadrunner_cors, #{origins => [~"https://a.example"]}}]
+                    },
+                    #{
+                        path => ~"/b",
+                        handler => roadrunner_hello_handler,
+                        middlewares => [{roadrunner_cors, #{origins => [~"https://b.example"]}}]
+                    }
+                ]
+            }),
+            roadrunner_listener:port(cors_per_route)
+        end,
+        fun(_) -> ok = roadrunner_listener:stop(cors_per_route) end, fun(Port) ->
+            {"each route is compiled with its own per-route policy", fun() ->
+                %% `https://a.example` is allowed on `/a` but not on `/b` —
+                %% each route's own `init/1` ran with its own config.
+                ReplyA = request(Port, [
+                    ~"GET /a HTTP/1.1\r\n",
+                    ~"Host: x\r\n",
+                    ~"Origin: https://a.example\r\n",
+                    ~"Connection: close\r\n\r\n"
+                ]),
+                {match, _} = re:run(
+                    ReplyA, ~"access-control-allow-origin: https://a.example", [caseless]
+                ),
+                ReplyB = request(Port, [
+                    ~"GET /b HTTP/1.1\r\n",
+                    ~"Host: x\r\n",
+                    ~"Origin: https://a.example\r\n",
+                    ~"Connection: close\r\n\r\n"
+                ]),
+                nomatch = re:run(ReplyB, ~"access-control-allow-origin", [caseless])
+            end}
+        end}.
+
 %% =============================================================================
 %% End-to-end through roadrunner_listener.
 %% =============================================================================

--- a/test/roadrunner_cors_tests.erl
+++ b/test/roadrunner_cors_tests.erl
@@ -15,7 +15,7 @@
 no_origin_passes_through_test() ->
     Req = req(~"GET", []),
     Next = fun(R) -> {{200, [{~"x", ~"y"}], ~"body"}, R} end,
-    {{200, Headers, ~"body"}, _Req2} = ?M:call(Req, Next, ?ALLOWLIST),
+    {{200, Headers, ~"body"}, _Req2} = call(Req, Next, ?ALLOWLIST),
     %% Untouched: no Access-Control / Vary headers added.
     ?assertEqual(undefined, header(~"access-control-allow-origin", Headers)),
     ?assertEqual(undefined, header(~"vary", Headers)).
@@ -65,13 +65,13 @@ expose_empty_omits_header_test() ->
 vary_appended_to_existing_test() ->
     Req = req(~"GET", [{~"origin", ?ORIGIN}]),
     Next = fun(R) -> {{200, [{~"vary", ~"Accept-Encoding"}], ~"b"}, R} end,
-    {{200, Headers, _}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    {{200, Headers, _}, _} = call(Req, Next, ?ALLOWLIST),
     ?assertEqual(~"Accept-Encoding, Origin", header(~"vary", Headers)).
 
 handler_acao_wins_test() ->
     Req = req(~"GET", [{~"origin", ?ORIGIN}]),
     Next = fun(R) -> {{200, [{~"access-control-allow-origin", ~"https://other"}], ~"b"}, R} end,
-    {{200, Headers, _}, _} = ?M:call(Req, Next, #{origins => any}),
+    {{200, Headers, _}, _} = call(Req, Next, #{origins => any}),
     ?assertEqual([~"https://other"], [V || {~"access-control-allow-origin", V} <- Headers]).
 
 %% --- response shapes ---
@@ -80,7 +80,7 @@ stream_response_decorated_test() ->
     Req = req(~"GET", [{~"origin", ?ORIGIN}]),
     Fun = fun(_Send) -> ok end,
     Next = fun(R) -> {{stream, 200, [], Fun}, R} end,
-    {{stream, 200, Headers, OutFun}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    {{stream, 200, Headers, OutFun}, _} = call(Req, Next, ?ALLOWLIST),
     ?assertEqual(Fun, OutFun),
     ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
 
@@ -88,21 +88,21 @@ sendfile_response_decorated_test() ->
     Req = req(~"GET", [{~"origin", ?ORIGIN}]),
     Spec = {~"/tmp/x", 0, 10},
     Next = fun(R) -> {{sendfile, 200, [], Spec}, R} end,
-    {{sendfile, 200, Headers, OutSpec}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    {{sendfile, 200, Headers, OutSpec}, _} = call(Req, Next, ?ALLOWLIST),
     ?assertEqual(Spec, OutSpec),
     ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
 
 loop_response_decorated_test() ->
     Req = req(~"GET", [{~"origin", ?ORIGIN}]),
     Next = fun(R) -> {{loop, 200, [], loop_state}, R} end,
-    {{loop, 200, Headers, OutState}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    {{loop, 200, Headers, OutState}, _} = call(Req, Next, ?ALLOWLIST),
     ?assertEqual(loop_state, OutState),
     ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
 
 websocket_passes_through_test() ->
     Req = req(~"GET", [{~"origin", ?ORIGIN}]),
     Next = fun(R) -> {{websocket, some_mod, init_state}, R} end,
-    {Response, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    {Response, _} = call(Req, Next, ?ALLOWLIST),
     ?assertMatch({websocket, some_mod, init_state}, Response).
 
 %% --- preflight ---
@@ -120,7 +120,7 @@ preflight_short_circuits_without_calling_next_test() ->
         {~"origin", ?ORIGIN}, {~"access-control-request-method", ~"POST"}
     ]),
     Next = fun(_R) -> error(next_must_not_run) end,
-    {{204, _Headers, ~""}, _} = ?M:call(Req, Next, ?ALLOWLIST).
+    {{204, _Headers, ~""}, _} = call(Req, Next, ?ALLOWLIST).
 
 preflight_disallowed_has_only_vary_test() ->
     {Status, Headers} = preflight(~"https://evil.example.com", ~"POST", [], ?ALLOWLIST),
@@ -167,7 +167,7 @@ options_without_request_method_is_not_preflight_test() ->
     %% not a preflight: the handler runs and gets the actual-request headers.
     Req = req(~"OPTIONS", [{~"origin", ?ORIGIN}]),
     Next = fun(R) -> {{200, [], ~"handled"}, R} end,
-    {{200, Headers, ~"handled"}, _} = ?M:call(Req, Next, ?ALLOWLIST),
+    {{200, Headers, ~"handled"}, _} = call(Req, Next, ?ALLOWLIST),
     ?assertEqual(?ORIGIN, header(~"access-control-allow-origin", Headers)).
 
 %% --- header injection guard ---
@@ -176,7 +176,7 @@ unsafe_origin_crashes_test() ->
     %% An attacker-controlled origin carrying CR/LF must not reach the wire.
     Req = req(~"GET", [{~"origin", <<"https://evil\r\nx-injected: 1">>}]),
     Next = fun(R) -> {{200, [], ~"b"}, R} end,
-    ?assertError({header_injection, value, _}, ?M:call(Req, Next, #{origins => any})).
+    ?assertError({header_injection, value, _}, call(Req, Next, #{origins => any})).
 
 %% --- config validation ---
 
@@ -268,6 +268,13 @@ end_to_end_test_() ->
 
 %% --- helpers ---
 
+%% Compile the config through `init/1` (as the pipeline does at startup), then
+%% invoke `call/3` with the resulting state — the contract every test exercises.
+%% A bad config raises `{invalid_cors_opt, ...}` from `init/1` here, which the
+%% config-validation tests assert on.
+call(Req, Next, Config) ->
+    ?M:call(Req, Next, ?M:init(Config)).
+
 %% Allowlist config with `Extra` merged in. Updates the `Extra` variable (not a
 %% literal map) so the compiler's update-literal warning doesn't fire.
 cfg(Extra) ->
@@ -278,7 +285,7 @@ cfg(Extra) ->
 simple(Origin, Config) ->
     Req = req(~"GET", [{~"origin", Origin}]),
     Next = fun(R) -> {{200, [], ~"body"}, R} end,
-    {{200, Headers, ~"body"}, Req2} = ?M:call(Req, Next, Config),
+    {{200, Headers, ~"body"}, Req2} = call(Req, Next, Config),
     {Headers, Req2}.
 
 %% Run a preflight OPTIONS; returns the response status and headers. The Next
@@ -288,7 +295,7 @@ preflight(Origin, RequestMethod, ExtraHeaders, Config) ->
         {~"origin", Origin}, {~"access-control-request-method", RequestMethod} | ExtraHeaders
     ]),
     Next = fun(_R) -> error(next_must_not_run) end,
-    {{Status, Headers, ~""}, _} = ?M:call(Req, Next, Config),
+    {{Status, Headers, ~""}, _} = call(Req, Next, Config),
     {Status, Headers}.
 
 req(Method, Headers) ->

--- a/test/roadrunner_etag_tests.erl
+++ b/test/roadrunner_etag_tests.erl
@@ -125,6 +125,23 @@ not_modified_keeps_cache_headers_test() ->
     ?assertEqual(undefined, header(~"content-type", Headers)),
     ?assertEqual(~"0", header(~"content-length", Headers)).
 
+%% =============================================================================
+%% Wired as a middleware — `compose/2` runs etag's stateless `init/1` once at
+%% compile time, then `call/3` per request, same conditional behavior.
+%% =============================================================================
+
+composed_pipeline_runs_init_then_handles_conditional_test() ->
+    Body = ~"hello",
+    Handler = fun(R) -> {{200, [{~"content-type", ~"text/plain"}], Body}, R} end,
+    Pipeline = roadrunner_middleware:compose([roadrunner_etag], Handler),
+    %% No If-None-Match → 200 carrying the derived weak ETag.
+    {{200, H200, Body}, _} = Pipeline(req(~"GET", [])),
+    ETag = header(~"etag", H200),
+    ?assertMatch(<<"W/\"", _/binary>>, ETag),
+    %% Echoing the ETag → 304, so init's state threaded into call/3.
+    {{304, _, RespBody}, _} = Pipeline(req(~"GET", [{~"if-none-match", ETag}])),
+    ?assertEqual(~"", iolist_to_binary(RespBody)).
+
 %% --- helpers ---
 
 req(Method, Headers) ->

--- a/test/roadrunner_http_tests.erl
+++ b/test/roadrunner_http_tests.erl
@@ -71,3 +71,39 @@ header_list_size_sums_fields_with_overhead_test() ->
         70,
         roadrunner_http:header_list_size([{~"a", ~"bb"}, {~"ccc", ~""}])
     ).
+
+%% --- with_defaults/2 ---
+
+with_defaults_empty_defaults_returns_headers_unchanged_test() ->
+    Headers = [{~"a", ~"1"}],
+    ?assertEqual(Headers, roadrunner_http:with_defaults(Headers, [])).
+
+with_defaults_prepends_absent_defaults_in_order_test() ->
+    %% Absent defaults are prepended, keeping their order, ahead of the
+    %% existing headers.
+    ?assertEqual(
+        [{~"x", ~"1"}, {~"y", ~"2"}, {~"a", ~"0"}],
+        roadrunner_http:with_defaults([{~"a", ~"0"}], [{~"x", ~"1"}, {~"y", ~"2"}])
+    ).
+
+with_defaults_existing_header_wins_test() ->
+    %% A default whose name the headers already carry is skipped (the
+    %% existing value wins); the others are still added.
+    ?assertEqual(
+        [{~"y", ~"2"}, {~"a", ~"keep"}],
+        roadrunner_http:with_defaults([{~"a", ~"keep"}], [{~"a", ~"drop"}, {~"y", ~"2"}])
+    ).
+
+%% --- drop_unset/1 ---
+
+drop_unset_keeps_only_set_values_in_order_test() ->
+    ?assertEqual(
+        [{~"a", ~"1"}, {~"c", ~""}],
+        roadrunner_http:drop_unset([{~"a", ~"1"}, {~"b", false}, {~"c", ~""}])
+    ).
+
+drop_unset_all_false_returns_empty_test() ->
+    ?assertEqual([], roadrunner_http:drop_unset([{~"a", false}, {~"b", false}])).
+
+drop_unset_empty_returns_empty_test() ->
+    ?assertEqual([], roadrunner_http:drop_unset([])).

--- a/test/roadrunner_middleware_tests.erl
+++ b/test/roadrunner_middleware_tests.erl
@@ -342,6 +342,29 @@ init_runs_once_at_compile_not_per_request_test_() ->
             end}
         end}.
 
+listener_middleware_init_runs_once_across_routes_test_() ->
+    {setup,
+        fun() ->
+            Ref = counters:new(1, []),
+            {ok, _} = roadrunner_listener:start_link(mw_test_listener_init_once, #{
+                port => 0,
+                middlewares => [{roadrunner_test_init_middleware, #{counter => Ref, tag => ~"x"}}],
+                routes => [
+                    #{path => ~"/a", handler => roadrunner_echo_headers_handler},
+                    #{path => ~"/b", handler => roadrunner_echo_headers_handler},
+                    #{path => ~"/c", handler => roadrunner_echo_headers_handler}
+                ]
+            }),
+            Ref
+        end,
+        fun(_) -> ok = roadrunner_listener:stop(mw_test_listener_init_once) end, fun(Ref) ->
+            {"a listener middleware is resolved once, not once per route", fun() ->
+                %% Three routes share the one listener middleware, so its init
+                %% ran a single time when the routes were compiled.
+                ?assertEqual(1, counters:get(Ref, 1))
+            end}
+        end}.
+
 %% --- helpers ---
 
 req() ->

--- a/test/roadrunner_middleware_tests.erl
+++ b/test/roadrunner_middleware_tests.erl
@@ -115,19 +115,18 @@ compose_same_module_twice_with_different_state_test() ->
     {{200, [], Body}, _Req2} = Pipeline(req()),
     ?assertEqual(~"b,a", Body).
 
-compose_bare_module_defaults_state_to_undefined_test() ->
-    %% A bare `module()` entry is shorthand for `{module(), undefined}`;
-    %% the behaviour `call/3` receives `undefined`.
-    Handler = fun(R) ->
-        {~"x-mw-mod", V} = lists:keyfind(~"x-mw-mod", 1, maps:get(headers, R)),
-        {{200, [], atom_to_binary(V)}, R}
-    end,
+compose_bare_module_defaults_config_to_empty_map_test() ->
+    %% A bare `module()` entry is shorthand for `{module(), #{}}`: `init/1`
+    %% receives `#{}`, and (identity here) `call/3` gets that `#{}` as its
+    %% state, stamped into `x-mw-mod`.
+    Handler = fun(R) -> {{200, maps:get(headers, R), ~"ok"}, R} end,
     Pipeline = roadrunner_middleware:compose([roadrunner_test_middlewares], Handler),
-    {{200, [], Body}, _Req2} = Pipeline(req()),
-    ?assertEqual(~"undefined", Body).
+    {{200, Headers, ~"ok"}, _Req2} = Pipeline(req()),
+    ?assertEqual(#{}, proplists:get_value(~"x-mw-mod", Headers)).
 
-compose_bare_fun_defaults_state_to_undefined_test() ->
-    %% A bare `fun/3` entry is shorthand for `{fun/3, undefined}`.
+compose_bare_fun_defaults_state_to_empty_map_test() ->
+    %% A bare `fun/3` entry is shorthand for `{fun/3, #{}}` — a fun has no
+    %% init, so the default config is its state verbatim.
     Self = self(),
     Ref = make_ref(),
     Mw = fun(R, Next, State) ->
@@ -139,9 +138,23 @@ compose_bare_fun_defaults_state_to_undefined_test() ->
     Req = req(),
     ?assertEqual({{200, [], ~"ok"}, Req}, Pipeline(Req)),
     receive
-        {Ref, State} -> ?assertEqual(undefined, State)
+        {Ref, State} -> ?assertEqual(#{}, State)
     after 50 -> error(no_state_received)
     end.
+
+compose_runs_module_init_and_threads_output_test() ->
+    %% A module entry's `init/1` runs at compose time and its OUTPUT (not
+    %% the raw config) is what `call/3` receives. The fixture compiles
+    %% `#{tag => ...}` into `{compiled, Tag}` and stamps the tag, so reading
+    %% it back proves the transform ran and threaded through.
+    Handler = fun(R) ->
+        {{200, [], roadrunner_req:header(~"x-init-tag", R)}, R}
+    end,
+    Pipeline = roadrunner_middleware:compose(
+        [{roadrunner_test_init_middleware, #{tag => ~"compiled-ok"}}], Handler
+    ),
+    {{200, [], Body}, _Req2} = Pipeline(req()),
+    ?assertEqual(~"compiled-ok", Body).
 
 %% =============================================================================
 %% End-to-end through roadrunner_conn — exercises the map-shape route's
@@ -294,6 +307,38 @@ listener_middleware_runs_outside_route_middleware_test_() ->
                 %% [wrapped] + x-wrapped header.
                 {match, _} = re:run(Reply, ~"x-wrapped: yes", [caseless]),
                 {match, _} = re:run(Reply, ~"\\[wrapped\\] fun=yes")
+            end}
+        end}.
+
+%% =============================================================================
+%% init/1 runs once at pipeline-compile time, never per request.
+%% =============================================================================
+
+init_runs_once_at_compile_not_per_request_test_() ->
+    {setup,
+        fun() ->
+            Ref = counters:new(1, []),
+            {ok, _} = roadrunner_listener:start_link(mw_test_init_once, #{
+                port => 0,
+                routes => #{
+                    handler => roadrunner_echo_headers_handler,
+                    middlewares => [
+                        {roadrunner_test_init_middleware, #{counter => Ref, tag => ~"x"}}
+                    ]
+                }
+            }),
+            {roadrunner_listener:port(mw_test_init_once), Ref}
+        end,
+        fun(_) -> ok = roadrunner_listener:stop(mw_test_init_once) end, fun({Port, Ref}) ->
+            {"init runs once while the pipeline is baked, not on each request", fun() ->
+                %% The pipeline was compiled at listener start, so init has
+                %% already run exactly once — before any request.
+                ?assertEqual(1, counters:get(Ref, 1)),
+                _ = http_get(Port, ~"/a"),
+                _ = http_get(Port, ~"/b"),
+                _ = http_get(Port, ~"/c"),
+                %% call/3 ran three times; init ran zero more times.
+                ?assertEqual(1, counters:get(Ref, 1))
             end}
         end}.
 

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -207,7 +207,11 @@ match_map_route_with_middlewares_test() ->
     %% covered end-to-end in `roadrunner_middleware_tests`.
     Compiled = roadrunner_router:compile(
         [
-            #{path => ~"/admin/*p", handler => admin_handler, middlewares => [auth_mw, log_mw]}
+            #{
+                path => ~"/admin/*p",
+                handler => admin_handler,
+                middlewares => [roadrunner_test_middlewares, roadrunner_test_init_middleware]
+            }
         ],
         []
     ),
@@ -223,7 +227,7 @@ match_map_route_with_state_and_middlewares_test() ->
                 path => ~"/api/:resource",
                 handler => api_handler,
                 state => #{db => primary},
-                middlewares => [auth_mw]
+                middlewares => [roadrunner_test_middlewares]
             }
         ],
         []
@@ -239,7 +243,11 @@ match_mixed_tuple_and_map_routes_test() ->
         [
             {~"/", home_handler},
             {~"/about", about_handler, ~"hello"},
-            #{path => ~"/api/*p", handler => api_handler, middlewares => [auth_mw]}
+            #{
+                path => ~"/api/*p",
+                handler => api_handler,
+                middlewares => [roadrunner_test_middlewares]
+            }
         ],
         []
     ),
@@ -410,7 +418,7 @@ compile_returns_callable_pipeline_test() ->
         [
             {~"/", h},
             {~"/x", h, undefined},
-            #{path => ~"/y", handler => h, middlewares => [auth_mw]}
+            #{path => ~"/y", handler => h, middlewares => [roadrunner_test_middlewares]}
         ],
         []
     ),

--- a/test/roadrunner_security_headers_tests.erl
+++ b/test/roadrunner_security_headers_tests.erl
@@ -11,7 +11,7 @@
 defaults_added_on_buffered_http_test() ->
     Req = req(http, []),
     Next = fun(R) -> {{200, [], ~"body"}, R} end,
-    {{200, Headers, ~"body"}, _Req2} = ?M:call(Req, Next, undefined),
+    {{200, Headers, ~"body"}, _Req2} = call(Req, Next, #{}),
     ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)),
     ?assertEqual(~"SAMEORIGIN", header(~"x-frame-options", Headers)),
     ?assertEqual(~"strict-origin-when-cross-origin", header(~"referrer-policy", Headers)),
@@ -24,14 +24,14 @@ hsts_off_by_default_on_https_test() ->
     %% host to HTTPS-only. The reversible defaults are still applied.
     Req = req(https, []),
     Next = fun(R) -> {{200, [], ~"body"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, undefined),
+    {{200, Headers, _}, _Req2} = call(Req, Next, #{}),
     ?assertEqual(undefined, header(~"strict-transport-security", Headers)),
     ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
 
 hsts_enabled_with_true_on_https_test() ->
     Req = req(https, []),
     Next = fun(R) -> {{200, [], ~"body"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, #{hsts => true}),
+    {{200, Headers, _}, _Req2} = call(Req, Next, #{hsts => true}),
     ?assertEqual(
         ~"max-age=31536000; includeSubDomains",
         header(~"strict-transport-security", Headers)
@@ -41,7 +41,7 @@ hsts_not_emitted_over_http_even_when_enabled_test() ->
     %% Enabled, but the connection is plain HTTP — no HSTS (RFC 6797 §8.1).
     Req = req(http, []),
     Next = fun(R) -> {{200, [], ~"body"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, #{hsts => true}),
+    {{200, Headers, _}, _Req2} = call(Req, Next, #{hsts => true}),
     ?assertEqual(undefined, header(~"strict-transport-security", Headers)).
 
 handler_header_wins_test() ->
@@ -49,7 +49,7 @@ handler_header_wins_test() ->
     %% or duplicate it.
     Req = req(http, []),
     Next = fun(R) -> {{200, [{~"x-frame-options", ~"DENY"}], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, undefined),
+    {{200, Headers, _}, _Req2} = call(Req, Next, #{}),
     ?assertEqual([~"DENY"], [V || {~"x-frame-options", V} <- Headers]),
     %% The other defaults still get added.
     ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
@@ -57,14 +57,14 @@ handler_header_wins_test() ->
 handler_hsts_wins_test() ->
     Req = req(https, []),
     Next = fun(R) -> {{200, [{~"strict-transport-security", ~"max-age=0"}], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, #{hsts => true}),
+    {{200, Headers, _}, _Req2} = call(Req, Next, #{hsts => true}),
     ?assertEqual([~"max-age=0"], [V || {~"strict-transport-security", V} <- Headers]).
 
 override_value_test() ->
     Req = req(http, []),
     Config = #{frame_options => ~"DENY", referrer_policy => ~"no-referrer"},
     Next = fun(R) -> {{200, [], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    {{200, Headers, _}, _Req2} = call(Req, Next, Config),
     ?assertEqual(~"DENY", header(~"x-frame-options", Headers)),
     ?assertEqual(~"no-referrer", header(~"referrer-policy", Headers)),
     %% Unconfigured defaults are unchanged.
@@ -74,7 +74,7 @@ disable_header_test() ->
     Req = req(http, []),
     Config = #{content_type_options => false},
     Next = fun(R) -> {{200, [], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    {{200, Headers, _}, _Req2} = call(Req, Next, Config),
     ?assertEqual(undefined, header(~"x-content-type-options", Headers)),
     ?assertEqual(~"SAMEORIGIN", header(~"x-frame-options", Headers)).
 
@@ -82,14 +82,14 @@ csp_opt_in_test() ->
     Req = req(http, []),
     Config = #{content_security_policy => ~"default-src 'self'"},
     Next = fun(R) -> {{200, [], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    {{200, Headers, _}, _Req2} = call(Req, Next, Config),
     ?assertEqual(~"default-src 'self'", header(~"content-security-policy", Headers)).
 
 hsts_disable_test() ->
     Req = req(https, []),
     Config = #{hsts => false},
     Next = fun(R) -> {{200, [], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    {{200, Headers, _}, _Req2} = call(Req, Next, Config),
     ?assertEqual(undefined, header(~"strict-transport-security", Headers)).
 
 hsts_sub_config_test() ->
@@ -97,14 +97,14 @@ hsts_sub_config_test() ->
     Req = req(https, []),
     Config = #{hsts => #{max_age => 600, include_subdomains => false, preload => true}},
     Next = fun(R) -> {{200, [], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    {{200, Headers, _}, _Req2} = call(Req, Next, Config),
     ?assertEqual(~"max-age=600; preload", header(~"strict-transport-security", Headers)).
 
 hsts_subdomains_without_preload_test() ->
     Req = req(https, []),
     Config = #{hsts => #{max_age => 100, include_subdomains => true, preload => false}},
     Next = fun(R) -> {{200, [], ~"b"}, R} end,
-    {{200, Headers, _}, _Req2} = ?M:call(Req, Next, Config),
+    {{200, Headers, _}, _Req2} = call(Req, Next, Config),
     ?assertEqual(
         ~"max-age=100; includeSubDomains",
         header(~"strict-transport-security", Headers)
@@ -114,7 +114,7 @@ stream_response_decorated_test() ->
     Req = req(http, []),
     Fun = fun(_Send) -> ok end,
     Next = fun(R) -> {{stream, 200, [], Fun}, R} end,
-    {{stream, 200, Headers, OutFun}, _Req2} = ?M:call(Req, Next, undefined),
+    {{stream, 200, Headers, OutFun}, _Req2} = call(Req, Next, #{}),
     ?assertEqual(Fun, OutFun),
     ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
 
@@ -124,21 +124,21 @@ sendfile_response_decorated_test() ->
     Req = req(http, []),
     Spec = {~"/tmp/x", 0, 10},
     Next = fun(R) -> {{sendfile, 200, [], Spec}, R} end,
-    {{sendfile, 200, Headers, OutSpec}, _Req2} = ?M:call(Req, Next, undefined),
+    {{sendfile, 200, Headers, OutSpec}, _Req2} = call(Req, Next, #{}),
     ?assertEqual(Spec, OutSpec),
     ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
 
 loop_response_decorated_test() ->
     Req = req(http, []),
     Next = fun(R) -> {{loop, 200, [], loop_state}, R} end,
-    {{loop, 200, Headers, OutState}, _Req2} = ?M:call(Req, Next, undefined),
+    {{loop, 200, Headers, OutState}, _Req2} = call(Req, Next, #{}),
     ?assertEqual(loop_state, OutState),
     ?assertEqual(~"nosniff", header(~"x-content-type-options", Headers)).
 
 websocket_passes_through_test() ->
     Req = req(http, []),
     Next = fun(R) -> {{websocket, some_mod, init_state}, R} end,
-    {Response, _Req2} = ?M:call(Req, Next, undefined),
+    {Response, _Req2} = call(Req, Next, #{}),
     ?assertMatch({websocket, some_mod, init_state}, Response).
 
 %% =============================================================================
@@ -204,6 +204,11 @@ tls_listener_sets_hsts_test_() ->
         end}.
 
 %% --- helpers ---
+
+%% Compile the config through `init/1` (as the pipeline does at startup), then
+%% invoke `call/3` with the resulting state — the contract every test exercises.
+call(Req, Next, Config) ->
+    ?M:call(Req, Next, ?M:init(Config)).
 
 req(Scheme, Headers) ->
     #{

--- a/test/roadrunner_test_init_middleware.erl
+++ b/test/roadrunner_test_init_middleware.erl
@@ -1,0 +1,36 @@
+-module(roadrunner_test_init_middleware).
+-moduledoc """
+Test fixture proving the `init/1` compile-time contract.
+
+`init/1` compiles its raw config into a `{compiled, Tag}` state — a shape
+distinct from the input — so a test can assert `call/3` sees init's
+**output**, not the raw config. When the config carries a `counter`,
+`init/1` bumps it once, letting a test assert init ran a single time at
+compile, never per request.
+""".
+
+-behaviour(roadrunner_middleware).
+
+-export([init/1, call/3]).
+
+%% Runs once when the pipeline is compiled. Bumps the caller's counter
+%% (when one is configured) so a test can prove it fires exactly once, and
+%% compiles the raw `tag` into a `{compiled, Tag}` state distinct from the
+%% input config.
+init(Config) ->
+    case Config of
+        #{counter := Ref} -> ok = counters:add(Ref, 1, 1);
+        #{} -> ok
+    end,
+    Tag =
+        case Config of
+            #{tag := T} -> T;
+            #{} -> ~"default"
+        end,
+    {compiled, Tag}.
+
+%% Stamps the COMPILED tag as a request header. Reading it back proves
+%% init's output (not the raw config map) threaded through to `call/3`.
+call(Req, Next, {compiled, Tag}) ->
+    H = maps:get(headers, Req),
+    Next(Req#{headers := [{~"x-init-tag", Tag} | H]}).

--- a/test/roadrunner_test_middlewares.erl
+++ b/test/roadrunner_test_middlewares.erl
@@ -10,18 +10,25 @@ by the `roadrunner_middleware` behaviour.
 
 Every entry takes the uniform `(Req, Next, State)` shape. The fun-form
 helpers ignore `State`; `call/3` stamps it into the request so tests can
-verify both behaviour dispatch and per-entry state threading.
+verify both behaviour dispatch and per-entry state threading. `init/1` is
+identity, so the entry's config reaches `call/3` unchanged.
 """.
 
 -behaviour(roadrunner_middleware).
 
 -export([
+    init/1,
     call/3,
     tag_request/3,
     wrap_response/3,
     halt_401/3,
     crash/3
 ]).
+
+%% Identity init — the entry's config is the `call/3` state verbatim, so
+%% the state-threading assertions read back exactly what was configured.
+init(Config) ->
+    Config.
 
 %% Module-form `call/3` callback. Stamps this entry's `State` as the
 %% `x-mw-mod` request header, so tests can assert the state threaded


### PR DESCRIPTION
# Description

Middleware modules now implement a required `init/1` callback that runs once when the pipeline is compiled (listener start and every `reload_routes/2`) and returns the `state()` that `call/3` receives on every request. Config validation and any precompute happen there, so a bad config fails loudly at startup instead of on a request, and derived values (validated CORS origins, pre-joined header sets) are built once rather than per request. Listener-wide middlewares are resolved a single time and shared across every route; per-route middlewares keep their own config and their own `init/1`. The built-in `roadrunner_cors` and `roadrunner_security_headers` are migrated to this shape with concrete compiled-state types; a fun-form middleware has no `init/1` and threads its config through verbatim.

```erlang
-module(my_auth).
-behaviour(roadrunner_middleware).
-export([init/1, call/3]).

%% Once, at compile time: validate and precompute the config.
init(#{header := Name}) when is_binary(Name) -> #{header => Name}.

%% Per request: reuse what init/1 returned.
call(Req, Next, #{header := Name}) ->
    case roadrunner_req:header(Name, Req) of
        undefined -> {roadrunner_resp:unauthorized(), Req};
        _ -> Next(Req)
    end.
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
