### PR TITLE
Make the middleware init/1 callback optional

### DIFF
--- a/src/roadrunner_compress.erl
+++ b/src/roadrunner_compress.erl
@@ -63,7 +63,7 @@
 
 -on_load(init_patterns/0).
 
--export([init/1, call/3]).
+-export([call/3]).
 
 -define(THRESHOLD, 860).
 -define(COMMA_CP_KEY, {?MODULE, comma_cp}).
@@ -72,15 +72,9 @@
 -type encoding() :: gzip | deflate | none.
 
 %% No per-instance config — encoding is negotiated per request from
-%% `Accept-Encoding`, and the match patterns are compiled at load, so the
-%% compiled state is just the empty map.
--type state() :: #{}.
-
--spec init(roadrunner_middleware:config()) -> state().
-init(_Config) ->
-    #{}.
-
--spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
+%% `Accept-Encoding`, and the match patterns are compiled at load. With no
+%% `init/1`, the entry's config reaches `call/3` as `State`, which is ignored.
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), roadrunner_middleware:state()) ->
     roadrunner_handler:result().
 call(Req, Next, _State) ->
     {Response, Req2} = Next(Req),

--- a/src/roadrunner_etag.erl
+++ b/src/roadrunner_etag.erl
@@ -36,18 +36,12 @@
 
 -behaviour(roadrunner_middleware).
 
--export([init/1, call/3]).
+-export([call/3]).
 
 %% No per-instance config — the validator is derived from the response body
-%% and the request's `If-None-Match` per request, so the compiled state is
-%% just the empty map.
--type state() :: #{}.
-
--spec init(roadrunner_middleware:config()) -> state().
-init(_Config) ->
-    #{}.
-
--spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
+%% and the request's `If-None-Match` per request. With no `init/1`, the entry's
+%% config reaches `call/3` as `State`, which is ignored.
+-spec call(roadrunner_req:request(), roadrunner_middleware:next(), roadrunner_middleware:state()) ->
     roadrunner_handler:result().
 call(Req, Next, _State) ->
     {Response, Req2} = Next(Req),

--- a/src/roadrunner_middleware.erl
+++ b/src/roadrunner_middleware.erl
@@ -84,9 +84,10 @@ its config as `{Callable, Config}`. A bare `Callable` is shorthand for
 omits the state a `{Path, Handler, State}` route carries.
 
 - `module()` / `{module(), Config}` — a module implementing this
-  behaviour. Its `init(Config)` callback runs **once**, at
-  pipeline-compile time, and the value it returns becomes the `State`
-  handed to every `Mod:call(Req, Next, State)`. See "init/1" below.
+  behaviour. If it exports the optional `init(Config)` callback, that runs
+  **once** at pipeline-compile time and the value it returns becomes the
+  `State` handed to every `Mod:call(Req, Next, State)`; otherwise the
+  config is threaded verbatim. See "init/1" below.
 - `fun((Request, Next, State) -> Result)` / `{Fun, State}` — a fun has no
   init step, so its paired `State` is threaded verbatim as the third
   argument: `Fun(Req, Next, State)`. Reach for a fun for lightweight
@@ -101,11 +102,11 @@ Middleware `State` is **not** the request's `state` field. Route state
 with `roadrunner_req:state/1`; middleware `State` is handed to `call/3`
 as an argument and never touches the request.
 
-## init/1: compile-time setup (modules only)
+## init/1: optional compile-time setup (modules only)
 
-A module middleware **must** implement `init/1`. It runs once when the
-pipeline is compiled (listener boot and every `reload_routes/2`), never
-per request, and turns the user's raw config into the runtime state
+A module middleware **may** implement `init/1`. When present, it runs once
+when the pipeline is compiled (listener boot and every `reload_routes/2`),
+never per request, and turns the user's raw config into the runtime state
 `call/3` receives:
 
 ```erlang
@@ -120,9 +121,11 @@ once instead of per request. A bare `module()` entry is initialised with
 `#{}`, so an `init/1` that reads an all-defaults config should accept the
 empty map.
 
-A fun-form middleware has no `init/1` (there's no module to host the
-callback); its paired `State` is used as-is, so precompute it yourself or
-pass a module if you want the compile-time hook.
+When a module **omits** `init/1`, its config is threaded straight through
+as the `call/3` state (`#{}` for a bare entry), exactly like a fun. So
+`init/1` is purely opt-in: implement it for the compile-time hook, skip it
+for a stateless middleware that only needs `call/3`. A fun-form middleware
+never has an `init/1` (there's no module to host the callback).
 
 ## Examples
 
@@ -212,23 +215,29 @@ bare `Callable` defaults it to `#{}`.
 -type middleware_list() :: [middleware()].
 
 -doc """
-Compile-time setup. Runs **once** when the pipeline is built (listener
-boot and every `roadrunner_listener:reload_routes/2`), never per request,
-and turns the entry's raw `t:config/0` into the `t:state/0` handed to
-every `call/3`. A bare `module()` entry is initialised with `#{}`.
+Optional compile-time setup. When a module exports it, it runs **once**
+as the pipeline is built (listener boot and every
+`roadrunner_listener:reload_routes/2`), never per request, and turns the
+entry's raw `t:config/0` into the `t:state/0` handed to every `call/3`. A
+bare `module()` entry is initialised with `#{}`.
 
 This is the place for config validation and precompute (compile patterns,
 pre-join binaries, build lookup tables): a bad config fails loudly at
-listener start, and the work is paid once rather than per request.
+listener start, and the work is paid once rather than per request. A
+module that omits `init/1` has its config threaded straight through as the
+`call/3` state, the same as a fun.
 """.
 -callback init(Config :: config()) -> state().
+
+-optional_callbacks([init/1]).
 
 -doc """
 The middleware contract. `Request` is the current request map;
 `Next` is a continuation that runs the rest of the pipeline (other
 middlewares + the inner handler) and returns the same
 `t:roadrunner_handler:result/0` shape every middleware returns. `State`
-is what this entry's `init/1` returned at compile time.
+is what this entry's `init/1` returned at compile time, or the entry's
+config verbatim when the module has no `init/1`.
 
 The middleware decides whether to:
 - pass through unchanged (`Next(Req)`),
@@ -256,18 +265,37 @@ resolve(Mws) ->
     [resolve_entry(Mw) || Mw <- Mws].
 
 %% Resolve one entry to its `{Callable, State}` runtime pair. A module entry
-%% runs its required `init/1` callback here, so the per-request closure reuses
-%% the returned state; a fun entry has no init, so its config is the state
-%% verbatim. A bare entry defaults its config to `#{}`.
+%% that exports the optional `init/1` callback runs it here, so the per-request
+%% closure reuses the returned state; a module without `init/1` (and any fun)
+%% threads its config through verbatim. A bare entry defaults its config to
+%% `#{}`.
 -spec resolve_entry(middleware()) -> resolved().
 resolve_entry({Mod, Config}) when is_atom(Mod) ->
-    {Mod, Mod:init(Config)};
+    resolve_module(Mod, Config);
 resolve_entry({Fun, Config}) when is_function(Fun, 3) ->
     {Fun, Config};
 resolve_entry(Mod) when is_atom(Mod) ->
-    {Mod, Mod:init(#{})};
+    resolve_module(Mod, #{});
 resolve_entry(Fun) when is_function(Fun, 3) ->
     {Fun, #{}}.
+
+-spec resolve_module(module(), config()) -> resolved().
+resolve_module(Mod, Config) ->
+    case has_init(Mod) of
+        true -> {Mod, Mod:init(Config)};
+        false -> {Mod, Config}
+    end.
+
+%% Whether `Mod` exports the optional `init/1`. The module is loaded first so
+%% `function_exported/3` can see it (it reports `false` for an unloaded module
+%% even when the export exists). A middleware module that can't be loaded is a
+%% config error worth failing at compile time (listener start), not per request.
+-spec has_init(module()) -> boolean().
+has_init(Mod) ->
+    case code:ensure_loaded(Mod) of
+        {module, Mod} -> erlang:function_exported(Mod, init, 1);
+        {error, Reason} -> error({middleware_module_not_loaded, Mod, Reason})
+    end.
 
 -doc """
 Compose a middleware list around a handler call, returning a single

--- a/test/roadrunner_middleware_tests.erl
+++ b/test/roadrunner_middleware_tests.erl
@@ -77,7 +77,10 @@ compose_two_middlewares_outer_wraps_inner_test() ->
     ?assertEqual({200, [], ~"O(I(x))"}, {Status, Headers, Body}).
 
 compose_module_form_dispatches_via_call3_test() ->
-    %% `{Mod, State}` dispatches to the behaviour `call/3` with State.
+    %% `{Mod, Config}` dispatches to the behaviour `call/3`. The fixture has
+    %% no `init/1`, so the config reaches `call/3` verbatim (the optional-init
+    %% path); `compose_runs_module_init_and_threads_output_test` covers the
+    %% with-init case.
     Handler = fun(R) ->
         {{200, [], roadrunner_req:header(~"x-mw-mod", R)}, R}
     end,
@@ -155,6 +158,14 @@ compose_runs_module_init_and_threads_output_test() ->
     ),
     {{200, [], Body}, _Req2} = Pipeline(req()),
     ?assertEqual(~"compiled-ok", Body).
+
+resolve_unloadable_module_crashes_test() ->
+    %% A middleware module that can't be loaded is a config error: it fails
+    %% when the pipeline is resolved (listener start), not on a request.
+    ?assertError(
+        {middleware_module_not_loaded, roadrunner_no_such_middleware, _},
+        roadrunner_middleware:resolve([roadrunner_no_such_middleware])
+    ).
 
 %% =============================================================================
 %% End-to-end through roadrunner_conn — exercises the map-shape route's

--- a/test/roadrunner_test_middlewares.erl
+++ b/test/roadrunner_test_middlewares.erl
@@ -10,25 +10,20 @@ by the `roadrunner_middleware` behaviour.
 
 Every entry takes the uniform `(Req, Next, State)` shape. The fun-form
 helpers ignore `State`; `call/3` stamps it into the request so tests can
-verify both behaviour dispatch and per-entry state threading. `init/1` is
-identity, so the entry's config reaches `call/3` unchanged.
+verify both behaviour dispatch and per-entry state threading. This module
+has **no** `init/1`, so it exercises the optional-init path: the entry's
+config reaches `call/3` verbatim.
 """.
 
 -behaviour(roadrunner_middleware).
 
 -export([
-    init/1,
     call/3,
     tag_request/3,
     wrap_response/3,
     halt_401/3,
     crash/3
 ]).
-
-%% Identity init — the entry's config is the `call/3` state verbatim, so
-%% the state-threading assertions read back exactly what was configured.
-init(Config) ->
-    Config.
 
 %% Module-form `call/3` callback. Stamps this entry's `State` as the
 %% `x-mw-mod` request header, so tests can assert the state threaded


### PR DESCRIPTION
# Description

A middleware module's `init/1` is now optional. When a module exports it, it still runs once at pipeline-compile time and its return value is the state `call/3` receives; when a module omits it, the entry's config is threaded straight through as the `call/3` state (`#{}` for a bare entry), exactly like a fun-form middleware. So a stateless module middleware only needs `call/3`, with no boilerplate `init/1` to satisfy the behaviour. The config-bearing built-ins (`roadrunner_cors`, `roadrunner_security_headers`) keep their `init/1` and behave identically; `roadrunner_compress` and `roadrunner_etag` drop their no-op `init/1` and ride the new path. A module named in a middlewares list that cannot be loaded fails at listener start with `{middleware_module_not_loaded, Module, Reason}`.

```erlang
-module(no_store).
-behaviour(roadrunner_middleware).
-export([call/3]).

%% No init/1 needed — this middleware has no config to compile.
call(Req, Next, _State) ->
    {{Status, Headers, Body}, Req2} = Next(Req),
    {{Status, [{~"cache-control", ~"no-store"} | Headers], Body}, Req2}.
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
