### PR TITLE
Shift the WebSocket unmask tail mask instead of repacking it

### DIFF
--- a/src/roadrunner_ws.erl
+++ b/src/roadrunner_ws.erl
@@ -783,16 +783,16 @@ unmask_chunks(<<O:32, Rest/binary>>, MK, Acc) ->
     T = O bxor MK,
     unmask_chunks(Rest, MK, <<Acc/binary, T:32>>);
 unmask_chunks(<<O:24>>, MK, Acc) ->
-    <<MK2:24, _:8>> = <<MK:32>>,
-    T = O bxor MK2,
+    %% Tail of 1-3 bytes: XOR against the high bytes of the 32-bit mask
+    %% (the bytes the cycle lands on next). Shifting the mask down beats
+    %% repacking it into a binary and re-matching the leading bytes.
+    T = O bxor (MK bsr 8),
     <<Acc/binary, T:24>>;
 unmask_chunks(<<O:16>>, MK, Acc) ->
-    <<MK2:16, _:16>> = <<MK:32>>,
-    T = O bxor MK2,
+    T = O bxor (MK bsr 16),
     <<Acc/binary, T:16>>;
 unmask_chunks(<<O:8>>, MK, Acc) ->
-    <<MK2:8, _:24>> = <<MK:32>>,
-    T = O bxor MK2,
+    T = O bxor (MK bsr 24),
     <<Acc/binary, T:8>>;
 unmask_chunks(<<>>, _MK, Acc) ->
     Acc.

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -626,16 +626,16 @@ unmask_slice_chunks(<<O:32, Rest/binary>>, MK, Acc) ->
     T = O bxor MK,
     unmask_slice_chunks(Rest, MK, <<Acc/binary, T:32>>);
 unmask_slice_chunks(<<O:24>>, MK, Acc) ->
-    <<MK2:24, _:8>> = <<MK:32>>,
-    T = O bxor MK2,
+    %% Tail of 1-3 bytes: XOR against the high bytes of the 32-bit mask
+    %% (the bytes the cycle lands on next). Shifting the mask down beats
+    %% repacking it into a binary and re-matching the leading bytes.
+    T = O bxor (MK bsr 8),
     <<Acc/binary, T:24>>;
 unmask_slice_chunks(<<O:16>>, MK, Acc) ->
-    <<MK2:16, _:16>> = <<MK:32>>,
-    T = O bxor MK2,
+    T = O bxor (MK bsr 16),
     <<Acc/binary, T:16>>;
 unmask_slice_chunks(<<O:8>>, MK, Acc) ->
-    <<MK2:8, _:24>> = <<MK:32>>,
-    T = O bxor MK2,
+    T = O bxor (MK bsr 24),
     <<Acc/binary, T:8>>;
 unmask_slice_chunks(<<>>, _MK, Acc) ->
     Acc.


### PR DESCRIPTION
# Description

The 1-3 byte tail of the WebSocket unmask loop extracted the leading mask bytes by repacking the 32-bit masking key into a binary and re-matching (`<<MK2:24, _:8>> = <<MK:32>>`). Replacing that with an integer shift (`MK bsr 8/16/24`) produces bit-identical output and avoids the per-tail binary allocation. Any frame whose payload length isn't a multiple of 4 hits a tail clause, so the common small-echo path benefits. Microbenchmark (pinned scheduler, paired sign test): ~6-10 ns saved per echo.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
