### PR TITLE
Trim per-request work on the HTTP/1 request hot path

### DIFF
--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -990,19 +990,20 @@ telemetry_metadata(
         peer := Peer,
         method := Method,
         target := Target,
-        scheme := Scheme
-    } = Req
+        scheme := Scheme,
+        listener_name := ListenerName
+    }
 ) ->
-    %% Destructure the five always-present keys in one match instead of
-    %% a `maps:get/2` each (matching the h2/h3 builders); `listener_name`
-    %% keeps its defaulted lookup since it is optional in the request map.
+    %% Destructure the six always-present keys in one match instead of a
+    %% `maps:get` each (matching the h2/h3 builders). `listener_name` is
+    %% added by `handle_request_bytes/2` before dispatch, so it is present.
     #{
         request_id => RequestId,
         peer => Peer,
         method => Method,
         path => Target,
         scheme => Scheme,
-        listener_name => maps:get(listener_name, Req, undefined)
+        listener_name => ListenerName
     }.
 
 -spec rejection(#loop_state{}, atom()) -> ok.

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -87,17 +87,33 @@ parse_request_line(Bin) ->
     {ok, Method :: binary(), Target :: binary(), version(), Rest :: binary()}
     | {more, undefined}
     | {error, bad_request_line | bad_version | request_line_too_long}.
-parse_request_line(<<"\r\n", Rest/binary>>, MaxReqLine) ->
+parse_request_line(Bin, MaxReqLine) ->
+    %% The internal variant also returns `Path` (the target with any `?query`
+    %% sliced off, captured for free during target validation). The public
+    %% contract is the documented 5-tuple, so drop it here; `parse_request/2`
+    %% calls the path-carrying variant directly and stores `Path`.
+    case parse_request_line_p(Bin, MaxReqLine) of
+        {ok, Method, Target, _Path, Version, Rest} -> {ok, Method, Target, Version, Rest};
+        Other -> Other
+    end.
+
+%% Path-carrying variant of `parse_request_line/2`: same logic, but the success
+%% tuple also returns the `?`-free path captured during target validation.
+-spec parse_request_line_p(binary(), pos_integer()) ->
+    {ok, Method :: binary(), Target :: binary(), Path :: binary(), version(), Rest :: binary()}
+    | {more, undefined}
+    | {error, bad_request_line | bad_version | request_line_too_long}.
+parse_request_line_p(<<"\r\n", Rest/binary>>, MaxReqLine) ->
     do_parse_request_line(
         Rest, persistent_term:get(?LF_KEY), persistent_term:get(?SPACE_KEY), MaxReqLine
     );
-parse_request_line(Bin, MaxReqLine) when is_binary(Bin) ->
+parse_request_line_p(Bin, MaxReqLine) when is_binary(Bin) ->
     do_parse_request_line(
         Bin, persistent_term:get(?LF_KEY), persistent_term:get(?SPACE_KEY), MaxReqLine
     ).
 
 -spec do_parse_request_line(binary(), binary:cp(), binary:cp(), pos_integer()) ->
-    {ok, Method :: binary(), Target :: binary(), version(), Rest :: binary()}
+    {ok, Method :: binary(), Target :: binary(), Path :: binary(), version(), Rest :: binary()}
     | {more, undefined}
     | {error, bad_request_line | bad_version | request_line_too_long}.
 do_parse_request_line(Bin, LfCp, SpaceCp, MaxReqLine) ->
@@ -113,7 +129,7 @@ do_parse_request_line(Bin, LfCp, SpaceCp, MaxReqLine) ->
     end.
 
 -spec extract_line(binary(), pos_integer(), binary:cp(), pos_integer()) ->
-    {ok, binary(), binary(), version(), binary()}
+    {ok, binary(), binary(), binary(), version(), binary()}
     | {error, bad_request_line | bad_version | request_line_too_long}.
 extract_line(Bin, LfPos, SpaceCp, MaxReqLine) ->
     LineLen = LfPos - 1,
@@ -127,7 +143,7 @@ extract_line(Bin, LfPos, SpaceCp, MaxReqLine) ->
     end.
 
 -spec parse_line(binary(), binary(), binary:cp()) ->
-    {ok, binary(), binary(), version(), binary()}
+    {ok, binary(), binary(), binary(), version(), binary()}
     | {error, bad_request_line | bad_version}.
 parse_line(Line, Rest, SpaceCp) ->
     case binary:split(Line, SpaceCp, [global]) of
@@ -138,15 +154,15 @@ parse_line(Line, Rest, SpaceCp) ->
     end.
 
 -spec classify(binary(), binary(), binary(), binary()) ->
-    {ok, binary(), binary(), version(), binary()}
+    {ok, binary(), binary(), binary(), version(), binary()}
     | {error, bad_request_line | bad_version}.
 classify(Method, Target, VersionBin, Rest) ->
     case validate_method(Method) of
         ok ->
             case validate_target(Target) of
-                ok ->
+                {ok, Path} ->
                     case parse_version(VersionBin) of
-                        {ok, V} -> {ok, Method, Target, V, Rest};
+                        {ok, V} -> {ok, Method, Target, Path, V, Rest};
                         error -> {error, bad_version}
                     end;
                 error ->
@@ -180,16 +196,35 @@ validate_method_chars(<<C, Rest/binary>>) when C >= $A, C =< $Z ->
 validate_method_chars(_) ->
     error.
 
--spec validate_target(binary()) -> ok | error.
+%% Validate the request-target (RFC 9110 §5.6.2: reject CTLs, SP, DEL) and, in
+%% the SAME byte-walk, slice off the `?query` so the caller gets the `?`-free
+%% path for free. The first `?` switches to query validation (later `?`s are
+%% valid query bytes); the path prefix is derived from a `byte_size` diff (no
+%% per-byte position counter). `Path` shares the target binary when there is no
+%% query, or is a sub-binary slice when there is — neither copies.
+-spec validate_target(binary()) -> {ok, Path :: binary()} | error.
 validate_target(<<>>) -> error;
-validate_target(T) -> validate_target_chars(T).
+validate_target(T) -> validate_path(T, T).
 
--spec validate_target_chars(binary()) -> ok | error.
-validate_target_chars(<<>>) ->
+-spec validate_path(binary(), binary()) -> {ok, binary()} | error.
+validate_path(<<>>, Target) ->
+    {ok, Target};
+validate_path(<<$?, Rest/binary>>, Target) ->
+    case validate_query(Rest) of
+        ok -> {ok, binary:part(Target, 0, byte_size(Target) - byte_size(Rest) - 1)};
+        error -> error
+    end;
+validate_path(<<C, Rest/binary>>, Target) when C > 16#20, C =/= 16#7F ->
+    validate_path(Rest, Target);
+validate_path(_, _) ->
+    error.
+
+-spec validate_query(binary()) -> ok | error.
+validate_query(<<>>) ->
     ok;
-validate_target_chars(<<C, Rest/binary>>) when C > 16#20, C =/= 16#7F ->
-    validate_target_chars(Rest);
-validate_target_chars(_) ->
+validate_query(<<C, Rest/binary>>) when C > 16#20, C =/= 16#7F ->
+    validate_query(Rest);
+validate_query(_) ->
     error.
 
 -spec parse_version(binary()) -> {ok, version()} | error.
@@ -677,13 +712,14 @@ The conn loop passes the listener's configured `http1_*` limits;
         | missing_host}.
 parse_request(Bin, {MaxReqLine, MaxHdrLine, MaxHdrBlock, MaxHdrCount}) when is_binary(Bin) ->
     maybe
-        {ok, Method, Target, Version, Rest} ?= parse_request_line(Bin, MaxReqLine),
+        {ok, Method, Target, Path, Version, Rest} ?= parse_request_line_p(Bin, MaxReqLine),
         {ok, Headers, Rest2} ?= parse_headers(Rest, {MaxHdrLine, MaxHdrBlock, MaxHdrCount}),
         Decisions = compute_cached_decisions(Headers),
         ok ?= validate_host(Version, Decisions),
         Req = #{
             method => Method,
             target => Target,
+            path => Path,
             version => Version,
             headers => Headers,
             cached_decisions => Decisions

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -41,6 +41,11 @@ care which protocol delivered the bytes.
 -type request() :: #{
     method := binary(),
     target := binary(),
+    %% The request target with any `?query` removed, sliced for free by the
+    %% h1 parser during target validation so `path/1` is an O(1) field read.
+    %% Absent on h2/h3 requests and on manually-built request maps, where
+    %% `path/1` falls back to splitting `target` on `?`.
+    path => binary(),
     version := version(),
     headers := headers(),
     %% H1-parser internal optimization — handlers should ignore.
@@ -208,7 +213,11 @@ are returned. The path is **not** percent-decoded — that's the
 router's job.
 """.
 -spec path(request()) -> binary().
+path(#{path := P}) ->
+    %% Fast path: the h1 parser sliced the `?`-free path at validation time.
+    P;
 path(#{target := T}) ->
+    %% Fallback for h2/h3 and manually-built maps that carry no `path`.
     case binary:split(T, persistent_term:get(?QMARK_CP_KEY)) of
         [P, _Q] -> P;
         [P] -> P

--- a/test/roadrunner_http1_tests.erl
+++ b/test/roadrunner_http1_tests.erl
@@ -476,6 +476,7 @@ request_full_test() ->
             #{
                 method => ~"GET",
                 target => ~"/foo",
+                path => ~"/foo",
                 version => {1, 1},
                 headers => [{~"host", ~"x"}],
                 cached_decisions => #{
@@ -508,6 +509,7 @@ request_http10_no_host_accepted_test() ->
             #{
                 method => ~"GET",
                 target => ~"/",
+                path => ~"/",
                 version => {1, 0},
                 headers => [],
                 cached_decisions => #{
@@ -530,6 +532,29 @@ request_http11_missing_host_returns_error_test() ->
     ?assertEqual(
         {error, missing_host},
         roadrunner_http1:parse_request(~"GET / HTTP/1.1\r\n\r\n")
+    ).
+
+request_query_sliced_into_path_test() ->
+    %% The parser slices the `?query` off into `path` while keeping the full
+    %% `target`, so `roadrunner_req:path/1` is an O(1) field read.
+    ?assertMatch(
+        {ok, #{target := ~"/foo?a=1&b=2", path := ~"/foo"}, ~""},
+        roadrunner_http1:parse_request(~"GET /foo?a=1&b=2 HTTP/1.1\r\nHost: x\r\n\r\n")
+    ).
+
+request_empty_query_keeps_path_test() ->
+    %% A trailing `?` with no query: path is the bytes before it, query empty.
+    ?assertMatch(
+        {ok, #{target := ~"/foo?", path := ~"/foo"}, ~""},
+        roadrunner_http1:parse_request(~"GET /foo? HTTP/1.1\r\nHost: x\r\n\r\n")
+    ).
+
+control_char_in_query_rejected_test() ->
+    %% Query bytes obey the same target char rules: a control char after the
+    %% `?` is still a malformed request-line.
+    ?assertEqual(
+        {error, bad_request_line},
+        roadrunner_http1:parse_request(~"GET /foo?a=\x{00} HTTP/1.1\r\nHost: x\r\n\r\n")
     ).
 
 cached_decisions_empty_for_empty_headers_test() ->

--- a/test/roadrunner_req_tests.erl
+++ b/test/roadrunner_req_tests.erl
@@ -32,6 +32,14 @@ path_no_query_test() ->
 path_with_query_test() ->
     ?assertEqual(~"/foo", roadrunner_req:path(sample_req_target(~"/foo?a=1&b=2"))).
 
+path_uses_stored_field_test() ->
+    %% When the h1 parser already sliced `path`, `path/1` reads it directly
+    %% (the O(1) fast clause) rather than re-splitting `target`.
+    ?assertEqual(
+        ~"/foo",
+        roadrunner_req:path(#{target => ~"/foo?a=1&b=2", path => ~"/foo"})
+    ).
+
 qs_no_query_test() ->
     ?assertEqual(~"", roadrunner_req:qs(sample_req_target(~"/foo"))).
 


### PR DESCRIPTION
# Description

Two hot-path micro-optimizations. The HTTP/1 parser slices the `?query` off the request target during the validation walk it already runs and stores the path, so `roadrunner_req:path/1` is an O(1) field read instead of splitting the target on every call. `telemetry_metadata` reads `listener_name` by pattern match instead of `maps:get/3`, matching the h2/h3 builders. Microbench: `path/1` drops from ~41ns to ~6ns per call.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
