### PR TITLE
Signal Connection: close when the server closes an HTTP/1 connection

### DIFF
--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -735,19 +735,20 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
     Metadata = telemetry_metadata(Req),
     ReqStart = roadrunner_telemetry:request_start(Metadata),
     try Pipeline(Req) of
-        {Response, Req2} when is_map(Req2) ->
-            _ = dispatch_response(S, Handler, Req2, Response),
+        {Response0, Req2} when is_map(Req2) ->
+            S2 = S#loop_state{requests_served = S#loop_state.requests_served + 1},
+            %% Decide keep-alive-vs-close BEFORE the response is sent so a
+            %% server-initiated close (count ceiling) lands on the wire as
+            %% `Connection: close` — see `ensure_close_signaled/3`.
+            Response = ensure_close_signaled(S2, Req2, Response0),
+            _ = dispatch_response(S2, Handler, Req2, Response),
             ok = roadrunner_telemetry:request_stop(
                 ReqStart,
                 Metadata,
                 roadrunner_conn:response_status(Response),
                 roadrunner_conn:response_kind(Response)
             ),
-            finishing_phase(
-                S#loop_state{requests_served = S#loop_state.requests_served + 1},
-                Req2,
-                Response
-            )
+            finishing_phase(S2, Req2, Response)
     catch
         Class:Reason:Stack ->
             ok = roadrunner_telemetry:request_exception(
@@ -762,6 +763,43 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
             }),
             _ = roadrunner_conn:send_internal_error(Socket),
             exit_normal(S)
+    end.
+
+%% RFC 9112 §9.6: a server that will not reuse the connection MUST signal it on
+%% the final response. The per-request keep-alive decision already reaches the
+%% wire whenever the client or handler set `Connection: close`; the gap is a
+%% *server-initiated* close the client cannot infer — reaching
+%% `max_keep_alive_requests` on a connection that was otherwise keep-alive. Add
+%% the header there (and only there) so a fronting proxy (nginx, ngrok) stops
+%% reusing a connection we are about to close, instead of racing a request onto
+%% it. Buffered + sendfile share Content-Length framing and are keep-alive
+%% eligible, so they get the header here. Websocket has already switched
+%% protocols (its 101 carried `Connection: Upgrade`), and stream / loop always
+%% force close in `finishing_phase` — none of the three runs through the
+%% request-count ceiling, so they pass through this helper untouched.
+-spec ensure_close_signaled(
+    #loop_state{}, roadrunner_req:request(), roadrunner_handler:response()
+) -> roadrunner_handler:response().
+ensure_close_signaled(S, Req, {Status, Headers, Body}) when is_integer(Status) ->
+    {Status, with_close_if_last(S, Req, Headers), Body};
+ensure_close_signaled(S, Req, {sendfile, Status, Headers, Spec}) when is_integer(Status) ->
+    {sendfile, Status, with_close_if_last(S, Req, Headers), Spec};
+ensure_close_signaled(_S, _Req, Response) ->
+    Response.
+
+%% Prepend `Connection: close` exactly when this request trips the keep-alive
+%% ceiling AND the connection would otherwise be reused. In the common case the
+%% response has no `connection` header, so the prepend is the only token; if a
+%% handler set one explicitly, `close` is the first token on the wire and takes
+%% precedence (RFC 9112 §9.6). Every other case is left byte-for-byte unchanged.
+-spec with_close_if_last(#loop_state{}, roadrunner_req:request(), roadrunner_http:headers()) ->
+    roadrunner_http:headers().
+with_close_if_last(
+    #loop_state{requests_served = Served, max_keep_alive_requests = Max}, Req, Headers
+) ->
+    case Served >= Max andalso roadrunner_conn:keep_alive_decision(Req, Headers) =:= keep_alive of
+        true -> [{~"connection", ~"close"} | Headers];
+        false -> Headers
     end.
 
 %% Dispatches the 5 response shapes that match the
@@ -941,19 +979,17 @@ buffered_finish(S, Req, Headers) ->
         {ok, ManualLeftover} ->
             case roadrunner_conn:keep_alive_decision(Req, Headers) of
                 close ->
+                    %% Either the client/handler asked to close, or
+                    %% `ensure_close_signaled/3` added `Connection: close`
+                    %% because this request tripped `max_keep_alive_requests`
+                    %% — both land here, and both close the connection.
                     exit_normal(S);
                 keep_alive ->
-                    Served = S#loop_state.requests_served,
-                    case Served >= S#loop_state.max_keep_alive_requests of
-                        true ->
-                            exit_normal(S);
-                        false ->
-                            Leftover = pipelined_leftover(Req, S, ManualLeftover),
-                            read_request_phase(S#loop_state{
-                                phase = keep_alive,
-                                buffered = Leftover
-                            })
-                    end
+                    Leftover = pipelined_leftover(Req, S, ManualLeftover),
+                    read_request_phase(S#loop_state{
+                        phase = keep_alive,
+                        buffered = Leftover
+                    })
             end;
         {error, _} ->
             %% Drain failure — close. Manual-mode handlers can leave the

--- a/src/roadrunner_loop_response.erl
+++ b/src/roadrunner_loop_response.erl
@@ -59,7 +59,11 @@ loop. Returns when the handler's `handle_info/3` returns `{stop, _}`.
     term()
 ) -> ok.
 run(Socket, Status, UserHeaders, Handler, State) ->
-    Headers = [{~"transfer-encoding", ~"chunked"} | UserHeaders],
+    %% A loop response always closes the connection (the conn loop force-
+    %% closes once this returns), so advertise it on the wire per RFC 9112
+    %% §9.6 — without it a fronting proxy treats the connection as reusable
+    %% and can race a request onto a socket we are about to drop.
+    Headers = [{~"transfer-encoding", ~"chunked"}, {~"connection", ~"close"} | UserHeaders],
     Head = roadrunner_http1:response(Status, Headers, ~""),
     _ = roadrunner_telemetry:response_send(
         roadrunner_transport:send(Socket, Head), loop_response_head

--- a/src/roadrunner_stream_response.erl
+++ b/src/roadrunner_stream_response.erl
@@ -36,7 +36,11 @@ decision).
     roadrunner_handler:stream_fun()
 ) -> ok | {error, term()}.
 run(Socket, Status, UserHeaders, Fun) ->
-    Headers = [{~"transfer-encoding", ~"chunked"} | UserHeaders],
+    %% A stream response always closes the connection (the conn loop force-
+    %% closes once this returns), so advertise it on the wire per RFC 9112
+    %% §9.6 — without it a fronting proxy treats the connection as reusable
+    %% and can race a request onto a socket we are about to drop.
+    Headers = [{~"transfer-encoding", ~"chunked"}, {~"connection", ~"close"} | UserHeaders],
     Head = roadrunner_http1:response(Status, Headers, ~""),
     _ = roadrunner_telemetry:response_send(
         roadrunner_transport:send(Socket, Head), stream_response_head

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1278,6 +1278,43 @@ sendfile_response_skips_body_for_head_method_test() ->
     persistent_term:erase({roadrunner_conn_loop_sendfile_handler, file}),
     file:delete(Path).
 
+sendfile_at_keep_alive_ceiling_signals_close_test() ->
+    %% RFC 9112 §9.6 — a sendfile response that trips
+    %% `max_keep_alive_requests` on an otherwise keep-alive connection must
+    %% carry `Connection: close`, even though the client never asked to
+    %% close. Mirrors the buffered ceiling case: `ensure_close_signaled/3`
+    %% routes both shapes through `with_close_if_last/3`.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Path = filename:join(["/tmp", "rr_conn_loop_sendfile_ceiling.txt"]),
+    ok = file:write_file(Path, ~"sendfile-content"),
+    persistent_term:put({roadrunner_conn_loop_sendfile_handler, file}, Path),
+    %% No client `Connection: close`: the count ceiling, not the client,
+    %% drives the close — exactly the server-initiated case under test.
+    Sink = spawn_active_sink_with_send_log(
+        Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
+    ),
+    Opts = (fake_opts(sendf_ceiling))#{
+        max_keep_alive_requests := 1,
+        dispatch :=
+            {handler, roadrunner_conn_loop_sendfile_handler,
+                fun roadrunner_conn_loop_sendfile_handler:handle/1, undefined}
+    },
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertMatch(<<"HTTP/1.1 200", _/binary>>, Sent),
+    ?assertNotEqual(nomatch, binary:match(Sent, ~"\r\nconnection: close\r\n")),
+    Sink ! stop,
+    persistent_term:erase({roadrunner_conn_loop_sendfile_handler, file}),
+    file:delete(Path).
+
 sendfile_dispatch_closes_socket_on_error_test() ->
     %% Sendfile responses honor keep-alive (per finishing_phase/3), so a
     %% mid-write failure would otherwise leave the conn idling for a

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -1082,6 +1082,9 @@ conn_loop_empty_push_emits_nothing_test_() ->
                 roadrunner_empty_push_test_conn ! stop,
                 Reply = recv_until_closed(Sock),
                 [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                %% A loop response always closes, so the server must signal it
+                %% (RFC 9112 §9.6) so a proxy stops reusing the connection.
+                ?assertNotEqual(nomatch, binary:match(Reply, ~"\r\nconnection: close\r\n")),
                 %% Empty push is no-op; only "hello" chunk + terminator.
                 ?assertEqual(~"5\r\nhello\r\n0\r\n\r\n", Body),
                 ok = gen_tcp:close(Sock)
@@ -1164,6 +1167,9 @@ conn_streams_chunked_response_test_() ->
                 Reply = recv_until_closed(Sock),
                 ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, Reply),
                 {match, _} = re:run(Reply, ~"transfer-encoding: chunked", [caseless]),
+                %% A stream response always closes, so the server must say so
+                %% (RFC 9112 §9.6) or a proxy will try to reuse the connection.
+                ?assertNotEqual(nomatch, binary:match(Reply, ~"\r\nconnection: close\r\n")),
                 %% The chunk framing should land "hello world" in the body.
                 {match, _} = re:run(Reply, ~"hello"),
                 {match, _} = re:run(Reply, ~"world"),

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -1190,6 +1190,10 @@ conn_keep_alive_serves_two_requests_test_() ->
                 ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, Reply1),
                 Reply2 = send_and_recv(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
                 ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, Reply2),
+                %% Below the ceiling the connection is reused, so neither
+                %% response should carry `Connection: close`.
+                ?assertEqual(nomatch, binary:match(Reply1, ~"\r\nconnection: close\r\n")),
+                ?assertEqual(nomatch, binary:match(Reply2, ~"\r\nconnection: close\r\n")),
                 ok = gen_tcp:close(Sock)
             end}
         end}.
@@ -1205,13 +1209,18 @@ conn_keep_alive_count_limit_test_() ->
             roadrunner_listener:port(conn_test_ka_max)
         end,
         fun(_) -> ok = roadrunner_listener:stop(conn_test_ka_max) end, fun(Port) ->
-            {"max_keep_alive_requests=1 closes after first response", fun() ->
+            {"max_keep_alive_requests=1 sends Connection: close then closes", fun() ->
                 {ok, Sock} = gen_tcp:connect(
                     {127, 0, 0, 1}, Port, [binary, {active, false}], 1000
                 ),
                 ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
+                %% `recv_until_closed/1` returns only once the socket is closed,
+                %% so reaching this line already proves the server closed.
                 Reply = recv_until_closed(Sock),
                 ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, Reply),
+                %% RFC 9112 §9.6: the ceiling-tripping response MUST tell the
+                %% client we are closing, so a fronting proxy stops reusing it.
+                ?assertNotEqual(nomatch, binary:match(Reply, ~"\r\nconnection: close\r\n")),
                 ok = gen_tcp:close(Sock)
             end}
         end}.


### PR DESCRIPTION
# Description

roadrunner now advertises `Connection: close` on the final HTTP/1 response whenever the server, not the client, is about to close a connection it was otherwise keeping alive. Without that header a fronting proxy (nginx, ngrok) treats the connection as reusable and can race a fresh request onto a socket the server is already dropping. Two paths now signal it: a buffered or sendfile response that reaches `max_keep_alive_requests`, and stream / loop responses (including SSE), which always close once the writer finishes. RFC 9112 §9.6 defines the `close` option as "a signal that the sender will close this connection after completion of the response", so a server that will close has to say so or the peer assumes reuse.

Response that hits `max_keep_alive_requests`, before: `200 OK` then the socket closes with no warning; after: `200 OK` plus `Connection: close`, then closes.
Streamed or SSE response, before: `200 OK` with `Transfer-Encoding: chunked` then closes silently; after: the same plus `Connection: close`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
