### PR TITLE
Add a cache_control option to the static file handler

### DIFF
--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -46,6 +46,39 @@ semantics and the simple "Range wins" rule matches what nginx does.
 The `Content-Type` always reflects the original file's extension,
 not the sibling's.
 
+## Cache-Control
+
+`#{cache_control => Value}` sets a `Cache-Control` response header,
+verbatim, on every cacheable response for the file — the `200` (full
+file and any precompressed sibling), the `206` range, and the
+`304 Not Modified`. A `404` or a `416` never carries it, so a missing
+file or an unsatisfiable range is never marked cacheable.
+
+The value is an opaque binary the operator controls in full —
+roadrunner does not parse, validate, or merge directives. This mirrors
+nginx's `add_header Cache-Control`, where the operator writes the exact
+directive string.
+
+The option is off by default. With no `cache_control` key the responses
+are byte-for-byte what they are without it, carrying no `Cache-Control`
+header at all. `ETag` and `Last-Modified` only enable conditional
+revalidation — a follow-up request that may come back `304` — whereas
+`Cache-Control` is what lets a browser or a CDN reuse the resource from
+its own cache without contacting the server at all.
+
+A typical value for content-hashed build assets:
+
+```
+{~"/static/*path", roadrunner_static, #{
+    dir => ~"/var/www",
+    cache_control => ~"public, max-age=31536000, immutable"
+}}
+```
+
+`max-age` caps how many seconds a cache may reuse the response,
+`immutable` tells browsers not to revalidate during that window, and
+`public` lets shared caches such as CDNs and proxies store it.
+
 ## Symlink policy
 
 `#{symlink_policy => Policy}` (default `refuse_escapes`) controls
@@ -139,9 +172,14 @@ handle(Req) ->
                     #{cache_ttl_ms := T} -> T;
                     _ -> ?DEFAULT_CACHE_TTL_MS
                 end,
+            CacheControl =
+                case State of
+                    #{cache_control := V} -> V;
+                    _ -> undefined
+                end,
             #{dir := Dir} = State,
             FilePath = filename:join([Dir | Segments]),
-            {serve_file(FilePath, TtlMs, Req), Req};
+            {maybe_cache_control(serve_file(FilePath, TtlMs, Req), CacheControl), Req};
         traversal ->
             {roadrunner_resp:not_found(), Req}
     end.
@@ -155,6 +193,24 @@ docroot, without restarting the listener.
 -spec cache_clear() -> ok.
 cache_clear() ->
     roadrunner_static_cache:clear().
+
+%% Prepend the configured `Cache-Control` header to the cacheable
+%% responses. `sendfile` responses are the 200 (full file and
+%% precompressed sibling) and the 206 range; the only cacheable buffered
+%% response is the 304 Not Modified. The 416 and 404 (and any other
+%% shape) fall through unchanged so an unsatisfiable range or a missing
+%% file is never marked cacheable, and `undefined` (the option unset)
+%% returns every response verbatim.
+-spec maybe_cache_control(roadrunner_handler:response(), binary() | undefined) ->
+    roadrunner_handler:response().
+maybe_cache_control(Resp, undefined) ->
+    Resp;
+maybe_cache_control({sendfile, Status, Headers, FileSpec}, Value) ->
+    {sendfile, Status, [{~"cache-control", Value} | Headers], FileSpec};
+maybe_cache_control({304, Headers, Body}, Value) ->
+    {304, [{~"cache-control", Value} | Headers], Body};
+maybe_cache_control(Resp, _Value) ->
+    Resp.
 
 -spec serve_file(
     file:filename_all(), non_neg_integer() | infinity, roadrunner_req:request()

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -540,6 +540,146 @@ symlink_policy_refuse_test_() ->
         end}.
 
 %% =============================================================================
+%% Cache-Control route opt — the configured value rides every cacheable
+%% response (200 full file, 200 precompressed sibling, 206 range, 304) and
+%% never the 404 / 416. A dedicated listener carries the opt; the default
+%% setup (opt unset) guards the no-header regression.
+%% =============================================================================
+
+-define(CACHE_CONTROL_VALUE, ~"public, max-age=31536000, immutable").
+
+cache_control_test_() ->
+    {setup, fun cache_control_setup/0, fun cache_control_cleanup/1, fun({_Name, _Dir, Port}) ->
+        [
+            {"200 full file carries the configured Cache-Control verbatim", fun() ->
+                Reply = http_get(Port, ~"/static/asset.css"),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                assert_cache_control(Reply, ?CACHE_CONTROL_VALUE)
+            end},
+            {"200 gzip sibling carries Cache-Control", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/asset.css", [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                {match, _} = re:run(Reply, ~"content-encoding: gzip", [caseless]),
+                assert_cache_control(Reply, ?CACHE_CONTROL_VALUE)
+            end},
+            {"200 br sibling carries Cache-Control", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/asset.css", [{~"Accept-Encoding", ~"br"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                {match, _} = re:run(Reply, ~"content-encoding: br", [caseless]),
+                assert_cache_control(Reply, ?CACHE_CONTROL_VALUE)
+            end},
+            {"206 range carries Cache-Control", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/asset.css", [{~"Range", ~"bytes=0-3"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 206 ", _/binary>>, Reply),
+                assert_cache_control(Reply, ?CACHE_CONTROL_VALUE)
+            end},
+            {"304 Not Modified carries Cache-Control", fun() ->
+                Reply1 = http_get(Port, ~"/static/asset.css"),
+                {match, [_, ETag]} = re:run(
+                    Reply1, ~"etag: (\"[^\"]+\")", [caseless, {capture, all, binary}]
+                ),
+                Reply2 = http_get_with(
+                    Port, ~"/static/asset.css", [{~"If-None-Match", ETag}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 304 ", _/binary>>, Reply2),
+                assert_cache_control(Reply2, ?CACHE_CONTROL_VALUE)
+            end},
+            {"416 unsatisfiable range never carries Cache-Control", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/asset.css", [{~"Range", ~"bytes=999-1000"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 416 ", _/binary>>, Reply),
+                assert_no_cache_control(Reply)
+            end},
+            {"404 missing file never carries Cache-Control", fun() ->
+                Reply = http_get(Port, ~"/static/nope.css"),
+                ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply),
+                assert_no_cache_control(Reply)
+            end}
+        ]
+    end}.
+
+cache_control_unset_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun({_Dir, Port}) ->
+        [
+            {"unset: 200 full file has no Cache-Control header", fun() ->
+                Reply = http_get(Port, ~"/static/hello.html"),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                assert_no_cache_control(Reply)
+            end},
+            {"unset: 200 gzip sibling has no Cache-Control header", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/compressible.css", [{~"Accept-Encoding", ~"gzip"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+                assert_no_cache_control(Reply)
+            end},
+            {"unset: 206 range has no Cache-Control header", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/hello.html", [{~"Range", ~"bytes=0-3"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 206 ", _/binary>>, Reply),
+                assert_no_cache_control(Reply)
+            end},
+            {"unset: 304 has no Cache-Control header", fun() ->
+                Reply1 = http_get(Port, ~"/static/hello.html"),
+                {match, [_, ETag]} = re:run(
+                    Reply1, ~"etag: (\"[^\"]+\")", [caseless, {capture, all, binary}]
+                ),
+                Reply2 = http_get_with(
+                    Port, ~"/static/hello.html", [{~"If-None-Match", ETag}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 304 ", _/binary>>, Reply2),
+                assert_no_cache_control(Reply2)
+            end},
+            {"unset: 416 has no Cache-Control header", fun() ->
+                Reply = http_get_with(
+                    Port, ~"/static/hello.html", [{~"Range", ~"bytes=100-200"}]
+                ),
+                ?assertMatch(<<"HTTP/1.1 416 ", _/binary>>, Reply),
+                assert_no_cache_control(Reply)
+            end},
+            {"unset: 404 has no Cache-Control header", fun() ->
+                Reply = http_get(Port, ~"/static/missing.txt"),
+                ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply),
+                assert_no_cache_control(Reply)
+            end}
+        ]
+    end}.
+
+cache_control_setup() ->
+    Name = static_test_cache_control,
+    Dir = filename:join(
+        "/tmp", "rr_cache_control_" ++ integer_to_list(rand:uniform(1000000))
+    ),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    Css = ~"body { color: red; }",
+    ok = file:write_file(filename:join(Dir, "asset.css"), Css),
+    %% Both siblings present so the gzip and brotli 200 paths are reachable.
+    ok = file:write_file(filename:join(Dir, "asset.css.gz"), zlib:gzip(Css)),
+    ok = file:write_file(filename:join(Dir, "asset.css.br"), ~"brotli-bytes-asset"),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        routes => [
+            {~"/static/*path", roadrunner_static, #{
+                dir => Dir, cache_control => ?CACHE_CONTROL_VALUE
+            }}
+        ]
+    }),
+    {Name, Dir, roadrunner_listener:port(Name)}.
+
+cache_control_cleanup({Name, Dir, _Port}) ->
+    ok = roadrunner_listener:stop(Name),
+    _ = file:del_dir_r(Dir),
+    ok.
+
+%% =============================================================================
 %% Metadata cache — direct cache helpers plus end-to-end coverage of the
 %% `cache_ttl_ms` route opt.
 %% =============================================================================
@@ -1016,3 +1156,12 @@ recv_until_closed(Sock, Acc) ->
         {ok, Data} -> recv_until_closed(Sock, <<Acc/binary, Data/binary>>);
         {error, _} -> Acc
     end.
+
+assert_cache_control(Reply, Value) ->
+    {match, [_, Got]} = re:run(
+        Reply, ~"cache-control: ([^\r\n]+)", [caseless, {capture, all, binary}]
+    ),
+    ?assertEqual(Value, Got).
+
+assert_no_cache_control(Reply) ->
+    ?assertEqual(nomatch, re:run(Reply, ~"cache-control:", [caseless])).


### PR DESCRIPTION
# Description

`roadrunner_static` sets `ETag` and `Last-Modified` for conditional revalidation but offers no way to set a `Cache-Control` header. This adds an opt-in `cache_control` route option whose verbatim value is set on the cacheable responses (the 200 full file and any precompressed sibling, the 206 range, and the 304 Not Modified), so browsers and CDNs can reuse a resource without contacting the server. It is off by default: with no `cache_control` key, responses are byte-for-byte unchanged.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
