### PR TITLE
Add per-route HTTP method allowlist returning 405 with Allow

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ routes => [
 ]
 ```
 
+Restrict a route to specific HTTP methods with the **map form**'s `methods` key
+(a non-empty list of uppercase method binaries). A request whose path matches a
+route but whose method is not listed gets `405 Method Not Allowed` with an `Allow`
+header; two routes may share a path with disjoint methods for REST-style dispatch.
+A route with no `methods` answers every method. Matching is literal -- a `[~"GET"]`
+route does not implicitly answer `HEAD`, so list every method the route accepts:
+
+```erlang
+routes => [
+    #{path => ~"/users", handler => users_index,  methods => [~"GET"]},
+    #{path => ~"/users", handler => users_create, methods => [~"POST"]}
+]
+```
+
 The request accessors (`method/1`, `path/1`, `header/2`, `parse_qs/1`,
 `bindings/1`, `peer/1`, `read_body/1`) all live in `roadrunner_req`.
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -72,6 +72,7 @@
     drain_oversized_body/3,
     send_internal_error/1,
     send_not_found/1,
+    send_method_not_allowed/2,
     resolve_handler/2,
     response_status/1,
     response_kind/1,
@@ -569,6 +570,7 @@ scheme({fake, _}) -> http.
 -doc false.
 -spec resolve_handler(dispatch(), roadrunner_req:request()) ->
     {ok, module(), roadrunner_router:bindings(), roadrunner_middleware:next(), term()}
+    | {method_not_allowed, [binary()]}
     | not_found.
 resolve_handler({handler, Mod, Pipeline, State}, _Req) ->
     {ok, Mod, #{}, Pipeline, State};
@@ -577,7 +579,7 @@ resolve_handler({router, ListenerName}, Req) ->
     %% the lookup is O(1) and `roadrunner_listener:reload_routes/2` can
     %% atomically swap the table without bouncing the listener.
     Compiled = persistent_term:get({roadrunner_routes, ListenerName}),
-    roadrunner_router:match(roadrunner_req:path(Req), Compiled).
+    roadrunner_router:match(roadrunner_req:method(Req), roadrunner_req:path(Req), Compiled).
 
 -doc false.
 -spec read_body(
@@ -1277,6 +1279,20 @@ send_not_found(Socket) ->
     Resp = roadrunner_http1:response(
         404,
         [{~"content-length", ~"0"}, {~"connection", ~"close"}],
+        ~""
+    ),
+    roadrunner_transport:send(Socket, Resp).
+
+-doc false.
+-spec send_method_not_allowed(roadrunner_transport:socket(), [binary()]) -> ok | {error, term()}.
+send_method_not_allowed(Socket, Allowed) ->
+    Resp = roadrunner_http1:response(
+        405,
+        [
+            {~"allow", iolist_to_binary(lists:join(~", ", Allowed))},
+            {~"content-length", ~"0"},
+            {~"connection", ~"close"}
+        ],
         ~""
     ),
     roadrunner_transport:send(Socket, Resp).

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -689,6 +689,12 @@ dispatch_phase(
             case roadrunner_conn:resolve_handler(Dispatch, Req) of
                 {ok, Handler, Bindings, Pipeline, _State} ->
                     run_pipeline(S, Handler, Req#{bindings => Bindings}, Pipeline);
+                {method_not_allowed, Allowed} ->
+                    %% Path matched but no route answers this method: 405 +
+                    %% Allow before any pipeline runs (the method gate is a
+                    %% routing decision, ahead of per-route middleware).
+                    _ = roadrunner_conn:send_method_not_allowed(Socket, Allowed),
+                    exit_normal(S);
                 not_found ->
                     _ = roadrunner_conn:send_not_found(Socket),
                     exit_normal(S)

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -1549,7 +1549,7 @@ build_dispatch(Opts, _ListenerName) ->
 %% Single-handler dispatch counterpart of the router's compile path.
 %% Defers to `roadrunner_middleware:compile_pipeline/3` after combining
 %% the listener-wide and per-handler mws lists. State is exposed
-%% alongside the pipeline so `roadrunner_router:match/2`-shaped
+%% alongside the pipeline so `roadrunner_router:match/3`-shaped
 %% callers (and other introspection paths) can read it without
 %% running the pipeline.
 -spec bake_dispatch(

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -471,7 +471,7 @@ dispatch_form(unsupported, _ContentType, _Req) ->
 Return the router-captured bindings for this request as a
 `#{Name => Value}` map of binaries.
 
-`roadrunner_conn` populates this from `roadrunner_router:match/2` before
+`roadrunner_conn` populates this from `roadrunner_router:match/3` before
 invoking the handler. Empty map when the listener is in single-handler
 mode (no router) or the matched route has no `:param` segments.
 """.

--- a/src/roadrunner_resp.erl
+++ b/src/roadrunner_resp.erl
@@ -27,6 +27,7 @@ WebSocket-upgrade handlers build their own tuple directly; see
     unauthorized/0,
     forbidden/0,
     not_found/0,
+    method_not_allowed/1,
     internal_error/0,
     status/1
 ]).
@@ -146,6 +147,15 @@ forbidden() -> empty_status(403).
 -doc "Empty 404 Not Found response.".
 -spec not_found() -> buffered_response().
 not_found() -> empty_status(404).
+
+-doc """
+Empty 405 Method Not Allowed response with an `Allow` header listing
+the permitted methods, comma-separated (RFC 9110 requires `Allow` on a
+405). Pass the uppercase method binaries the resource accepts.
+""".
+-spec method_not_allowed([binary()]) -> buffered_response().
+method_not_allowed(Allowed) ->
+    add_header(empty_status(405), ~"allow", lists:join(~", ", Allowed)).
 
 -doc "Empty 500 Internal Server Error response.".
 -spec internal_error() -> buffered_response().

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -13,13 +13,23 @@ same `Path` and `Handler`:
 - `{Path, Handler, State}` — adds opaque per-handler state surfaced
   via `roadrunner_req:state/1`.
 - `#{path => Path, handler => Handler, state => State, middlewares
-  => [Mw, ...]}` — full map form. Use this when you want to attach
-  per-route middlewares (or any future per-route framework knob).
-  Only `path` and `handler` are required.
+  => [Mw, ...], methods => [~"GET", ...]}` — full map form. Use this
+  when you want to attach per-route middlewares, an HTTP-method
+  allowlist, or any future per-route framework knob. Only `path` and
+  `handler` are required; an absent `methods` answers every method.
 
 The tuple shorthand intentionally cannot carry middlewares — that
 keeps the simple case syntactically light and pushes "more than just
 state" to the more verbose map form.
+
+A route may restrict the HTTP methods it answers via the map form's
+`methods` key (a list of **uppercase** method binaries, e.g.
+`[~"GET", ~"POST"]`). A request whose path matches a route but whose
+method is not in that route's list does not match — `match/3` keeps
+scanning, and if no route on that path accepts the method it returns
+`{method_not_allowed, Allowed}` carrying the union of the methods
+declared by the path-matching routes (for a `405` `Allow` header). A
+route with no `methods` answers every method.
 
 `Path` is a binary like `/users/:id/posts/:post_id`. Segments
 starting with `:` capture a single segment into bindings keyed by
@@ -40,9 +50,9 @@ opaque `compiled()` shape is a list of pre-parsed segment patterns;
 swapping to a trie/DAG later is a non-breaking change for callers.
 """.
 
--export([compile/2, match/2]).
+-export([compile/2, match/3]).
 
--export_type([route/0, routes/0, compiled/0, bindings/0]).
+-export_type([route/0, routes/0, compiled/0, bindings/0, methods/0]).
 
 -doc """
 A single route entry. Three shapes are accepted:
@@ -50,13 +60,16 @@ A single route entry. Three shapes are accepted:
 - `{Path, Handler}` — shorthand: no state, no middlewares.
 - `{Path, Handler, State}` — shorthand with state only.
 - `#{path := Path, handler := Handler, state => State,
-   middlewares => Mws}` — map form; use this to attach per-route
-  middlewares or future per-route framework knobs.
+   middlewares => Mws, methods => [~"GET", ...]}` — map form; use this
+  to attach per-route middlewares, an HTTP-method allowlist, or future
+  per-route framework knobs.
 
 `Path` is a binary pattern (literal segments, `:param` captures, or
 `*wildcard` catch-all). `Handler` is the module implementing
 `roadrunner_handler`. `State` is opaque per-route data threaded back
 to the handler via `roadrunner_req:state/1`; unset → `undefined`.
+`methods` is a list of uppercase method binaries the route answers;
+unset → every method.
 """.
 -type route() ::
     {Path :: binary(), Handler :: module()}
@@ -65,14 +78,35 @@ to the handler via `roadrunner_req:state/1`; unset → `undefined`.
         path := binary(),
         handler := module(),
         state => term(),
-        middlewares => roadrunner_middleware:middleware_list()
+        middlewares => roadrunner_middleware:middleware_list(),
+        methods => methods()
     }.
+
+-doc """
+An HTTP-method allowlist for a route: a list of **uppercase** method
+binaries (`[~"GET", ~"POST"]`), or `undefined` to answer every method.
+`compile/2` turns the list into a `#{Method => true}` set-map so match
+time is an O(1) `is_map_key/2` rather than a list scan; methods are
+matched byte-exact against `roadrunner_req:method/1` (already uppercase
+on the wire), so callers must pass uppercase.
+
+Matching is **literal**: a `[~"GET"]` route does *not* implicitly answer
+`HEAD` (or any other verb) -- list every method the route accepts.
+A present `methods` must be a non-empty list of binaries; `compile/2`
+raises `{invalid_route_methods, _}` on an empty list or non-binary
+entries (both would otherwise silently reject every request).
+""".
+-type methods() :: [binary()] | undefined.
+
+%% The compiled form of `methods()`: a set-as-map for O(1) membership,
+%% or `undefined` for a route that answers every method.
+-type method_lookup() :: #{binary() => true} | undefined.
 
 -doc "An ordered list of routes; matched first-to-last.".
 -type routes() :: [route()].
 
 -doc """
-Captured route parameters, populated by `match/2`.
+Captured route parameters, populated by `match/3`.
 
 `:param` segments produce a single binary value
 (`#{~"id" => ~"42"}`). `*wildcard` segments produce the list of
@@ -84,13 +118,15 @@ remaining path segments
 -type segment() :: {literal, binary()} | {param, binary()} | {wildcard, binary()}.
 
 -doc """
-The compiled-routes representation `match/2` consumes. Treat as
+The compiled-routes representation `match/3` consumes. Treat as
 opaque: the shape is an implementation detail and may change.
 """.
--opaque compiled() :: [{[segment()], module(), roadrunner_middleware:next(), term()}].
+-opaque compiled() :: [
+    {[segment()], module(), roadrunner_middleware:next(), term(), method_lookup()}
+].
 
 -doc """
-Compile a list of routes into the lookup form `match/2` expects.
+Compile a list of routes into the lookup form `match/3` expects.
 
 Each path is split on `/` (empty leading/trailing segments dropped),
 and segments starting with `:` are recorded as named captures.
@@ -109,12 +145,13 @@ compile(Routes, ListenerMws) when is_list(Routes), is_list(ListenerMws) ->
     [compile_route(R, ResolvedListener) || R <- Routes].
 
 -spec compile_route(route(), [roadrunner_middleware:resolved()]) ->
-    {[segment()], module(), roadrunner_middleware:next(), term()}.
+    {[segment()], module(), roadrunner_middleware:next(), term(), method_lookup()}.
 compile_route({Path, Handler}, ResolvedListener) when is_binary(Path), is_atom(Handler) ->
     {
         compile_path(Path),
         Handler,
         roadrunner_middleware:compile_pipeline(ResolvedListener, [], Handler, no_state),
+        undefined,
         undefined
     };
 compile_route({Path, Handler, State}, ResolvedListener) when is_binary(Path), is_atom(Handler) ->
@@ -122,12 +159,14 @@ compile_route({Path, Handler, State}, ResolvedListener) when is_binary(Path), is
         compile_path(Path),
         Handler,
         roadrunner_middleware:compile_pipeline(ResolvedListener, [], Handler, {state, State}),
-        State
+        State,
+        undefined
     };
 compile_route(#{path := Path, handler := Handler} = Route, ResolvedListener) when
     is_binary(Path), is_atom(Handler)
 ->
     RouteMws = maps:get(middlewares, Route, []),
+    Methods = compile_methods(maps:get(methods, Route, undefined)),
     {StateArg, StateValue} =
         case Route of
             #{state := S} -> {{state, S}, S};
@@ -137,7 +176,8 @@ compile_route(#{path := Path, handler := Handler} = Route, ResolvedListener) whe
         compile_path(Path),
         Handler,
         roadrunner_middleware:compile_pipeline(ResolvedListener, RouteMws, Handler, StateArg),
-        StateValue
+        StateValue,
+        Methods
     }.
 
 -spec compile_path(binary()) -> [segment()].
@@ -149,8 +189,25 @@ compile_segment(<<":", Name/binary>>) -> {param, Name};
 compile_segment(<<"*", Name/binary>>) -> {wildcard, Name};
 compile_segment(Lit) -> {literal, Lit}.
 
+%% Compile a route's `methods` allowlist into a set-map for O(1) match-time
+%% membership; `undefined` (no allowlist) passes through to answer every method.
+%% A present `methods` must be a non-empty list of binaries -- an empty list
+%% (a route that answers nothing) or non-binary entries (which could never
+%% match the binary wire method) are config errors, raised loudly rather than
+%% silently 405-ing every request.
+-spec compile_methods(methods()) -> method_lookup().
+compile_methods(undefined) ->
+    undefined;
+compile_methods(Methods) when is_list(Methods), Methods =/= [] ->
+    case lists:all(fun is_binary/1, Methods) of
+        true -> maps:from_keys(Methods, true);
+        false -> error({invalid_route_methods, Methods})
+    end;
+compile_methods(Methods) ->
+    error({invalid_route_methods, Methods}).
+
 -doc """
-Look up the handler for a given request path.
+Look up the handler for a given request method + path.
 
 Returns `{ok, Handler, Bindings, Pipeline, State}` on a match —
 `Bindings` is a map populated with captures from `:param` segments
@@ -161,26 +218,60 @@ optionally wrapped in a state-injecting outermost closure, ending in
 attached by the user at compile time (or `undefined` when the route
 shape didn't carry any). The conn loop just calls `Pipeline` —
 `State` is for callers who need to introspect a route outside the
-request flow. Returns `not_found` when no compiled route matches.
-""".
--spec match(Path :: binary(), compiled()) ->
-    {ok, module(), bindings(), roadrunner_middleware:next(), term()} | not_found.
-match(Path, Compiled) when is_binary(Path), is_list(Compiled) ->
-    Segments = path_segments(Path),
-    match_first(Segments, Compiled).
+request flow.
 
--spec match_first([binary()], compiled()) ->
-    {ok, module(), bindings(), roadrunner_middleware:next(), term()} | not_found.
-match_first(_Segments, []) ->
+`Method` is the uppercase request-method binary. A route with no
+`methods` allowlist answers every method; otherwise the method must be
+a member. When a route's path matches but its method does not, the
+scan continues (so a later same-path route can answer the method —
+that is how same-path method dispatch works). If at least one route's
+path matched but none answered the method, returns
+`{method_not_allowed, Allowed}` where `Allowed` is the sorted,
+de-duplicated union of those routes' methods (for a `405` `Allow`
+header). Returns `not_found` when no compiled route's path matches at
+all.
+""".
+-spec match(Method :: binary(), Path :: binary(), compiled()) ->
+    {ok, module(), bindings(), roadrunner_middleware:next(), term()}
+    | {method_not_allowed, [binary()]}
+    | not_found.
+match(Method, Path, Compiled) when is_binary(Method), is_binary(Path), is_list(Compiled) ->
+    Segments = path_segments(Path),
+    match_first(Method, Segments, Compiled, #{}).
+
+%% `Allow` is a set-map accumulator of the methods declared by every
+%% path-matching-but-method-rejected route; `maps:merge/2` unions and
+%% de-duplicates it. At the end its sorted keys become the `405` Allow
+%% header (sort makes the header deterministic regardless of map order).
+-spec match_first(binary(), [binary()], compiled(), #{binary() => true}) ->
+    {ok, module(), bindings(), roadrunner_middleware:next(), term()}
+    | {method_not_allowed, [binary()]}
+    | not_found.
+match_first(_Method, _Segments, [], Allow) when map_size(Allow) =:= 0 ->
     not_found;
-match_first(Segments, [{Pattern, Handler, Pipeline, State} | Rest]) ->
+match_first(_Method, _Segments, [], Allow) ->
+    {method_not_allowed, lists:sort(maps:keys(Allow))};
+match_first(Method, Segments, [{Pattern, Handler, Pipeline, State, Methods} | Rest], Allow) ->
     case match_pattern(Pattern, Segments, #{}) of
-        no_match -> match_first(Segments, Rest);
-        Bindings -> {ok, Handler, Bindings, Pipeline, State}
+        no_match ->
+            match_first(Method, Segments, Rest, Allow);
+        Bindings ->
+            case method_allowed(Method, Methods) of
+                true -> {ok, Handler, Bindings, Pipeline, State};
+                false -> match_first(Method, Segments, Rest, maps:merge(Allow, Methods))
+            end
     end.
 
+%% A route with no `methods` allowlist answers every method; otherwise
+%% the request method must be a key in the compiled set-map.
+-spec method_allowed(binary(), method_lookup()) -> boolean().
+method_allowed(_Method, undefined) ->
+    true;
+method_allowed(Method, MethodsMap) ->
+    is_map_key(Method, MethodsMap).
+
 %% Returns the bare bindings map on a match (no `{ok, _}` wrap) so the
-%% caller `match_first/2` can splice it straight into its own
+%% caller `match_first/4` can splice it straight into its own
 %% `{ok, Handler, Bindings, _, _}` tuple without paying the intermediate
 %% 2-tuple alloc per matched route. `no_match` is the sentinel for the
 %% miss path — disjoint from any map shape `match_pattern` would produce.

--- a/test/property_test/roadrunner_router_props.erl
+++ b/test/property_test/roadrunner_router_props.erl
@@ -5,7 +5,7 @@ Property-based tests for `roadrunner_router`.
 Headline property: **parameter bindings round-trip.** Given a
 randomly-generated route pattern (a mix of literal and `:param`
 segments) and randomly-generated values for each `:param`, the
-constructed path must match the route and `roadrunner_router:match/2`
+constructed path must match the route and `roadrunner_router:match/3`
 must reproduce the param map verbatim.
 
 This catches off-by-one bugs in segment parsing, encoding mismatches,
@@ -27,7 +27,7 @@ prop_param_bindings_round_trip() ->
             PathBin = build_path(Pattern, Values),
             RouteBin = build_route(Pattern),
             Compiled = roadrunner_router:compile([{RouteBin, my_handler}], []),
-            case roadrunner_router:match(PathBin, Compiled) of
+            case roadrunner_router:match(~"GET", PathBin, Compiled) of
                 {ok, my_handler, Bindings, Pipeline, _State} when is_function(Pipeline, 1) ->
                     %% Every `:Name` in the pattern must show up in
                     %% Bindings under that exact binary name and value.

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -769,6 +769,45 @@ not_found_writes_404_test() ->
     Sink ! stop,
     persistent_term:erase({roadrunner_routes, Listener}).
 
+method_not_allowed_writes_405_test() ->
+    %% Router dispatch where the path matches but the method isn't in the
+    %% route's allowlist → 405 with a comma-joined, sorted Allow header,
+    %% emitted before any pipeline runs.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Listener = mna405,
+    Compiled = roadrunner_router:compile(
+        [
+            #{
+                path => ~"/post-only",
+                handler => roadrunner_test_handler,
+                methods => [~"POST", ~"DELETE"]
+            }
+        ],
+        []
+    ),
+    persistent_term:put({roadrunner_routes, Listener}, Compiled),
+    Sink = spawn_active_sink_with_send_log(
+        Self, Tag, ~"GET /post-only HTTP/1.1\r\nHost: x\r\n\r\n"
+    ),
+    Opts = (fake_opts(Listener))#{
+        dispatch := {router, Listener}
+    },
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertMatch(<<"HTTP/1.1 405", _/binary>>, Sent),
+    %% Allow header is sorted: DELETE < POST.
+    ?assertNotEqual(nomatch, binary:match(Sent, ~"DELETE, POST")),
+    Sink ! stop,
+    persistent_term:erase({roadrunner_routes, Listener}).
+
 two_pipelined_requests_in_one_packet_serve_both_test() ->
     %% RFC 7230 §6.3 pipelining — two requests delivered as one TCP
     %% packet should both be served. The keepalive handler (no

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -462,8 +462,28 @@ resolve_handler_router_no_match_returns_not_found_test() ->
         roadrunner_router:compile([{~"/known", some_mod}], [])
     ),
     try
-        Req = #{target => ~"/missing"},
+        Req = #{method => ~"GET", target => ~"/missing"},
         ?assertEqual(not_found, roadrunner_conn:resolve_handler({router, Name}, Req))
+    after
+        persistent_term:erase({roadrunner_routes, Name})
+    end.
+
+resolve_handler_router_method_not_allowed_test() ->
+    %% Path matches a method-restricted route but the verb doesn't:
+    %% resolve_handler surfaces the 405 + Allow set for the conn loop.
+    Name = resolve_handler_router_method_not_allowed,
+    persistent_term:put(
+        {roadrunner_routes, Name},
+        roadrunner_router:compile(
+            [#{path => ~"/known", handler => some_mod, methods => [~"POST"]}], []
+        )
+    ),
+    try
+        Req = #{method => ~"GET", target => ~"/known"},
+        ?assertEqual(
+            {method_not_allowed, [~"POST"]},
+            roadrunner_conn:resolve_handler({router, Name}, Req)
+        )
     after
         persistent_term:erase({roadrunner_routes, Name})
     end.
@@ -700,7 +720,12 @@ conn_dispatches_via_router_test_() ->
                 port => 0,
                 routes => [
                     {~"/", roadrunner_hello_handler, undefined},
-                    {~"/created", roadrunner_test_handler, undefined}
+                    {~"/created", roadrunner_test_handler, undefined},
+                    #{
+                        path => ~"/post-only",
+                        handler => roadrunner_test_handler,
+                        methods => [~"POST"]
+                    }
                 ]
             }),
             roadrunner_listener:port(conn_test_routes)
@@ -715,6 +740,9 @@ conn_dispatches_via_router_test_() ->
                 end},
                 {"unknown path returns 404", fun() ->
                     assert_status(Port, ~"GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 404)
+                end},
+                {"disallowed method on a matched path returns 405", fun() ->
+                    assert_status(Port, ~"GET /post-only HTTP/1.1\r\nHost: x\r\n\r\n", 405)
                 end}
             ]
         end}.

--- a/test/roadrunner_resp_tests.erl
+++ b/test/roadrunner_resp_tests.erl
@@ -126,6 +126,14 @@ forbidden_test() ->
 not_found_test() ->
     ?assertEqual({404, [{~"content-length", ~"0"}], ~""}, roadrunner_resp:not_found()).
 
+method_not_allowed_test() ->
+    %% 405 carries an `Allow` header (prepended, so it wins on lookup)
+    %% listing the permitted methods comma-separated.
+    ?assertEqual(
+        {405, [{~"allow", ~"GET, POST"}, {~"content-length", ~"0"}], ~""},
+        roadrunner_resp:method_not_allowed([~"GET", ~"POST"])
+    ).
+
 internal_error_test() ->
     ?assertEqual({500, [{~"content-length", ~"0"}], ~""}, roadrunner_resp:internal_error()).
 

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -3,7 +3,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% =============================================================================
-%% compile/1 + match/2 — literal paths
+%% compile/1 + match/3 — literal paths
 %% =============================================================================
 
 compile_empty_test() ->
@@ -386,7 +386,7 @@ match_wildcard_followed_by_literal_does_not_match_test() ->
 match_nul_byte_in_segment_is_captured_raw_test() ->
     %% NUL is just a byte to the router — the request-line parser
     %% rejects NUL upstream so a real wire request can't reach here
-    %% with a NUL, but a caller invoking `match/2` directly with a
+    %% with a NUL, but a caller invoking `match/3` directly with a
     %% poisoned binary gets it back verbatim. Documented as caller's
     %% responsibility to validate.
     Compiled = roadrunner_router:compile([{~"/admin/:p", h}], []),
@@ -412,7 +412,7 @@ match_path_without_leading_slash_resolves_same_as_with_test() ->
 
 compile_returns_callable_pipeline_test() ->
     %% Every compiled route, regardless of shape, ends with a 1-arity
-    %% fun in the 4th element of `match/2`'s return. Behavior is
+    %% fun in the 4th element of `match/3`'s return. Behavior is
     %% covered by `roadrunner_middleware_tests`.
     Compiled = roadrunner_router:compile(
         [
@@ -425,7 +425,7 @@ compile_returns_callable_pipeline_test() ->
     [
         ?assert(is_function(P, 1))
      || Path <- [~"/", ~"/x", ~"/y"],
-        {ok, _, _, P, _} <- [roadrunner_router:match(Path, Compiled)]
+        {ok, _, _, P, _} <- [roadrunner_router:match(~"GET", Path, Compiled)]
     ].
 
 compile_bakes_state_into_pipeline_test() ->
@@ -436,7 +436,7 @@ compile_bakes_state_into_pipeline_test() ->
     Compiled = roadrunner_router:compile(
         [{~"/", roadrunner_state_echo_handler, #{my => state}}], []
     ),
-    {ok, _, _, Pipeline, _State} = roadrunner_router:match(~"/", Compiled),
+    {ok, _, _, Pipeline, _State} = roadrunner_router:match(~"GET", ~"/", Compiled),
     {{200, _, Body}, _} = Pipeline(empty_req()),
     ?assertEqual(#{my => state}, binary_to_term(Body)).
 
@@ -455,7 +455,7 @@ match_exposes_state_as_5th_element_test() ->
         []
     ),
     [
-        ?assertEqual(Expected, element(5, roadrunner_router:match(P, Compiled)))
+        ?assertEqual(Expected, element(5, roadrunner_router:match(~"GET", P, Compiled)))
      || {P, Expected} <- [
             {~"/none", undefined},
             {~"/legacy", undefined},
@@ -465,14 +465,130 @@ match_exposes_state_as_5th_element_test() ->
         ]
     ].
 
+%% =============================================================================
+%% Method-aware routing (map-form `methods` allowlist)
+%% =============================================================================
+
+match_method_in_allowlist_test() ->
+    Compiled = roadrunner_router:compile(
+        [#{path => ~"/account", handler => acct_handler, methods => [~"POST"]}], []
+    ),
+    ?assertEqual(
+        {ok, acct_handler, #{}, #{}},
+        match_no_pipeline(~"POST", ~"/account", Compiled)
+    ).
+
+match_method_not_in_allowlist_returns_405_test() ->
+    Compiled = roadrunner_router:compile(
+        [#{path => ~"/account", handler => acct_handler, methods => [~"POST"]}], []
+    ),
+    ?assertEqual(
+        {method_not_allowed, [~"POST"]},
+        roadrunner_router:match(~"GET", ~"/account", Compiled)
+    ).
+
+match_no_methods_key_answers_every_method_test() ->
+    %% A route with no `methods` allowlist accepts any verb.
+    Compiled = roadrunner_router:compile(
+        [#{path => ~"/any", handler => any_handler}], []
+    ),
+    [
+        ?assertEqual(
+            {ok, any_handler, #{}, #{}},
+            match_no_pipeline(M, ~"/any", Compiled)
+        )
+     || M <- [~"GET", ~"POST", ~"DELETE", ~"PROPFIND"]
+    ].
+
+match_same_path_dispatches_on_method_test() ->
+    %% Two routes share a path with disjoint methods — the verb selects
+    %% the handler (REST-style dispatch).
+    Compiled = roadrunner_router:compile(
+        [
+            #{path => ~"/users", handler => users_index, methods => [~"GET"]},
+            #{path => ~"/users", handler => users_create, methods => [~"POST"]}
+        ],
+        []
+    ),
+    ?assertEqual(
+        {ok, users_index, #{}, #{}},
+        match_no_pipeline(~"GET", ~"/users", Compiled)
+    ),
+    ?assertEqual(
+        {ok, users_create, #{}, #{}},
+        match_no_pipeline(~"POST", ~"/users", Compiled)
+    ).
+
+match_405_allow_unions_same_path_methods_test() ->
+    %% A method matching neither same-path route yields a 405 whose Allow
+    %% set is the sorted, de-duplicated union — sorted regardless of the
+    %% order the methods were declared in (here `HEAD` before `GET`).
+    Compiled = roadrunner_router:compile(
+        [
+            #{path => ~"/users", handler => users_index, methods => [~"HEAD", ~"GET"]},
+            #{path => ~"/users", handler => users_create, methods => [~"GET", ~"POST"]}
+        ],
+        []
+    ),
+    ?assertEqual(
+        {method_not_allowed, [~"GET", ~"HEAD", ~"POST"]},
+        roadrunner_router:match(~"DELETE", ~"/users", Compiled)
+    ).
+
+match_method_mismatch_with_no_path_match_is_not_found_test() ->
+    %% A disallowed method only yields 405 when some path matched; an
+    %% unknown path is still a 404, not a 405.
+    Compiled = roadrunner_router:compile(
+        [#{path => ~"/account", handler => acct_handler, methods => [~"POST"]}], []
+    ),
+    ?assertEqual(not_found, roadrunner_router:match(~"GET", ~"/nope", Compiled)).
+
+compile_rejects_empty_methods_list_test() ->
+    %% An empty `methods` (a route that answers nothing) is a config error.
+    ?assertError(
+        {invalid_route_methods, []},
+        roadrunner_router:compile([#{path => ~"/x", handler => h, methods => []}], [])
+    ).
+
+compile_rejects_non_binary_methods_test() ->
+    %% Atom methods would never match the binary wire method — raise loudly.
+    ?assertError(
+        {invalid_route_methods, [get, post]},
+        roadrunner_router:compile([#{path => ~"/x", handler => h, methods => [get, post]}], [])
+    ).
+
+match_all_methods_route_shadows_later_specific_test() ->
+    %% Declaration order wins: an all-methods route on a path short-circuits
+    %% before a later same-path method-specific route is considered.
+    Compiled = roadrunner_router:compile(
+        [
+            #{path => ~"/x", handler => catch_all},
+            #{path => ~"/x", handler => only_post, methods => [~"POST"]}
+        ],
+        []
+    ),
+    ?assertEqual(
+        {ok, catch_all, #{}, #{}},
+        match_no_pipeline(~"POST", ~"/x", Compiled)
+    ),
+    ?assertEqual(
+        {ok, catch_all, #{}, #{}},
+        match_no_pipeline(~"GET", ~"/x", Compiled)
+    ).
+
 %% --- helpers ---
 
 %% Drop the pipeline (4th element) and state (5th) so the handler
 %% module + bindings can be asserted with `?assertEqual`. The
 %% pipeline is funs-are-not-comparable, and state has its own
 %% dedicated test (`match_exposes_state_as_5th_element_test`).
+%% Defaults the method to GET — the path-matching tests use routes with
+%% no `methods` allowlist, so every method (incl. GET) is accepted.
 match_no_pipeline(Path, Compiled) ->
-    case roadrunner_router:match(Path, Compiled) of
+    match_no_pipeline(~"GET", Path, Compiled).
+
+match_no_pipeline(Method, Path, Compiled) ->
+    case roadrunner_router:match(Method, Path, Compiled) of
         {ok, Mod, Bindings, _Pipeline, _State} -> {ok, Mod, Bindings, #{}};
         Other -> Other
     end.


### PR DESCRIPTION
# Description

The router now matches on HTTP method as well as path. The map-form route gains an optional `methods` key (a non-empty list of uppercase method binaries); a route with no `methods` answers every method, exactly as before.

`roadrunner_router:match/2` becomes `match/3`, taking the request method alongside the path. When a path matches but no route on it answers the method, `match/3` returns a new `{method_not_allowed, Allowed}` result (the sorted, de-duplicated union of the methods declared by the path-matching routes); the connection loop renders this as a `405 Method Not Allowed` with an `Allow` header, before any per-route middleware runs. Two routes may share a path with disjoint methods for REST-style dispatch.

Methods compile to a `#{Method => true}` set-map so match-time membership is an O(1) `is_map_key/2` rather than a list scan. Matching is literal: a `[~"GET"]` route does not implicitly answer `HEAD`, so list every method the route accepts. An empty or non-binary `methods` is a config error (`{invalid_route_methods, _}`) rather than a route that silently rejects every request. A `roadrunner_resp:method_not_allowed/1` helper rounds out the status-builder set.

Breaking change: `roadrunner_router:match/2` is replaced by `match/3` (the lookup now requires the request method). The opaque compiled-routes shape also changed.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
