### PR TITLE
Add an ip listener option to bind a specific local interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,9 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   `rate_limit` (opt-in per-peer request-rate guard)
 - **Real client IP**: `proxy_protocol` (read the PROXY-protocol header an
   L4 balancer prepends, so `roadrunner_req:peer/1` is the real client)
+- **Bind address**: `ip` (restrict a listener to a specific local
+  interface, e.g. `{127,0,0,1}` for loopback-only; default binds all
+  interfaces)
 - **Middleware**: `middlewares`
 - **Body buffering**: `body_buffering`
 - **Graceful drain**: `graceful_drain`, `slot_reconciliation`

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -139,6 +139,12 @@ Optional middleware and timing knobs (durations in milliseconds):
   depth). Default 1024. Raise it for connection bursts (load tests,
   health-check storms); Linux clamps the effective value at
   `net.core.somaxconn`.
+- `ip` — local interface to bind. Unset (the default) binds all
+  interfaces (`0.0.0.0` / `::`); set a specific address such as
+  `{127,0,0,1}` to restrict the listener to loopback, e.g. a
+  dev/admin/metrics endpoint that must not be reachable from the LAN.
+  Applies to every socket the listener binds: plain TCP, TLS, and the
+  HTTP/3 UDP socket.
 - `min_bytes_per_second` — slow-loris guard on the request-read
   phase (0 disables). Default 100.
 - `rate_check_interval` — how often the rate guard re-checks
@@ -194,6 +200,10 @@ ops-tuning rationale.
     max_clients => pos_integer(),
     max_concurrent_requests => infinity | pos_integer(),
     socket_backlog => pos_integer(),
+    %% Local interface to bind. Unset means all interfaces
+    %% (`0.0.0.0` / `::`). Set to `{127,0,0,1}` to restrict the
+    %% listener to loopback.
+    ip => inet:ip_address(),
     min_bytes_per_second => non_neg_integer(),
     %% How often `reading_request` re-checks the running
     %% bytes-per-second average against `min_bytes_per_second`.
@@ -719,10 +729,10 @@ start_quic(Port, Opts, Protocols, ProtoOpts) ->
             %% when asked for an ephemeral port, hold a reuseport probe
             %% socket to pin a free port, start the pool on it, then drop
             %% the probe (the pool listeners keep the port via reuseport).
-            {QuicPort, Probe} = resolve_quic_port(Port),
+            {QuicPort, Probe} = resolve_quic_port(Port, Opts),
             Listeners = maps:get(http3_listeners, ProtoOpts, ?DEFAULT_H3_LISTENERS),
             MaxStreamsBidi = maps:get(http3_max_streams_bidi, ProtoOpts, ?H3_MAX_STREAMS_BIDI),
-            Res = start_quic_pool(QuicPort, #{
+            PoolOpts = #{
                 cert => Cert,
                 key => Key,
                 cert_chain => CertChain,
@@ -730,7 +740,15 @@ start_quic(Port, Opts, Protocols, ProtoOpts) ->
                 max_streams_bidi => MaxStreamsBidi,
                 connection_handler => Handler,
                 pool_size => Listeners - 1
-            }),
+            },
+            %% Bind the QUIC pool to the same interface as the TCP socket
+            %% when `ip` is set, so an h3 listener honors loopback too.
+            PoolOptsIp =
+                case Opts of
+                    #{ip := IP} -> PoolOpts#{ip => IP};
+                    #{} -> PoolOpts
+                end,
+            Res = start_quic_pool(QuicPort, PoolOptsIp),
             ok = close_quic_probe(Probe),
             Res
     end.
@@ -753,13 +771,20 @@ start_quic_pool(Port, PoolOpts) ->
 
 %% Pin a free UDP port with a reuseport probe socket so all pool
 %% listeners bind the same concrete port; a fixed port is used as-is.
--spec resolve_quic_port(inet:port_number()) ->
+%% The probe binds the same interface as the pool (via `ip`) so the
+%% pinned port is genuinely free on that address, not just on `0.0.0.0`.
+-spec resolve_quic_port(inet:port_number(), opts()) ->
     {inet:port_number(), gen_udp:socket() | undefined}.
-resolve_quic_port(0) ->
-    {ok, Probe} = gen_udp:open(0, [{reuseport, true}]),
+resolve_quic_port(0, Opts) ->
+    ProbeOpts =
+        case Opts of
+            #{ip := IP} -> [{reuseport, true}, {ip, IP}];
+            #{} -> [{reuseport, true}]
+        end,
+    {ok, Probe} = gen_udp:open(0, ProbeOpts),
     {ok, ProbePort} = inet:port(Probe),
     {ProbePort, Probe};
-resolve_quic_port(Port) ->
+resolve_quic_port(Port, _Opts) ->
     {Port, undefined}.
 
 -spec close_quic_probe(gen_udp:socket() | undefined) -> ok.
@@ -948,7 +973,7 @@ base_listen_opts(Opts) ->
     %% default `max_clients = 150`). See `erlang/otp#9423` and
     %% `ninenines/cowlib#143` for the upstream context that prompted
     %% this tuning.
-    [
+    Base = [
         binary,
         {active, false},
         {reuseaddr, true},
@@ -956,7 +981,16 @@ base_listen_opts(Opts) ->
         {nodelay, true},
         {backlog, maps:get(socket_backlog, Opts, ?DEFAULT_SOCKET_BACKLOG)},
         {buffer, 65536}
-    ].
+    ],
+    %% Prepend `{ip, IP}` only when the caller set it, so the default
+    %% list (and the default all-interfaces bind) is unchanged. Both
+    %% `gen_tcp:listen/2` and `ssl:listen/2` accept `{ip, _}`, and the
+    %% TLS path builds on this list, so a loopback bind covers HTTP and
+    %% HTTPS alike.
+    case Opts of
+        #{ip := IP} -> [{ip, IP} | Base];
+        #{} -> Base
+    end.
 
 %% Multiple acceptor processes all calling gen_tcp:accept on the same listen
 %% socket — Linux/BSD accept is thread-safe and avoids thundering-herd via

--- a/src/roadrunner_quic_listener.erl
+++ b/src/roadrunner_quic_listener.erl
@@ -59,6 +59,9 @@
     transport_params := roadrunner_quic_transport_params:params(),
     connection_handler := fun((pid()) -> {ok, pid()} | {error, term()}),
     reuseport => boolean(),
+    %% Local interface to bind. Unset binds all interfaces; set to a
+    %% specific address (e.g. `{127,0,0,1}`) to bind that one only.
+    ip => inet:ip_address(),
     %% The connection-id routing table. A SO_REUSEPORT pool injects one shared
     %% table (owned by the pool supervisor) so a datagram landing on any pool
     %% socket routes to the owning connection; a standalone listener omits it
@@ -129,7 +132,12 @@ init(
     process_flag(trap_exit, true),
     [Parent | _] = get('$ancestors'),
     ReusePort = maps:get(reuseport, Opts, false),
-    case roadrunner_quic_socket:open(Port, #{active => ?ACTIVE_N, reuseport => ReusePort}) of
+    SocketOpts =
+        case Opts of
+            #{ip := IP} -> #{active => ?ACTIVE_N, reuseport => ReusePort, ip => IP};
+            #{} -> #{active => ?ACTIVE_N, reuseport => ReusePort}
+        end,
+    case roadrunner_quic_socket:open(Port, SocketOpts) of
         {ok, Socket} ->
             {ok, {_Ip, BoundPort}} = roadrunner_quic_socket:sockname(Socket),
             proc_lib:set_label({?MODULE, BoundPort}),

--- a/src/roadrunner_quic_listener_sup.erl
+++ b/src/roadrunner_quic_listener_sup.erl
@@ -53,7 +53,8 @@
     alpn := [binary(), ...],
     max_streams_bidi := non_neg_integer(),
     connection_handler := fun((pid()) -> {ok, pid()} | {error, term()}),
-    pool_size := non_neg_integer()
+    pool_size := non_neg_integer(),
+    ip => inet:ip_address()
 }.
 
 %% =============================================================================
@@ -147,7 +148,7 @@ listener_opts(Port, PoolOpts, Registry, ReusePort) ->
         max_streams_bidi := MaxStreamsBidi,
         connection_handler := Handler
     } = PoolOpts,
-    #{
+    Base = #{
         port => Port,
         %% The native listener takes the full chain leaf-first; pool_opts keeps
         %% the leaf and intermediates separate (the dep's split).
@@ -159,7 +160,13 @@ listener_opts(Port, PoolOpts, Registry, ReusePort) ->
         connection_handler => Handler,
         reuseport => ReusePort,
         registry => Registry
-    }.
+    },
+    %% Carry `ip` through to the per-listener bind only when the pool was
+    %% started with it, so an all-interfaces pool is unchanged.
+    case PoolOpts of
+        #{ip := IP} -> Base#{ip => IP};
+        #{} -> Base
+    end.
 
 -spec transport_params(non_neg_integer()) -> roadrunner_quic_transport_params:params().
 transport_params(MaxStreamsBidi) ->

--- a/src/roadrunner_quic_socket.erl
+++ b/src/roadrunner_quic_socket.erl
@@ -27,7 +27,8 @@
     recbuf => pos_integer(),
     sndbuf => pos_integer(),
     reuseport => boolean(),
-    active => active()
+    active => active(),
+    ip => inet:ip_address()
 }.
 
 %% Larger than the OS default, so a burst of datagrams is not dropped
@@ -57,13 +58,15 @@ per `N` datagrams with `activate/2` instead of once per datagram with
 Set `reuseport` to `true` to enable `SO_REUSEPORT`, which lets a pool of
 sockets share one concrete port with kernel datagram fan-out (the shape the
 listener pool uses); it defaults to `false` for a lone socket.
+
+Set `ip` to a specific local address (e.g. `{127,0,0,1}`) to bind that
+interface only; unset binds all interfaces.
 """.
 -spec open(inet:port_number(), open_opts()) -> {ok, socket()} | {error, term()}.
 open(Port, Opts) ->
-    #{recbuf := RecBuf, sndbuf := SndBuf, reuseport := ReusePort, active := Active} = validate_opts(
-        Opts
-    ),
-    SocketOpts = [
+    Validated = validate_opts(Opts),
+    #{recbuf := RecBuf, sndbuf := SndBuf, reuseport := ReusePort, active := Active} = Validated,
+    BaseOpts = [
         binary,
         {active, Active},
         {reuseaddr, true},
@@ -71,6 +74,13 @@ open(Port, Opts) ->
         {recbuf, RecBuf},
         {sndbuf, SndBuf}
     ],
+    %% Bind a specific interface only when `ip` was set, so the default
+    %% binds all interfaces exactly as before.
+    SocketOpts =
+        case Validated of
+            #{ip := IP} -> [{ip, IP} | BaseOpts];
+            #{} -> BaseOpts
+        end,
     case gen_udp:open(Port, SocketOpts) of
         {ok, Socket} -> {ok, {gen_udp, Socket}};
         {error, _} = Error -> Error
@@ -153,7 +163,8 @@ sockname({gen_udp, Socket}) ->
         recbuf := pos_integer(),
         sndbuf := pos_integer(),
         reuseport := boolean(),
-        active := active()
+        active := active(),
+        ip => inet:ip_address()
     }.
 validate_opts(Opts) ->
     Defaults = #{
@@ -175,5 +186,7 @@ validate_opt(active, Value, Acc) when Value =:= once; Value =:= false ->
     Acc#{active => Value};
 validate_opt(active, Value, Acc) when is_integer(Value), Value > 0 ->
     Acc#{active => Value};
+validate_opt(ip, Value, Acc) when is_tuple(Value) ->
+    Acc#{ip => Value};
 validate_opt(Key, Value, _Acc) ->
     error({invalid_quic_socket_opt, Key, Value}).

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -56,6 +56,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     cert_chain/1,
     quic_start_failure_releases_tcp/1,
     co_listen/1,
+    ip_binds_loopback/1,
     rejects_http3_without_tls/1,
     max_clients_refuse/1,
     max_concurrent_requests_refuse/1,
@@ -128,6 +129,7 @@ all() ->
         cert_chain,
         quic_start_failure_releases_tcp,
         co_listen,
+        ip_binds_loopback,
         rejects_http3_without_tls,
         max_clients_refuse,
         max_concurrent_requests_refuse,
@@ -195,6 +197,7 @@ init_per_testcase(Case, Config) when
     Case =:= cert_chain;
     Case =:= quic_start_failure_releases_tcp;
     Case =:= co_listen;
+    Case =:= ip_binds_loopback;
     Case =:= rejects_http3_without_tls;
     Case =:= max_clients_refuse;
     Case =:= max_concurrent_requests_refuse;
@@ -692,6 +695,20 @@ protocols_tuple_form(_Config) ->
         tls => roadrunner_test_certs:server_opts(),
         routes => roadrunner_h3_test_handler
     }),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/")))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+%% `ip` restricts the whole listener, including the HTTP/3 UDP socket, to a
+%% single interface: an h3 listener bound to loopback still serves a request
+%% over loopback, proving `ip` threads through to the QUIC bind, not just TCP.
+ip_binds_loopback(_Config) ->
+    Name = listener_name(ip_binds_loopback),
+    {ok, _} = start_h3(Name, #{ip => {127, 0, 0, 1}}),
     Conn = connect(roadrunner_listener:port(Name)),
     try
         ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/")))

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -121,6 +121,25 @@ listener_honors_socket_backlog_opt_test() ->
     ok = gen_tcp:close(Sock),
     ok = roadrunner_listener:stop(Name).
 
+listener_honors_ip_opt_test() ->
+    %% A custom `ip` must flow into `gen_tcp:listen` and bind that
+    %% interface. Bind loopback on an ephemeral port and serve one
+    %% request through the socket to prove the listen option was
+    %% accepted, not just stored.
+    Name = listener_test_ip,
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        ip => {127, 0, 0, 1},
+        routes => roadrunner_hello_handler
+    }),
+    Port = roadrunner_listener:port(Name),
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"),
+    {ok, Reply} = gen_tcp:recv(Sock, 0, 1000),
+    ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+    ok = gen_tcp:close(Sock),
+    ok = roadrunner_listener:stop(Name).
+
 %% =============================================================================
 %% notify_drain/2 (soft drain — broadcast without stopping the listener)
 %% =============================================================================

--- a/test/roadrunner_quic_socket_SUITE.erl
+++ b/test/roadrunner_quic_socket_SUITE.erl
@@ -18,6 +18,7 @@ clause is unit-tested in `roadrunner_quic_socket_tests`.
     recv_timeout/1,
     open_in_use_errors/1,
     open_with_custom_buffers/1,
+    open_binds_to_ip/1,
     reuseport_allows_shared_bind/1,
     active_once_delivers_messages/1,
     active_n_batches_then_passive/1
@@ -34,6 +35,7 @@ all() ->
         recv_timeout,
         open_in_use_errors,
         open_with_custom_buffers,
+        open_binds_to_ip,
         reuseport_allows_shared_bind,
         active_once_delivers_messages,
         active_n_batches_then_passive
@@ -151,6 +153,13 @@ open_in_use_errors(_Config) ->
 open_with_custom_buffers(_Config) ->
     {ok, Socket} = roadrunner_quic_socket:open(0, #{recbuf => 131072, sndbuf => 131072}),
     {ok, {_Ip, _Port}} = roadrunner_quic_socket:sockname(Socket),
+    ok = roadrunner_quic_socket:close(Socket).
+
+%% `ip` binds a single interface: the socket's local address is the one
+%% requested (loopback), not the all-interfaces `0.0.0.0`.
+open_binds_to_ip(_Config) ->
+    {ok, Socket} = roadrunner_quic_socket:open(0, #{ip => ?LOOPBACK}),
+    ?assertMatch({ok, {?LOOPBACK, _Port}}, roadrunner_quic_socket:sockname(Socket)),
     ok = roadrunner_quic_socket:close(Socket).
 
 %% Two sockets share one concrete port when both set reuseport, the

--- a/test/roadrunner_quic_socket_tests.erl
+++ b/test/roadrunner_quic_socket_tests.erl
@@ -24,6 +24,9 @@ open_rejects_non_boolean_reuseport_test() ->
 open_rejects_invalid_active_test() ->
     ?assertError({invalid_quic_socket_opt, active, true}, ?M:open(0, #{active => true})).
 
+open_rejects_non_tuple_ip_test() ->
+    ?assertError({invalid_quic_socket_opt, ip, "bad"}, ?M:open(0, #{ip => "bad"})).
+
 from_message_ignores_foreign_message_test() ->
     %% A message that is not this socket's datagram (a different socket's data,
     %% a DOWN, a system message) parses to `ignore` without opening any I/O.


### PR DESCRIPTION
# Description

Add an optional `ip` listener option that binds a listener to one local interface instead of all interfaces. Unset keeps today's behavior (bind `0.0.0.0` / `::`); set it to an address such as `{127,0,0,1}` to restrict the listener to that interface, so a dev, admin, or metrics endpoint can be reachable only from the local host. The option is honored on every socket the listener opens: plain TCP, TLS, and the HTTP/3 UDP socket, including the ephemeral-port probe, so the pinned port is reserved on the bound address rather than on all interfaces.

```erlang
roadrunner_listener:start_link(my_listener, #{
    port => 8080,
    ip => {127, 0, 0, 1},
    routes => my_handler
}).
```

Proof: a loopback-bound listener serves a request over `127.0.0.1` on both TCP and HTTP/3, and a QUIC socket opened with `ip => {127,0,0,1}` reports that address from `sockname/1`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
