### PR TITLE
Percent-decode captured route parameters

### DIFF
--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -112,6 +112,19 @@ Captured route parameters, populated by `match/3`.
 (`#{~"id" => ~"42"}`). `*wildcard` segments produce the list of
 remaining path segments
 (`#{~"rest" => [~"a", ~"b"]}`). Empty for routes with no captures.
+
+Captured values are percent-decoded (`/users/caf%C3%A9` binds
+`<<"café"/utf8>>`), consistent with query params; a segment whose
+percent-escapes are malformed (a `%` not followed by two hex digits)
+is kept raw. Decoding does not validate UTF-8, so `%FF` binds the raw
+`0xFF` byte. There is no `+` -> space translation -- that is a
+query-string convention, so a literal `+` in a path stays a `+`.
+
+Because decoding happens after the path is split on raw `/`, a decoded
+value can contain a `/` (`%2F`), a `..`, or a leading `/` — it is not a
+single clean path component. A handler that builds a filesystem path or
+an outbound URL from a captured value must reject `..` and absolute
+segments itself; see `roadrunner_static` for the reference check.
 """.
 -type bindings() :: #{binary() => binary() | [binary()]}.
 
@@ -257,7 +270,7 @@ match_first(Method, Segments, [{Pattern, Handler, Pipeline, State, Methods} | Re
             match_first(Method, Segments, Rest, Allow);
         Bindings ->
             case method_allowed(Method, Methods) of
-                true -> {ok, Handler, Bindings, Pipeline, State};
+                true -> {ok, Handler, decode_bindings(Bindings), Pipeline, State};
                 false -> match_first(Method, Segments, Rest, maps:merge(Allow, Methods))
             end
     end.
@@ -287,6 +300,41 @@ match_pattern([{wildcard, Name}], Segs, Bindings) ->
     Bindings#{Name => Segs};
 match_pattern(_, _, _) ->
     no_match.
+
+%% Percent-decode the captured bindings of the matched route. `match/3` splits
+%% the path on raw `/`, so a `:param`/`*wildcard` segment arrives still
+%% percent-encoded (`/users/caf%C3%A9` captures `<<"caf%C3%A9">>`); decode each
+%% captured segment so handlers see the real characters, consistent with query
+%% params (`roadrunner_qs`). Decoding runs once, on the winning route only, and
+%% short-circuits the common capture-free route. Done here rather than in
+%% `match_pattern/3` so a partially-matching route that later fails does not pay
+%% to decode captures it then discards.
+-spec decode_bindings(bindings()) -> bindings().
+decode_bindings(Bindings) when map_size(Bindings) =:= 0 ->
+    Bindings;
+decode_bindings(Bindings) ->
+    #{Name => decode_value(Value) || Name := Value <- Bindings}.
+
+%% A `:param` value is a single segment; a `*wildcard` value is the list of
+%% remaining segments -- decode each element.
+-spec decode_value(binary() | [binary()]) -> binary() | [binary()].
+decode_value(Value) when is_binary(Value) ->
+    decode_segment(Value);
+decode_value(Segments) when is_list(Segments) ->
+    [decode_segment(Segment) || Segment <- Segments].
+
+%% Percent-decode one captured segment, keeping it raw on a malformed escape (a
+%% `%` not followed by two hex digits) rather than failing the match on
+%% attacker-controllable input. Decoding does not validate UTF-8, so non-UTF-8
+%% escapes pass through as their raw bytes. No `+` -> space: that is a
+%% query/form-encoding convention, not a path one (a literal `+` is valid,
+%% unencoded path data).
+-spec decode_segment(binary()) -> binary().
+decode_segment(Segment) ->
+    case roadrunner_uri:percent_decode(Segment) of
+        {ok, Decoded} -> Decoded;
+        {error, badarg} -> Segment
+    end.
 
 -spec path_segments(binary()) -> [binary()].
 path_segments(Path) ->

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -625,14 +625,27 @@ range_not_satisfiable(Size, ETag, LastMod) ->
         ],
         ~""}.
 
-%% Reject any segment that's `..` — defense against path traversal.
-%% Empty segments are already stripped by `roadrunner_router:path_segments/1`.
+%% Reject a path-traversal segment. `roadrunner_router` percent-decodes captured
+%% segments, so a single wildcard segment can now carry an embedded `/`, a `..`,
+%% or a leading `/`:
+%%   - `/static/%2e%2e%2fetc` decodes to one `<<"../etc">>` segment, and
+%%   - `/static/%2fetc%2fpasswd` decodes to one absolute `<<"/etc/passwd">>`.
+%% An absolute segment is the more dangerous case: `filename:join/1` drops the
+%% docroot entirely as soon as a later component is absolute, so the join
+%% escapes without ever going through `..`. Reject a segment that is absolute or
+%% that carries a `..` component; a bare `S =:= ~".."` would miss both. Empty
+%% segments are already stripped by `roadrunner_router:path_segments/1`.
 -spec validate_segments([binary()]) -> ok | traversal.
 validate_segments(Segments) ->
-    case lists:any(fun(S) -> S =:= ~".." end, Segments) of
+    case lists:any(fun segment_traverses/1, Segments) of
         true -> traversal;
         false -> ok
     end.
+
+-spec segment_traverses(binary()) -> boolean().
+segment_traverses(Segment) ->
+    filename:pathtype(Segment) =/= relative orelse
+        lists:member(~"..", filename:split(Segment)).
 
 %% Decide whether a symlink leaf may be served under the route's policy.
 -spec symlink_allowed(file:filename_all(), roadrunner_req:request()) -> boolean().

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -123,6 +123,53 @@ match_root_wildcard_test() ->
         match_no_pipeline(~"/", Compiled)
     ).
 
+%% =============================================================================
+%% Percent-decoded captures
+%% =============================================================================
+
+match_param_is_percent_decoded_test() ->
+    Compiled = roadrunner_router:compile([{~"/users/:name", users_handler}], []),
+    ?assertEqual(
+        {ok, users_handler, #{~"name" => <<"café"/utf8>>}, #{}},
+        match_no_pipeline(~"/users/caf%C3%A9", Compiled)
+    ).
+
+match_param_decodes_encoded_slash_within_segment_test() ->
+    %% `%2F` is not a raw `/`, so the router does not split on it — it stays one
+    %% captured segment that decodes to a literal `/` in the value.
+    Compiled = roadrunner_router:compile([{~"/files/:name", files_handler}], []),
+    ?assertEqual(
+        {ok, files_handler, #{~"name" => ~"a/b"}, #{}},
+        match_no_pipeline(~"/files/a%2Fb", Compiled)
+    ).
+
+match_param_malformed_escape_kept_raw_test() ->
+    %% A bad %-escape (non-hex) is left as the raw segment rather than failing
+    %% the match on attacker-controllable input.
+    Compiled = roadrunner_router:compile([{~"/users/:name", users_handler}], []),
+    ?assertEqual(
+        {ok, users_handler, #{~"name" => ~"a%ZZ"}, #{}},
+        match_no_pipeline(~"/users/a%ZZ", Compiled)
+    ).
+
+match_param_literal_plus_preserved_test() ->
+    %% No `+` -> space: that is a query-string convention. A `+` in a path
+    %% segment is literal data.
+    Compiled = roadrunner_router:compile([{~"/tags/:tag", tags_handler}], []),
+    ?assertEqual(
+        {ok, tags_handler, #{~"tag" => ~"a+b"}, #{}},
+        match_no_pipeline(~"/tags/a+b", Compiled)
+    ).
+
+match_wildcard_segments_are_percent_decoded_test() ->
+    %% Each captured wildcard segment decodes independently; an encoded slash
+    %% stays within its segment (the split already happened on raw `/`).
+    Compiled = roadrunner_router:compile([{~"/static/*path", static_handler}], []),
+    ?assertEqual(
+        {ok, static_handler, #{~"path" => [<<"café"/utf8>>, ~"a/b"]}, #{}},
+        match_no_pipeline(~"/static/caf%C3%A9/a%2Fb", Compiled)
+    ).
+
 match_route_with_state_test() ->
     %% 3-tuple route attaches per-handler state. State is baked into
     %% the pipeline closure (verified behaviorally by
@@ -305,11 +352,11 @@ match_empty_path_matches_root_route_test() ->
     ?assertEqual({ok, home_handler, #{}, #{}}, match_no_pipeline(~"", Compiled)).
 
 match_param_captures_percent_encoded_segment_test() ->
-    %% Router does not percent-decode — handlers see the raw segment.
-    %% Documented as "literal segments must match byte-exactly".
+    %% The router percent-decodes captured segments, so `%20` becomes a space
+    %% (consistent with query params).
     Compiled = roadrunner_router:compile([{~"/users/:id", users_handler}], []),
     ?assertEqual(
-        {ok, users_handler, #{~"id" => ~"joe%20bob"}, #{}},
+        {ok, users_handler, #{~"id" => ~"joe bob"}, #{}},
         match_no_pipeline(~"/users/joe%20bob", Compiled)
     ).
 

--- a/test/roadrunner_static_tests.erl
+++ b/test/roadrunner_static_tests.erl
@@ -7,7 +7,7 @@
 %% =============================================================================
 
 static_test_() ->
-    {setup, fun setup/0, fun cleanup/1, fun({_Dir, Port}) ->
+    {setup, fun setup/0, fun cleanup/1, fun({Dir, Port}) ->
         [
             {"serves a file with text/html content-type", fun() ->
                 Reply = http_get(Port, ~"/static/hello.html"),
@@ -274,14 +274,49 @@ static_test_() ->
                 [_Head, Body] = binary:split(Reply, ~"\r\n\r\n"),
                 ?assertEqual(<<>>, Body)
             end},
-            {"percent-encoded .. is not normalized — stays a literal segment", fun() ->
-                %% Defense-in-depth pin: the wildcard captures `%2E%2E`
-                %% byte-for-byte, the `..` validator therefore lets it
-                %% through, and `file:read_file_info/1` fails to locate
-                %% a real entry by that name → 404. If we ever start
-                %% percent-decoding wildcard segments, this test forces
-                %% us to re-derive the traversal defense.
+            {"percent-encoded .. decodes to a .. segment and is rejected", fun() ->
+                %% The router now percent-decodes captured segments, so
+                %% `%2E%2E` becomes `..`; here it lands as its own
+                %% segment (there is a raw `/` after it), which the
+                %% `..` validator rejects → 404. (Before decoding this
+                %% 404'd only incidentally, as a literal missing entry.)
                 Reply = http_get(Port, ~"/static/%2E%2E/hello.html"),
+                ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
+            end},
+            {"percent-encoded ../ inside one segment cannot escape the docroot", fun() ->
+                %% The dangerous case decoding introduces: `%2e%2e%2f...`
+                %% has no raw `/`, so it is ONE captured segment that
+                %% decodes to `../<docroot>/hello.html` — a real, existing
+                %% file reached by escaping and re-entering the docroot. A
+                %% whole-segment `=:= ".."` check would pass this and serve
+                %% the file; `validate_segments/1` splits the segment and
+                %% rejects the `..` component → 404.
+                Base = list_to_binary(filename:basename(Dir)),
+                Escape = iolist_to_binary([~"/static/%2e%2e%2f", Base, ~"%2fhello.html"]),
+                Reply = http_get(Port, Escape),
+                ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
+            end},
+            {"percent-encoded absolute path cannot escape the docroot", fun() ->
+                %% The other case decoding introduces: encoding every `/` as
+                %% `%2f` leaves no raw `/`, so the whole thing is ONE captured
+                %% segment that decodes to an ABSOLUTE path (here hello.html's
+                %% own absolute path — a real, existing file). `filename:join/1`
+                %% drops the docroot the moment a component is absolute, so a
+                %% `..`-only check would serve the file; `validate_segments/1`
+                %% rejects the absolute segment → 404.
+                AbsFile = list_to_binary(filename:join(Dir, "hello.html")),
+                Encoded = binary:replace(AbsFile, ~"/", ~"%2f", [global]),
+                Reply = http_get(Port, <<"/static/", Encoded/binary>>),
+                ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
+            end},
+            {"percent-encoded control byte in a segment → 404, no crash", fun() ->
+                %% Decoding now hands the handler attacker-controlled bytes,
+                %% including the control range `%00`-`%1f`. A decoded NUL
+                %% passes the traversal check (relative, no `..`) and reaches
+                %% `file:read_link_info/2`, which returns `{error, badarg}` —
+                %% the catch-all serves 404 rather than letting the badarg
+                %% crash the connection process.
+                Reply = http_get(Port, ~"/static/foo%00bar"),
                 ?assertMatch(<<"HTTP/1.1 404 ", _/binary>>, Reply)
             end},
             {"directory path resolves to a non-regular file → 404", fun() ->


### PR DESCRIPTION
# Description

Captured `:param` and `*wildcard` route segments are now percent-decoded, so handlers see the real characters (`/users/caf%C3%A9` binds `<<"café"/utf8>>`), matching how query params are decoded. A segment with a malformed escape is kept raw, and there is no `+` to space translation since that is a query-string convention. Because decoding runs after the path is split on raw `/`, a decoded segment can now carry a `/` (`%2F`), a `..`, or a leading `/`, so the static file handler rejects absolute and `..`-bearing segments before `filename:join` — without that, a decoded absolute segment makes `filename:join` drop the docroot and serve a file outside it.

```
GET /static/%2Fetc%2Fpasswd
  -> wildcard captures "%2Fetc%2Fpasswd" -> decodes to one absolute segment "/etc/passwd"
  -> validate_segments rejects the absolute segment -> 404 (previously would have served /etc/passwd)
```

Covered by new tests for absolute-path, `..`-re-entry, and decoded control-byte inputs; full suite passes with 100% coverage on the router and static modules.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
