### PR TITLE
Add per-route rate-limit overrides on map-form routes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -467,6 +467,26 @@ demonstrate the pattern they want. The single-route equality check
 is the wrong model for catch-all routes (`/api/*path`) that
 multiplex methods downstream.
 
+### Per-route `max_body => non_neg_integer()` body-size override — medium
+
+**What:** A per-route override of the listener-global `max_content_length`, so an
+endpoint can cap its body tighter than the default (e.g. `/login` at 64 KB while
+the listener allows 10 MB). The per-route `rate_limit` override already ships;
+this is its body-size sibling.
+
+**Why harder than `rate_limit`:** `max_content_length` is enforced *during* body
+read/accumulation in all three protocols, which runs *before* the route is
+resolved today. The path is known right after headers, so the fix is early route
+resolution at headers-complete (gated on any route declaring `max_body`, to keep
+the common path unchanged), caching the matched route to reuse at dispatch: H1
+resolves before the body-read phase and passes the route's limit to the existing
+body reader (reusing the oversized-body drain + 413 path); H2/H3 store the
+effective limit on the stream entry and enforce it in the DATA-accumulation size
+check.
+
+**Scope:** medium. The early-route-match plumbing is the bulk; the limit
+enforcement reuses the existing oversized-body paths.
+
 ### Nested route groups with shared prefix + middlewares — medium
 
 **What:** Phoenix-style scope / pipeline:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -442,6 +442,24 @@ top-level keys add new per-route capabilities without breaking
 existing routes. None of the below is wired up yet; the map shape
 is ready when one of these has a real caller behind it.
 
+### Reuse the dispatch route match for the per-route rate-limit lookup — medium
+
+**What:** The rate guard runs before route resolution so a refused request skips
+routing entirely. To find a per-route `rate_limit` it therefore does its own
+`path_segments/1` split and its own first-match scan, and dispatch then repeats
+both moments later in `match/3`. A listener with any per-route limit pays
+roughly double the router work per request.
+
+**Why deferred:** the duplication only exists when a per-route limit is
+configured (the compiled subset is `undefined` otherwise, and the lookup is
+skipped), and the router match is cheap next to the handler. Collapsing it means
+either routing before the guard (so refused requests pay for routing) or
+threading the matched route from the guard into dispatch, which widens the
+dispatch signature across all three protocol loops.
+
+**Scope:** medium. The win is real but narrow; wants a profile on a
+per-route-limited listener before taking on the plumbing.
+
 ### Per-route `name => atom()` for telemetry / reverse routing — small
 
 **What:** Let a route declare a stable name (e.g. `name =>
@@ -453,19 +471,6 @@ to a path.
 **Why deferred:** no telemetry consumer asking for it today.
 `(listener_name, method, path)` is already enough to identify a
 route in dashboards; named lookup is a niceness, not a need.
-
-### Per-route `methods => [binary()]` allowlist with automatic 405 — small
-
-**What:** `methods => [~"GET", ~"PUT"]` on a route map means the
-framework returns `405 Method Not Allowed` (with the right `Allow`
-header) for any other method on that path. Eliminates the
-boilerplate every handler currently writes to gate on
-`roadrunner_req:method/1`.
-
-**Why deferred:** simple to bolt on once a couple of real handlers
-demonstrate the pattern they want. The single-route equality check
-is the wrong model for catch-all routes (`/api/*path`) that
-multiplex methods downstream.
 
 ### Per-route `max_body => non_neg_integer()` body-size override — medium
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -67,6 +67,8 @@
     send_rate_limited/2,
     rate_limit_check/6,
     rate_limit_key/2,
+    rate_limit_lookup/2,
+    rate_limit_apply/2,
     resolve_rate_limit/3,
     maybe_put_client_ip/2,
     rate_limited_telemetry/2,
@@ -194,33 +196,43 @@
     handler_start_timeout => timeout()
 }.
 
-%% Resolved per-peer rate-limit config, built by `roadrunner_listener` when the
-%% `rate_limit` opt is set: `rate` requests per `period` seconds with a `burst`
-%% bucket capacity, and an `idle_ttl`/`sweep_interval` (ms) eviction policy for
-%% the ETS `table` holding each peer's bucket. The cumulative refusal count
-%% lives in the top-level `rate_limited_counter`.
+%% Resolved rate-limit config in `proto_opts`, built by `roadrunner_listener`
+%% when rate limiting is active (a listener-global `rate_limit` opt OR any
+%% per-route override): an `idle_ttl`/`sweep_interval` (ms) eviction policy for
+%% the ETS `table` holding the buckets. `rate`/`burst`/`period` are present only
+%% for a listener-global limit (absent when only per-route limits exist). The
+%% cumulative refusal count lives in the top-level `rate_limited_counter`.
 -type rate_limit() :: #{
-    rate := pos_integer(),
-    burst := pos_integer(),
-    period := pos_integer(),
+    rate => pos_integer(),
+    burst => pos_integer(),
+    period => pos_integer(),
     idle_ttl := pos_integer(),
     sweep_interval := pos_integer(),
     table := ets:table()
 }.
 
-%% The per-connection rate-limit guard state cached on each conn loop's record:
-%% the `{Rate, Cap, Cost, Table, Counter, Key}` resolved from `proto_opts` + the
-%% peer once at setup (see `resolve_rate_limit/3`) — with `Cap`/`Cost` already
-%% derived so the per-request check does no arithmetic — or `undefined` when the
-%% guard is off or the peer IP is unknown. `Key` is the baked peer `IP`, or the
-%% `client_ip` marker when the `real_ip` opt is also set, meaning the bucket
-%% keys on the per-request resolved client IP (read via `rate_limit_key/2`).
-%% Checked by `rate_limit_check/6`.
+%% A bucket key: the client IP for a listener-global limit, or `{RoutePath, IP}`
+%% for a per-route limit (its own namespace in the shared table). The check and
+%% eviction treat it opaquely.
+-type bucket_key() :: inet:ip_address() | {binary(), inet:ip_address()}.
+
+%% The pre-derived `{Rate, Cap, Cost}` unit triple of one limit, baked once so
+%% the per-request check does no arithmetic.
+-type rate_limit_units() :: {pos_integer(), pos_integer(), pos_integer()}.
+
+%% The per-connection rate-limit guard state cached on each conn loop's record,
+%% resolved once at setup (see `resolve_rate_limit/3`), or `undefined` when no
+%% rate limiting is active or the peer IP is unknown. The tuple carries the
+%% listener-global limit (`rate_limit_units()` or `undefined` when per-route
+%% only), the per-route override subset (`roadrunner_router:route_rate_limits()`,
+%% itself `undefined` when none), the shared bucket `Table`, the refusal
+%% `Counter`, and `Key` — the address baked at setup whenever it cannot change,
+%% or the `client_ip` marker only when a trusted proxy makes it vary per request
+%% (see `rate_limit_key/2`). Consulted by `rate_limit_lookup/2`.
 -type rate_limit_state() ::
     {
-        pos_integer(),
-        pos_integer(),
-        pos_integer(),
+        rate_limit_units() | undefined,
+        roadrunner_router:route_rate_limits(),
         ets:table(),
         atomics:atomics_ref(),
         inet:ip_address() | client_ip
@@ -359,13 +371,14 @@ try_acquire_request_slot(Max, Counter) ->
             false
     end.
 
-%% Resolve the per-connection rate-limit tuple `{Rate, Cap, Cost, Table,
-%% Counter, Key}` from `proto_opts` + the (constant-per-conn) peer once at setup,
-%% or `undefined` when the guard is off, so the per-request check is a single
-%% branch on a cached value. `Key` is the baked peer `IP`, or the `client_ip`
-%% marker when `real_ip` is configured (then the bucket keys on the per-request
-%% resolved client IP). The catch-all covers a missing peer (a 2-tuple `{IP, _}`
-%% is required) and `rate_limit => undefined`.
+%% Resolve the per-connection rate-limit state from `proto_opts` + the
+%% (constant-per-conn) peer once at setup, or `undefined` when no rate limiting
+%% is active or the peer is unknown. The global `{Rate,Cap,Cost}` triple is baked
+%% here (so the per-request check does no arithmetic), the per-route override
+%% subset is read once from persistent_term, and `Key` is the baked peer `IP` or
+%% the `client_ip` marker when `real_ip` is set. The first clause matches only
+%% when the bucket `table` exists (rate limiting active); the catch-all covers a
+%% missing peer and `rate_limit => undefined`.
 -doc false.
 -spec resolve_rate_limit(
     proto_opts(),
@@ -374,18 +387,33 @@ try_acquire_request_slot(Max, Counter) ->
 ) -> rate_limit_state().
 resolve_rate_limit(
     #{
-        rate_limit := #{rate := Rate, burst := Burst, period := Period, table := Table},
+        rate_limit := #{table := Table} = RateLimit,
         rate_limited_counter := Counter
-    },
+    } = ProtoOpts,
     {IP, _Port},
     Prepared
 ) ->
-    %% Bake the derived `Cost` (units/request) and `Cap` (bucket capacity) here,
-    %% once per connection, so the per-request `rate_limit_check/6` does no
-    %% multiplication.
-    Cost = Period * 1000,
-    Cap = Burst * Cost,
-    %% Bake the bucket key too, as far as the config allows. Only a trusted peer
+    Global =
+        case RateLimit of
+            #{rate := Rate, burst := Burst, period := Period} ->
+                {Cap, Cost} = roadrunner_rate_limit:units(Burst, Period),
+                {Rate, Cap, Cost};
+            _ ->
+                undefined
+        end,
+    %% `listener_name` is read with a default rather than matched in the head on
+    %% purpose: a head match would send proto_opts that omit it to the
+    %% `undefined` catch-all, silently disabling the whole guard instead of
+    %% failing loudly. Absent, it costs the per-route subset but keeps the
+    %% global limit enforced.
+    RouteLimits =
+        case ProtoOpts of
+            #{listener_name := ListenerName} ->
+                persistent_term:get({roadrunner_rate_limit_routes, ListenerName}, undefined);
+            #{} ->
+                undefined
+        end,
+    %% Bake the bucket key as far as the config allows. Only a trusted peer
     %% (`{walk, ...}`) can produce a different client per request and so needs
     %% the `client_ip` marker; the opt being off or the peer being untrusted
     %% yields one fixed address for the whole connection, so the per-request
@@ -396,7 +424,7 @@ resolve_rate_limit(
             {const, ClientIP} -> ClientIP;
             undefined -> IP
         end,
-    {Rate, Cap, Cost, Table, Counter, Key};
+    {Global, RouteLimits, Table, Counter, Key};
 resolve_rate_limit(_ProtoOpts, _Peer, _Prepared) ->
     undefined.
 
@@ -407,6 +435,68 @@ resolve_rate_limit(_ProtoOpts, _Peer, _Prepared) ->
 %% peer's own trust check already happened once at connection setup
 %% (`roadrunner_real_ip:prepare/2`), so an untrusted peer costs a single field
 %% read here rather than a per-request CIDR scan.
+
+%% Pick the rate-limit bucket for a request: the per-route override when its
+%% method+path matches (keyed `{RoutePath, ClientIP}` in its own namespace),
+%% else the listener-global limit (keyed on the client IP), else `skip`. The
+%% global-only state (`RouteLimits = undefined`) avoids the method/path
+%% extraction entirely. The conn loops gate the off path (`rate_limit_state` is
+%% `undefined`) inline before calling this, so the `undefined` clause here is
+%% only reached by direct callers/tests.
+-doc false.
+-spec rate_limit_lookup(rate_limit_state(), roadrunner_req:request()) ->
+    skip
+    | {check, ets:table(), bucket_key(), pos_integer(), pos_integer(), pos_integer(),
+        atomics:atomics_ref()}.
+rate_limit_lookup(undefined, _Req) ->
+    skip;
+rate_limit_lookup({Global, undefined, Table, Counter, KeySpec}, Req) ->
+    global_bucket(Global, Table, Counter, rate_limit_key(KeySpec, Req));
+rate_limit_lookup({Global, RouteLimits, Table, Counter, KeySpec}, Req) ->
+    IP = rate_limit_key(KeySpec, Req),
+    case
+        roadrunner_router:match_rate_limit(
+            roadrunner_req:method(Req), roadrunner_req:path(Req), RouteLimits
+        )
+    of
+        {Rate, Cap, Cost, RoutePath} ->
+            {check, Table, {RoutePath, IP}, Rate, Cap, Cost, Counter};
+        nomatch ->
+            global_bucket(Global, Table, Counter, IP)
+    end.
+
+-spec global_bucket(
+    rate_limit_units() | undefined, ets:table(), atomics:atomics_ref(), bucket_key()
+) ->
+    skip
+    | {check, ets:table(), bucket_key(), pos_integer(), pos_integer(), pos_integer(),
+        atomics:atomics_ref()}.
+global_bucket(undefined, _Table, _Counter, _IP) ->
+    skip;
+global_bucket({Rate, Cap, Cost}, Table, Counter, IP) ->
+    {check, Table, IP, Rate, Cap, Cost, Counter}.
+
+%% Apply the rate-limit guard to a request: pick the bucket (`rate_limit_lookup/2`)
+%% and spend a token. Returns `allow` (limit not exceeded, or no applicable
+%% limit) or `{deny, RetryAfterSecs, Counter}` so the caller emits the
+%% protocol-appropriate 429 and bumps the refusal `Counter`. Collapsing `skip`
+%% into `allow` keeps the three protocol gates to a single allow/deny branch.
+-doc false.
+-spec rate_limit_apply(rate_limit_state(), roadrunner_req:request()) ->
+    allow | {deny, pos_integer(), atomics:atomics_ref()}.
+rate_limit_apply(State, Req) ->
+    case rate_limit_lookup(State, Req) of
+        skip ->
+            allow;
+        {check, Table, Key, Rate, Cap, Cost, Counter} ->
+            case
+                rate_limit_check(Table, Key, Rate, Cap, Cost, erlang:monotonic_time(millisecond))
+            of
+                allow -> allow;
+                {deny, RetryAfter} -> {deny, RetryAfter, Counter}
+            end
+    end.
+
 -doc false.
 -spec maybe_put_client_ip(roadrunner_real_ip:prepared(), roadrunner_req:request()) ->
     roadrunner_req:request().
@@ -439,7 +529,7 @@ contract `try_acquire_request_slot/2` documents.
 deterministically testable).
 """.
 -spec rate_limit_check(
-    ets:table(), inet:ip_address(), pos_integer(), pos_integer(), pos_integer(), integer()
+    ets:table(), bucket_key(), pos_integer(), pos_integer(), pos_integer(), integer()
 ) ->
     allow | {deny, pos_integer()}.
 rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) ->

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -754,13 +754,11 @@ dispatch_phase(
 ) -> boolean().
 rate_limit_allows(undefined, _Socket, _ListenerName, _Req) ->
     true;
-rate_limit_allows({Rate, Cap, Cost, Table, Counter, KeySpec}, Socket, ListenerName, Req) ->
-    IP = roadrunner_conn:rate_limit_key(KeySpec, Req),
-    NowMs = erlang:monotonic_time(millisecond),
-    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
+rate_limit_allows(RateLimit, Socket, ListenerName, Req) ->
+    case roadrunner_conn:rate_limit_apply(RateLimit, Req) of
         allow ->
             true;
-        {deny, RetryAfter} ->
+        {deny, RetryAfter, Counter} ->
             ok = roadrunner_conn:rate_limited_telemetry(ListenerName, Counter),
             _ = roadrunner_conn:send_rate_limited(Socket, RetryAfter),
             false

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1795,22 +1795,20 @@ throttle_stream(#loop{proto_opts = #{throttled_counter := Counter}}, ListenerNam
 rate_limit_refused(#loop{rate_limit = undefined}, _StreamId, _Req) ->
     ok;
 rate_limit_refused(
-    #loop{
-        rate_limit = {Rate, Cap, Cost, Table, Counter, KeySpec},
-        listener_name = ListenerName
-    } = State,
-    StreamId,
-    Req
+    #loop{rate_limit = RateLimit, listener_name = ListenerName} = State, StreamId, Req
 ) ->
-    IP = roadrunner_conn:rate_limit_key(KeySpec, Req),
-    NowMs = erlang:monotonic_time(millisecond),
-    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
+    case roadrunner_conn:rate_limit_apply(RateLimit, Req) of
         allow ->
             ok;
-        {deny, RetryAfter} ->
+        {deny, RetryAfter, Counter} ->
             ok = roadrunner_conn:rate_limited_telemetry(ListenerName, Counter),
             State1 = encode_and_send_response_atomic(
-                State, StreamId, 429, [{~"retry-after", integer_to_binary(RetryAfter)}], ~"", 0
+                State,
+                StreamId,
+                429,
+                [{~"retry-after", integer_to_binary(RetryAfter)}],
+                ~"",
+                0
             ),
             _ = send_rst_stream(State1, StreamId, no_error),
             {refused, State1}

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -898,20 +898,12 @@ throttle_stream(#h3{proto_opts = #{throttled_counter := Counter}, listener_name 
 rate_limit_refused(#h3{rate_limit = undefined}, _StreamId, _Req) ->
     ok;
 rate_limit_refused(
-    #h3{
-        rate_limit = {Rate, Cap, Cost, Table, Counter, KeySpec},
-        conn = Conn,
-        listener_name = ListenerName
-    } = State,
-    StreamId,
-    Req
+    #h3{rate_limit = RateLimit, conn = Conn, listener_name = ListenerName} = State, StreamId, Req
 ) ->
-    IP = roadrunner_conn:rate_limit_key(KeySpec, Req),
-    NowMs = erlang:monotonic_time(millisecond),
-    case roadrunner_conn:rate_limit_check(Table, IP, Rate, Cap, Cost, NowMs) of
+    case roadrunner_conn:rate_limit_apply(RateLimit, Req) of
         allow ->
             ok;
-        {deny, RetryAfter} ->
+        {deny, RetryAfter, Counter} ->
             ok = roadrunner_conn:rate_limited_telemetry(ListenerName, Counter),
             ok = roadrunner_http3_stream_worker:send_buffered(
                 Conn, StreamId, 429, [{~"retry-after", integer_to_binary(RetryAfter)}], ~""

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -918,9 +918,24 @@ publish_routes(ListenerName, #{routes := Routes} = Opts) when is_list(Routes) ->
     persistent_term:put(
         {roadrunner_routes, ListenerName},
         roadrunner_router:compile(Routes, ListenerMws)
-    );
+    ),
+    publish_rate_limit_routes(ListenerName, Routes);
 publish_routes(_ListenerName, _Opts) ->
     ok.
+
+%% Publish the compiled per-route `rate_limit` subset (or remove the entry when
+%% none), read per-connection by `roadrunner_conn:resolve_rate_limit/2`. Kept
+%% symmetric with the routes pterm so `reload_routes/2` updates both.
+-spec publish_rate_limit_routes(atom(), roadrunner_router:routes()) -> ok.
+publish_rate_limit_routes(ListenerName, Routes) ->
+    Key = {roadrunner_rate_limit_routes, ListenerName},
+    case roadrunner_router:compile_rate_limits(Routes) of
+        undefined ->
+            _ = persistent_term:erase(Key),
+            ok;
+        Limits ->
+            persistent_term:put(Key, Limits)
+    end.
 
 %% Recover the registered name we were started with. `start_link/2` always
 %% calls `gen_server:start_link({local, Name}, ...)` so the name is set
@@ -1073,7 +1088,12 @@ build_proto_opts(Opts, ListenerName) ->
     %% `info/1` surfaces it as 0 when the guard is off); the per-peer bucket
     %% store is created only when `rate_limit` is configured.
     RateLimitedCounter = atomics:new(1, [{signed, false}]),
-    RateLimit = build_rate_limit(maps:get(rate_limit, Opts, undefined)),
+    %% Per-route `rate_limit` overrides are published to persistent_term by
+    %% `publish_routes/2` (called just before this); their presence forces the
+    %% bucket table even when there is no listener-global `rate_limit`.
+    HasPerRouteRateLimit =
+        persistent_term:get({roadrunner_rate_limit_routes, ListenerName}, undefined) =/= undefined,
+    RateLimit = build_rate_limit(maps:get(rate_limit, Opts, undefined), HasPerRouteRateLimit),
     %% Public `ws` opts are a nested map; flatten to the `ws_*`
     %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
     %% → `http2_*` flattening above.
@@ -1517,25 +1537,33 @@ validate_ws_opts(Opts) when is_map(Opts) ->
 validate_ws_opts(Other) ->
     error({invalid_listener_opt, ws, Other}).
 
-%% Validate the `rate_limit` opt and, when set, create its per-listener ETS
-%% bucket store. `undefined` (the default) skips the guard entirely.
--spec build_rate_limit(term()) -> undefined | roadrunner_conn:rate_limit().
-build_rate_limit(RawOpt) ->
-    case validate_rate_limit(RawOpt) of
-        undefined ->
+%% Validate the listener-global `rate_limit` opt and, when rate limiting is
+%% active (a global opt OR any per-route override, `HasPerRoute`), create the
+%% shared per-listener ETS bucket store. `undefined` (no global, no per-route)
+%% skips the guard entirely. When only per-route limits exist there is no global
+%% `rate`/`burst`/`period` — the map carries just the table + default eviction
+%% policy, and `roadrunner_conn:resolve_rate_limit/2` keys on the matched route.
+-spec build_rate_limit(term(), boolean()) -> undefined | roadrunner_conn:rate_limit().
+build_rate_limit(RawOpt, HasPerRoute) ->
+    case {validate_rate_limit(RawOpt), HasPerRoute} of
+        {undefined, false} ->
             undefined;
-        Config ->
-            %% Anonymous public table, one per listener, owned by this
-            %% gen_server so it dies with the listener. `write_concurrency, auto`
-            %% adapts the lock count to load (matching the QUIC CID registry);
-            %% no `read_concurrency` — each request reads then writes the same
-            %% key (interleaved RMW), the one pattern it would slow down.
-            Config#{
-                table => ets:new(roadrunner_rate_limit, [
-                    set, public, {write_concurrency, auto}
-                ])
-            }
+        {undefined, true} ->
+            #{table => new_rate_limit_table(), idle_ttl => 60000, sweep_interval => 10000};
+        {Config, _} ->
+            Config#{table => new_rate_limit_table()}
     end.
+
+%% Anonymous public table, one per listener, owned by this gen_server so it dies
+%% with the listener. `write_concurrency, auto` adapts the lock count to load
+%% (matching the QUIC CID registry); no `read_concurrency` — each request reads
+%% then writes the same key (interleaved RMW), the one pattern it would slow
+%% down. Rows are `{Key, Units, LastMs}` where `Key` is the client IP, or
+%% `{RoutePath, ClientIP}` for a per-route bucket — the check and eviction treat
+%% the key opaquely, so both shapes share the table.
+-spec new_rate_limit_table() -> ets:table().
+new_rate_limit_table() ->
+    ets:new(roadrunner_rate_limit, [set, public, {write_concurrency, auto}]).
 
 -spec validate_rate_limit(term()) ->
     undefined
@@ -1673,6 +1701,7 @@ do_reload_routes(
         {roadrunner_routes, Name},
         roadrunner_router:compile(Routes, ListenerMws)
     ),
+    ok = publish_rate_limit_routes(Name, Routes),
     ok;
 do_reload_routes(#state{proto_opts = #{dispatch := {handler, _, _, _}}}, _Routes) ->
     {error, no_routes}.

--- a/src/roadrunner_rate_limit.erl
+++ b/src/roadrunner_rate_limit.erl
@@ -11,9 +11,52 @@
 %% ETS bucket store in `roadrunner_conn`) derives `Cost` and the cap; this
 %% module is socket- and state-free so the bucket math is exhaustively testable.
 
--export([refill/5, spend/2, retry_after_secs/3]).
+-export([refill/5, spend/2, retry_after_secs/3, units/2, compile_route_config/1]).
 
 -define(MILLI, 1000).
+
+%% Derive the integer-unit pair the bucket check uses from a `Burst`/`Period`:
+%% one request costs `Cost = Period * 1000` units and the bucket holds `Burst`
+%% requests, i.e. `Cap = Burst * Cost` units. The single source of this
+%% derivation, shared by the listener-global path (`roadrunner_conn`) and the
+%% per-route compile path (`compile_route_config/1`).
+-doc false.
+-spec units(pos_integer(), pos_integer()) -> {pos_integer(), pos_integer()}.
+units(Burst, Period) ->
+    Cost = Period * ?MILLI,
+    {Burst * Cost, Cost}.
+
+%% Validate a per-route `rate_limit` config and derive its `{Rate, Cap, Cost}`
+%% triple. Accepts a map with `rate` (required, positive int) and optional
+%% `burst` (default `rate`) / `period` (default 1, so `rate` is per-second).
+%% Any other key is rejected — the table-global `idle_ttl`/`sweep_interval` are
+%% listener policy, not per-bucket. Raises `{invalid_rate_limit, Opts}` on bad
+%% input so a bad route config fails loudly at listener init.
+-doc false.
+-spec compile_route_config(term()) -> {pos_integer(), pos_integer(), pos_integer()}.
+compile_route_config(Opts) when is_map(Opts) ->
+    Resolved = maps:fold(
+        fun(K, V, Acc) ->
+            case
+                (K =:= rate orelse K =:= burst orelse K =:= period) andalso
+                    is_integer(V) andalso V > 0
+            of
+                true -> Acc#{K => V};
+                false -> error({invalid_rate_limit, Opts})
+            end
+        end,
+        #{},
+        Opts
+    ),
+    case Resolved of
+        #{rate := Rate} ->
+            {Cap, Cost} = units(maps:get(burst, Resolved, Rate), maps:get(period, Resolved, 1)),
+            {Rate, Cap, Cost};
+        #{} ->
+            error({invalid_rate_limit, Opts})
+    end;
+compile_route_config(Opts) ->
+    error({invalid_rate_limit, Opts}).
 
 %% Refill a bucket holding `Units`, last touched at `LastMs`, to its level at
 %% `NowMs`: add `Elapsed * Rate` units (the refill rate is `Rate` units/ms),

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -50,9 +50,9 @@ opaque `compiled()` shape is a list of pre-parsed segment patterns;
 swapping to a trie/DAG later is a non-breaking change for callers.
 """.
 
--export([compile/2, match/3]).
+-export([compile/2, match/3, compile_rate_limits/1, match_rate_limit/3]).
 
--export_type([route/0, routes/0, compiled/0, bindings/0, methods/0]).
+-export_type([route/0, routes/0, compiled/0, bindings/0, methods/0, route_rate_limits/0]).
 
 -doc """
 A single route entry. Three shapes are accepted:
@@ -79,7 +79,8 @@ unset → every method.
         handler := module(),
         state => term(),
         middlewares => roadrunner_middleware:middleware_list(),
-        methods => methods()
+        methods => methods(),
+        rate_limit => map()
     }.
 
 -doc """
@@ -137,6 +138,18 @@ opaque: the shape is an implementation detail and may change.
 -opaque compiled() :: [
     {[segment()], module(), roadrunner_middleware:next(), term(), method_lookup()}
 ].
+
+-doc """
+The compiled per-route `rate_limit` overrides `match_rate_limit/3` consumes: a
+path+method-keyed subset of the routes that declare a `rate_limit`, each with
+its pre-derived `{Rate, Cap, Cost}` unit triple and the route's path binary as
+the bucket-namespace key. `undefined` when no route declares one (so the gate
+pays nothing) — `roadrunner_conn` matches that to take its global-only fast
+path, so this is a plain (non-opaque) type.
+""".
+-type route_rate_limits() ::
+    [{[segment()], method_lookup(), {pos_integer(), pos_integer(), pos_integer()}, binary()}]
+    | undefined.
 
 -doc """
 Compile a list of routes into the lookup form `match/3` expects.
@@ -334,6 +347,72 @@ decode_segment(Segment) ->
     case roadrunner_uri:percent_decode(Segment) of
         {ok, Decoded} -> Decoded;
         {error, badarg} -> Segment
+    end.
+
+-doc """
+Compile the per-route `rate_limit` overrides out of a route list.
+
+Keeps only the map-form routes that carry a `rate_limit` key, pairing each
+route's compiled path + method allowlist with its pre-derived `{Rate, Cap, Cost}`
+triple (validated and derived by `roadrunner_rate_limit`) and its path binary
+(the bucket-namespace key). Returns `undefined` when no route declares one, so
+the caller can bake an absent subset and skip the lookup entirely. Raises
+`{invalid_rate_limit, Opts}` (from the config compiler) on a bad per-route
+config, at listener init.
+""".
+-spec compile_rate_limits(routes()) -> route_rate_limits().
+compile_rate_limits(Routes) when is_list(Routes) ->
+    case [compile_rate_limit(R) || R <- Routes, is_rate_limited(R)] of
+        [] -> undefined;
+        Limits -> Limits
+    end.
+
+-spec is_rate_limited(route()) -> boolean().
+is_rate_limited(#{rate_limit := _}) -> true;
+is_rate_limited(_) -> false.
+
+-spec compile_rate_limit(map()) ->
+    {[segment()], method_lookup(), {pos_integer(), pos_integer(), pos_integer()}, binary()}.
+compile_rate_limit(#{path := Path, rate_limit := Opts} = Route) when is_binary(Path) ->
+    {
+        compile_path(Path),
+        compile_methods(maps:get(methods, Route, undefined)),
+        roadrunner_rate_limit:compile_route_config(Opts),
+        Path
+    }.
+
+-doc """
+Find the per-route `rate_limit` for a request method + path, or `nomatch`.
+
+First-match-wins over the compiled subset (declaration order), reusing the same
+path + method matchers as `match/3`. A path-match whose method is not in the
+route's allowlist keeps scanning, so a per-route limit only applies to the
+methods that route declares; an exhausted scan returns `nomatch` and the caller
+falls back to the listener-global limit.
+""".
+-spec match_rate_limit(binary(), binary(), route_rate_limits()) ->
+    {pos_integer(), pos_integer(), pos_integer(), binary()} | nomatch.
+match_rate_limit(_Method, _Path, undefined) ->
+    nomatch;
+match_rate_limit(Method, Path, Limits) when is_binary(Method), is_binary(Path) ->
+    match_rate_limit_1(Method, path_segments(Path), Limits).
+
+-spec match_rate_limit_1(binary(), [binary()], [tuple()]) ->
+    {pos_integer(), pos_integer(), pos_integer(), binary()} | nomatch.
+match_rate_limit_1(_Method, _Segments, []) ->
+    nomatch;
+match_rate_limit_1(Method, Segments, [{Pattern, Methods, Units, Key} | Rest]) ->
+    case match_pattern(Pattern, Segments, #{}) of
+        no_match ->
+            match_rate_limit_1(Method, Segments, Rest);
+        _Bindings ->
+            case method_allowed(Method, Methods) of
+                true ->
+                    {Rate, Cap, Cost} = Units,
+                    {Rate, Cap, Cost, Key};
+                false ->
+                    match_rate_limit_1(Method, Segments, Rest)
+            end
     end.
 
 -spec path_segments(binary()) -> [binary()].

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -389,6 +389,11 @@ path + method matchers as `match/3`. A path-match whose method is not in the
 route's allowlist keeps scanning, so a per-route limit only applies to the
 methods that route declares; an exhausted scan returns `nomatch` and the caller
 falls back to the listener-global limit.
+
+A matched per-route limit **replaces** the listener-global one for that request,
+it does not stack with it. A route declaring a budget larger than the global
+limit therefore escapes the global limit entirely, which is the point of an
+override but is worth stating: the global limit is a default, not a ceiling.
 """.
 -spec match_rate_limit(binary(), binary(), route_rate_limits()) ->
     {pos_integer(), pos_integer(), pos_integer(), binary()} | nomatch.

--- a/test/roadrunner_rate_limit_listener_tests.erl
+++ b/test/roadrunner_rate_limit_listener_tests.erl
@@ -118,6 +118,69 @@ h2c_second_stream_is_rate_limited_test() ->
         ?assert(lists:member(~"429", Statuses))
     end).
 
+%% =============================================================================
+%% Per-route rate-limit overrides (HTTP/1 end-to-end).
+%% =============================================================================
+
+per_route_only_limits_one_route_test() ->
+    %% No listener-global limit; only `/login` is throttled. `/login` 429s on the
+    %% second request while `/` (no per-route limit) stays open.
+    Routes = [
+        #{
+            path => ~"/login",
+            handler => roadrunner_hello_handler,
+            rate_limit => #{rate => 1, burst => 1}
+        },
+        #{path => ~"/", handler => roadrunner_hello_handler}
+    ],
+    with_route_listener(Routes, undefined, fun(Port) ->
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_get(Port, ~"/login")),
+        ?assertMatch(<<"HTTP/1.1 429", _/binary>>, h1_get(Port, ~"/login")),
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_get(Port, ~"/")),
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_get(Port, ~"/"))
+    end).
+
+per_route_overrides_global_test() ->
+    %% A generous global limit with a stricter per-route override: `/login` 429s
+    %% on its second request (route limit 1), `/` rides the generous global.
+    Routes = [
+        #{
+            path => ~"/login",
+            handler => roadrunner_hello_handler,
+            rate_limit => #{rate => 1, burst => 1}
+        },
+        #{path => ~"/", handler => roadrunner_hello_handler}
+    ],
+    with_route_listener(Routes, #{rate => 1000, burst => 1000}, fun(Port) ->
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_get(Port, ~"/login")),
+        ?assertMatch(<<"HTTP/1.1 429", _/binary>>, h1_get(Port, ~"/login")),
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_get(Port, ~"/")),
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_get(Port, ~"/"))
+    end).
+
+per_route_unmatched_path_uses_global_test() ->
+    %% A path with no per-route limit falls back to the global limit.
+    Routes = [
+        #{
+            path => ~"/login",
+            handler => roadrunner_hello_handler,
+            rate_limit => #{rate => 1, burst => 1}
+        },
+        #{path => ~"/open", handler => roadrunner_hello_handler}
+    ],
+    with_route_listener(Routes, #{rate => 1, burst => 1}, fun(Port) ->
+        ?assertMatch(<<"HTTP/1.1 200", _/binary>>, h1_get(Port, ~"/open")),
+        ?assertMatch(<<"HTTP/1.1 429", _/binary>>, h1_get(Port, ~"/open"))
+    end).
+
+per_route_invalid_config_rejected_test() ->
+    process_flag(trap_exit, true),
+    Routes = [#{path => ~"/x", handler => roadrunner_hello_handler, rate_limit => #{rate => 0}}],
+    R = roadrunner_listener:start_link(unique(rl_bad_route), #{
+        port => 0, protocols => [http1], routes => Routes
+    }),
+    ?assertMatch({error, {{invalid_rate_limit, _}, _}}, R).
+
 %% --- helpers ---
 
 start(Name, Protocols, RateLimit) ->
@@ -144,8 +207,31 @@ with_listener(Protocols, RateLimit, Fun) ->
         ok = roadrunner_listener:stop(Name)
     end.
 
+with_route_listener(Routes, RateLimit, Fun) ->
+    Name = unique(rl_route_it),
+    Base = #{port => 0, protocols => [http1], routes => Routes},
+    Opts =
+        case RateLimit of
+            undefined -> Base;
+            _ -> Base#{rate_limit => RateLimit}
+        end,
+    {ok, _} = roadrunner_listener:start_link(Name, Opts),
+    Port = roadrunner_listener:port(Name),
+    try
+        Fun(Port)
+    after
+        ok = roadrunner_listener:stop(Name)
+    end.
+
 unique(Prefix) ->
     list_to_atom(atom_to_list(Prefix) ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
+
+h1_get(Port, Path) ->
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Sock, [~"GET ", Path, ~" HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"]),
+    Reply = recv_for(Sock, <<>>, 1000),
+    ok = gen_tcp:close(Sock),
+    Reply.
 
 h1_request(Port) ->
     {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),

--- a/test/roadrunner_rate_limit_store_tests.erl
+++ b/test/roadrunner_rate_limit_store_tests.erl
@@ -55,9 +55,10 @@ resolve_off_without_peer_test() ->
 resolve_on_test() ->
     Table = new_table(),
     {Counter, Opts} = proto_opts_with_counter(Table),
-    %% rate 10, burst 20, period 30 → Cost 30000, Cap 600000 baked in.
+    %% rate 10, burst 20, period 30 → Cost 30000, Cap 600000 baked as the global
+    %% triple; no per-route subset (undefined); key is the peer IP.
     ?assertEqual(
-        {10, 600000, 30000, Table, Counter, ?IP},
+        {{10, 600000, 30000}, undefined, Table, Counter, ?IP},
         ?M:resolve_rate_limit(Opts, {?IP, 5000}, undefined)
     ).
 
@@ -69,7 +70,7 @@ resolve_on_with_trusted_peer_keys_per_request_test() ->
     {Counter, Opts} = proto_opts_with_counter(Table, RealIp),
     Prepared = roadrunner_real_ip:prepare(RealIp, {?IP, 5000}),
     ?assertEqual(
-        {10, 600000, 30000, Table, Counter, client_ip},
+        {{10, 600000, 30000}, undefined, Table, Counter, client_ip},
         ?M:resolve_rate_limit(Opts, {?IP, 5000}, Prepared)
     ).
 
@@ -83,7 +84,7 @@ resolve_on_with_untrusted_peer_bakes_the_key_test() ->
     {Counter, Opts} = proto_opts_with_counter(Table, RealIp),
     Prepared = roadrunner_real_ip:prepare(RealIp, {Peer, 5000}),
     ?assertEqual(
-        {10, 600000, 30000, Table, Counter, Peer},
+        {{10, 600000, 30000}, undefined, Table, Counter, Peer},
         ?M:resolve_rate_limit(Opts, {Peer, 5000}, Prepared)
     ).
 
@@ -106,8 +107,65 @@ resolve_on_without_optional_keys_test() ->
         rate_limited_counter => Counter
     },
     ?assertEqual(
-        {10, 600000, 30000, Table, Counter, ?IP},
+        {{10, 600000, 30000}, undefined, Table, Counter, ?IP},
         ?M:resolve_rate_limit(Opts, {?IP, 5000}, undefined)
+    ).
+
+%% --- rate_limit_lookup/2 ---
+
+lookup_undefined_skips_test() ->
+    ?assertEqual(skip, ?M:rate_limit_lookup(undefined, req(~"GET", ~"/x"))).
+
+lookup_global_only_test() ->
+    Table = new_table(),
+    Counter = atomics:new(1, [{signed, false}]),
+    State = {{10, 600000, 30000}, undefined, Table, Counter, ?IP},
+    ?assertEqual(
+        {check, Table, ?IP, 10, 600000, 30000, Counter},
+        ?M:rate_limit_lookup(State, req(~"GET", ~"/x"))
+    ).
+
+lookup_per_route_hit_keys_on_route_and_ip_test() ->
+    Table = new_table(),
+    Counter = atomics:new(1, [{signed, false}]),
+    Routes = roadrunner_router:compile_rate_limits([
+        #{path => ~"/login", handler => h, rate_limit => #{rate => 1}}
+    ]),
+    State = {{10, 600000, 30000}, Routes, Table, Counter, ?IP},
+    ?assertEqual(
+        {check, Table, {~"/login", ?IP}, 1, 1000, 1000, Counter},
+        ?M:rate_limit_lookup(State, req(~"POST", ~"/login"))
+    ).
+
+lookup_per_route_miss_falls_back_to_global_test() ->
+    Table = new_table(),
+    Counter = atomics:new(1, [{signed, false}]),
+    Routes = roadrunner_router:compile_rate_limits([
+        #{path => ~"/login", handler => h, rate_limit => #{rate => 1}}
+    ]),
+    State = {{10, 600000, 30000}, Routes, Table, Counter, ?IP},
+    ?assertEqual(
+        {check, Table, ?IP, 10, 600000, 30000, Counter},
+        ?M:rate_limit_lookup(State, req(~"GET", ~"/other"))
+    ).
+
+lookup_per_route_only_miss_skips_test() ->
+    Table = new_table(),
+    Counter = atomics:new(1, [{signed, false}]),
+    Routes = roadrunner_router:compile_rate_limits([
+        #{path => ~"/login", handler => h, rate_limit => #{rate => 1}}
+    ]),
+    State = {undefined, Routes, Table, Counter, ?IP},
+    ?assertEqual(skip, ?M:rate_limit_lookup(State, req(~"GET", ~"/other"))).
+
+lookup_resolves_client_ip_marker_test() ->
+    Table = new_table(),
+    Counter = atomics:new(1, [{signed, false}]),
+    State = {{10, 600000, 30000}, undefined, Table, Counter, client_ip},
+    Req = (req(~"GET", ~"/x"))#{client_ip => {203, 0, 113, 7}},
+    ?assertEqual(
+        {check, Table, {203, 0, 113, 7}, 10, 600000, 30000, Counter},
+        ?M:rate_limit_lookup(State, Req)
     ).
 
 %% --- rate_limit_key/2 ---
@@ -143,6 +201,16 @@ evicts_only_idle_rows_test() ->
 evict_empty_table_test() ->
     Table = new_table(),
     ?assertEqual(0, ?M:rate_limit_evict_idle(Table, 2000, 1500)).
+
+evicts_composite_route_keys_test() ->
+    %% Per-route buckets are keyed `{RoutePath, IP}`; the sweep matches on the
+    %% timestamp (element 3), so composite-keyed rows evict like bare-IP ones.
+    Table = new_table(),
+    true = ets:insert(Table, {{~"/login", {1, 1, 1, 1}}, 5000, 0}),
+    true = ets:insert(Table, {{~"/login", {2, 2, 2, 2}}, 5000, 1000}),
+    ?assertEqual(1, ?M:rate_limit_evict_idle(Table, 2000, 1500)),
+    ?assertEqual([], ets:lookup(Table, {~"/login", {1, 1, 1, 1}})),
+    ?assertMatch([{{~"/login", {2, 2, 2, 2}}, _, _}], ets:lookup(Table, {~"/login", {2, 2, 2, 2}})).
 
 evict_clears_all_idle_in_one_pass_test() ->
     Table = new_table(),
@@ -181,7 +249,8 @@ proto_opts(RateLimit) ->
     #{
         rate_limit => Cfg,
         rate_limited_counter => atomics:new(1, [{signed, false}]),
-        real_ip => undefined
+        real_ip => undefined,
+        listener_name => rate_limit_store_test
     }.
 
 proto_opts_with_counter(Table) ->
@@ -199,5 +268,11 @@ proto_opts_with_counter(Table, RealIp) ->
             table => Table
         },
         rate_limited_counter => Counter,
-        real_ip => RealIp
+        real_ip => RealIp,
+        listener_name => rate_limit_store_test
     }}.
+
+%% A minimal request map for `rate_limit_lookup/2` (needs only method + path,
+%% plus `client_ip` when exercising the marker key).
+req(Method, Path) ->
+    #{method => Method, path => Path, headers => []}.

--- a/test/roadrunner_rate_limit_tests.erl
+++ b/test/roadrunner_rate_limit_tests.erl
@@ -57,3 +57,43 @@ retry_after_partial_deficit_test() ->
 
 retry_after_never_below_one_test() ->
     ?assertEqual(1, ?M:retry_after_secs(999, 1000, 1000)).
+
+%% --- units/2 ---
+
+units_per_second_test() ->
+    %% Period 1 → Cost 1000 units/request; Cap = Burst * Cost.
+    ?assertEqual({5000, 1000}, ?M:units(5, 1)).
+
+units_per_minute_test() ->
+    ?assertEqual({120000, 60000}, ?M:units(2, 60)).
+
+%% --- compile_route_config/1 ---
+
+compile_route_config_rate_only_test() ->
+    %% burst defaults to rate, period to 1: Cost 1000, Cap = rate * 1000.
+    ?assertEqual({10, 10000, 1000}, ?M:compile_route_config(#{rate => 10})).
+
+compile_route_config_full_test() ->
+    ?assertEqual(
+        {1, 60000, 60000}, ?M:compile_route_config(#{rate => 1, burst => 1, period => 60})
+    ).
+
+compile_route_config_burst_test() ->
+    ?assertEqual({2, 5000, 1000}, ?M:compile_route_config(#{rate => 2, burst => 5})).
+
+compile_route_config_missing_rate_test() ->
+    ?assertError({invalid_rate_limit, #{burst := 5}}, ?M:compile_route_config(#{burst => 5})).
+
+compile_route_config_rejects_table_keys_test() ->
+    %% `idle_ttl`/`sweep_interval` are table-global, not per-route.
+    Opts = #{rate => 1, idle_ttl => 1000},
+    ?assertError({invalid_rate_limit, Opts}, ?M:compile_route_config(Opts)).
+
+compile_route_config_non_positive_test() ->
+    ?assertError({invalid_rate_limit, _}, ?M:compile_route_config(#{rate => 0})).
+
+compile_route_config_non_integer_test() ->
+    ?assertError({invalid_rate_limit, _}, ?M:compile_route_config(#{rate => fast})).
+
+compile_route_config_non_map_test() ->
+    ?assertError({invalid_rate_limit, true}, ?M:compile_route_config(true)).

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -642,3 +642,67 @@ match_no_pipeline(Method, Path, Compiled) ->
 
 empty_req() ->
     #{method => ~"GET", target => ~"/", version => {1, 1}, headers => []}.
+
+%% =============================================================================
+%% compile_rate_limits/1 + match_rate_limit/3 — per-route rate-limit overrides
+%% =============================================================================
+
+rate_limits_none_is_undefined_test() ->
+    %% No route declares a rate_limit → undefined (the gate skips the lookup).
+    ?assertEqual(
+        undefined,
+        roadrunner_router:compile_rate_limits([{~"/", h}, #{path => ~"/x", handler => h}])
+    ).
+
+rate_limits_match_hit_test() ->
+    Limits = roadrunner_router:compile_rate_limits([
+        #{path => ~"/login", handler => h, rate_limit => #{rate => 1}}
+    ]),
+    %% rate 1, burst/period default → {1, 1000, 1000}, keyed on the path binary.
+    ?assertEqual(
+        {1, 1000, 1000, ~"/login"},
+        roadrunner_router:match_rate_limit(~"POST", ~"/login", Limits)
+    ).
+
+rate_limits_match_miss_test() ->
+    Limits = roadrunner_router:compile_rate_limits([
+        #{path => ~"/login", handler => h, rate_limit => #{rate => 1}}
+    ]),
+    ?assertEqual(nomatch, roadrunner_router:match_rate_limit(~"GET", ~"/other", Limits)).
+
+rate_limits_undefined_subset_is_nomatch_test() ->
+    ?assertEqual(nomatch, roadrunner_router:match_rate_limit(~"GET", ~"/login", undefined)).
+
+rate_limits_method_specific_test() ->
+    %% A method allowlist scopes the override; other methods fall through.
+    Limits = roadrunner_router:compile_rate_limits([
+        #{path => ~"/login", handler => h, methods => [~"POST"], rate_limit => #{rate => 1}}
+    ]),
+    ?assertMatch(
+        {1, 1000, 1000, ~"/login"}, roadrunner_router:match_rate_limit(~"POST", ~"/login", Limits)
+    ),
+    ?assertEqual(nomatch, roadrunner_router:match_rate_limit(~"GET", ~"/login", Limits)).
+
+rate_limits_param_path_test() ->
+    Limits = roadrunner_router:compile_rate_limits([
+        #{path => ~"/users/:id", handler => h, rate_limit => #{rate => 5}}
+    ]),
+    ?assertMatch(
+        {5, 5000, 1000, ~"/users/:id"},
+        roadrunner_router:match_rate_limit(~"GET", ~"/users/42", Limits)
+    ).
+
+rate_limits_first_match_wins_test() ->
+    Limits = roadrunner_router:compile_rate_limits([
+        #{path => ~"/a", handler => h, rate_limit => #{rate => 1}},
+        #{path => ~"/a", handler => h, rate_limit => #{rate => 9}}
+    ]),
+    ?assertMatch({1, _, _, ~"/a"}, roadrunner_router:match_rate_limit(~"GET", ~"/a", Limits)).
+
+rate_limits_bad_config_raises_test() ->
+    ?assertError(
+        {invalid_rate_limit, _},
+        roadrunner_router:compile_rate_limits([
+            #{path => ~"/x", handler => h, rate_limit => #{rate => 0}}
+        ])
+    ).


### PR DESCRIPTION
# Description

The `rate_limit` guard is listener-global, so a cheap health check and an expensive report endpoint share one budget. A `rate_limit` key on a map-form route now overrides the listener default for that path, with its own bucket namespace so the two do not contend. Routes that declare no override keep using the listener-global limit, and when no route declares one the compiled subset is `undefined` and the lookup is skipped entirely. Matching reuses the same path and method matchers as dispatch, first-match-wins in declaration order; a path match whose method falls outside the route's allowlist keeps scanning, so an override only applies to the methods that route declares.

```erlang
Routes = [
    #{path => ~"/health", handler => health_h},
    #{path => ~"/reports", handler => reports_h, methods => [~"POST"],
      rate_limit => #{limit => 5, window => 60_000}}
].
```

Per-route configs are validated and derived to their `{Rate, Cap, Cost}` triple at listener init, so a bad config raises there rather than on the request path.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)