### PR TITLE
Anchor the HTTP/1 slowloris rate window at the first request byte

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -416,6 +416,24 @@ Surfaced by the post-merge HTTP/3 review.
 
 **Scope:** small, cross-protocol (the same response paths as the 1xx item).
 
+### Anchor the manual-mode body rate window at the first body byte — small
+
+**What:** `make_recv/3` (`roadrunner_conn.erl`) captures its rate-window start at
+closure creation (`read_body_phase/3`), so in manual body-buffering mode a handler
+that delays before calling `roadrunner_req:read_body/1,2` has its think-time counted
+toward the body's minimum-byte-rate average. Auto mode has no gap (it reads the
+body synchronously right after the closure is built), and the request-read phase
+already anchors at the first byte.
+
+**Why deferred:** bounded today by the request_timeout `Deadline` threaded into the
+same closure (it fires first), and the residual is a narrow self-inflicted case
+(manual mode + a slow handler + a configured `min_bytes_per_second` + a small body).
+Anchoring at the first body recv would also slightly weaken Slowloris protection for
+a client that stalls between headers-done and body-start, so it is defensible as-is.
+Revisit only if a real workload reports false `slow_client` drops.
+
+**Scope:** small.
+
 ## Per-route framework knobs the map shape unlocks
 
 The map-shape route entry (`#{path => ..., handler => ..., state =>

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -121,8 +121,9 @@
     %% `recv_passive/2` tracks bytes received since `recv_phase_start`
     %% and closes the conn if the running average drops below
     %% `min_rate` after a 1 s grace (matches `roadrunner_conn:rate_ok/3`).
-    %% Reset at every `read_request_phase` entry (per-request window —
-    %% each request gets its own grace + budget).
+    %% `recv_phase_bytes` is reset to 0 at every `read_request_phase`
+    %% entry; `recv_phase_start` is then anchored at the first byte of
+    %% that request (per-request window, idle keep-alive gap excluded).
     min_rate = 0 :: non_neg_integer(),
     recv_phase_start = 0 :: integer(),
     recv_phase_bytes = 0 :: non_neg_integer(),
@@ -343,10 +344,13 @@ read_request_phase(#loop_state{buffered = Buf} = S) ->
     %% `state_timeout` semantics in a hand-rolled receive.
     Now = erlang:monotonic_time(millisecond),
     Deadline = Now + Timeout,
-    %% Reset the slowloris window at every read_request_phase entry —
-    %% pipelined keep-alive iterations get their own grace + budget,
-    %% same shape as `roadrunner_conn:make_recv/3`.
-    S1 = S#loop_state{recv_phase_start = Now, recv_phase_bytes = 0},
+    %% Reset the per-request byte counter. The slowloris rate window is
+    %% anchored at the first byte actually received (in `recv_passive/2`
+    %% and `recv_with_hibernate/3`), NOT at phase entry — so an idle
+    %% keep-alive gap before a reused connection's next request is not
+    %% counted as slow transmission. `recv_phase_bytes =:= 0` is the
+    %% "no byte yet this request" signal those paths key off to anchor.
+    S1 = S#loop_state{recv_phase_bytes = 0},
     case Buf of
         <<>> ->
             recv_request_bytes(S1, Deadline);
@@ -418,14 +422,24 @@ recv_passive(
                     %% the conn if `min_rate` isn't met after the 1 s
                     %% grace. Cheap when `min_rate = 0` because
                     %% `roadrunner_conn:rate_ok/3` short-circuits at
-                    %% `MinRate * Elapsed = 0`.
+                    %% `MinRate * Elapsed = 0`. Anchor the window at the
+                    %% first byte of the request (`PhaseBytes =:= 0`), not
+                    %% at phase entry — `recv` never returns `{ok, <<>>}`
+                    %% on a stream socket, so the first chunk always sets
+                    %% the anchor and subsequent chunks measure from there.
+                    PhaseStart1 =
+                        case PhaseBytes of
+                            0 -> Now;
+                            _ -> PhaseStart
+                        end,
                     NewBytes = PhaseBytes + byte_size(Bytes),
-                    case roadrunner_conn:rate_ok(Now - PhaseStart, NewBytes, MinRate) of
+                    case roadrunner_conn:rate_ok(Now - PhaseStart1, NewBytes, MinRate) of
                         true ->
                             handle_request_bytes(
                                 S#loop_state{
                                     buffered = <<Buf/binary, Bytes/binary>>,
-                                    recv_phase_bytes = NewBytes
+                                    recv_phase_bytes = NewBytes,
+                                    recv_phase_start = PhaseStart1
                                 },
                                 Deadline
                             );
@@ -485,14 +499,24 @@ recv_with_hibernate(
     receive
         {DataTag, _Sock, Bytes} ->
             _ = erlang:cancel_timer(DeadlineRef),
-            NewBytes = PhaseBytes + byte_size(Bytes),
             Now = erlang:monotonic_time(millisecond),
-            case roadrunner_conn:rate_ok(Now - PhaseStart, NewBytes, MinRate) of
+            %% Anchor the slowloris window at the first byte of the
+            %% request (`PhaseBytes =:= 0`), not at phase entry, so an
+            %% idle keep-alive gap before a reused connection's next
+            %% request is not counted as slow transmission.
+            PhaseStart1 =
+                case PhaseBytes of
+                    0 -> Now;
+                    _ -> PhaseStart
+                end,
+            NewBytes = PhaseBytes + byte_size(Bytes),
+            case roadrunner_conn:rate_ok(Now - PhaseStart1, NewBytes, MinRate) of
                 true ->
                     handle_request_bytes(
                         S#loop_state{
                             buffered = <<Buf/binary, Bytes/binary>>,
-                            recv_phase_bytes = NewBytes
+                            recv_phase_bytes = NewBytes,
+                            recv_phase_start = PhaseStart1
                         },
                         Deadline
                     );

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -326,18 +326,29 @@ setopts_on_dead_socket_exits_silently_test() ->
     _ = Self.
 
 slowloris_during_passive_recv_drops_client_test() ->
-    %% Passive recv path: deliver a tiny amount of bytes after the
-    %% 1 s grace, with `min_rate` set high enough that the running
-    %% average falls under it. The conn must close silently.
+    %% Passive recv path: a real slowloris client dribbles bytes — one
+    %% byte inside the 1 s grace, then a second byte after the grace
+    %% boundary, keeping the running average far below `min_rate`. The
+    %% rate window is anchored at the FIRST byte (not at phase entry), so
+    %% the drop is driven by genuine slow transmission. The conn must
+    %% close silently.
     ensure_pg(),
     Self = self(),
-    %% Sink that waits past the grace window, then delivers 3 bytes
-    %% in response to the conn's first recv.
+    %% Deliver 1 byte immediately (anchors the window), then sleep past
+    %% the grace and deliver 1 more byte. Total 2 bytes over ~1.2 s
+    %% (~1.7 B/s), well under 1 MB/s. The conn's drain-tick recvs during
+    %% the sleep queue up; the held reply lands on whichever recv is
+    %% pending when the sink wakes.
     Sink = spawn(fun() ->
         receive
-            {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
-                timer:sleep(1100),
-                ConnPid ! {roadrunner_fake_recv_reply, {ok, ~"GET"}}
+            {roadrunner_fake_recv, C1, _, _} ->
+                C1 ! {roadrunner_fake_recv_reply, {ok, ~"G"}}
+        after 5000 -> ok
+        end,
+        timer:sleep(1200),
+        receive
+            {roadrunner_fake_recv, C2, _, _} ->
+                C2 ! {roadrunner_fake_recv_reply, {ok, ~"E"}}
         after 5000 -> ok
         end,
         receive
@@ -359,20 +370,27 @@ slowloris_during_passive_recv_drops_client_test() ->
     _ = Self.
 
 slowloris_during_active_mode_recv_drops_client_test() ->
-    %% Active-mode hibernate path: deliver a tiny amount of bytes
-    %% after the 1 s grace, with `min_rate` set high enough that the
-    %% running average falls under it. The conn must close silently
-    %% (no 408, same as the passive path's slowloris branch).
+    %% Active-mode hibernate path: a real slowloris client dribbles bytes
+    %% — one byte inside the 1 s grace, then a second byte after the
+    %% grace boundary, with `min_rate` set high enough that the running
+    %% average falls under it. The window is anchored at the first byte.
+    %% The conn must close silently (no 408, same as the passive path's
+    %% slowloris branch).
     ensure_pg(),
     Self = self(),
-    %% Sink that waits past the grace window, then delivers 3 bytes
-    %% — running average becomes `3 * 1000 / 1100 ≈ 2.7 B/s`, well
-    %% under 1 MB/s.
+    %% Deliver 1 byte immediately (anchors the window), then sleep past
+    %% the grace and deliver 1 more byte. Total 2 bytes over ~1.2 s
+    %% (~1.7 B/s), well under 1 MB/s.
     Sink = spawn(fun() ->
         receive
-            {roadrunner_fake_setopts, ConnPid, _Opts} ->
-                timer:sleep(1100),
-                ConnPid ! {roadrunner_fake_data, undefined, ~"GET"}
+            {roadrunner_fake_setopts, C1, _} ->
+                C1 ! {roadrunner_fake_data, undefined, ~"G"}
+        after 5000 -> ok
+        end,
+        timer:sleep(1200),
+        receive
+            {roadrunner_fake_setopts, C2, _} ->
+                C2 ! {roadrunner_fake_data, undefined, ~"E"}
         after 5000 -> ok
         end,
         receive
@@ -393,6 +411,68 @@ slowloris_during_active_mode_recv_drops_client_test() ->
     end,
     Sink ! stop,
     _ = Self.
+
+keep_alive_reuse_after_idle_serves_second_request_passive_test() ->
+    %% Regression: a reused keep-alive connection that idles past the
+    %% grace before its next request must NOT be dropped. The rate window
+    %% is anchored at the first byte of each request, so the idle gap is
+    %% not counted as slow transmission. Under the old phase-entry anchor
+    %% the second request was silently dropped (one response on the wire).
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+    Sink = spawn_keepalive_idle_sink(Self, Tag, Req, 1500),
+    Opts = (fake_opts(ka_reuse_passive))#{
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
+        max_keep_alive_requests := 2,
+        keep_alive_timeout := 5000,
+        request_timeout := 5000,
+        min_bytes_per_second => 1000000
+    },
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 6000 -> error(no_normal_exit_on_keep_alive_reuse)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 200)),
+    %% Two 200 OK responses on the wire (leading empty + one per response).
+    ?assertEqual(3, length(binary:split(Sent, ~"HTTP/1.1 ", [global]))),
+    Sink ! stop.
+
+keep_alive_reuse_after_idle_serves_second_request_hibernate_test() ->
+    %% Same regression on the active-mode hibernate path: `hibernate_after`
+    %% is short enough that the conn hibernates during the idle gap and
+    %% wakes via `recv_request_bytes_hib` when the second request arrives.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+    Sink = spawn_keepalive_idle_sink(Self, Tag, Req, 1500),
+    Opts = (fake_opts(ka_reuse_hib))#{
+        dispatch :=
+            {handler, roadrunner_keepalive_handler, fun roadrunner_keepalive_handler:handle/1,
+                undefined},
+        max_keep_alive_requests := 2,
+        keep_alive_timeout := 5000,
+        request_timeout := 5000,
+        hibernate_after => 50,
+        min_bytes_per_second => 1000000
+    },
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 6000 -> error(no_normal_exit_on_keep_alive_reuse)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 200)),
+    ?assertEqual(3, length(binary:split(Sent, ~"HTTP/1.1 ", [global]))),
+    Sink ! stop.
 
 stray_msg_during_read_request_is_ignored_test() ->
     ensure_pg(),
@@ -1482,6 +1562,56 @@ active_sink_loop(Logger, Tag, Bytes, Delivered) ->
         _Other ->
             active_sink_loop(Logger, Tag, Bytes, Delivered)
     end.
+
+%% Keep-alive reuse sink — serves `Req` for the first request, idles
+%% `IdleMs` (so the conn loops back into the keep-alive read phase and
+%% waits past the 1 s grace), then serves `Req` again for the second
+%% request. Handles both the passive recv path and the active-mode
+%% setopts path. Forwards sends to `Logger` so the test can count the
+%% responses on the wire. No sends arrive during the idle (the first
+%% response is already forwarded and the second request hasn't been
+%% dispatched yet), so sleeping inline doesn't drop any.
+spawn_keepalive_idle_sink(Logger, Tag, Req, IdleMs) ->
+    spawn(fun() -> keepalive_idle_sink_loop(Logger, Tag, Req, IdleMs, 0) end).
+
+keepalive_idle_sink_loop(Logger, Tag, Req, IdleMs, Delivered) ->
+    receive
+        stop ->
+            ok;
+        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
+            keepalive_idle_deliver(Logger, Tag, Req, IdleMs, Delivered, ConnPid, passive);
+        {roadrunner_fake_setopts, ConnPid, _Opts} ->
+            keepalive_idle_deliver(Logger, Tag, Req, IdleMs, Delivered, ConnPid, active);
+        {roadrunner_fake_send, _Pid, Data} ->
+            Logger ! {Tag, sent, Data},
+            keepalive_idle_sink_loop(Logger, Tag, Req, IdleMs, Delivered);
+        _Other ->
+            keepalive_idle_sink_loop(Logger, Tag, Req, IdleMs, Delivered)
+    end.
+
+keepalive_idle_deliver(Logger, Tag, Req, IdleMs, Delivered, ConnPid, Mode) ->
+    case Delivered of
+        0 ->
+            deliver_req(ConnPid, Req, Mode),
+            keepalive_idle_sink_loop(Logger, Tag, Req, IdleMs, 1);
+        1 ->
+            %% Second request: idle past the grace, then deliver. Under
+            %% the old phase-entry anchor this idle gap was miscounted as
+            %% slow transmission and the request was dropped.
+            timer:sleep(IdleMs),
+            deliver_req(ConnPid, Req, Mode),
+            keepalive_idle_sink_loop(Logger, Tag, Req, IdleMs, 2);
+        _ ->
+            %% No more requests — let any further passive recv close.
+            deliver_close(ConnPid, Mode),
+            keepalive_idle_sink_loop(Logger, Tag, Req, IdleMs, Delivered)
+    end.
+
+deliver_req(ConnPid, Req, passive) -> ConnPid ! {roadrunner_fake_recv_reply, {ok, Req}};
+deliver_req(ConnPid, Req, active) -> ConnPid ! {roadrunner_fake_data, undefined, Req}.
+
+deliver_close(ConnPid, passive) -> ConnPid ! {roadrunner_fake_recv_reply, {error, closed}};
+deliver_close(_ConnPid, active) -> ok.
 
 %% Scripted sink — handles BOTH active-mode setopts (replies with
 %% `{roadrunner_fake_data, _, Bytes}`) and passive-mode recv (replies


### PR DESCRIPTION
# Description

A reused HTTP/1.1 keep-alive connection that idled past the 1s grace had the idle gap counted as slow transmission by the anti-Slowloris rate check, so its next request was silently dropped (502/503 behind connection-pooling proxies like nginx upstream keepalive or ngrok). The rate window now anchors at the first received byte of each request instead of at keep-alive loop-back, excluding the idle wait.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
