### PR TITLE
Serve brotli .br precompressed static siblings

### DIFF
--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -12,27 +12,39 @@ Configure via a 3-tuple route with `#{dir => Path}` opts and a
 Reads the file from disk, sets `Content-Type` from the extension,
 returns 404 on a missing file or any path that contains `..`.
 
-## Gzip-sibling serving
+## Precompressed-sibling serving
 
-When a request carries `Accept-Encoding: gzip` and the requested
-file has a `<file>.gz` sibling on disk, the sibling is served
-verbatim with `Content-Encoding: gzip` plus `Vary: Accept-Encoding`.
-This matches nginx's `gzip_static on` behaviour and lets operators
-pre-compress build assets once instead of paying the deflate cost
-per request.
+When a request's `Accept-Encoding` opts into a compressed encoding
+and the requested file has a matching precompressed sibling on disk,
+the sibling is served verbatim with the corresponding
+`Content-Encoding` plus `Vary: Accept-Encoding`. This matches nginx's
+`gzip_static on` behaviour and lets operators pre-compress build
+assets once instead of paying the compression cost per request.
 
-`Accept-Encoding` is matched via plain substring (`gzip`) rather
-than full RFC 9110 §12.5.3 qvalue ranking. The static path is
-typically hit by browsers and benchmark clients that always
-include `gzip` plainly. Brotli (`.br`) siblings are not served —
-gzip is the universally supported encoding.
+Two encodings are negotiated, brotli first:
 
-The original file's ETag is reused for the gzip variant, so a
-follow-up `If-None-Match` returns 304 regardless of which variant
-was first served. A `Range` request disables the gzip path on that
-request — byte offsets over a compressed representation have
-subtle semantics and the simple "Range wins" rule matches what
-nginx does.
+- `Accept-Encoding: br` with a `<file>.br` sibling on disk →
+  `Content-Encoding: br`
+- `Accept-Encoding: gzip` with a `<file>.gz` sibling on disk →
+  `Content-Encoding: gzip`
+
+Brotli wins when the client accepts both and the `.br` sibling
+exists; gzip is the fallback. With neither sibling on disk (or
+neither encoding accepted) the raw file is served. Roadrunner never
+compresses on the fly — it only `sendfile`s a sibling an operator
+placed on disk, so there is no brotli or gzip codec dependency.
+
+`Accept-Encoding` is matched via plain substring (`br`, `gzip`)
+rather than full RFC 9110 §12.5.3 qvalue ranking. Browsers and
+clients that reach the static path send these tokens plainly.
+
+The original file's ETag is reused for every variant, so a follow-up
+`If-None-Match` returns 304 regardless of which variant was first
+served. A `Range` request disables the precompressed path on that
+request — byte offsets over a compressed representation have subtle
+semantics and the simple "Range wins" rule matches what nginx does.
+The `Content-Type` always reflects the original file's extension,
+not the sibling's.
 
 ## Symlink policy
 
@@ -93,6 +105,15 @@ under an `infinity` (or long) TTL.
 
 -export([handle/1, cache_clear/0]).
 
+-export_type([siblings/0]).
+
+-doc """
+Precompressed siblings found on disk for a regular file, keyed by
+encoding. A key is present only when that sibling is a regular file;
+the value is its size in bytes. `#{}` means neither sibling exists.
+""".
+-type siblings() :: #{br => non_neg_integer(), gz => non_neg_integer()}.
+
 -define(MIME_TYPES, #{
     ~".html" => ~"text/html; charset=utf-8",
     ~".css" => ~"text/css; charset=utf-8",
@@ -140,8 +161,8 @@ cache_clear() ->
 ) -> roadrunner_handler:response().
 serve_file(FilePath, TtlMs, Req) ->
     case cached_lookup(FilePath, TtlMs) of
-        {ok, Size, Mtime, ETag, LastMod, GzInfo} ->
-            serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, GzInfo, Req);
+        {ok, Size, Mtime, ETag, LastMod, Siblings} ->
+            serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Siblings, Req);
         miss ->
             fresh_lookup(FilePath, TtlMs, Req)
     end.
@@ -152,7 +173,7 @@ serve_file(FilePath, TtlMs, Req) ->
 %% always bypass the cache because the policy gate needs the un-followed
 %% `read_link_info` result.
 -spec cached_lookup(file:filename_all(), non_neg_integer() | infinity) ->
-    {ok, non_neg_integer(), integer(), binary(), binary(), {gz, non_neg_integer()} | nogz} | miss.
+    {ok, non_neg_integer(), integer(), binary(), binary(), siblings()} | miss.
 cached_lookup(_FilePath, TtlMs) when is_integer(TtlMs), TtlMs =< 0 ->
     miss;
 cached_lookup(FilePath, _TtlMs) ->
@@ -182,12 +203,12 @@ fresh_lookup(FilePath, TtlMs, Req) ->
             roadrunner_resp:not_found()
     end.
 
-%% Caching off (non-positive TTL): serve `lazy` — the gzip sibling is
-%% stat'd per request only when the client accepts gzip, the default-path
-%% behaviour, and nothing is cached. Caching on (positive TTL or
-%% infinity): stat the gzip sibling once now and cache the full metadata,
-%% so every later hit skips both that stat and the ETag/Last-Modified
-%% recompute.
+%% Caching off (non-positive TTL): serve `lazy` — a precompressed sibling
+%% is stat'd per request only for an encoding the client actually accepts,
+%% the default-path behaviour, and nothing is cached. Caching on (positive
+%% TTL or infinity): stat both siblings once now and cache the full
+%% metadata, so every later hit skips both that stat and the
+%% ETag/Last-Modified recompute.
 -spec serve_and_maybe_cache(
     file:filename_all(),
     non_neg_integer(),
@@ -202,9 +223,9 @@ serve_and_maybe_cache(FilePath, Size, Mtime, ETag, LastMod, TtlMs, Req) when
 ->
     serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, lazy, Req);
 serve_and_maybe_cache(FilePath, Size, Mtime, ETag, LastMod, TtlMs, Req) ->
-    GzInfo = stat_gz(FilePath),
-    ok = roadrunner_static_cache:store(FilePath, Size, Mtime, ETag, LastMod, GzInfo, TtlMs),
-    serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, GzInfo, Req).
+    Siblings = stat_siblings(FilePath),
+    ok = roadrunner_static_cache:store(FilePath, Size, Mtime, ETag, LastMod, Siblings, TtlMs),
+    serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Siblings, Req).
 
 %% Read leaf-stat after the symlink-policy gate has approved follow.
 -spec serve_followed_file(file:filename_all(), roadrunner_req:request()) ->
@@ -214,8 +235,9 @@ serve_followed_file(FilePath, Req) ->
         {ok, #file_info{type = regular, size = Size, mtime = Mtime}} ->
             ETag = etag(Size, Mtime),
             LastMod = roadrunner_http:format_http_date(Mtime),
-            %% Symlink leaves never cache, so the gzip sibling is resolved
-            %% lazily (stat'd per request, only when gzip is accepted).
+            %% Symlink leaves never cache, so a precompressed sibling is
+            %% resolved lazily (stat'd per request, only for an accepted
+            %% encoding).
             serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, lazy, Req);
         _ ->
             roadrunner_resp:not_found()
@@ -227,10 +249,10 @@ serve_followed_file(FilePath, Req) ->
     integer(),
     binary(),
     binary(),
-    lazy | {gz, non_neg_integer()} | nogz,
+    lazy | siblings(),
     roadrunner_req:request()
 ) -> roadrunner_handler:response().
-serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, GzMeta, Req) ->
+serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Siblings, Req) ->
     case is_cached(Req, ETag, Mtime) of
         true ->
             {304,
@@ -241,81 +263,128 @@ serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, GzMeta, Req) ->
                 ],
                 ~""};
         false ->
-            case maybe_serve_gzip(FilePath, ETag, LastMod, GzMeta, Req) of
+            case maybe_serve_precompressed(FilePath, ETag, LastMod, Siblings, Req) of
                 {ok, Resp} -> Resp;
                 none -> serve_with_range(FilePath, Size, ETag, LastMod, Req)
             end
     end.
 
-%% When the client opted into gzip and a `<file>.gz` sibling is on
-%% disk, serve the sibling with `Content-Encoding: gzip`. `Range`
-%% requests skip this path — byte offsets over a compressed
-%% representation have subtle semantics, so we let Range win and
-%% serve the raw file.
--spec maybe_serve_gzip(
+%% Serve a precompressed `<file>.br` / `<file>.gz` sibling when the
+%% client accepts a matching encoding and the sibling is on disk, brotli
+%% preferred. `Range` requests skip this path — byte offsets over a
+%% compressed representation have subtle semantics, so we let Range win
+%% and serve the raw file.
+-spec maybe_serve_precompressed(
     file:filename_all(),
     binary(),
     binary(),
-    lazy | {gz, non_neg_integer()} | nogz,
+    lazy | siblings(),
     roadrunner_req:request()
 ) -> {ok, roadrunner_handler:response()} | none.
-maybe_serve_gzip(FilePath, ETag, LastMod, GzMeta, Req) ->
-    case
-        (roadrunner_req:header(~"range", Req) =:= undefined) andalso
-            accepts_gzip(Req)
-    of
-        true ->
-            case resolve_gz(FilePath, GzMeta) of
-                {gz, GzSize} ->
-                    {ok, gzip_response(FilePath, gz_path(FilePath), GzSize, ETag, LastMod)};
-                nogz ->
+maybe_serve_precompressed(FilePath, ETag, LastMod, Siblings, Req) ->
+    case roadrunner_req:header(~"range", Req) of
+        undefined ->
+            case choose_sibling(FilePath, Siblings, Req) of
+                {Encoding, SiblingPath, SiblingSize} ->
+                    {ok,
+                        precompressed_response(
+                            FilePath, Encoding, SiblingPath, SiblingSize, ETag, LastMod
+                        )};
+                none ->
                     none
             end;
-        false ->
+        _ ->
             none
     end.
 
-%% Resolve the gzip-sibling result: use the cached value, or stat the
-%% sibling now (`lazy` — the no-cache / symlink path).
--spec resolve_gz(file:filename_all(), lazy | {gz, non_neg_integer()} | nogz) ->
-    {gz, non_neg_integer()} | nogz.
-resolve_gz(FilePath, lazy) -> stat_gz(FilePath);
-resolve_gz(_FilePath, GzInfo) -> GzInfo.
-
-%% Stat the `<file>.gz` sibling: `{gz, GzSize}` when it is a regular file,
-%% `nogz` otherwise.
--spec stat_gz(file:filename_all()) -> {gz, non_neg_integer()} | nogz.
-stat_gz(FilePath) ->
-    case file:read_file_info(gz_path(FilePath), [raw, {time, posix}]) of
-        {ok, #file_info{type = regular, size = GzSize}} -> {gz, GzSize};
-        _ -> nogz
+%% Negotiate which precompressed sibling (if any) to serve. Brotli wins
+%% over gzip when the client accepts both and the `.br` sibling exists.
+%% Returns `{ContentEncoding, SiblingPath, SiblingSize}` or `none`.
+-spec choose_sibling(file:filename_all(), lazy | siblings(), roadrunner_req:request()) ->
+    {binary(), binary(), non_neg_integer()} | none.
+choose_sibling(FilePath, Siblings, Req) ->
+    AcceptEnc = roadrunner_req:header(~"accept-encoding", Req),
+    case try_encoding(FilePath, br, ~"br", AcceptEnc, Siblings) of
+        none -> try_encoding(FilePath, gz, ~"gzip", AcceptEnc, Siblings);
+        Chosen -> Chosen
     end.
 
--spec gz_path(file:filename_all()) -> binary().
-gz_path(FilePath) ->
-    iolist_to_binary([FilePath, ~".gz"]).
-
--spec accepts_gzip(roadrunner_req:request()) -> boolean().
-accepts_gzip(Req) ->
-    case roadrunner_req:header(~"accept-encoding", Req) of
-        undefined -> false;
-        Bin -> binary:match(Bin, ~"gzip") =/= nomatch
+%% Resolve one candidate encoding: the client must accept its token and
+%% the sibling must be on disk. The `andalso` short-circuits so the lazy
+%% (no-cache) path only stats a sibling for an encoding the client
+%% accepts. The accept token doubles as the `Content-Encoding` value.
+-spec try_encoding(
+    file:filename_all(), br | gz, binary(), binary() | undefined, lazy | siblings()
+) -> {binary(), binary(), non_neg_integer()} | none.
+try_encoding(FilePath, Key, Token, AcceptEnc, Siblings) ->
+    case accepts(AcceptEnc, Token) andalso sibling_size(FilePath, Key, Siblings) of
+        false -> none;
+        none -> none;
+        Size -> {Token, sibling_path(FilePath, suffix(Key)), Size}
     end.
 
--spec gzip_response(
-    file:filename_all(), file:filename_all(), non_neg_integer(), binary(), binary()
+%% Plain substring match of an `Accept-Encoding` token, matching the
+%% module's documented simplification over RFC 9110 qvalue ranking.
+-spec accepts(binary() | undefined, binary()) -> boolean().
+accepts(undefined, _Token) -> false;
+accepts(AcceptEnc, Token) -> binary:match(AcceptEnc, Token) =/= nomatch.
+
+%% Size of a precompressed sibling, or `none` when it is not on disk.
+%% `lazy` (no-cache / symlink path) stats the sibling now; a cached
+%% `siblings()` map already carries the size under the encoding key.
+-spec sibling_size(file:filename_all(), br | gz, lazy | siblings()) ->
+    non_neg_integer() | none.
+sibling_size(FilePath, Key, lazy) ->
+    stat_sibling(sibling_path(FilePath, suffix(Key)));
+sibling_size(_FilePath, Key, Siblings) ->
+    case Siblings of
+        #{Key := Size} -> Size;
+        _ -> none
+    end.
+
+%% Stat both precompressed siblings once for caching: a `siblings()` map
+%% carrying the size of each sibling that is a regular file on disk.
+-spec stat_siblings(file:filename_all()) -> siblings().
+stat_siblings(FilePath) ->
+    Base = add_sibling(#{}, br, stat_sibling(sibling_path(FilePath, ~".br"))),
+    add_sibling(Base, gz, stat_sibling(sibling_path(FilePath, ~".gz"))).
+
+%% Insert an encoding's size into the siblings map only when on disk.
+-spec add_sibling(siblings(), br | gz, non_neg_integer() | none) -> siblings().
+add_sibling(Siblings, _Key, none) -> Siblings;
+add_sibling(Siblings, Key, Size) -> Siblings#{Key => Size}.
+
+%% Stat a precompressed sibling path: its byte size when it is a regular
+%% file, `none` otherwise.
+-spec stat_sibling(file:filename_all()) -> non_neg_integer() | none.
+stat_sibling(Path) ->
+    case file:read_file_info(Path, [raw, {time, posix}]) of
+        {ok, #file_info{type = regular, size = Size}} -> Size;
+        _ -> none
+    end.
+
+-spec suffix(br | gz) -> binary().
+suffix(br) -> ~".br";
+suffix(gz) -> ~".gz".
+
+-spec sibling_path(file:filename_all(), binary()) -> binary().
+sibling_path(FilePath, Suffix) ->
+    iolist_to_binary([FilePath, Suffix]).
+
+-spec precompressed_response(
+    file:filename_all(), binary(), file:filename_all(), non_neg_integer(), binary(), binary()
 ) -> roadrunner_handler:response().
-gzip_response(OrigPath, GzPath, GzSize, ETag, LastMod) ->
+precompressed_response(OrigPath, Encoding, SiblingPath, SiblingSize, ETag, LastMod) ->
     {sendfile, 200,
         [
             {~"content-type", content_type_for(OrigPath)},
-            {~"content-encoding", ~"gzip"},
-            {~"content-length", integer_to_binary(GzSize)},
+            {~"content-encoding", Encoding},
+            {~"content-length", integer_to_binary(SiblingSize)},
             {~"etag", ETag},
             {~"last-modified", LastMod},
             {~"vary", ~"Accept-Encoding"}
         ],
-        {GzPath, 0, GzSize}}.
+        {SiblingPath, 0, SiblingSize}}.
 
 %% Cache hit when either:
 %% - `If-None-Match` matches the current ETag (strong validator), or

--- a/src/roadrunner_static_cache.erl
+++ b/src/roadrunner_static_cache.erl
@@ -3,11 +3,12 @@
 
 %% Owner and API for the node-global static-file metadata cache.
 %%
-%% `roadrunner_static` caches each served file's `{Size, Mtime, Expiry}`
-%% (opt-in via the `cache_ttl_ms` route option) so hot paths skip the
-%% per-request `read_link_info` syscall. This module owns the backing
-%% store and exposes `lookup/1` / `store/4` / `clear/0`; callers never
-%% see the representation.
+%% `roadrunner_static` caches each served file's metadata (size, mtime,
+%% derived validators, precompressed-siblings map, expiry) opt-in via the
+%% `cache_ttl_ms` route option so hot paths skip the per-request
+%% `read_link_info` syscall. This module owns the backing store and
+%% exposes `lookup/1` / `store/7` / `clear/0`; callers never see the
+%% representation.
 %%
 %% The store is a public named ETS table, so `lookup`/`store`/`clear`
 %% run in the CALLER process (no message round-trip): reads and writes
@@ -30,20 +31,21 @@ start_link() ->
 %% Read the cached metadata for FilePath if it is still within its TTL.
 %% An infinity entry is always a hit; an expired entry is dropped (cheap
 %% in ETS) and reported as a miss. The cached value carries the derived
-%% ETag + Last-Modified strings and the gzip-sibling result, so a hit
-%% skips recomputing them and skips the per-request `<file>.gz` stat.
+%% ETag + Last-Modified strings and the precompressed-siblings map, so a
+%% hit skips recomputing them and skips the per-request `.br` / `.gz`
+%% sibling stats.
 -spec lookup(file:filename_all()) ->
-    {ok, non_neg_integer(), integer(), binary(), binary(), {gz, non_neg_integer()} | nogz} | miss.
+    {ok, non_neg_integer(), integer(), binary(), binary(), roadrunner_static:siblings()} | miss.
 lookup(FilePath) ->
     case ets:lookup(?TABLE, FilePath) of
         [] ->
             miss;
-        [{_, {Size, Mtime, ETag, LastMod, GzInfo, infinity}}] ->
-            {ok, Size, Mtime, ETag, LastMod, GzInfo};
-        [{_, {Size, Mtime, ETag, LastMod, GzInfo, ExpiresAt}}] ->
+        [{_, {Size, Mtime, ETag, LastMod, Siblings, infinity}}] ->
+            {ok, Size, Mtime, ETag, LastMod, Siblings};
+        [{_, {Size, Mtime, ETag, LastMod, Siblings, ExpiresAt}}] ->
             case erlang:monotonic_time(millisecond) of
                 Now when Now =< ExpiresAt ->
-                    {ok, Size, Mtime, ETag, LastMod, GzInfo};
+                    {ok, Size, Mtime, ETag, LastMod, Siblings};
                 _ ->
                     true = ets:delete(?TABLE, FilePath),
                     miss
@@ -51,25 +53,25 @@ lookup(FilePath) ->
     end.
 
 %% Store the size, mtime, derived ETag + Last-Modified strings, and the
-%% gzip-sibling result (`{gz, GzSize}` when a `<file>.gz` is on disk,
-%% `nogz` otherwise) for FilePath with a TTL of TtlMs ms from now, or
-%% forever when TtlMs is infinity. Concurrent stores for the same path
-%% are last-writer-wins (each insert is atomic per key).
+%% precompressed-siblings map (the size of each `<file>.br` / `<file>.gz`
+%% sibling on disk, keyed by encoding) for FilePath with a TTL of TtlMs ms
+%% from now, or forever when TtlMs is infinity. Concurrent stores for the
+%% same path are last-writer-wins (each insert is atomic per key).
 -spec store(
     file:filename_all(),
     non_neg_integer(),
     integer(),
     binary(),
     binary(),
-    {gz, non_neg_integer()} | nogz,
+    roadrunner_static:siblings(),
     pos_integer() | infinity
 ) -> ok.
-store(FilePath, Size, Mtime, ETag, LastMod, GzInfo, infinity) ->
-    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, GzInfo, infinity}}),
+store(FilePath, Size, Mtime, ETag, LastMod, Siblings, infinity) ->
+    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, Siblings, infinity}}),
     ok;
-store(FilePath, Size, Mtime, ETag, LastMod, GzInfo, TtlMs) when is_integer(TtlMs), TtlMs > 0 ->
+store(FilePath, Size, Mtime, ETag, LastMod, Siblings, TtlMs) when is_integer(TtlMs), TtlMs > 0 ->
     ExpiresAt = erlang:monotonic_time(millisecond) + TtlMs,
-    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, GzInfo, ExpiresAt}}),
+    true = ets:insert(?TABLE, {FilePath, {Size, Mtime, ETag, LastMod, Siblings, ExpiresAt}}),
     ok.
 
 %% Drop every cached entry in one call.

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -412,6 +412,99 @@ static_test_() ->
                     ]
                 ),
                 ?assertMatch(<<"HTTP/1.1 304 ", _/binary>>, Reply2)
+            end},
+            {"Accept-Encoding br serves the .br sibling with Content-Encoding", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/bronly.css", [{~"Accept-Encoding", ~"br"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                {match, _} = re:run(Reply, ~"content-encoding: br", [caseless]),
+                {match, _} = re:run(Reply, ~"vary: Accept-Encoding", [caseless]),
+                %% Content-Type reflects the original `.css`, not `.br`.
+                {match, _} = re:run(Reply, ~"content-type: text/css", [caseless]),
+                %% Content-Length is the `.br` sibling's size (19 bytes).
+                {match, _} = re:run(Reply, ~"content-length: 19", [caseless]),
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(~"brotli-bytes-bronly", Body)
+            end},
+            {"br is preferred over gzip when both siblings exist", fun() ->
+                %% Browsers send `br;q=1, gzip;q=0.8`; plain substring of
+                %% both tokens matches, and brotli wins.
+                Reply = http_get_with(
+                    Port,
+                    ~"/static/both.css",
+                    [{~"Accept-Encoding", ~"br;q=1, gzip;q=0.8"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                {match, _} = re:run(Reply, ~"content-encoding: br", [caseless]),
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(~"brotli-bytes-both", Body)
+            end},
+            {"br accepted but no .br sibling falls back to the .gz sibling", fun() ->
+                %% compressible.css has a `.gz` but no `.br`; a client that
+                %% accepts both gets gzip.
+                Reply = http_get_with(
+                    Port,
+                    ~"/static/compressible.css",
+                    [{~"Accept-Encoding", ~"br, gzip"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                {match, _} = re:run(Reply, ~"content-encoding: gzip", [caseless]),
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(
+                    zlib:gzip(<<"body { background: white; padding: 1em; }">>), Body
+                )
+            end},
+            {"br-only accept with just a .gz sibling serves raw", fun() ->
+                %% br is accepted but no `.br` exists; gzip is not accepted,
+                %% so the existing `.gz` is not served — raw file wins.
+                Reply = http_get_with(
+                    Port, ~"/static/compressible.css", [{~"Accept-Encoding", ~"br"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                nomatch = re:run(Reply, ~"content-encoding:", [caseless]),
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(<<"body { background: white; padding: 1em; }">>, Body)
+            end},
+            {"both encodings accepted but no siblings on disk serves raw", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/main.css", [{~"Accept-Encoding", ~"br, gzip"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                nomatch = re:run(Reply, ~"content-encoding:", [caseless]),
+                {match, _} = re:run(Reply, ~"color: red")
+            end},
+            {"Range header disables the br-sibling and serves raw bytes", fun() ->
+                Reply = http_get_with(
+                    Port,
+                    ~"/static/bronly.css",
+                    [
+                        {~"Accept-Encoding", ~"br"},
+                        {~"Range", ~"bytes=0-1"}
+                    ]
+                ),
+                ?assertMatch(<<"HTTP/1.1 206 ", _/binary>>, Reply),
+                nomatch = re:run(Reply, ~"content-encoding:", [caseless]),
+                [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+                ?assertEqual(~"h1", Body)
+            end},
+            {"If-None-Match from a br-served response still 304s", fun() ->
+                %% ETag is the original file's, reused across variants.
+                Reply = http_get_with(
+                    Port, ~"/static/bronly.css", [{~"Accept-Encoding", ~"br"}]
+                ),
+                {match, [_, ETag]} = re:run(
+                    Reply, ~"etag: (\"[^\"]+\")", [caseless, {capture, all, binary}]
+                ),
+                Reply2 = http_get_with(
+                    Port,
+                    ~"/static/bronly.css",
+                    [
+                        {~"Accept-Encoding", ~"br"},
+                        {~"If-None-Match", ETag}
+                    ]
+                ),
+                ?assertMatch(<<"HTTP/1.1 304 ", _/binary>>, Reply2)
             end}
         ]
     end}.
@@ -461,33 +554,34 @@ cache_helpers_test_() ->
             {"cache_put then cache_get within TTL returns the entry", fun() ->
                 FilePath = filename:join(Dir, "fresh.txt"),
                 ok = roadrunner_static_cache:store(
-                    FilePath, 100, 1700000000, ~"etag-fresh", ~"lm-fresh", nogz, 60000
+                    FilePath, 100, 1700000000, ~"etag-fresh", ~"lm-fresh", #{}, 60000
                 ),
                 ?assertEqual(
-                    {ok, 100, 1700000000, ~"etag-fresh", ~"lm-fresh", nogz},
+                    {ok, 100, 1700000000, ~"etag-fresh", ~"lm-fresh", #{}},
                     roadrunner_static_cache:lookup(FilePath)
                 )
             end},
             {"cache_get returns miss after TTL expires", fun() ->
                 FilePath = filename:join(Dir, "expiring.txt"),
-                ok = roadrunner_static_cache:store(FilePath, 50, 1700000000, ~"e", ~"lm", nogz, 1),
+                ok = roadrunner_static_cache:store(FilePath, 50, 1700000000, ~"e", ~"lm", #{}, 1),
                 timer:sleep(20),
                 ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath))
             end},
             {"cache_ttl_ms => infinity entries never expire", fun() ->
                 %% No `monotonic_time + infinity` arithmetic; sleeping
-                %% past any finite TTL must still return the entry.
+                %% past any finite TTL must still return the entry. The
+                %% siblings map carries both encodings' sizes.
                 FilePath = filename:join(Dir, "forever.txt"),
                 ok = roadrunner_static_cache:store(
-                    FilePath, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", {gz, 17}, infinity
+                    FilePath, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", #{br => 9, gz => 17}, infinity
                 ),
                 ?assertEqual(
-                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", {gz, 17}},
+                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", #{br => 9, gz => 17}},
                     roadrunner_static_cache:lookup(FilePath)
                 ),
                 timer:sleep(10),
                 ?assertEqual(
-                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", {gz, 17}},
+                    {ok, 42, 1700000000, ~"etag-fvr", ~"lm-fvr", #{br => 9, gz => 17}},
                     roadrunner_static_cache:lookup(FilePath)
                 )
             end},
@@ -495,9 +589,9 @@ cache_helpers_test_() ->
                 F1 = filename:join(Dir, "clear_a.txt"),
                 F2 = filename:join(Dir, "clear_b.txt"),
                 ok = roadrunner_static_cache:store(
-                    F1, 10, 1700000000, ~"e1", ~"lm1", nogz, infinity
+                    F1, 10, 1700000000, ~"e1", ~"lm1", #{}, infinity
                 ),
-                ok = roadrunner_static_cache:store(F2, 20, 1700000000, ~"e2", ~"lm2", nogz, 60000),
+                ok = roadrunner_static_cache:store(F2, 20, 1700000000, ~"e2", ~"lm2", #{}, 60000),
                 ok = roadrunner_static:cache_clear(),
                 ?assertEqual(miss, roadrunner_static_cache:lookup(F1)),
                 ?assertEqual(miss, roadrunner_static_cache:lookup(F2))
@@ -518,7 +612,7 @@ cache_populated_after_request_test_() ->
                 ?assertEqual(miss, roadrunner_static_cache:lookup(FilePath)),
                 _Reply = http_get(Port, ~"/static/cached.txt"),
                 ?assertMatch(
-                    {ok, _Size, _Mtime, _ETag, _LastMod, _GzInfo},
+                    {ok, _Size, _Mtime, _ETag, _LastMod, _Siblings},
                     roadrunner_static_cache:lookup(FilePath)
                 )
             end},
@@ -547,6 +641,56 @@ cache_populated_after_request_test_() ->
                 ),
                 {match, _} = re:run(R1, ~"content-encoding: gzip", [caseless]),
                 {match, _} = re:run(R2, ~"content-encoding: gzip", [caseless])
+            end},
+            {"cache hit serves the br sibling from the cached map", fun() ->
+                R1 = http_get_with(
+                    Port, ~"/static/br_cached.css", [{~"Accept-Encoding", ~"br"}]
+                ),
+                R2 = http_get_with(
+                    Port, ~"/static/br_cached.css", [{~"Accept-Encoding", ~"br"}]
+                ),
+                {match, _} = re:run(R1, ~"content-encoding: br", [caseless]),
+                {match, _} = re:run(R2, ~"content-encoding: br", [caseless]),
+                [_, Body] = binary:split(R2, ~"\r\n\r\n"),
+                ?assertEqual(~"brotli-cached-bytes", Body)
+            end},
+            {"cache hit prefers br over gz from the cached map", fun() ->
+                R1 = http_get_with(
+                    Port, ~"/static/dual_cached.css", [{~"Accept-Encoding", ~"br, gzip"}]
+                ),
+                R2 = http_get_with(
+                    Port, ~"/static/dual_cached.css", [{~"Accept-Encoding", ~"br, gzip"}]
+                ),
+                {match, _} = re:run(R1, ~"content-encoding: br", [caseless]),
+                {match, _} = re:run(R2, ~"content-encoding: br", [caseless]),
+                [_, Body] = binary:split(R2, ~"\r\n\r\n"),
+                ?assertEqual(~"brotli-dual-bytes", Body)
+            end},
+            {"cached br-absent falls back to gz from the map", fun() ->
+                %% gz_cached.css has only a `.gz`; a client accepting both
+                %% gets gzip from the cached map (no per-request stat).
+                R1 = http_get_with(
+                    Port, ~"/static/gz_cached.css", [{~"Accept-Encoding", ~"br, gzip"}]
+                ),
+                R2 = http_get_with(
+                    Port, ~"/static/gz_cached.css", [{~"Accept-Encoding", ~"br, gzip"}]
+                ),
+                {match, _} = re:run(R1, ~"content-encoding: gzip", [caseless]),
+                {match, _} = re:run(R2, ~"content-encoding: gzip", [caseless])
+            end},
+            {"cached gz-absent with gzip-only serves raw", fun() ->
+                %% br_cached.css has only a `.br`; a gzip-only client gets
+                %% the raw file from the cached map.
+                R1 = http_get_with(
+                    Port, ~"/static/br_cached.css", [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                R2 = http_get_with(
+                    Port, ~"/static/br_cached.css", [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                nomatch = re:run(R1, ~"content-encoding:", [caseless]),
+                nomatch = re:run(R2, ~"content-encoding:", [caseless]),
+                [_, Body] = binary:split(R2, ~"\r\n\r\n"),
+                ?assertEqual(~"a{}", Body)
             end}
         ]
     end}.
@@ -624,6 +768,12 @@ cache_enabled_setup() ->
     ok = file:write_file(filename:join(Dir, "cached.txt"), ~"cached"),
     ok = file:write_file(filename:join(Dir, "gz_cached.css"), ~"body{}"),
     ok = file:write_file(filename:join(Dir, "gz_cached.css.gz"), zlib:gzip(~"body{}")),
+    %% Brotli-only and both-siblings fixtures for the cached negotiation.
+    ok = file:write_file(filename:join(Dir, "br_cached.css"), ~"a{}"),
+    ok = file:write_file(filename:join(Dir, "br_cached.css.br"), ~"brotli-cached-bytes"),
+    ok = file:write_file(filename:join(Dir, "dual_cached.css"), ~"b{}"),
+    ok = file:write_file(filename:join(Dir, "dual_cached.css.br"), ~"brotli-dual-bytes"),
+    ok = file:write_file(filename:join(Dir, "dual_cached.css.gz"), zlib:gzip(~"b{}")),
     {ok, _} = roadrunner_listener:start_link(Name, #{
         port => 0,
         routes => [
@@ -774,6 +924,15 @@ setup() ->
     GzOriginal = <<"body { background: white; padding: 1em; }">>,
     ok = file:write_file(filename:join(Dir, "compressible.css"), GzOriginal),
     ok = file:write_file(filename:join(Dir, "compressible.css.gz"), zlib:gzip(GzOriginal)),
+    %% Brotli-sibling fixtures. We serve a `.br` sibling verbatim with no
+    %% codec dependency, so its bytes are an opaque marker — distinct from
+    %% the original so tests can verify which file was opened.
+    ok = file:write_file(filename:join(Dir, "bronly.css"), ~"h1 { color: blue; }"),
+    ok = file:write_file(filename:join(Dir, "bronly.css.br"), ~"brotli-bytes-bronly"),
+    %% Both siblings present — brotli must win when the client accepts both.
+    ok = file:write_file(filename:join(Dir, "both.css"), ~"p { margin: 0; }"),
+    ok = file:write_file(filename:join(Dir, "both.css.br"), ~"brotli-bytes-both"),
+    ok = file:write_file(filename:join(Dir, "both.css.gz"), zlib:gzip(~"p { margin: 0; }")),
     ok = file:write_file(filename:join(Dir, "empty.txt"), <<>>),
     ok = file:write_file(filename:join(Dir, "notes.txt"), ~"hello via link"),
     %% Safe in-docroot symlink (relative target, no `..`).


### PR DESCRIPTION
# Description

`roadrunner_static` already serves a `<file>.gz` sibling when the client sends `Accept-Encoding: gzip`. This generalizes that to also serve a `<file>.br` brotli sibling, preferring brotli over gzip when the client accepts both and the `.br` sibling exists, then falling back to gzip and finally the raw file. It stays serve-only: roadrunner `sendfile`s a sibling the operator placed on disk, with no compression codec dependency. The original file's `Content-Type`, ETag, and Last-Modified are reused, and a `Range` request still serves the raw file.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
