### PR TITLE
Make header and packet list-building hot paths tail-recursive

### DIFF
--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -461,28 +461,60 @@ parse_headers(Bin, {MaxLine, MaxBlock, MaxCount}) when is_binary(Bin) ->
         | header_too_long
         | header_block_too_long
         | too_many_headers}.
-parse_headers_loop(_Bin, Count, _Consumed, _LfCp, _ColonCp, _MaxLine, _MaxBlock, MaxCount) when
+parse_headers_loop(Bin, Count, Consumed, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount) ->
+    parse_headers_loop(Bin, Count, Consumed, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount, []).
+
+%% Tail-recursive: the count, consumed-byte tally, and the parsed pairs
+%% thread forward as arguments (pairs consed in reverse, flipped once at
+%% the terminating blank line), rather than unpacking and repacking the
+%% `{ok, headers(), binary()}` tuple on every header as body recursion does.
+-spec parse_headers_loop(
+    binary(),
+    non_neg_integer(),
+    non_neg_integer(),
+    binary:cp(),
+    binary:cp(),
+    pos_integer(),
+    pos_integer(),
+    pos_integer(),
+    headers()
+) ->
+    {ok, headers(), binary()}
+    | {more, undefined}
+    | {error,
+        bad_header
+        | header_too_long
+        | header_block_too_long
+        | too_many_headers}.
+parse_headers_loop(
+    _Bin, Count, _Consumed, _LfCp, _ColonCp, _MaxLine, _MaxBlock, MaxCount, _Acc
+) when
     Count > MaxCount
 ->
     {error, too_many_headers};
-parse_headers_loop(_Bin, _Count, Consumed, _LfCp, _ColonCp, _MaxLine, MaxBlock, _MaxCount) when
+parse_headers_loop(
+    _Bin, _Count, Consumed, _LfCp, _ColonCp, _MaxLine, MaxBlock, _MaxCount, _Acc
+) when
     Consumed > MaxBlock
 ->
     {error, header_block_too_long};
-parse_headers_loop(Bin, Count, Consumed, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount) ->
+parse_headers_loop(Bin, Count, Consumed, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount, Acc) ->
     case parse_header(Bin, LfCp, ColonCp, MaxLine) of
         {ok, Name, Value, Rest} ->
             Used = byte_size(Bin) - byte_size(Rest),
-            case
-                parse_headers_loop(
-                    Rest, Count + 1, Consumed + Used, LfCp, ColonCp, MaxLine, MaxBlock, MaxCount
-                )
-            of
-                {ok, Tail, FinalRest} -> {ok, [{Name, Value} | Tail], FinalRest};
-                Other -> Other
-            end;
+            parse_headers_loop(
+                Rest,
+                Count + 1,
+                Consumed + Used,
+                LfCp,
+                ColonCp,
+                MaxLine,
+                MaxBlock,
+                MaxCount,
+                [{Name, Value} | Acc]
+            );
         {end_of_headers, Rest} ->
-            {ok, [], Rest};
+            {ok, lists:reverse(Acc), Rest};
         {more, _} = More ->
             More;
         {error, _} = Err ->

--- a/src/roadrunner_http2_hpack.erl
+++ b/src/roadrunner_http2_hpack.erl
@@ -292,9 +292,17 @@ take_pending_update(#hpack_ctx{pending_update = true, max_size = N} = Ctx) ->
     {encode_size_update(N), Ctx#hpack_ctx{pending_update = false}}.
 
 -spec encode_each([header()], context()) -> {iodata(), context()}.
-encode_each([], Ctx) ->
-    {[], Ctx};
-encode_each([{Name, Value} = H | Rest], Ctx) ->
+encode_each(Headers, Ctx) ->
+    encode_each(Headers, Ctx, []).
+
+%% Tail-recursive: the dynamic-table context threads forward as an
+%% argument and the per-header iodata conses in reverse (flipped once
+%% at the end), rather than unpacking and repacking the
+%% `{iodata(), context()}` tuple on every frame as body recursion does.
+-spec encode_each([header()], context(), [iodata()]) -> {iodata(), context()}.
+encode_each([], Ctx, Acc) ->
+    {lists:reverse(Acc), Ctx};
+encode_each([{Name, Value} = H | Rest], Ctx, Acc) ->
     %% `full_match/3` and `name_match/2` return a bare
     %% `pos_integer() | none` — skipping the prior `{ok, _}` tuple
     %% wrapper avoids a per-lookup heap alloc on the dyn-table hit
@@ -312,8 +320,7 @@ encode_each([{Name, Value} = H | Rest], Ctx) ->
             Idx ->
                 {encode_indexed(Idx), Ctx}
         end,
-    {Tail, Ctx2} = encode_each(Rest, Ctx1),
-    {[Bytes | Tail], Ctx2}.
+    encode_each(Rest, Ctx1, [Bytes | Acc]).
 
 -spec encode_indexed(pos_integer()) -> iodata().
 encode_indexed(Idx) ->

--- a/src/roadrunner_http2_hpack.erl
+++ b/src/roadrunner_http2_hpack.erl
@@ -500,15 +500,20 @@ evict_to(Target, #hpack_ctx{table = Table} = Ctx) ->
 %% on `[]` is the desired "trust the invariant" failure mode.
 -spec keep_within([header()], non_neg_integer()) ->
     {[header()], non_neg_integer()}.
-keep_within([H | T], Budget) ->
+keep_within(Headers, Budget) ->
+    keep_within(Headers, Budget, [], 0).
+
+%% Tail-recursive: the kept entries and their running size thread forward
+%% as arguments (entries flipped once when an entry first fails to fit),
+%% rather than rebuilding the `{[header()], size}` tuple on every frame.
+%% The first entry that doesn't fit drops H and every older entry.
+-spec keep_within([header()], non_neg_integer(), [header()], non_neg_integer()) ->
+    {[header()], non_neg_integer()}.
+keep_within([H | T], Budget, Kept, Size) ->
     HSize = entry_size(H),
     case HSize =< Budget of
-        true ->
-            {Kept, KeptSize} = keep_within(T, Budget - HSize),
-            {[H | Kept], KeptSize + HSize};
-        false ->
-            %% H itself doesn't fit — drop H and every older entry.
-            {[], 0}
+        true -> keep_within(T, Budget - HSize, [H | Kept], Size + HSize);
+        false -> {lists:reverse(Kept), Size}
     end.
 
 -spec entry_size(header()) -> non_neg_integer().

--- a/src/roadrunner_http2_request.erl
+++ b/src/roadrunner_http2_request.erl
@@ -114,19 +114,23 @@ partition([H | Rest], Pseudo) ->
         {error, _} = E -> E
     end.
 
-%% Body-recurse the regular-header tail. A pseudo-header arriving
-%% here is RFC 9113 §8.1.2.1 PROTOCOL_ERROR.
+%% A pseudo-header arriving in the regular-header tail is
+%% RFC 9113 §8.1.2.1 PROTOCOL_ERROR. Tail-recursive: the validated
+%% headers cons into an accumulator (flipped once at the end) rather
+%% than rebuilding the `{ok, _}` result tuple on every frame.
 -spec partition_regular(roadrunner_http:headers()) ->
     {ok, roadrunner_http:headers()} | {error, build_error()}.
-partition_regular([]) ->
-    {ok, []};
-partition_regular([{<<":", _/binary>>, _} | _]) ->
+partition_regular(Headers) ->
+    partition_regular(Headers, []).
+
+-spec partition_regular(roadrunner_http:headers(), roadrunner_http:headers()) ->
+    {ok, roadrunner_http:headers()} | {error, build_error()}.
+partition_regular([], Acc) ->
+    {ok, lists:reverse(Acc)};
+partition_regular([{<<":", _/binary>>, _} | _], _Acc) ->
     {error, pseudo_after_regular};
-partition_regular([H | Rest]) ->
-    case partition_regular(Rest) of
-        {ok, Tail} -> {ok, [H | Tail]};
-        {error, _} = E -> E
-    end.
+partition_regular([H | Rest], Acc) ->
+    partition_regular(Rest, [H | Acc]).
 
 -spec validate_pseudo(map()) ->
     {ok, binary(), binary(), binary(), binary() | undefined}

--- a/src/roadrunner_http3_request.erl
+++ b/src/roadrunner_http3_request.erl
@@ -119,19 +119,23 @@ partition([H | Rest], Pseudo) ->
         {error, _} = E -> E
     end.
 
-%% Body-recurse the regular-header tail. A pseudo-header arriving here
-%% is RFC 9114 §4.3.1 malformed (pseudo after regular).
+%% A pseudo-header arriving in the regular-header tail is
+%% RFC 9114 §4.3.1 malformed (pseudo after regular). Tail-recursive: the
+%% validated headers cons into an accumulator (flipped once at the end)
+%% rather than rebuilding the `{ok, _}` result tuple on every frame.
 -spec partition_regular(roadrunner_http:headers()) ->
     {ok, roadrunner_http:headers()} | {error, build_error()}.
-partition_regular([]) ->
-    {ok, []};
-partition_regular([{<<":", _/binary>>, _} | _]) ->
+partition_regular(Headers) ->
+    partition_regular(Headers, []).
+
+-spec partition_regular(roadrunner_http:headers(), roadrunner_http:headers()) ->
+    {ok, roadrunner_http:headers()} | {error, build_error()}.
+partition_regular([], Acc) ->
+    {ok, lists:reverse(Acc)};
+partition_regular([{<<":", _/binary>>, _} | _], _Acc) ->
     {error, pseudo_after_regular};
-partition_regular([H | Rest]) ->
-    case partition_regular(Rest) of
-        {ok, Tail} -> {ok, [H | Tail]};
-        {error, _} = E -> E
-    end.
+partition_regular([H | Rest], Acc) ->
+    partition_regular(Rest, [H | Acc]).
 
 -spec validate_pseudo(map()) ->
     {ok, binary(), binary(), binary(), binary() | undefined}

--- a/src/roadrunner_quic_loss.erl
+++ b/src/roadrunner_quic_loss.erl
@@ -372,31 +372,43 @@ ack_eliciting_bytes(false, _Size) -> 0.
 max_largest_acked(undefined, Largest) -> Largest;
 max_largest_acked(Current, Largest) -> max(Current, Largest).
 
-%% Body recursion (cons on the way out) preserves the newest-first order
-%% in both output lists.
+%% Tail-recursive partition; both output lists are reversed once at the end
+%% to preserve the newest-first order the caller relies on, rather than
+%% rebuilding the `{Acked, Unacked}` tuple on every frame.
 -spec classify([#sent{}], [{non_neg_integer(), non_neg_integer()}]) -> {[#sent{}], [#sent{}]}.
-classify([], _Ranges) ->
-    {[], []};
-classify([#sent{pn = PN} = Packet | Rest], Ranges) ->
-    {Acked, Unacked} = classify(Rest, Ranges),
+classify(Packets, Ranges) ->
+    classify(Packets, Ranges, [], []).
+
+-spec classify(
+    [#sent{}], [{non_neg_integer(), non_neg_integer()}], [#sent{}], [#sent{}]
+) -> {[#sent{}], [#sent{}]}.
+classify([], _Ranges, Acked, Unacked) ->
+    {lists:reverse(Acked), lists:reverse(Unacked)};
+classify([#sent{pn = PN} = Packet | Rest], Ranges, Acked, Unacked) ->
     case pn_in_ranges(PN, Ranges) of
-        true -> {[Packet | Acked], Unacked};
-        false -> {Acked, [Packet | Unacked]}
+        true -> classify(Rest, Ranges, [Packet | Acked], Unacked);
+        false -> classify(Rest, Ranges, Acked, [Packet | Unacked])
     end.
 
 %% Split the unacknowledged packets into newly lost and still-in-flight by
 %% the packet threshold (a packet at least 3 below the largest acked) and
-%% the time threshold (RFC 9002 §6.1). Survivors keep their newest-first
-%% order for the next prepend.
+%% the time threshold (RFC 9002 §6.1). Tail-recursive; both lists are
+%% reversed once at the end so survivors keep their newest-first order for
+%% the next prepend, rather than rebuilding the result tuple per frame.
 -spec split_lost([#sent{}], non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
     {[#sent{}], [#sent{}]}.
-split_lost([], _LargestAcked, _Now, _LossDelay) ->
-    {[], []};
-split_lost([Packet | Rest], LargestAcked, Now, LossDelay) ->
-    {Lost, Survivors} = split_lost(Rest, LargestAcked, Now, LossDelay),
+split_lost(Packets, LargestAcked, Now, LossDelay) ->
+    split_lost(Packets, LargestAcked, Now, LossDelay, [], []).
+
+-spec split_lost(
+    [#sent{}], non_neg_integer(), non_neg_integer(), non_neg_integer(), [#sent{}], [#sent{}]
+) -> {[#sent{}], [#sent{}]}.
+split_lost([], _LargestAcked, _Now, _LossDelay, Lost, Survivors) ->
+    {lists:reverse(Lost), lists:reverse(Survivors)};
+split_lost([Packet | Rest], LargestAcked, Now, LossDelay, Lost, Survivors) ->
     case lost_packet(Packet, LargestAcked, Now, LossDelay) of
-        true -> {[Packet | Lost], Survivors};
-        false -> {Lost, [Packet | Survivors]}
+        true -> split_lost(Rest, LargestAcked, Now, LossDelay, [Packet | Lost], Survivors);
+        false -> split_lost(Rest, LargestAcked, Now, LossDelay, Lost, [Packet | Survivors])
     end.
 
 %% Whether a still-unacknowledged packet is lost (RFC 9002 §6.1): only packets


### PR DESCRIPTION
# Description

Converts the list-building hot paths that thread both a built-up list and a fold accumulator from body recursion to tail recursion, following OTP PR #11225, which made `lists:mapfoldl`/`mapfoldr` 2-3x faster by removing the per-frame tuple unpack and repack that body recursion forces for that shape. The same shape appears in HPACK header encoding, HTTP/1 header parsing, HTTP/2 and HTTP/3 request header partitioning, and QUIC loss detection, so each now threads its state forward as arguments and reverses once at the end, which is semantically identical and verified by the existing suite at 100% coverage. Each conversion was kept only after a paired-per-round interleaved microbench showed a stable same-sign gain in every round (for example HPACK encoding about 10% faster on the steady-state path, and HTTP/1 header parsing faster in 21 of 21 rounds); candidates that measured as noise were dropped.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
