### PR TITLE
Resolve the real client IP behind a trusted reverse proxy

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -514,6 +514,23 @@ undercuts the saving. Wants a real large-body-flood driver before taking it on.
 **Scope:** small code, but the RST-delivery hazard makes the current post-body
 placement the safer default.
 
+### Trusted `Forwarded` (RFC 7239) real-IP resolution — small
+
+**What:** The `real_ip` opt resolves the client from a bare-IP, comma-separated
+header (`X-Forwarded-For` and friends) against the `trusted_proxies` allow-list.
+Extend the trusted recursive walk to the RFC 7239 `Forwarded` header, parsing
+each element's `for=` identifier (quoted IPv6, optional `:port`, and the
+obfuscated/`unknown` forms).
+
+**Why deferred:** `X-Forwarded-For` and single-value headers
+(`X-Real-IP`, `CF-Connecting-IP`) cover nginx, Cloudflare, ALB, and GCP; the
+RFC 7239 grammar is a meaningfully larger parse for a header rarely emitted for
+real-IP. `roadrunner_req:forwarded_for/1` already exposes the leftmost
+`Forwarded`/`X-Forwarded-For` value untrusted for callers who want it.
+
+**Scope:** small. Per-element `for=` parsing on top of the existing
+`roadrunner_real_ip` walk; the trust model and CIDR matching are unchanged.
+
 ### Graceful load-shedding — small-medium
 
 **What:** Turn the hard `max_clients` / `max_concurrent_requests` caps

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -66,6 +66,7 @@
     send_payload_too_large/1,
     send_rate_limited/2,
     rate_limit_check/6,
+    rate_limit_key/2,
     resolve_rate_limit/2,
     maybe_put_client_ip/3,
     rate_limited_telemetry/2,
@@ -208,10 +209,13 @@
 }.
 
 %% The per-connection rate-limit guard state cached on each conn loop's record:
-%% the `{Rate, Cap, Cost, Table, Counter, IP}` resolved from `proto_opts` + the
+%% the `{Rate, Cap, Cost, Table, Counter, Key}` resolved from `proto_opts` + the
 %% peer once at setup (see `resolve_rate_limit/2`) — with `Cap`/`Cost` already
 %% derived so the per-request check does no arithmetic — or `undefined` when the
-%% guard is off or the peer IP is unknown. Checked by `rate_limit_check/6`.
+%% guard is off or the peer IP is unknown. `Key` is the baked peer `IP`, or the
+%% `client_ip` marker when the `real_ip` opt is also set, meaning the bucket
+%% keys on the per-request resolved client IP (read via `rate_limit_key/2`).
+%% Checked by `rate_limit_check/6`.
 -type rate_limit_state() ::
     {
         pos_integer(),
@@ -219,7 +223,7 @@
         pos_integer(),
         ets:table(),
         atomics:atomics_ref(),
-        inet:ip_address()
+        inet:ip_address() | client_ip
     }
     | undefined.
 
@@ -355,12 +359,13 @@ try_acquire_request_slot(Max, Counter) ->
             false
     end.
 
-%% Resolve the per-connection rate-limit tuple `{Rate, Burst, Table, Counter,
-%% IP}` from `proto_opts` + the (constant-per-conn) peer once at setup, or
-%% `undefined` when the guard is off, so the per-request check is a single
-%% branch on a cached value. The peer IP is baked in here, so the catch-all
-%% also covers a missing peer (a 2-tuple `{IP, _}` is required) as well as
-%% `rate_limit => undefined` and the hand-built proto_opts in unit tests.
+%% Resolve the per-connection rate-limit tuple `{Rate, Cap, Cost, Table,
+%% Counter, Key}` from `proto_opts` + the (constant-per-conn) peer once at setup,
+%% or `undefined` when the guard is off, so the per-request check is a single
+%% branch on a cached value. `Key` is the baked peer `IP`, or the `client_ip`
+%% marker when `real_ip` is configured (then the bucket keys on the per-request
+%% resolved client IP). The catch-all covers a missing peer (a 2-tuple `{IP, _}`
+%% is required) and `rate_limit => undefined`.
 -doc false.
 -spec resolve_rate_limit(
     proto_opts(), {inet:ip_address(), inet:port_number()} | undefined
@@ -368,7 +373,8 @@ try_acquire_request_slot(Max, Counter) ->
 resolve_rate_limit(
     #{
         rate_limit := #{rate := Rate, burst := Burst, period := Period, table := Table},
-        rate_limited_counter := Counter
+        rate_limited_counter := Counter,
+        real_ip := RealIp
     },
     {IP, _Port}
 ) ->
@@ -377,7 +383,12 @@ resolve_rate_limit(
     %% multiplication.
     Cost = Period * 1000,
     Cap = Burst * Cost,
-    {Rate, Cap, Cost, Table, Counter, IP};
+    Key =
+        case RealIp of
+            undefined -> IP;
+            _ -> client_ip
+        end,
+    {Rate, Cap, Cost, Table, Counter, Key};
 resolve_rate_limit(_ProtoOpts, _Peer) ->
     undefined.
 
@@ -401,6 +412,17 @@ maybe_put_client_ip(Cfg, #{headers := Headers} = Req, Peer) ->
         undefined -> Req;
         IP -> Req#{client_ip => IP}
     end.
+
+%% Resolve a rate-limit-state `Key` to the bucket IP. A baked `IP` keys on
+%% itself; the `client_ip` marker (the `real_ip` opt is set) keys on the
+%% per-request resolved client IP stashed by `maybe_put_client_ip/3` — present
+%% on every request the marker variant sees, since the marker is only emitted
+%% for a known peer.
+-doc false.
+-spec rate_limit_key(inet:ip_address() | client_ip, roadrunner_req:request()) ->
+    inet:ip_address().
+rate_limit_key(client_ip, #{client_ip := IP}) -> IP;
+rate_limit_key(IP, _Req) -> IP.
 
 -doc """
 Per-peer token-bucket check, the per-source sibling of

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -67,8 +67,8 @@
     send_rate_limited/2,
     rate_limit_check/6,
     rate_limit_key/2,
-    resolve_rate_limit/2,
-    maybe_put_client_ip/3,
+    resolve_rate_limit/3,
+    maybe_put_client_ip/2,
     rate_limited_telemetry/2,
     rate_limit_evict_idle/3,
     drain_oversized_body/3,
@@ -210,7 +210,7 @@
 
 %% The per-connection rate-limit guard state cached on each conn loop's record:
 %% the `{Rate, Cap, Cost, Table, Counter, Key}` resolved from `proto_opts` + the
-%% peer once at setup (see `resolve_rate_limit/2`) — with `Cap`/`Cost` already
+%% peer once at setup (see `resolve_rate_limit/3`) — with `Cap`/`Cost` already
 %% derived so the per-request check does no arithmetic — or `undefined` when the
 %% guard is off or the peer IP is unknown. `Key` is the baked peer `IP`, or the
 %% `client_ip` marker when the `real_ip` opt is also set, meaning the bucket
@@ -368,57 +368,56 @@ try_acquire_request_slot(Max, Counter) ->
 %% is required) and `rate_limit => undefined`.
 -doc false.
 -spec resolve_rate_limit(
-    proto_opts(), {inet:ip_address(), inet:port_number()} | undefined
+    proto_opts(),
+    {inet:ip_address(), inet:port_number()} | undefined,
+    roadrunner_real_ip:prepared()
 ) -> rate_limit_state().
 resolve_rate_limit(
     #{
         rate_limit := #{rate := Rate, burst := Burst, period := Period, table := Table},
         rate_limited_counter := Counter
-    } = ProtoOpts,
-    {IP, _Port}
+    },
+    {IP, _Port},
+    Prepared
 ) ->
     %% Bake the derived `Cost` (units/request) and `Cap` (bucket capacity) here,
     %% once per connection, so the per-request `rate_limit_check/6` does no
     %% multiplication.
     Cost = Period * 1000,
     Cap = Burst * Cost,
-    %% `real_ip` is read with a default rather than matched in the head on
-    %% purpose: a head match would send proto_opts that omit the key to the
-    %% `undefined` catch-all, silently disabling the guard instead of failing
-    %% loudly. Absent key means the opt is off, which is the common case.
+    %% Bake the bucket key too, as far as the config allows. Only a trusted peer
+    %% (`{walk, ...}`) can produce a different client per request and so needs
+    %% the `client_ip` marker; the opt being off or the peer being untrusted
+    %% yields one fixed address for the whole connection, so the per-request
+    %% marker lookup is skipped entirely.
     Key =
-        case ProtoOpts of
-            #{real_ip := Cfg} when Cfg =/= undefined -> client_ip;
-            #{} -> IP
+        case Prepared of
+            {walk, _Trusted, _Header, _PeerIP} -> client_ip;
+            {const, ClientIP} -> ClientIP;
+            undefined -> IP
         end,
     {Rate, Cap, Cost, Table, Counter, Key};
-resolve_rate_limit(_ProtoOpts, _Peer) ->
+resolve_rate_limit(_ProtoOpts, _Peer, _Prepared) ->
     undefined.
 
-%% Stash the trusted real client IP on `Req` when the listener `real_ip` opt is
-%% set, resolving it from the request's forwarded header against the immediate
-%% `Peer`. The `undefined` clause (the opt is off) is the common path and
-%% returns `Req` untouched — no resolution, no added field. A resolution that
-%% yields `undefined` (unknown peer) is also left off so `client_ip` stays a
-%% concrete `inet:ip_address()`; `roadrunner_req:client_ip/1` falls back to the
-%% peer in that case.
+%% Stash the trusted real client IP on `Req` from the connection's prepared
+%% `real_ip` state. The `undefined` clause (the opt is off, or the peer is
+%% unknown) is the common path and returns `Req` untouched — no resolution, no
+%% added field, and `roadrunner_req:client_ip/1` falls back to the peer. The
+%% peer's own trust check already happened once at connection setup
+%% (`roadrunner_real_ip:prepare/2`), so an untrusted peer costs a single field
+%% read here rather than a per-request CIDR scan.
 -doc false.
--spec maybe_put_client_ip(
-    undefined | roadrunner_real_ip:config(),
-    roadrunner_req:request(),
-    {inet:ip_address(), inet:port_number()} | undefined
-) -> roadrunner_req:request().
-maybe_put_client_ip(undefined, Req, _Peer) ->
+-spec maybe_put_client_ip(roadrunner_real_ip:prepared(), roadrunner_req:request()) ->
+    roadrunner_req:request().
+maybe_put_client_ip(undefined, Req) ->
     Req;
-maybe_put_client_ip(Cfg, #{headers := Headers} = Req, Peer) ->
-    case roadrunner_real_ip:resolve(Cfg, Peer, Headers) of
-        undefined -> Req;
-        IP -> Req#{client_ip => IP}
-    end.
+maybe_put_client_ip(Prepared, #{headers := Headers} = Req) ->
+    Req#{client_ip => roadrunner_real_ip:resolve(Prepared, Headers)}.
 
 %% Resolve a rate-limit-state `Key` to the bucket IP. A baked `IP` keys on
 %% itself; the `client_ip` marker (the `real_ip` opt is set) keys on the
-%% per-request resolved client IP stashed by `maybe_put_client_ip/3` — present
+%% per-request resolved client IP stashed by `maybe_put_client_ip/2` — present
 %% on every request the marker variant sees, since the marker is only emitted
 %% for a known peer.
 -doc false.
@@ -445,7 +444,7 @@ deterministically testable).
     allow | {deny, pos_integer()}.
 rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) ->
     %% `Cap` (bucket capacity) and `Cost` (units per request) are resolved once
-    %% per connection (see `resolve_rate_limit/2`), not per request. A
+    %% per connection (see `resolve_rate_limit/3`), not per request. A
     %% never-seen peer starts at a full bucket (`Cap`) and needs no refill; an
     %% existing one is refilled for the elapsed time in place (no intermediate
     %% tuple).

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -67,6 +67,7 @@
     send_rate_limited/2,
     rate_limit_check/6,
     resolve_rate_limit/2,
+    maybe_put_client_ip/3,
     rate_limited_telemetry/2,
     rate_limit_evict_idle/3,
     drain_oversized_body/3,
@@ -141,6 +142,12 @@
     %% the request peer is the real client. TCP-only; the listener rejects it on
     %% an HTTP/3-only listener.
     proxy_protocol => boolean(),
+    %% Trusted real-client-IP resolution config, compiled by
+    %% `roadrunner_real_ip:compile/1` from the listener `real_ip` opt
+    %% (`undefined` when unset — the common case). When set, the conn loop
+    %% resolves the client IP per request from the forwarded header and stashes
+    %% it as `client_ip` on the request; see `t:roadrunner_listener:opts/0`.
+    real_ip => undefined | roadrunner_real_ip:config(),
     %% Enabled protocols as a flat atom list in user-supplied (ALPN
     %% preference) order. On plain TCP with `[http2]`,
     %% `roadrunner_conn_loop:awaiting_shoot/3` routes straight to the
@@ -373,6 +380,27 @@ resolve_rate_limit(
     {Rate, Cap, Cost, Table, Counter, IP};
 resolve_rate_limit(_ProtoOpts, _Peer) ->
     undefined.
+
+%% Stash the trusted real client IP on `Req` when the listener `real_ip` opt is
+%% set, resolving it from the request's forwarded header against the immediate
+%% `Peer`. The `undefined` clause (the opt is off) is the common path and
+%% returns `Req` untouched — no resolution, no added field. A resolution that
+%% yields `undefined` (unknown peer) is also left off so `client_ip` stays a
+%% concrete `inet:ip_address()`; `roadrunner_req:client_ip/1` falls back to the
+%% peer in that case.
+-doc false.
+-spec maybe_put_client_ip(
+    undefined | roadrunner_real_ip:config(),
+    roadrunner_req:request(),
+    {inet:ip_address(), inet:port_number()} | undefined
+) -> roadrunner_req:request().
+maybe_put_client_ip(undefined, Req, _Peer) ->
+    Req;
+maybe_put_client_ip(Cfg, #{headers := Headers} = Req, Peer) ->
+    case roadrunner_real_ip:resolve(Cfg, Peer, Headers) of
+        undefined -> Req;
+        IP -> Req#{client_ip => IP}
+    end.
 
 -doc """
 Per-peer token-bucket check, the per-source sibling of

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -373,9 +373,8 @@ try_acquire_request_slot(Max, Counter) ->
 resolve_rate_limit(
     #{
         rate_limit := #{rate := Rate, burst := Burst, period := Period, table := Table},
-        rate_limited_counter := Counter,
-        real_ip := RealIp
-    },
+        rate_limited_counter := Counter
+    } = ProtoOpts,
     {IP, _Port}
 ) ->
     %% Bake the derived `Cost` (units/request) and `Cap` (bucket capacity) here,
@@ -383,10 +382,14 @@ resolve_rate_limit(
     %% multiplication.
     Cost = Period * 1000,
     Cap = Burst * Cost,
+    %% `real_ip` is read with a default rather than matched in the head on
+    %% purpose: a head match would send proto_opts that omit the key to the
+    %% `undefined` catch-all, silently disabling the guard instead of failing
+    %% loudly. Absent key means the opt is off, which is the common case.
     Key =
-        case RealIp of
-            undefined -> IP;
-            _ -> client_ip
+        case ProtoOpts of
+            #{real_ip := Cfg} when Cfg =/= undefined -> client_ip;
+            #{} -> IP
         end,
     {Rate, Cap, Cost, Table, Counter, Key};
 resolve_rate_limit(_ProtoOpts, _Peer) ->

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -130,7 +130,12 @@
     %% Per-peer rate-limit guard resolved from `proto_opts` + peer once at
     %% `shoot` (`undefined` when off — the common case, a single branch in
     %% `dispatch_phase/2`).
-    rate_limit = undefined :: roadrunner_conn:rate_limit_state()
+    rate_limit = undefined :: roadrunner_conn:rate_limit_state(),
+    %% Compiled `real_ip` config cached from `proto_opts` at `shoot`
+    %% (`undefined` when off — the common case). When set,
+    %% `handle_request_bytes/2` resolves the client IP per request; the
+    %% `undefined` branch adds nothing to the request map.
+    real_ip = undefined :: undefined | roadrunner_real_ip:config()
 }).
 
 -spec start(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) ->
@@ -253,7 +258,8 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
                     maps:get(http1_max_header_block, ProtoOpts, 10240),
                     maps:get(http1_max_header_count, ProtoOpts, 100)
                 },
-                rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer)
+                rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
+                real_ip = maps:get(real_ip, ProtoOpts, undefined)
             },
             read_request_phase(S)
     end.
@@ -577,7 +583,8 @@ handle_request_bytes(
         peer = Peer,
         scheme = Scheme,
         requests_counter = ReqCounter,
-        http1_limits = Http1Limits
+        http1_limits = Http1Limits,
+        real_ip = RealIp
     } = S,
     Deadline
 ) ->
@@ -588,12 +595,16 @@ handle_request_bytes(
             {RequestId, NewBuffer} = roadrunner_conn:generate_request_id(
                 S#loop_state.req_id_buffer
             ),
-            Req = Req0#{
-                peer => Peer,
-                scheme => Scheme,
-                request_id => RequestId,
-                listener_name => ListenerName
-            },
+            Req = roadrunner_conn:maybe_put_client_ip(
+                RealIp,
+                Req0#{
+                    peer => Peer,
+                    scheme => Scheme,
+                    request_id => RequestId,
+                    listener_name => ListenerName
+                },
+                Peer
+            ),
             ok = roadrunner_conn:set_request_logger_metadata(Req),
             ok = roadrunner_conn:maybe_send_continue(Socket, Req, Rest),
             read_body_phase(

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -135,7 +135,7 @@
     %% (`undefined` when off — the common case). When set,
     %% `handle_request_bytes/2` resolves the client IP per request; the
     %% `undefined` branch adds nothing to the request map.
-    real_ip = undefined :: undefined | roadrunner_real_ip:config()
+    real_ip = undefined :: roadrunner_real_ip:prepared()
 }).
 
 -spec start(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) ->
@@ -222,6 +222,11 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
                 Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered
             );
         false ->
+            %% Decide the peer's proxy-trust once per connection; the peer cannot
+            %% change while it lives, so per-request resolution never repeats it.
+            RealIp = roadrunner_real_ip:prepare(
+                maps:get(real_ip, ProtoOpts, undefined), Peer
+            ),
             #{
                 requests_counter := RequestsCounter,
                 dispatch := Dispatch,
@@ -258,8 +263,8 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
                     maps:get(http1_max_header_block, ProtoOpts, 10240),
                     maps:get(http1_max_header_count, ProtoOpts, 100)
                 },
-                rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
-                real_ip = maps:get(real_ip, ProtoOpts, undefined)
+                rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer, RealIp),
+                real_ip = RealIp
             },
             read_request_phase(S)
     end.
@@ -602,8 +607,7 @@ handle_request_bytes(
                     scheme => Scheme,
                     request_id => RequestId,
                     listener_name => ListenerName
-                },
-                Peer
+                }
             ),
             ok = roadrunner_conn:set_request_logger_metadata(Req),
             ok = roadrunner_conn:maybe_send_continue(Socket, Req, Rest),

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -719,7 +719,7 @@ dispatch_phase(
     } = S,
     Req
 ) ->
-    case rate_limit_allows(RateLimit, Socket, ListenerName) of
+    case rate_limit_allows(RateLimit, Socket, ListenerName, Req) of
         true ->
             case roadrunner_conn:resolve_handler(Dispatch, Req) of
                 {ok, Handler, Bindings, Pipeline, _State} ->
@@ -745,11 +745,13 @@ dispatch_phase(
 -spec rate_limit_allows(
     roadrunner_conn:rate_limit_state(),
     roadrunner_transport:socket(),
-    atom()
+    atom(),
+    roadrunner_req:request()
 ) -> boolean().
-rate_limit_allows(undefined, _Socket, _ListenerName) ->
+rate_limit_allows(undefined, _Socket, _ListenerName, _Req) ->
     true;
-rate_limit_allows({Rate, Cap, Cost, Table, Counter, IP}, Socket, ListenerName) ->
+rate_limit_allows({Rate, Cap, Cost, Table, Counter, KeySpec}, Socket, ListenerName, Req) ->
+    IP = roadrunner_conn:rate_limit_key(KeySpec, Req),
     NowMs = erlang:monotonic_time(millisecond),
     case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
         allow ->

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1145,7 +1145,7 @@ dispatch_stream(
                 {ok, Req0} ->
                     Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0, Peer),
                     StateBuf = State#loop{req_id_buffer = NewBuf},
-                    case rate_limit_refused(StateBuf, StreamId) of
+                    case rate_limit_refused(StateBuf, StreamId, Req) of
                         {refused, State1} ->
                             %% Per-peer rate exceeded: 429 + RST(no_error) sent,
                             %% no worker spawned. 429 (not REFUSED_STREAM) so the
@@ -1787,16 +1787,19 @@ throttle_stream(#loop{proto_opts = #{throttled_counter := Counter}}, ListenerNam
 %% (not `REFUSED_STREAM`) so the client honors `Retry-After` instead of
 %% retrying the stream immediately. The guard being off (`undefined`) or a
 %% missing peer IP proceeds.
--spec rate_limit_refused(#loop{}, stream_id()) -> ok | {refused, #loop{}}.
-rate_limit_refused(#loop{rate_limit = undefined}, _StreamId) ->
+-spec rate_limit_refused(#loop{}, stream_id(), roadrunner_req:request()) ->
+    ok | {refused, #loop{}}.
+rate_limit_refused(#loop{rate_limit = undefined}, _StreamId, _Req) ->
     ok;
 rate_limit_refused(
     #loop{
-        rate_limit = {Rate, Cap, Cost, Table, Counter, IP},
+        rate_limit = {Rate, Cap, Cost, Table, Counter, KeySpec},
         listener_name = ListenerName
     } = State,
-    StreamId
+    StreamId,
+    Req
 ) ->
+    IP = roadrunner_conn:rate_limit_key(KeySpec, Req),
     NowMs = erlang:monotonic_time(millisecond),
     case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
         allow ->

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -250,7 +250,7 @@
     %% Compiled `real_ip` config cached from proto_opts at `enter/6`
     %% (`undefined` when off). When set, `dispatch_stream/2` resolves the client
     %% IP per request onto the request map.
-    real_ip = undefined :: undefined | roadrunner_real_ip:config(),
+    real_ip = undefined :: roadrunner_real_ip:prepared(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -316,6 +316,9 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered) ->
     InflightCounter = maps:get(inflight_counter, ProtoOpts, undefined),
     HandshakeTimeout = handshake_timeout(),
     IdleTimeout = idle_timeout(),
+    %% Decide the peer's proxy-trust once per connection; the peer cannot
+    %% change while it lives, so per-request resolution never repeats it.
+    RealIp = roadrunner_real_ip:prepare(maps:get(real_ip, ProtoOpts, undefined), Peer),
     State = #loop{
         socket = Socket,
         proto_opts = ProtoOpts,
@@ -340,8 +343,8 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered) ->
         alt_svc = AltSvc,
         max_concurrent_requests = MaxConcReq,
         inflight_counter = InflightCounter,
-        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
-        real_ip = maps:get(real_ip, ProtoOpts, undefined),
+        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer, RealIp),
+        real_ip = RealIp,
         handshake_timeout = HandshakeTimeout,
         idle_timeout = IdleTimeout
     },
@@ -1143,7 +1146,7 @@ dispatch_stream(
             },
             case roadrunner_http2_request:from_headers(Headers, BodyIolist, RequestContext) of
                 {ok, Req0} ->
-                    Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0, Peer),
+                    Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0),
                     StateBuf = State#loop{req_id_buffer = NewBuf},
                     case rate_limit_refused(StateBuf, StreamId, Req) of
                         {refused, State1} ->

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -247,6 +247,10 @@
     %% Per-peer rate-limit guard resolved from proto_opts + peer at `enter/6`
     %% (`undefined` when off). Checked in `dispatch_stream/2`.
     rate_limit = undefined :: roadrunner_conn:rate_limit_state(),
+    %% Compiled `real_ip` config cached from proto_opts at `enter/6`
+    %% (`undefined` when off). When set, `dispatch_stream/2` resolves the client
+    %% IP per request onto the request map.
+    real_ip = undefined :: undefined | roadrunner_real_ip:config(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -337,6 +341,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered) ->
         max_concurrent_requests = MaxConcReq,
         inflight_counter = InflightCounter,
         rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
+        real_ip = maps:get(real_ip, ProtoOpts, undefined),
         handshake_timeout = HandshakeTimeout,
         idle_timeout = IdleTimeout
     },
@@ -1111,7 +1116,8 @@ dispatch_stream(
         scheme = Scheme,
         listener_name = ListenerName,
         max_concurrent_requests = MaxConcReq,
-        inflight_counter = InflightCounter
+        inflight_counter = InflightCounter,
+        real_ip = RealIp
     } = State
 ) ->
     #{
@@ -1136,7 +1142,8 @@ dispatch_stream(
                 request_id => RequestId
             },
             case roadrunner_http2_request:from_headers(Headers, BodyIolist, RequestContext) of
-                {ok, Req} ->
+                {ok, Req0} ->
+                    Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0, Peer),
                     StateBuf = State#loop{req_id_buffer = NewBuf},
                     case rate_limit_refused(StateBuf, StreamId) of
                         {refused, State1} ->

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -800,7 +800,7 @@ dispatch_decoded(
             reset_and_drop(State1, StreamId, ?H3_MESSAGE_ERROR);
         {ok, Req0} ->
             Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0, Peer),
-            case rate_limit_refused(State1, StreamId) of
+            case rate_limit_refused(State1, StreamId, Req) of
                 {refused, State2} ->
                     %% Per-peer rate exceeded: 429 + Retry-After sent, stream
                     %% dropped. 429 (not H3_REQUEST_REJECTED) so the client backs
@@ -890,17 +890,20 @@ throttle_stream(#h3{proto_opts = #{throttled_counter := Counter}, listener_name 
 %% H3_REQUEST_REJECTED) so the client honors `Retry-After` instead of retrying
 %% the request immediately. The guard being off (`undefined`) or a missing peer
 %% IP proceeds.
--spec rate_limit_refused(#h3{}, non_neg_integer()) -> ok | {refused, #h3{}}.
-rate_limit_refused(#h3{rate_limit = undefined}, _StreamId) ->
+-spec rate_limit_refused(#h3{}, non_neg_integer(), roadrunner_req:request()) ->
+    ok | {refused, #h3{}}.
+rate_limit_refused(#h3{rate_limit = undefined}, _StreamId, _Req) ->
     ok;
 rate_limit_refused(
     #h3{
-        rate_limit = {Rate, Cap, Cost, Table, Counter, IP},
+        rate_limit = {Rate, Cap, Cost, Table, Counter, KeySpec},
         conn = Conn,
         listener_name = ListenerName
     } = State,
-    StreamId
+    StreamId,
+    Req
 ) ->
+    IP = roadrunner_conn:rate_limit_key(KeySpec, Req),
     NowMs = erlang:monotonic_time(millisecond),
     case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
         allow ->

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -147,7 +147,11 @@
     inflight_counter :: counters:counters_ref() | undefined,
     %% Per-peer rate-limit guard resolved from proto_opts + peer at conn start
     %% (`undefined` when off). Checked in `dispatch_decoded/4`.
-    rate_limit = undefined :: roadrunner_conn:rate_limit_state()
+    rate_limit = undefined :: roadrunner_conn:rate_limit_state(),
+    %% Compiled `real_ip` config cached from proto_opts at conn start
+    %% (`undefined` when off). When set, `dispatch_decoded/4` resolves the
+    %% client IP per request onto the request map.
+    real_ip = undefined :: undefined | roadrunner_real_ip:config()
 }).
 
 -doc """
@@ -210,7 +214,8 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
         ),
         max_concurrent_requests = maps:get(max_concurrent_requests, ProtoOpts, infinity),
         inflight_counter = maps:get(inflight_counter, ProtoOpts, undefined),
-        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer)
+        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
+        real_ip = maps:get(real_ip, ProtoOpts, undefined)
     }).
 
 -spec loop(#h3{}) -> ok.
@@ -768,12 +773,22 @@ respond_field_section_too_large(#h3{conn = Conn} = State, StreamId) ->
 
 -spec dispatch_decoded(#h3{}, non_neg_integer(), roadrunner_http:headers(), iodata()) ->
     handle_result().
-dispatch_decoded(State, StreamId, Headers, Body) ->
-    {ReqId, NewBuf} = roadrunner_conn:generate_request_id(State#h3.req_id_buffer),
+dispatch_decoded(
+    #h3{
+        peer = Peer,
+        listener_name = ListenerName,
+        req_id_buffer = ReqIdBuffer,
+        real_ip = RealIp
+    } = State,
+    StreamId,
+    Headers,
+    Body
+) ->
+    {ReqId, NewBuf} = roadrunner_conn:generate_request_id(ReqIdBuffer),
     RequestContext = #{
-        peer => State#h3.peer,
+        peer => Peer,
         scheme => https,
-        listener_name => State#h3.listener_name,
+        listener_name => ListenerName,
         request_id => ReqId
     },
     State1 = State#h3{req_id_buffer = NewBuf},
@@ -783,7 +798,8 @@ dispatch_decoded(State, StreamId, Headers, Body) ->
             %% connection-specific header) — RFC 9114 §4.1.2 / §4.2:
             %% stream error H3_MESSAGE_ERROR.
             reset_and_drop(State1, StreamId, ?H3_MESSAGE_ERROR);
-        {ok, Req} ->
+        {ok, Req0} ->
+            Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0, Peer),
             case rate_limit_refused(State1, StreamId) of
                 {refused, State2} ->
                     %% Per-peer rate exceeded: 429 + Retry-After sent, stream

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -151,7 +151,7 @@
     %% Compiled `real_ip` config cached from proto_opts at conn start
     %% (`undefined` when off). When set, `dispatch_decoded/4` resolves the
     %% client IP per request onto the request map.
-    real_ip = undefined :: undefined | roadrunner_real_ip:config()
+    real_ip = undefined :: roadrunner_real_ip:prepared()
 }).
 
 -doc """
@@ -199,6 +199,9 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
         listener_name => ListenerName, peer => Peer
     }),
     MaxHeaderBlock = maps:get(http3_max_header_block, ProtoOpts, ?MAX_HEADER_BLOCK),
+    %% Decide the peer's proxy-trust once per connection; the peer cannot
+    %% change while it lives, so per-request resolution never repeats it.
+    RealIp = roadrunner_real_ip:prepare(maps:get(real_ip, ProtoOpts, undefined), Peer),
     loop(#h3{
         conn = Conn,
         proto_opts = ProtoOpts,
@@ -214,8 +217,8 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
         ),
         max_concurrent_requests = maps:get(max_concurrent_requests, ProtoOpts, infinity),
         inflight_counter = maps:get(inflight_counter, ProtoOpts, undefined),
-        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
-        real_ip = maps:get(real_ip, ProtoOpts, undefined)
+        rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer, RealIp),
+        real_ip = RealIp
     }).
 
 -spec loop(#h3{}) -> ok.
@@ -799,7 +802,7 @@ dispatch_decoded(
             %% stream error H3_MESSAGE_ERROR.
             reset_and_drop(State1, StreamId, ?H3_MESSAGE_ERROR);
         {ok, Req0} ->
-            Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0, Peer),
+            Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0),
             case rate_limit_refused(State1, StreamId, Req) of
                 {refused, State2} ->
                     %% Per-peer rate exceeded: 429 + Retry-After sent, stream

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -248,6 +248,23 @@ ops-tuning rationale.
         idle_ttl => pos_integer(),
         sweep_interval => pos_integer()
     },
+    %% Opt in to trusted real-client-IP resolution behind an HTTP-terminating
+    %% reverse proxy (nginx/caddy/ALB), where the socket peer is the proxy and
+    %% the client travels in a forwarded header. `trusted_proxies` (required) is
+    %% a non-empty list of CIDR binaries (`~"10.0.0.0/8"`, `~"::1/128"`) or bare
+    %% addresses; `header` (default `~"x-forwarded-for"`) names the
+    %% comma-separated bare-IP header to read (`~"x-real-ip"`,
+    %% `~"cf-connecting-ip"`, ...). The immediate peer must itself match
+    %% `trusted_proxies` before the header is honored, then the chain is walked
+    %% right-to-left, skipping trusted proxies, to the first untrusted address —
+    %% so a direct client cannot spoof its IP. The result feeds
+    %% `roadrunner_req:client_ip/1` and, when `rate_limit` is also set, the
+    %% per-peer bucket key. Composes with `proxy_protocol` (the PROXY-reported
+    %% address becomes the immediate hop, which `trusted_proxies` must list).
+    real_ip => #{
+        trusted_proxies := [binary()],
+        header => binary()
+    },
     %% When set, the per-connection process auto-hibernates after
     %% `Ms` milliseconds of idle main-loop time. Most useful for
     %% long-lived keep-alive HTTP/1.1 connections that mostly sit
@@ -1098,6 +1115,7 @@ build_proto_opts(Opts, ListenerName) ->
             proxy_protocol => validate_proxy_protocol(
                 maps:get(proxy_protocol, Opts, false), Protocols
             ),
+            real_ip => roadrunner_real_ip:compile(maps:get(real_ip, Opts, undefined)),
             protocols => Protocols
         }),
         ProtoFlats

--- a/src/roadrunner_real_ip.erl
+++ b/src/roadrunner_real_ip.erl
@@ -151,22 +151,30 @@ reject_unknown_keys(Opts) ->
 
 %% --- resolution (hot path, only when configured) ---
 
-%% Collect every instance of the forwarded header, in received order, into one
-%% left-to-right parsed chain. RFC 9110 §5.3: repeated field lines are
-%% equivalent to the single comma-joined value, so a proxy that emits the chain
-%% as separate lines is handled the same as one that combines it — and the
-%% right-to-left walk still lands on the nearest untrusted hop.
--spec header_chain(binary(), roadrunner_http:headers()) -> [{ok, inet:ip_address()} | bad].
+%% Collect every instance of the forwarded header, in received order, as one
+%% left-to-right list of raw (unparsed) comma-separated segments. RFC 9110 §5.3:
+%% repeated field lines are equivalent to the single comma-joined value, so a
+%% proxy that emits the chain as separate lines is handled the same as one that
+%% combines it — and the right-to-left walk still lands on the nearest untrusted
+%% hop.
+%%
+%% Segments are deliberately left unparsed here. The walk reads the chain
+%% right-to-left and stops at the first untrusted hop, which is normally the
+%% first or second entry, while everything to the left of the proxy's own append
+%% is supplied by the client. Parsing the whole chain up front would spend an
+%% `inet:parse_address` call (and its list conversion) on every attacker-chosen
+%% entry the walk then never consults.
+-spec header_chain(binary(), roadrunner_http:headers()) -> [binary()].
 header_chain(HeaderName, Headers) ->
-    [Entry || {Name, Value} <- Headers, Name =:= HeaderName, Entry <- parse_chain(Value)].
+    [
+        Part
+     || {Name, Value} <- Headers,
+        Name =:= HeaderName,
+        Part <- binary:split(Value, persistent_term:get(?COMMA_CP_KEY), [global])
+    ].
 
-%% Parse one header value into a left-to-right list of `{ok, IP}` (with v4-mapped
-%% IPv6 unwrapped) or `bad` for unparseable entries, preserving position so the
-%% walk can stop at a malformed hop.
--spec parse_chain(binary()) -> [{ok, inet:ip_address()} | bad].
-parse_chain(Value) ->
-    [parse_entry(P) || P <- binary:split(Value, persistent_term:get(?COMMA_CP_KEY), [global])].
-
+%% Parse one chain segment into `{ok, IP}` (with v4-mapped IPv6 unwrapped) or
+%% `bad` when it is not an address.
 -spec parse_entry(binary()) -> {ok, inet:ip_address()} | bad.
 parse_entry(Part) ->
     case inet:parse_address(binary_to_list(roadrunner_bin:trim_ows(Part))) of
@@ -178,23 +186,27 @@ parse_entry(Part) ->
 %% nearest hop): skip trusted proxies, return the first untrusted address (the
 %% real client). All-trusted yields the leftmost entry; an empty chain or a
 %% malformed nearest hop yields the carried fallback (the trusted hop to its
-%% right, or the peer).
--spec walk([{ok, inet:ip_address()} | bad, ...], [cidr()], inet:ip_address()) ->
-    inet:ip_address().
+%% right, or the peer). Each segment is parsed only when the walk reaches it, so
+%% a long client-supplied chain costs one reversal of sub-binaries plus the few
+%% parses the walk actually consults.
+-spec walk([binary(), ...], [cidr()], inet:ip_address()) -> inet:ip_address().
 walk(Entries, Trusted, PeerIP) ->
     %% `binary:split/3` always yields a non-empty list, so `Entries` has at
     %% least one element; an empty chain can't reach here.
     do_walk(lists:reverse(Entries), PeerIP, Trusted).
 
--spec do_walk([{ok, inet:ip_address()} | bad], inet:ip_address(), [cidr()]) -> inet:ip_address().
+-spec do_walk([binary()], inet:ip_address(), [cidr()]) -> inet:ip_address().
 do_walk([], Fallback, _Trusted) ->
     Fallback;
-do_walk([bad | _], Fallback, _Trusted) ->
-    Fallback;
-do_walk([{ok, IP} | Rest], _Fallback, Trusted) ->
-    case trusted(IP, Trusted) of
-        true -> do_walk(Rest, IP, Trusted);
-        false -> IP
+do_walk([Part | Rest], Fallback, Trusted) ->
+    case parse_entry(Part) of
+        bad ->
+            Fallback;
+        {ok, IP} ->
+            case trusted(IP, Trusted) of
+                true -> do_walk(Rest, IP, Trusted);
+                false -> IP
+            end
     end.
 
 -spec trusted(inet:ip_address(), [cidr()]) -> boolean().

--- a/src/roadrunner_real_ip.erl
+++ b/src/roadrunner_real_ip.erl
@@ -16,8 +16,8 @@
 %% check is a shift + compare); `resolve/3` runs on the request hot path, but
 %% only when the opt is set — the conn loop gates the call on the cached config.
 
--export([compile/1, resolve/3]).
--export_type([config/0]).
+-export([compile/1, prepare/2, resolve/2]).
+-export_type([config/0, prepared/0]).
 
 -on_load(init_patterns/0).
 
@@ -65,30 +65,60 @@ compile(Other) ->
     error({invalid_listener_opt, real_ip, Other}).
 
 -doc """
-Resolve the real client IP for a request, per the module's recursion rules.
+Per-connection resolution state, built once by `prepare/2`.
 
-`Peer` is the immediate transport peer (`{IP, Port}` or `undefined`); `Headers`
-is the request's header list (names already lowercased on every protocol path).
-Returns the resolved `inet:ip_address()`, falling back to the peer's IP when the
-peer is untrusted or the header is absent, and `undefined` when the peer is
-unknown.
+`undefined` when the opt is off or the peer is unknown (no per-request work at
+all). `{const, IP}` when the immediate peer is not a configured proxy: its
+forwarded header is never honored, so every request on the connection resolves
+to the same address and `resolve/2` is a field read. `{walk, ...}` when the peer
+IS a trusted proxy and the answer therefore varies per request with the
+forwarded header.
 """.
--spec resolve(config(), Peer, roadrunner_http:headers()) -> inet:ip_address() | undefined when
+-type prepared() ::
+    undefined
+    | {const, inet:ip_address()}
+    | {walk, [cidr()], binary(), inet:ip_address()}.
+
+-doc """
+Build the per-connection resolution state from the compiled config and the
+connection's peer.
+
+The peer is fixed for the life of a connection, so whether it is a trusted proxy
+(and its v4-mapped-IPv6 normalization) is decided here, once, instead of on
+every request. An untrusted peer collapses to a constant answer; only a trusted
+one needs the per-request header walk.
+""".
+-spec prepare(undefined | config(), Peer) -> prepared() when
     Peer :: {inet:ip_address(), inet:port_number()} | undefined.
-resolve(_Config, undefined, _Headers) ->
+prepare(undefined, _Peer) ->
     undefined;
-resolve(#{trusted := Trusted, header := HeaderName}, {PeerIP0, _Port}, Headers) ->
+prepare(_Config, undefined) ->
+    undefined;
+prepare(#{trusted := Trusted, header := HeaderName}, {PeerIP0, _Port}) ->
     PeerIP = unmap(PeerIP0),
     case trusted(PeerIP, Trusted) of
         false ->
             %% The immediate peer is not a configured proxy: never honor its
             %% forwarded header (it could be a direct client spoofing one).
-            PeerIP;
+            {const, PeerIP};
         true ->
-            case header_chain(HeaderName, Headers) of
-                [] -> PeerIP;
-                Chain -> walk(Chain, Trusted, PeerIP)
-            end
+            {walk, Trusted, HeaderName, PeerIP}
+    end.
+
+-doc """
+Resolve the real client IP for one request against the prepared state.
+
+`Headers` is the request's header list (names already lowercased on every
+protocol path). Falls back to the peer's IP when the forwarded header is absent
+or its nearest hop is malformed.
+""".
+-spec resolve(prepared(), roadrunner_http:headers()) -> inet:ip_address().
+resolve({const, IP}, _Headers) ->
+    IP;
+resolve({walk, Trusted, HeaderName, PeerIP}, Headers) ->
+    case header_chain(HeaderName, Headers) of
+        [] -> PeerIP;
+        Chain -> walk(Chain, Trusted, PeerIP)
     end.
 
 %% --- config compilation (init time) ---

--- a/src/roadrunner_real_ip.erl
+++ b/src/roadrunner_real_ip.erl
@@ -1,0 +1,230 @@
+-module(roadrunner_real_ip).
+-moduledoc false.
+
+%% Trusted real-client-IP resolution for HTTP-terminating reverse proxies (the
+%% `roadrunner_listener` `real_ip` opt). Behind nginx/caddy/ALB the socket peer
+%% is the proxy, not the client; the client travels in a forwarded header
+%% (`X-Forwarded-For` and friends). This resolves the real client using
+%% nginx-`realip`-style recursion: the immediate peer must itself be a trusted
+%% proxy before any header is honored, then the forwarded chain is walked
+%% right-to-left, skipping trusted proxies, to the first untrusted address (the
+%% real client). A direct (untrusted) peer's headers are never trusted, so a
+%% client that bypasses the proxy can't spoof its own address.
+%%
+%% Pure and socket-free: `compile/1` validates + pre-builds the config once at
+%% listener init (CIDRs become `{Family, NetPrefix, Shift}` so the per-request
+%% check is a shift + compare); `resolve/3` runs on the request hot path, but
+%% only when the opt is set — the conn loop gates the call on the cached config.
+
+-export([compile/1, resolve/3]).
+-export_type([config/0]).
+
+-on_load(init_patterns/0).
+
+%% Compiled `,` split pattern for the forwarded chain, stashed in
+%% persistent_term at load (the project convention — never inline-compile on
+%% the path).
+-define(COMMA_CP_KEY, {?MODULE, comma_cp}).
+
+%% A trusted-proxy CIDR pre-reduced for matching: the address family as the IP
+%% tuple's size (`4` for IPv4, `8` for IPv6), the network's high bits
+%% (`ip_to_int(Net) bsr Shift`), and `Shift = TotalBits - PrefixLen`. A
+%% candidate matches when its family equals `Family` and `Int bsr Shift` equals
+%% `NetPrefix`.
+-type cidr() :: {4 | 8, non_neg_integer(), 0..128}.
+
+-doc """
+Compiled `real_ip` config: the trusted-proxy CIDRs and the (lowercased)
+forwarded header name to read. Built by `compile/1`, carried in
+`t:roadrunner_conn:proto_opts/0`, consumed by `resolve/3`.
+""".
+-type config() :: #{
+    trusted := [cidr()],
+    header := binary()
+}.
+
+-doc """
+Validate and pre-build the listener `real_ip` opt, or `undefined` when unset.
+
+`Opts` is `#{trusted_proxies := [binary()], header => binary()}`:
+`trusted_proxies` is a non-empty list of CIDR binaries (`~"10.0.0.0/8"`,
+`~"::1/128"`) or bare addresses (treated as a full-length prefix); `header`
+defaults to `~"x-forwarded-for"` and accepts any single-value, comma-separated
+bare-IP header (`~"x-real-ip"`, `~"cf-connecting-ip"`, ...). Raises
+`{invalid_listener_opt, real_ip, _}` on bad input (the listener convention).
+""".
+-spec compile(undefined | map()) -> undefined | config().
+compile(undefined) ->
+    undefined;
+compile(Opts) when is_map(Opts) ->
+    Trusted = compile_trusted(maps:get(trusted_proxies, Opts, undefined)),
+    Header = compile_header(maps:get(header, Opts, ~"x-forwarded-for")),
+    ok = reject_unknown_keys(Opts),
+    #{trusted => Trusted, header => Header};
+compile(Other) ->
+    error({invalid_listener_opt, real_ip, Other}).
+
+-doc """
+Resolve the real client IP for a request, per the module's recursion rules.
+
+`Peer` is the immediate transport peer (`{IP, Port}` or `undefined`); `Headers`
+is the request's header list (names already lowercased on every protocol path).
+Returns the resolved `inet:ip_address()`, falling back to the peer's IP when the
+peer is untrusted or the header is absent, and `undefined` when the peer is
+unknown.
+""".
+-spec resolve(config(), Peer, roadrunner_http:headers()) -> inet:ip_address() | undefined when
+    Peer :: {inet:ip_address(), inet:port_number()} | undefined.
+resolve(_Config, undefined, _Headers) ->
+    undefined;
+resolve(#{trusted := Trusted, header := HeaderName}, {PeerIP0, _Port}, Headers) ->
+    PeerIP = unmap(PeerIP0),
+    case trusted(PeerIP, Trusted) of
+        false ->
+            %% The immediate peer is not a configured proxy: never honor its
+            %% forwarded header (it could be a direct client spoofing one).
+            PeerIP;
+        true ->
+            case header_chain(HeaderName, Headers) of
+                [] -> PeerIP;
+                Chain -> walk(Chain, Trusted, PeerIP)
+            end
+    end.
+
+%% --- config compilation (init time) ---
+
+-spec compile_trusted(term()) -> [cidr(), ...].
+compile_trusted(undefined) ->
+    error({invalid_listener_opt, real_ip, trusted_proxies_required});
+compile_trusted([]) ->
+    error({invalid_listener_opt, real_ip, empty_trusted_proxies});
+compile_trusted(Proxies) when is_list(Proxies) ->
+    [compile_cidr(P) || P <- Proxies];
+compile_trusted(Other) ->
+    error({invalid_listener_opt, real_ip, {trusted_proxies, Other}}).
+
+-spec compile_cidr(term()) -> cidr().
+compile_cidr(Bin) when is_binary(Bin) ->
+    case binary:split(Bin, ~"/") of
+        [AddrBin, PrefixBin] ->
+            {Addr, Family, TotalBits} = parse_addr(AddrBin),
+            make_cidr(Addr, Family, TotalBits, parse_prefix(PrefixBin, TotalBits));
+        [AddrBin] ->
+            {Addr, Family, TotalBits} = parse_addr(AddrBin),
+            make_cidr(Addr, Family, TotalBits, TotalBits)
+    end;
+compile_cidr(Other) ->
+    error({invalid_listener_opt, real_ip, {trusted_proxy, Other}}).
+
+-spec parse_addr(binary()) -> {inet:ip_address(), 4 | 8, 32 | 128}.
+parse_addr(AddrBin) ->
+    case inet:parse_address(binary_to_list(AddrBin)) of
+        {ok, Addr} when tuple_size(Addr) =:= 4 -> {Addr, 4, 32};
+        {ok, Addr} when tuple_size(Addr) =:= 8 -> {Addr, 8, 128};
+        _ -> error({invalid_listener_opt, real_ip, {trusted_proxy, AddrBin}})
+    end.
+
+-spec parse_prefix(binary(), 32 | 128) -> non_neg_integer().
+parse_prefix(PrefixBin, TotalBits) ->
+    case string:to_integer(PrefixBin) of
+        {N, <<>>} when N >= 0, N =< TotalBits -> N;
+        _ -> error({invalid_listener_opt, real_ip, {prefix, PrefixBin}})
+    end.
+
+-spec make_cidr(inet:ip_address(), 4 | 8, 32 | 128, non_neg_integer()) -> cidr().
+make_cidr(Addr, Family, TotalBits, Prefix) ->
+    Shift = TotalBits - Prefix,
+    {Family, ip_to_int(Addr) bsr Shift, Shift}.
+
+-spec compile_header(term()) -> binary().
+compile_header(H) when is_binary(H), byte_size(H) > 0 ->
+    roadrunner_bin:ascii_lowercase(H);
+compile_header(Other) ->
+    error({invalid_listener_opt, real_ip, {header, Other}}).
+
+-spec reject_unknown_keys(map()) -> ok.
+reject_unknown_keys(Opts) ->
+    case maps:keys(maps:without([trusted_proxies, header], Opts)) of
+        [] -> ok;
+        Unknown -> error({invalid_listener_opt, real_ip, {unknown_keys, Unknown}})
+    end.
+
+%% --- resolution (hot path, only when configured) ---
+
+%% Collect every instance of the forwarded header, in received order, into one
+%% left-to-right parsed chain. RFC 9110 §5.3: repeated field lines are
+%% equivalent to the single comma-joined value, so a proxy that emits the chain
+%% as separate lines is handled the same as one that combines it — and the
+%% right-to-left walk still lands on the nearest untrusted hop.
+-spec header_chain(binary(), roadrunner_http:headers()) -> [{ok, inet:ip_address()} | bad].
+header_chain(HeaderName, Headers) ->
+    [Entry || {Name, Value} <- Headers, Name =:= HeaderName, Entry <- parse_chain(Value)].
+
+%% Parse one header value into a left-to-right list of `{ok, IP}` (with v4-mapped
+%% IPv6 unwrapped) or `bad` for unparseable entries, preserving position so the
+%% walk can stop at a malformed hop.
+-spec parse_chain(binary()) -> [{ok, inet:ip_address()} | bad].
+parse_chain(Value) ->
+    [parse_entry(P) || P <- binary:split(Value, persistent_term:get(?COMMA_CP_KEY), [global])].
+
+-spec parse_entry(binary()) -> {ok, inet:ip_address()} | bad.
+parse_entry(Part) ->
+    case inet:parse_address(binary_to_list(roadrunner_bin:trim_ows(Part))) of
+        {ok, IP} -> {ok, unmap(IP)};
+        {error, _} -> bad
+    end.
+
+%% Walk the chain right-to-left (proxies append, so the rightmost entry is the
+%% nearest hop): skip trusted proxies, return the first untrusted address (the
+%% real client). All-trusted yields the leftmost entry; an empty chain or a
+%% malformed nearest hop yields the carried fallback (the trusted hop to its
+%% right, or the peer).
+-spec walk([{ok, inet:ip_address()} | bad, ...], [cidr()], inet:ip_address()) ->
+    inet:ip_address().
+walk(Entries, Trusted, PeerIP) ->
+    %% `binary:split/3` always yields a non-empty list, so `Entries` has at
+    %% least one element; an empty chain can't reach here.
+    do_walk(lists:reverse(Entries), PeerIP, Trusted).
+
+-spec do_walk([{ok, inet:ip_address()} | bad], inet:ip_address(), [cidr()]) -> inet:ip_address().
+do_walk([], Fallback, _Trusted) ->
+    Fallback;
+do_walk([bad | _], Fallback, _Trusted) ->
+    Fallback;
+do_walk([{ok, IP} | Rest], _Fallback, Trusted) ->
+    case trusted(IP, Trusted) of
+        true -> do_walk(Rest, IP, Trusted);
+        false -> IP
+    end.
+
+-spec trusted(inet:ip_address(), [cidr()]) -> boolean().
+trusted(IP, Trusted) ->
+    is_trusted(ip_to_int(IP), tuple_size(IP), Trusted).
+
+-spec is_trusted(non_neg_integer(), 4 | 8, [cidr()]) -> boolean().
+is_trusted(_Int, _Fam, []) ->
+    false;
+is_trusted(Int, Fam, [{Fam, NetPrefix, Shift} | _]) when (Int bsr Shift) =:= NetPrefix ->
+    true;
+is_trusted(Int, Fam, [_ | Rest]) ->
+    is_trusted(Int, Fam, Rest).
+
+%% Collapse a v4-mapped IPv6 address (`::ffff:a.b.c.d`) to plain IPv4 so a
+%% dual-stack proxy's mapped address matches IPv4 CIDRs.
+-spec unmap(inet:ip_address()) -> inet:ip_address().
+unmap({0, 0, 0, 0, 0, 16#ffff, G, H}) ->
+    {G bsr 8, G band 16#ff, H bsr 8, H band 16#ff};
+unmap(IP) ->
+    IP.
+
+-spec ip_to_int(inet:ip_address()) -> non_neg_integer().
+ip_to_int({A, B, C, D}) ->
+    (A bsl 24) bor (B bsl 16) bor (C bsl 8) bor D;
+ip_to_int({A, B, C, D, E, F, G, H}) ->
+    (A bsl 112) bor (B bsl 96) bor (C bsl 80) bor (D bsl 64) bor
+        (E bsl 48) bor (F bsl 32) bor (G bsl 16) bor H.
+
+-spec init_patterns() -> ok.
+init_patterns() ->
+    persistent_term:put(?COMMA_CP_KEY, binary:compile_pattern(~",")),
+    ok.

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -71,6 +71,11 @@ care which protocol delivered the bytes.
     %% `inet:peername/1`. `undefined` when the OS call fails (rare;
     %% usually socket teardown).
     peer => {inet:ip_address(), inet:port_number()} | undefined,
+    %% Trusted real client IP, resolved per request from the configured
+    %% forwarded header when the listener `real_ip` opt is set (see
+    %% `client_ip/1`). Absent when the opt is off, so the default hot path
+    %% carries no extra field.
+    client_ip => inet:ip_address(),
     %% Connection scheme — `http` for plain TCP, `https` for TLS.
     %% Set once per connection by `roadrunner_conn` from the
     %% transport tag.
@@ -177,6 +182,7 @@ to absorb a chunk's payload across multiple length-bounded calls.
     read_form/1,
     bindings/1,
     peer/1,
+    client_ip/1,
     forwarded_for/1,
     scheme/1,
     state/1,
@@ -508,6 +514,25 @@ can reach the listener directly would let that peer spoof its own address.
     {inet:ip_address(), inet:port_number()} | undefined.
 peer(#{peer := P}) -> P;
 peer(_) -> undefined.
+
+-doc """
+Return the trusted real client IP for this request.
+
+When the listener `real_ip` opt is set, `roadrunner_conn` resolves the client
+from the configured forwarded header (recursively, against the
+`trusted_proxies` allow-list — see `t:roadrunner_listener:opts/0`) and this
+returns that address. Without the opt it falls back to the connection peer's IP
+(the client when there is no proxy), and `undefined` when the peer is unknown.
+
+Unlike `forwarded_for/1`, this is safe to trust as the client identity: a
+forwarded header is honored only when the immediate peer is itself a configured
+proxy, so a direct client cannot spoof it. Returns the bare IP (no port);
+`X-Forwarded-For` carries no port.
+""".
+-spec client_ip(request()) -> inet:ip_address() | undefined.
+client_ip(#{client_ip := IP}) -> IP;
+client_ip(#{peer := {IP, _}}) -> IP;
+client_ip(_) -> undefined.
 
 -doc """
 Return the leftmost client identifier from the `Forwarded` header

--- a/test/roadrunner_client_ip_handler.erl
+++ b/test/roadrunner_client_ip_handler.erl
@@ -1,0 +1,27 @@
+-module(roadrunner_client_ip_handler).
+-moduledoc false.
+
+%% Test fixture: echoes the request's resolved client IP literal (e.g.
+%% `203.0.113.7`) so a real-IP test can assert the trusted-proxy resolution
+%% produced the forwarded client address, not the socket peer.
+
+-behaviour(roadrunner_handler).
+
+-export([handle/1]).
+
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
+handle(Req) ->
+    Body =
+        case roadrunner_req:client_ip(Req) of
+            undefined -> ~"undefined";
+            Ip -> list_to_binary(inet:ntoa(Ip))
+        end,
+    Resp =
+        {200,
+            [
+                {~"content-type", ~"text/plain"},
+                {~"content-length", integer_to_binary(byte_size(Body))},
+                {~"connection", ~"close"}
+            ],
+            Body},
+    {Resp, Req}.

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -2252,21 +2252,36 @@ request_slot_release_many_test() ->
     ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 4)),
     ?assertEqual(0, counters:get(Ref, 1)).
 
-%% --- maybe_put_client_ip/3 ---
+%% --- maybe_put_client_ip/2 ---
 
 maybe_put_client_ip_off_is_noop_test() ->
     Req = #{headers => [{~"x-forwarded-for", ~"203.0.113.7"}]},
-    ?assertEqual(Req, roadrunner_conn:maybe_put_client_ip(undefined, Req, {{127, 0, 0, 1}, 80})).
+    ?assertEqual(Req, roadrunner_conn:maybe_put_client_ip(undefined, Req)).
 
 maybe_put_client_ip_resolves_test() ->
     Cfg = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
+    Prepared = roadrunner_real_ip:prepare(Cfg, {{127, 0, 0, 1}, 80}),
     Req = #{headers => [{~"x-forwarded-for", ~"203.0.113.7"}]},
-    Result = roadrunner_conn:maybe_put_client_ip(Cfg, Req, {{127, 0, 0, 1}, 80}),
+    Result = roadrunner_conn:maybe_put_client_ip(Prepared, Req),
     ?assertEqual({203, 0, 113, 7}, maps:get(client_ip, Result)).
 
+maybe_put_client_ip_untrusted_peer_uses_the_baked_constant_test() ->
+    %% An untrusted peer's forwarded header is ignored, and the answer was
+    %% already decided at `prepare/2`, so no header is scanned here.
+    Cfg = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
+    Prepared = roadrunner_real_ip:prepare(Cfg, {{198, 51, 100, 9}, 80}),
+    Req = #{headers => [{~"x-forwarded-for", ~"203.0.113.7"}]},
+    Result = roadrunner_conn:maybe_put_client_ip(Prepared, Req),
+    ?assertEqual({198, 51, 100, 9}, maps:get(client_ip, Result)).
+
 maybe_put_client_ip_unknown_peer_skips_field_test() ->
-    %% Peer unknown: resolution yields `undefined`, so no `client_ip` is stored
+    %% Peer unknown: `prepare/2` yields `undefined`, so no `client_ip` is stored
     %% (it stays a concrete IP type) and the request is returned untouched.
     Cfg = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
     Req = #{headers => [{~"x-forwarded-for", ~"203.0.113.7"}]},
-    ?assertEqual(Req, roadrunner_conn:maybe_put_client_ip(Cfg, Req, undefined)).
+    ?assertEqual(
+        Req,
+        roadrunner_conn:maybe_put_client_ip(
+            roadrunner_real_ip:prepare(Cfg, undefined), Req
+        )
+    ).

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -2251,3 +2251,22 @@ request_slot_release_many_test() ->
     ?assertEqual(4, counters:get(Ref, 1)),
     ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 4)),
     ?assertEqual(0, counters:get(Ref, 1)).
+
+%% --- maybe_put_client_ip/3 ---
+
+maybe_put_client_ip_off_is_noop_test() ->
+    Req = #{headers => [{~"x-forwarded-for", ~"203.0.113.7"}]},
+    ?assertEqual(Req, roadrunner_conn:maybe_put_client_ip(undefined, Req, {{127, 0, 0, 1}, 80})).
+
+maybe_put_client_ip_resolves_test() ->
+    Cfg = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
+    Req = #{headers => [{~"x-forwarded-for", ~"203.0.113.7"}]},
+    Result = roadrunner_conn:maybe_put_client_ip(Cfg, Req, {{127, 0, 0, 1}, 80}),
+    ?assertEqual({203, 0, 113, 7}, maps:get(client_ip, Result)).
+
+maybe_put_client_ip_unknown_peer_skips_field_test() ->
+    %% Peer unknown: resolution yields `undefined`, so no `client_ip` is stored
+    %% (it stays a concrete IP type) and the request is returned untouched.
+    Cfg = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
+    Req = #{headers => [{~"x-forwarded-for", ~"203.0.113.7"}]},
+    ?assertEqual(Req, roadrunner_conn:maybe_put_client_ip(Cfg, Req, undefined)).

--- a/test/roadrunner_rate_limit_store_tests.erl
+++ b/test/roadrunner_rate_limit_store_tests.erl
@@ -60,6 +60,28 @@ resolve_on_test() ->
         {10, 600000, 30000, Table, Counter, ?IP}, ?M:resolve_rate_limit(Opts, {?IP, 5000})
     ).
 
+resolve_on_with_real_ip_keys_per_request_test() ->
+    %% With `real_ip` set, the baked key is the `client_ip` marker, not the peer:
+    %% the bucket keys on the per-request resolved client IP.
+    Table = new_table(),
+    RealIp = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
+    {Counter, Opts} = proto_opts_with_counter(Table, RealIp),
+    ?assertEqual(
+        {10, 600000, 30000, Table, Counter, client_ip},
+        ?M:resolve_rate_limit(Opts, {?IP, 5000})
+    ).
+
+%% --- rate_limit_key/2 ---
+
+rate_limit_key_baked_ip_test() ->
+    ?assertEqual(?IP, ?M:rate_limit_key(?IP, #{headers => []})).
+
+rate_limit_key_marker_reads_client_ip_test() ->
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:rate_limit_key(client_ip, #{client_ip => {203, 0, 113, 7}})
+    ).
+
 %% --- rate_limited_telemetry/2 ---
 
 telemetry_bumps_counter_test() ->
@@ -119,10 +141,14 @@ proto_opts(RateLimit) ->
         end,
     #{
         rate_limit => Cfg,
-        rate_limited_counter => atomics:new(1, [{signed, false}])
+        rate_limited_counter => atomics:new(1, [{signed, false}]),
+        real_ip => undefined
     }.
 
 proto_opts_with_counter(Table) ->
+    proto_opts_with_counter(Table, undefined).
+
+proto_opts_with_counter(Table, RealIp) ->
     Counter = atomics:new(1, [{signed, false}]),
     {Counter, #{
         rate_limit => #{
@@ -133,5 +159,6 @@ proto_opts_with_counter(Table) ->
             sweep_interval => 10000,
             table => Table
         },
-        rate_limited_counter => Counter
+        rate_limited_counter => Counter,
+        real_ip => RealIp
     }}.

--- a/test/roadrunner_rate_limit_store_tests.erl
+++ b/test/roadrunner_rate_limit_store_tests.erl
@@ -71,6 +71,27 @@ resolve_on_with_real_ip_keys_per_request_test() ->
         ?M:resolve_rate_limit(Opts, {?IP, 5000})
     ).
 
+resolve_on_without_real_ip_key_test() ->
+    %% proto_opts that omit `real_ip` entirely must still resolve to an active
+    %% guard keyed on the peer. Matching the key in the function head would send
+    %% this map to the `undefined` catch-all and silently disable rate limiting.
+    Table = new_table(),
+    Counter = atomics:new(1, [{signed, false}]),
+    Opts = #{
+        rate_limit => #{
+            rate => 10,
+            burst => 20,
+            period => 30,
+            idle_ttl => 60000,
+            sweep_interval => 10000,
+            table => Table
+        },
+        rate_limited_counter => Counter
+    },
+    ?assertEqual(
+        {10, 600000, 30000, Table, Counter, ?IP}, ?M:resolve_rate_limit(Opts, {?IP, 5000})
+    ).
+
 %% --- rate_limit_key/2 ---
 
 rate_limit_key_baked_ip_test() ->

--- a/test/roadrunner_rate_limit_store_tests.erl
+++ b/test/roadrunner_rate_limit_store_tests.erl
@@ -46,35 +46,52 @@ per_minute_rate_test() ->
 %% --- resolve_rate_limit/2 ---
 
 resolve_off_without_config_test() ->
-    ?assertEqual(undefined, ?M:resolve_rate_limit(proto_opts(undefined), {?IP, 5000})).
+    ?assertEqual(undefined, ?M:resolve_rate_limit(proto_opts(undefined), {?IP, 5000}, undefined)).
 
 resolve_off_without_peer_test() ->
     Table = new_table(),
-    ?assertEqual(undefined, ?M:resolve_rate_limit(proto_opts(Table), undefined)).
+    ?assertEqual(undefined, ?M:resolve_rate_limit(proto_opts(Table), undefined, undefined)).
 
 resolve_on_test() ->
     Table = new_table(),
     {Counter, Opts} = proto_opts_with_counter(Table),
     %% rate 10, burst 20, period 30 → Cost 30000, Cap 600000 baked in.
     ?assertEqual(
-        {10, 600000, 30000, Table, Counter, ?IP}, ?M:resolve_rate_limit(Opts, {?IP, 5000})
+        {10, 600000, 30000, Table, Counter, ?IP},
+        ?M:resolve_rate_limit(Opts, {?IP, 5000}, undefined)
     ).
 
-resolve_on_with_real_ip_keys_per_request_test() ->
-    %% With `real_ip` set, the baked key is the `client_ip` marker, not the peer:
-    %% the bucket keys on the per-request resolved client IP.
+resolve_on_with_trusted_peer_keys_per_request_test() ->
+    %% A TRUSTED peer's client can differ per request, so the key stays the
+    %% `client_ip` marker and the bucket follows the resolved client.
     Table = new_table(),
     RealIp = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
     {Counter, Opts} = proto_opts_with_counter(Table, RealIp),
+    Prepared = roadrunner_real_ip:prepare(RealIp, {?IP, 5000}),
     ?assertEqual(
         {10, 600000, 30000, Table, Counter, client_ip},
-        ?M:resolve_rate_limit(Opts, {?IP, 5000})
+        ?M:resolve_rate_limit(Opts, {?IP, 5000}, Prepared)
     ).
 
-resolve_on_without_real_ip_key_test() ->
-    %% proto_opts that omit `real_ip` entirely must still resolve to an active
-    %% guard keyed on the peer. Matching the key in the function head would send
-    %% this map to the `undefined` catch-all and silently disable rate limiting.
+resolve_on_with_untrusted_peer_bakes_the_key_test() ->
+    %% An UNTRUSTED peer always resolves to the same client, so the concrete
+    %% address is baked into the key and the per-request marker lookup is
+    %% skipped entirely.
+    Table = new_table(),
+    Peer = {198, 51, 100, 9},
+    RealIp = roadrunner_real_ip:compile(#{trusted_proxies => [~"127.0.0.1/32"]}),
+    {Counter, Opts} = proto_opts_with_counter(Table, RealIp),
+    Prepared = roadrunner_real_ip:prepare(RealIp, {Peer, 5000}),
+    ?assertEqual(
+        {10, 600000, 30000, Table, Counter, Peer},
+        ?M:resolve_rate_limit(Opts, {Peer, 5000}, Prepared)
+    ).
+
+resolve_on_without_optional_keys_test() ->
+    %% proto_opts that omit optional keys entirely must still resolve to an
+    %% active guard keyed on the peer. Matching such a key in the function head
+    %% would send this map to the `undefined` catch-all and silently disable
+    %% rate limiting.
     Table = new_table(),
     Counter = atomics:new(1, [{signed, false}]),
     Opts = #{
@@ -89,7 +106,8 @@ resolve_on_without_real_ip_key_test() ->
         rate_limited_counter => Counter
     },
     ?assertEqual(
-        {10, 600000, 30000, Table, Counter, ?IP}, ?M:resolve_rate_limit(Opts, {?IP, 5000})
+        {10, 600000, 30000, Table, Counter, ?IP},
+        ?M:resolve_rate_limit(Opts, {?IP, 5000}, undefined)
     ).
 
 %% --- rate_limit_key/2 ---

--- a/test/roadrunner_real_ip_listener_tests.erl
+++ b/test/roadrunner_real_ip_listener_tests.erl
@@ -64,6 +64,34 @@ h1_recursive_skips_trusted_chain_test() ->
     end).
 
 %% =============================================================================
+%% Rate limiting keys on the resolved client IP (real_ip + rate_limit together).
+%% =============================================================================
+
+rate_limit_keys_per_resolved_ip_test() ->
+    %% rate 1/burst 1, loopback trusted. Two requests forwarding the same client
+    %% share a bucket (second refused); a different forwarded client gets its own.
+    with_rl_listener(#{trusted_proxies => [~"127.0.0.1/32"]}, #{rate => 1, burst => 1}, fun(Port) ->
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, send(Port, ~"x-forwarded-for: 203.0.113.7\r\n")),
+        ?assertMatch(
+            <<"HTTP/1.1 429", _/binary>>, send(Port, ~"x-forwarded-for: 203.0.113.7\r\n")
+        ),
+        ?assertMatch(
+            <<"HTTP/1.1 200", _/binary>>, send(Port, ~"x-forwarded-for: 198.51.100.9\r\n")
+        )
+    end).
+
+rate_limit_untrusted_peer_shares_peer_bucket_test() ->
+    %% Loopback is untrusted, so the forwarded header is ignored and every
+    %% request keys on the socket peer — even distinct forwarded clients share
+    %% the one bucket, so the second is refused.
+    with_rl_listener(#{trusted_proxies => [~"10.0.0.0/8"]}, #{rate => 1, burst => 1}, fun(Port) ->
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, send(Port, ~"x-forwarded-for: 203.0.113.7\r\n")),
+        ?assertMatch(
+            <<"HTTP/1.1 429", _/binary>>, send(Port, ~"x-forwarded-for: 198.51.100.9\r\n")
+        )
+    end).
+
+%% =============================================================================
 %% End-to-end resolution over HTTP/2 (h2c) — proves the multiplexed build path
 %% stashes the resolved client IP onto the request.
 %% =============================================================================
@@ -107,17 +135,38 @@ with_listener(Protocols, RealIp, Fun) ->
         ok = roadrunner_listener:stop(Name)
     end.
 
+with_rl_listener(RealIp, RateLimit, Fun) ->
+    Name = unique(ri_rl_it),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => [http1],
+        real_ip => RealIp,
+        rate_limit => RateLimit,
+        routes => roadrunner_client_ip_handler
+    }),
+    Port = roadrunner_listener:port(Name),
+    try
+        Fun(Port)
+    after
+        ok = roadrunner_listener:stop(Name)
+    end.
+
 unique(Prefix) ->
     list_to_atom(atom_to_list(Prefix) ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
 
-%% Send a GET with the given extra header lines and return the response body.
+%% Send a GET with the given extra header lines and return the resolved client
+%% IP the handler echoed (the response body).
 h1_client_ip(Port, ExtraHeaders) ->
+    body(send(Port, ExtraHeaders)).
+
+%% Send a GET with the given extra header lines and return the full response.
+send(Port, ExtraHeaders) ->
     {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
     Req = [~"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n", ExtraHeaders, ~"\r\n"],
     ok = gen_tcp:send(Sock, Req),
     Reply = recv_for(Sock, <<>>, 1000),
     ok = gen_tcp:close(Sock),
-    body(Reply).
+    Reply.
 
 body(Reply) ->
     case binary:split(Reply, ~"\r\n\r\n") of

--- a/test/roadrunner_real_ip_listener_tests.erl
+++ b/test/roadrunner_real_ip_listener_tests.erl
@@ -1,0 +1,149 @@
+-module(roadrunner_real_ip_listener_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% =============================================================================
+%% Opt validation (trap_exit so the bad start surfaces as `{error, _}`).
+%% =============================================================================
+
+valid_real_ip_starts_test() ->
+    with_listener([http1], #{trusted_proxies => [~"127.0.0.1/32"]}, fun(_Port, Name) ->
+        ?assert(is_integer(roadrunner_listener:port(Name)))
+    end).
+
+rejects_missing_trusted_proxies_test() ->
+    ?assertMatch(
+        {error, {{invalid_listener_opt, real_ip, trusted_proxies_required}, _}},
+        start(ri_missing, [http1], #{header => ~"x-real-ip"})
+    ).
+
+rejects_non_map_real_ip_test() ->
+    ?assertMatch(
+        {error, {{invalid_listener_opt, real_ip, true}, _}},
+        start(ri_non_map, [http1], true)
+    ).
+
+rejects_bad_cidr_test() ->
+    ?assertMatch(
+        {error, {{invalid_listener_opt, real_ip, {trusted_proxy, _}}, _}},
+        start(ri_bad_cidr, [http1], #{trusted_proxies => [~"999.0.0.0/8"]})
+    ).
+
+%% =============================================================================
+%% End-to-end resolution over HTTP/1.
+%% =============================================================================
+
+h1_trusted_peer_resolves_xff_test() ->
+    %% The loopback test client is a trusted proxy, so its X-Forwarded-For is
+    %% honored: the handler sees the forwarded client, not 127.0.0.1.
+    with_listener([http1], #{trusted_proxies => [~"127.0.0.1/32"]}, fun(Port, _Name) ->
+        ?assertEqual(~"203.0.113.7", h1_client_ip(Port, ~"x-forwarded-for: 203.0.113.7\r\n"))
+    end).
+
+h1_untrusted_peer_ignores_xff_test() ->
+    %% Loopback is NOT in the trust list, so the forwarded header is ignored and
+    %% the request keys on the real socket peer.
+    with_listener([http1], #{trusted_proxies => [~"10.0.0.0/8"]}, fun(Port, _Name) ->
+        ?assertEqual(~"127.0.0.1", h1_client_ip(Port, ~"x-forwarded-for: 203.0.113.7\r\n"))
+    end).
+
+h1_no_header_uses_peer_test() ->
+    with_listener([http1], #{trusted_proxies => [~"127.0.0.1/32"]}, fun(Port, _Name) ->
+        ?assertEqual(~"127.0.0.1", h1_client_ip(Port, ~""))
+    end).
+
+h1_recursive_skips_trusted_chain_test() ->
+    %% client -> trusted hop (10.1.2.3) -> us: walk past the trusted hop to the
+    %% real client.
+    Cfg = #{trusted_proxies => [~"127.0.0.1/32", ~"10.0.0.0/8"]},
+    with_listener([http1], Cfg, fun(Port, _Name) ->
+        ?assertEqual(
+            ~"203.0.113.7",
+            h1_client_ip(Port, ~"x-forwarded-for: 203.0.113.7, 10.1.2.3\r\n")
+        )
+    end).
+
+%% =============================================================================
+%% End-to-end resolution over HTTP/2 (h2c) — proves the multiplexed build path
+%% stashes the resolved client IP onto the request.
+%% =============================================================================
+
+h2c_trusted_peer_resolves_xff_test() ->
+    with_listener([http2], #{trusted_proxies => [~"127.0.0.1/32"]}, fun(Port, _Name) ->
+        {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        Preface = ~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+        EmptySettings = <<0:24, 4, 0, 0:32>>,
+        ok = gen_tcp:send(Sock, [Preface, EmptySettings | h2_request_frames()]),
+        Reply = recv_for(Sock, <<>>, 800),
+        ok = gen_tcp:close(Sock),
+        %% The handler writes the resolved IP literal as the response body (a
+        %% DATA frame payload), so the forwarded client appears verbatim.
+        ?assertMatch({match, _}, re:run(Reply, ~"203\\.0\\.113\\.7"))
+    end).
+
+%% --- helpers ---
+
+start(Name, Protocols, RealIp) ->
+    process_flag(trap_exit, true),
+    roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => Protocols,
+        real_ip => RealIp,
+        routes => roadrunner_client_ip_handler
+    }).
+
+with_listener(Protocols, RealIp, Fun) ->
+    Name = unique(ri_it),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        protocols => Protocols,
+        real_ip => RealIp,
+        routes => roadrunner_client_ip_handler
+    }),
+    Port = roadrunner_listener:port(Name),
+    try
+        Fun(Port, Name)
+    after
+        ok = roadrunner_listener:stop(Name)
+    end.
+
+unique(Prefix) ->
+    list_to_atom(atom_to_list(Prefix) ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
+
+%% Send a GET with the given extra header lines and return the response body.
+h1_client_ip(Port, ExtraHeaders) ->
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    Req = [~"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n", ExtraHeaders, ~"\r\n"],
+    ok = gen_tcp:send(Sock, Req),
+    Reply = recv_for(Sock, <<>>, 1000),
+    ok = gen_tcp:close(Sock),
+    body(Reply).
+
+body(Reply) ->
+    case binary:split(Reply, ~"\r\n\r\n") of
+        [_Headers, Body] -> Body;
+        _ -> Reply
+    end.
+
+recv_for(Sock, Acc, Timeout) ->
+    case gen_tcp:recv(Sock, 0, Timeout) of
+        {ok, Data} -> recv_for(Sock, <<Acc/binary, Data/binary>>, Timeout);
+        {error, _} -> Acc
+    end.
+
+h2_request_frames() ->
+    {Block, _Enc} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"http"},
+            {~":authority", ~"x"},
+            {~":path", ~"/"},
+            {~"x-forwarded-for", ~"203.0.113.7"}
+        ],
+        roadrunner_http2_hpack:new_encoder(4096)
+    ),
+    [
+        roadrunner_http2_frame:encode(
+            {headers, 1, 16#04 bor 16#01, undefined, iolist_to_binary(Block)}
+        )
+    ].

--- a/test/roadrunner_real_ip_tests.erl
+++ b/test/roadrunner_real_ip_tests.erl
@@ -1,0 +1,245 @@
+-module(roadrunner_real_ip_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, roadrunner_real_ip).
+
+%% A config trusting loopback, the RFC1918 10/8 block, and IPv6 loopback,
+%% reading the default `x-forwarded-for` header.
+cfg() ->
+    ?M:compile(#{trusted_proxies => [~"127.0.0.1/32", ~"10.0.0.0/8", ~"::1/128"]}).
+
+xff(Value) ->
+    [{~"host", ~"example.com"}, {~"x-forwarded-for", Value}].
+
+%% --- compile/1: validation ---
+
+compile_undefined_test() ->
+    ?assertEqual(undefined, ?M:compile(undefined)).
+
+compile_ok_default_header_test() ->
+    Cfg = ?M:compile(#{trusted_proxies => [~"10.0.0.0/8"]}),
+    ?assertMatch(#{header := ~"x-forwarded-for", trusted := [_]}, Cfg).
+
+compile_ok_custom_header_lowercased_test() ->
+    Cfg = ?M:compile(#{trusted_proxies => [~"10.0.0.0/8"], header => ~"X-Real-IP"}),
+    ?assertMatch(#{header := ~"x-real-ip"}, Cfg).
+
+compile_bare_address_is_full_prefix_test() ->
+    %% A bare address (no `/prefix`) trusts only that exact host (full /32).
+    Cfg = ?M:compile(#{trusted_proxies => [~"192.0.2.1"]}),
+    %% A neighbor is untrusted, so its header is ignored and it keys on itself.
+    ?assertEqual({192, 0, 2, 2}, ?M:resolve(Cfg, {{192, 0, 2, 2}, 1}, xff(~"203.0.113.5"))),
+    ?assertEqual(
+        {203, 0, 113, 5},
+        ?M:resolve(Cfg, {{192, 0, 2, 1}, 1}, xff(~"203.0.113.5"))
+    ).
+
+compile_v6_cidr_test() ->
+    Cfg = ?M:compile(#{trusted_proxies => [~"2001:db8::/32"]}),
+    ?assertMatch(#{trusted := [{8, _, _}]}, Cfg).
+
+compile_missing_trusted_proxies_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, trusted_proxies_required},
+        ?M:compile(#{header => ~"x-real-ip"})
+    ).
+
+compile_empty_trusted_proxies_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, empty_trusted_proxies},
+        ?M:compile(#{trusted_proxies => []})
+    ).
+
+compile_trusted_proxies_not_a_list_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {trusted_proxies, ~"10.0.0.0/8"}},
+        ?M:compile(#{trusted_proxies => ~"10.0.0.0/8"})
+    ).
+
+compile_non_binary_cidr_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {trusted_proxy, {10, 0, 0, 0}}},
+        ?M:compile(#{trusted_proxies => [{10, 0, 0, 0}]})
+    ).
+
+compile_bad_address_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {trusted_proxy, ~"999.1.1.1"}},
+        ?M:compile(#{trusted_proxies => [~"999.1.1.1/8"]})
+    ).
+
+compile_prefix_too_large_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {prefix, ~"33"}},
+        ?M:compile(#{trusted_proxies => [~"10.0.0.0/33"]})
+    ).
+
+compile_prefix_not_integer_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {prefix, ~"8x"}},
+        ?M:compile(#{trusted_proxies => [~"10.0.0.0/8x"]})
+    ).
+
+compile_v6_prefix_too_large_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {prefix, ~"129"}},
+        ?M:compile(#{trusted_proxies => [~"2001:db8::/129"]})
+    ).
+
+compile_bad_header_type_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {header, not_a_binary}},
+        ?M:compile(#{trusted_proxies => [~"10.0.0.0/8"], header => not_a_binary})
+    ).
+
+compile_empty_header_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {header, ~""}},
+        ?M:compile(#{trusted_proxies => [~"10.0.0.0/8"], header => ~""})
+    ).
+
+compile_unknown_keys_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, {unknown_keys, [recursive]}},
+        ?M:compile(#{trusted_proxies => [~"10.0.0.0/8"], recursive => true})
+    ).
+
+compile_non_map_test() ->
+    ?assertError(
+        {invalid_listener_opt, real_ip, true},
+        ?M:compile(true)
+    ).
+
+%% --- resolve/3 ---
+
+resolve_undefined_peer_test() ->
+    ?assertEqual(undefined, ?M:resolve(cfg(), undefined, xff(~"203.0.113.7"))).
+
+resolve_untrusted_peer_ignores_header_test() ->
+    %% A direct (untrusted) client cannot spoof its IP via the header.
+    ?assertEqual(
+        {198, 51, 100, 9},
+        ?M:resolve(cfg(), {{198, 51, 100, 9}, 4321}, xff(~"203.0.113.7"))
+    ).
+
+resolve_trusted_peer_no_header_test() ->
+    ?assertEqual(
+        {10, 0, 0, 1},
+        ?M:resolve(cfg(), {{10, 0, 0, 1}, 80}, [{~"host", ~"example.com"}])
+    ).
+
+resolve_single_client_test() ->
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"203.0.113.7"))
+    ).
+
+resolve_spoofed_leftmost_ignored_test() ->
+    %% Client sent `X-Forwarded-For: 1.2.3.4`; the trusted proxy appended the
+    %% real socket address. The rightmost untrusted entry wins.
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"1.2.3.4, 203.0.113.7"))
+    ).
+
+resolve_recursive_skips_trusted_chain_test() ->
+    %% client -> trusted CDN (10.1.2.3) -> us. Walk past the trusted hop.
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"203.0.113.7, 10.1.2.3"))
+    ).
+
+resolve_all_trusted_returns_leftmost_test() ->
+    ?assertEqual(
+        {10, 9, 9, 9},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"10.9.9.9, 10.1.2.3"))
+    ).
+
+resolve_leading_ows_trimmed_test() ->
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"   203.0.113.7   "))
+    ).
+
+resolve_empty_header_value_falls_back_to_peer_test() ->
+    ?assertEqual(
+        {10, 0, 0, 1},
+        ?M:resolve(cfg(), {{10, 0, 0, 1}, 80}, xff(~""))
+    ).
+
+resolve_bad_nearest_hop_falls_back_to_peer_test() ->
+    %% Malformed rightmost entry: stop, key on the peer.
+    ?assertEqual(
+        {10, 0, 0, 1},
+        ?M:resolve(cfg(), {{10, 0, 0, 1}, 80}, xff(~"203.0.113.7, garbage"))
+    ).
+
+resolve_bad_entry_behind_trusted_falls_back_to_trusted_test() ->
+    %% client(bad) -> trusted hop -> us: the trusted hop is the last good.
+    ?assertEqual(
+        {10, 1, 2, 3},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"garbage, 10.1.2.3"))
+    ).
+
+resolve_joins_repeated_headers_in_order_test() ->
+    %% Two X-Forwarded-For lines are equivalent to one comma-joined value
+    %% (RFC 9110 §5.3): client -> trusted hop, split across lines.
+    Headers = [
+        {~"x-forwarded-for", ~"203.0.113.7"},
+        {~"x-forwarded-for", ~"10.1.2.3"}
+    ],
+    ?assertEqual({203, 0, 113, 7}, ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, Headers)).
+
+resolve_repeated_headers_ignore_spoofed_leftmost_test() ->
+    %% A proxy that forwards the client's header as a separate line before
+    %% appending the real client: the rightmost untrusted entry still wins, so
+    %% the spoofed first line is ignored (keyfind-first would have trusted it).
+    Headers = [
+        {~"x-forwarded-for", ~"1.2.3.4"},
+        {~"x-forwarded-for", ~"203.0.113.7"}
+    ],
+    ?assertEqual({203, 0, 113, 7}, ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, Headers)).
+
+resolve_custom_header_test() ->
+    Cfg = ?M:compile(#{trusted_proxies => [~"10.0.0.0/8"], header => ~"x-real-ip"}),
+    Headers = [{~"x-real-ip", ~"203.0.113.42"}],
+    ?assertEqual({203, 0, 113, 42}, ?M:resolve(Cfg, {{10, 0, 0, 5}, 80}, Headers)).
+
+resolve_ipv6_peer_and_client_test() ->
+    Cfg = ?M:compile(#{trusted_proxies => [~"2001:db8::/32"]}),
+    Peer = {{16#2001, 16#db8, 0, 0, 0, 0, 0, 1}, 80},
+    ?assertEqual(
+        {16#2606, 16#4700, 0, 0, 0, 0, 0, 16#1111},
+        ?M:resolve(Cfg, Peer, xff(~"2606:4700::1111"))
+    ).
+
+resolve_v4_mapped_peer_matches_v4_cidr_test() ->
+    %% A dual-stack proxy reports `::ffff:10.0.0.1`; it must match `10.0.0.0/8`.
+    Mapped = {0, 0, 0, 0, 0, 16#ffff, 16#0a00, 16#0001},
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(cfg(), {Mapped, 80}, xff(~"203.0.113.7"))
+    ).
+
+resolve_v4_mapped_chain_entry_unwrapped_test() ->
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"::ffff:203.0.113.7"))
+    ).
+
+resolve_family_mismatch_not_trusted_test() ->
+    %% An IPv6 client against a v4-only trust list is untrusted (returned as-is
+    %% only if it were the peer); here the v6 entry is the rightmost untrusted.
+    ?assertEqual(
+        {16#2001, 16#db8, 0, 0, 0, 0, 0, 16#99},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"2001:db8::99"))
+    ).
+
+resolve_prefix_zero_trusts_all_v4_test() ->
+    Cfg = ?M:compile(#{trusted_proxies => [~"0.0.0.0/0"]}),
+    %% Every v4 peer is trusted, so the header is always honored.
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(Cfg, {{198, 51, 100, 9}, 80}, xff(~"203.0.113.7"))
+    ).

--- a/test/roadrunner_real_ip_tests.erl
+++ b/test/roadrunner_real_ip_tests.erl
@@ -4,6 +4,15 @@
 
 -define(M, roadrunner_real_ip).
 
+%% Drive the two-phase API the conn loops use: prepare once per connection,
+%% then resolve per request. Mirrors `roadrunner_conn:maybe_put_client_ip/2`,
+%% which skips resolution entirely when `prepare/2` yields `undefined`.
+resolve(Cfg, Peer, Headers) ->
+    case ?M:prepare(Cfg, Peer) of
+        undefined -> undefined;
+        Prepared -> ?M:resolve(Prepared, Headers)
+    end.
+
 %% A config trusting loopback, the RFC1918 10/8 block, and IPv6 loopback,
 %% reading the default `x-forwarded-for` header.
 cfg() ->
@@ -11,6 +20,34 @@ cfg() ->
 
 xff(Value) ->
     [{~"host", ~"example.com"}, {~"x-forwarded-for", Value}].
+
+%% --- prepare/2: per-connection baking ---
+
+prepare_off_is_undefined_test() ->
+    ?assertEqual(undefined, ?M:prepare(undefined, {{127, 0, 0, 1}, 80})).
+
+prepare_unknown_peer_is_undefined_test() ->
+    ?assertEqual(undefined, ?M:prepare(cfg(), undefined)).
+
+prepare_untrusted_peer_bakes_a_constant_test() ->
+    %% An untrusted peer can never have its forwarded header honored, so the
+    %% answer is fixed for the whole connection and no header is ever scanned.
+    ?assertEqual(
+        {const, {198, 51, 100, 9}}, ?M:prepare(cfg(), {{198, 51, 100, 9}, 4321})
+    ).
+
+prepare_untrusted_peer_unmaps_v4_mapped_test() ->
+    %% The v4-mapped normalization is part of the baked constant, not repeated.
+    Mapped = {0, 0, 0, 0, 0, 16#ffff, 16#c633, 16#6409},
+    ?assertEqual({const, {198, 51, 100, 9}}, ?M:prepare(cfg(), {Mapped, 4321})).
+
+prepare_trusted_peer_keeps_the_walk_test() ->
+    %% Only a trusted peer's client can vary per request, so only it carries
+    %% the trusted set and header name forward for the per-request walk.
+    ?assertMatch(
+        {walk, [_ | _], ~"x-forwarded-for", {127, 0, 0, 1}},
+        ?M:prepare(cfg(), {{127, 0, 0, 1}, 80})
+    ).
 
 %% --- compile/1: validation ---
 
@@ -29,10 +66,10 @@ compile_bare_address_is_full_prefix_test() ->
     %% A bare address (no `/prefix`) trusts only that exact host (full /32).
     Cfg = ?M:compile(#{trusted_proxies => [~"192.0.2.1"]}),
     %% A neighbor is untrusted, so its header is ignored and it keys on itself.
-    ?assertEqual({192, 0, 2, 2}, ?M:resolve(Cfg, {{192, 0, 2, 2}, 1}, xff(~"203.0.113.5"))),
+    ?assertEqual({192, 0, 2, 2}, resolve(Cfg, {{192, 0, 2, 2}, 1}, xff(~"203.0.113.5"))),
     ?assertEqual(
         {203, 0, 113, 5},
-        ?M:resolve(Cfg, {{192, 0, 2, 1}, 1}, xff(~"203.0.113.5"))
+        resolve(Cfg, {{192, 0, 2, 1}, 1}, xff(~"203.0.113.5"))
     ).
 
 compile_v6_cidr_test() ->
@@ -114,25 +151,25 @@ compile_non_map_test() ->
 %% --- resolve/3 ---
 
 resolve_undefined_peer_test() ->
-    ?assertEqual(undefined, ?M:resolve(cfg(), undefined, xff(~"203.0.113.7"))).
+    ?assertEqual(undefined, resolve(cfg(), undefined, xff(~"203.0.113.7"))).
 
 resolve_untrusted_peer_ignores_header_test() ->
     %% A direct (untrusted) client cannot spoof its IP via the header.
     ?assertEqual(
         {198, 51, 100, 9},
-        ?M:resolve(cfg(), {{198, 51, 100, 9}, 4321}, xff(~"203.0.113.7"))
+        resolve(cfg(), {{198, 51, 100, 9}, 4321}, xff(~"203.0.113.7"))
     ).
 
 resolve_trusted_peer_no_header_test() ->
     ?assertEqual(
         {10, 0, 0, 1},
-        ?M:resolve(cfg(), {{10, 0, 0, 1}, 80}, [{~"host", ~"example.com"}])
+        resolve(cfg(), {{10, 0, 0, 1}, 80}, [{~"host", ~"example.com"}])
     ).
 
 resolve_single_client_test() ->
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"203.0.113.7"))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"203.0.113.7"))
     ).
 
 resolve_spoofed_leftmost_ignored_test() ->
@@ -140,7 +177,7 @@ resolve_spoofed_leftmost_ignored_test() ->
     %% real socket address. The rightmost untrusted entry wins.
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"1.2.3.4, 203.0.113.7"))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"1.2.3.4, 203.0.113.7"))
     ).
 
 resolve_garbage_left_of_the_client_is_never_consulted_test() ->
@@ -150,46 +187,46 @@ resolve_garbage_left_of_the_client_is_never_consulted_test() ->
     Junk = binary:copy(~"not-an-ip, ", 50),
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(<<Junk/binary, "203.0.113.7">>))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(<<Junk/binary, "203.0.113.7">>))
     ).
 
 resolve_recursive_skips_trusted_chain_test() ->
     %% client -> trusted CDN (10.1.2.3) -> us. Walk past the trusted hop.
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"203.0.113.7, 10.1.2.3"))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"203.0.113.7, 10.1.2.3"))
     ).
 
 resolve_all_trusted_returns_leftmost_test() ->
     ?assertEqual(
         {10, 9, 9, 9},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"10.9.9.9, 10.1.2.3"))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"10.9.9.9, 10.1.2.3"))
     ).
 
 resolve_leading_ows_trimmed_test() ->
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"   203.0.113.7   "))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"   203.0.113.7   "))
     ).
 
 resolve_empty_header_value_falls_back_to_peer_test() ->
     ?assertEqual(
         {10, 0, 0, 1},
-        ?M:resolve(cfg(), {{10, 0, 0, 1}, 80}, xff(~""))
+        resolve(cfg(), {{10, 0, 0, 1}, 80}, xff(~""))
     ).
 
 resolve_bad_nearest_hop_falls_back_to_peer_test() ->
     %% Malformed rightmost entry: stop, key on the peer.
     ?assertEqual(
         {10, 0, 0, 1},
-        ?M:resolve(cfg(), {{10, 0, 0, 1}, 80}, xff(~"203.0.113.7, garbage"))
+        resolve(cfg(), {{10, 0, 0, 1}, 80}, xff(~"203.0.113.7, garbage"))
     ).
 
 resolve_bad_entry_behind_trusted_falls_back_to_trusted_test() ->
     %% client(bad) -> trusted hop -> us: the trusted hop is the last good.
     ?assertEqual(
         {10, 1, 2, 3},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"garbage, 10.1.2.3"))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"garbage, 10.1.2.3"))
     ).
 
 resolve_joins_repeated_headers_in_order_test() ->
@@ -199,7 +236,7 @@ resolve_joins_repeated_headers_in_order_test() ->
         {~"x-forwarded-for", ~"203.0.113.7"},
         {~"x-forwarded-for", ~"10.1.2.3"}
     ],
-    ?assertEqual({203, 0, 113, 7}, ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, Headers)).
+    ?assertEqual({203, 0, 113, 7}, resolve(cfg(), {{127, 0, 0, 1}, 80}, Headers)).
 
 resolve_repeated_headers_ignore_spoofed_leftmost_test() ->
     %% A proxy that forwards the client's header as a separate line before
@@ -209,19 +246,19 @@ resolve_repeated_headers_ignore_spoofed_leftmost_test() ->
         {~"x-forwarded-for", ~"1.2.3.4"},
         {~"x-forwarded-for", ~"203.0.113.7"}
     ],
-    ?assertEqual({203, 0, 113, 7}, ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, Headers)).
+    ?assertEqual({203, 0, 113, 7}, resolve(cfg(), {{127, 0, 0, 1}, 80}, Headers)).
 
 resolve_custom_header_test() ->
     Cfg = ?M:compile(#{trusted_proxies => [~"10.0.0.0/8"], header => ~"x-real-ip"}),
     Headers = [{~"x-real-ip", ~"203.0.113.42"}],
-    ?assertEqual({203, 0, 113, 42}, ?M:resolve(Cfg, {{10, 0, 0, 5}, 80}, Headers)).
+    ?assertEqual({203, 0, 113, 42}, resolve(Cfg, {{10, 0, 0, 5}, 80}, Headers)).
 
 resolve_ipv6_peer_and_client_test() ->
     Cfg = ?M:compile(#{trusted_proxies => [~"2001:db8::/32"]}),
     Peer = {{16#2001, 16#db8, 0, 0, 0, 0, 0, 1}, 80},
     ?assertEqual(
         {16#2606, 16#4700, 0, 0, 0, 0, 0, 16#1111},
-        ?M:resolve(Cfg, Peer, xff(~"2606:4700::1111"))
+        resolve(Cfg, Peer, xff(~"2606:4700::1111"))
     ).
 
 resolve_v4_mapped_peer_matches_v4_cidr_test() ->
@@ -229,13 +266,13 @@ resolve_v4_mapped_peer_matches_v4_cidr_test() ->
     Mapped = {0, 0, 0, 0, 0, 16#ffff, 16#0a00, 16#0001},
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(cfg(), {Mapped, 80}, xff(~"203.0.113.7"))
+        resolve(cfg(), {Mapped, 80}, xff(~"203.0.113.7"))
     ).
 
 resolve_v4_mapped_chain_entry_unwrapped_test() ->
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"::ffff:203.0.113.7"))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"::ffff:203.0.113.7"))
     ).
 
 resolve_family_mismatch_not_trusted_test() ->
@@ -243,7 +280,7 @@ resolve_family_mismatch_not_trusted_test() ->
     %% only if it were the peer); here the v6 entry is the rightmost untrusted.
     ?assertEqual(
         {16#2001, 16#db8, 0, 0, 0, 0, 0, 16#99},
-        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"2001:db8::99"))
+        resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"2001:db8::99"))
     ).
 
 resolve_prefix_zero_trusts_all_v4_test() ->
@@ -251,5 +288,5 @@ resolve_prefix_zero_trusts_all_v4_test() ->
     %% Every v4 peer is trusted, so the header is always honored.
     ?assertEqual(
         {203, 0, 113, 7},
-        ?M:resolve(Cfg, {{198, 51, 100, 9}, 80}, xff(~"203.0.113.7"))
+        resolve(Cfg, {{198, 51, 100, 9}, 80}, xff(~"203.0.113.7"))
     ).

--- a/test/roadrunner_real_ip_tests.erl
+++ b/test/roadrunner_real_ip_tests.erl
@@ -143,6 +143,16 @@ resolve_spoofed_leftmost_ignored_test() ->
         ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(~"1.2.3.4, 203.0.113.7"))
     ).
 
+resolve_garbage_left_of_the_client_is_never_consulted_test() ->
+    %% Everything left of the proxy's own append is client-supplied. The walk
+    %% stops at the rightmost untrusted hop, so unparseable junk further left
+    %% must not change the result (nor cost a parse).
+    Junk = binary:copy(~"not-an-ip, ", 50),
+    ?assertEqual(
+        {203, 0, 113, 7},
+        ?M:resolve(cfg(), {{127, 0, 0, 1}, 80}, xff(<<Junk/binary, "203.0.113.7">>))
+    ).
+
 resolve_recursive_skips_trusted_chain_test() ->
     %% client -> trusted CDN (10.1.2.3) -> us. Walk past the trusted hop.
     ?assertEqual(

--- a/test/roadrunner_req_tests.erl
+++ b/test/roadrunner_req_tests.erl
@@ -441,6 +441,19 @@ peer_present_test() ->
 peer_absent_returns_undefined_test() ->
     ?assertEqual(undefined, roadrunner_req:peer(sample_req())).
 
+%% --- client_ip/1 ---
+
+client_ip_resolved_test() ->
+    Req = (sample_req())#{peer => {{127, 0, 0, 1}, 80}, client_ip => {203, 0, 113, 7}},
+    ?assertEqual({203, 0, 113, 7}, roadrunner_req:client_ip(Req)).
+
+client_ip_falls_back_to_peer_test() ->
+    Req = (sample_req())#{peer => {{198, 51, 100, 9}, 4321}},
+    ?assertEqual({198, 51, 100, 9}, roadrunner_req:client_ip(Req)).
+
+client_ip_absent_returns_undefined_test() ->
+    ?assertEqual(undefined, roadrunner_req:client_ip(sample_req())).
+
 %% --- scheme/1 ---
 
 scheme_http_test() ->


### PR DESCRIPTION
# Description

Behind an HTTP-terminating reverse proxy the socket peer is the proxy, so `roadrunner_req:client_ip/1` reports the proxy for every request and the per-peer `rate_limit` bucket collapses onto a single key. The new `real_ip` listener option opts into nginx-`realip`-style resolution: the immediate peer must itself match `trusted_proxies` before any forwarded header is honored, then the chain is walked right-to-left, skipping trusted proxies, to the first untrusted address. A client that bypasses the proxy has its own header ignored, so it cannot spoof its address. The resolved address feeds both `client_ip/1` and the rate-limit key, and composes with `proxy_protocol` (the PROXY-reported address becomes the immediate hop). CIDRs are pre-compiled at listener init to `{Family, NetPrefix, Shift}`, so the per-request check is a shift and a compare.

```erlang
roadrunner:start_listener(api, #{
    port => 8080,
    real_ip => #{trusted_proxies => [~"10.0.0.0/8", ~"::1/128"]},
    rate_limit => #{limit => 100, window => 1000}
}, Routes).
```

RFC 9110 §5.3 makes repeated field lines equivalent to the single comma-joined value, so a proxy that emits the chain as separate header lines resolves identically to one that combines it.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)