### PR TITLE
Add per-route body-size overrides on map-form routes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -472,25 +472,24 @@ to a path.
 `(listener_name, method, path)` is already enough to identify a
 route in dashboards; named lookup is a niceness, not a need.
 
-### Per-route `max_body => non_neg_integer()` body-size override — medium
+### Pre-read body-cap enforcement for per-route `max_body` on h2/h3 — medium
 
-**What:** A per-route override of the listener-global `max_content_length`, so an
-endpoint can cap its body tighter than the default (e.g. `/login` at 64 KB while
-the listener allows 10 MB). The per-route `rate_limit` override already ships;
-this is its body-size sibling.
+**What:** The per-route `max_body` override ships, but h2/h3 enforce it *after*
+the body is accumulated (a 413 at dispatch), not during. H1 already rejects
+before reading (it knows the path right after headers). For h2 the path is known
+at `finalize_headers` (before DATA), so the effective cap could move onto the
+stream entry and reject in `on_data` mid-accumulation. h3 decodes the QPACK
+header block only at dispatch today, so it needs an eager header decode at the
+HEADERS frame to know the path during DATA accumulation.
 
-**Why harder than `rate_limit`:** `max_content_length` is enforced *during* body
-read/accumulation in all three protocols, which runs *before* the route is
-resolved today. The path is known right after headers, so the fix is early route
-resolution at headers-complete (gated on any route declaring `max_body`, to keep
-the common path unchanged), caching the matched route to reuse at dispatch: H1
-resolves before the body-read phase and passes the route's limit to the existing
-body reader (reusing the oversized-body drain + 413 path); H2/H3 store the
-effective limit on the stream entry and enforce it in the DATA-accumulation size
-check.
+**Why deferred:** the global `max_content_length` already bounds what h2/h3
+accumulate, so the post-accumulation check is a correct tighter cap; reading up
+to the global before rejecting is an efficiency gap, not a correctness one, and
+matters only for direct (non-proxied) h2/h3 clients. The reverse-proxy path
+(nginx → h1) already gets pre-read rejection.
 
-**Scope:** medium. The early-route-match plumbing is the bulk; the limit
-enforcement reuses the existing oversized-body paths.
+**Scope:** medium. h2 is a stream-field + `on_data` change; h3 additionally
+needs eager QPACK decode at the HEADERS frame, threaded to dispatch.
 
 ### Nested route groups with shared prefix + middlewares — medium
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -472,24 +472,22 @@ to a path.
 `(listener_name, method, path)` is already enough to identify a
 route in dashboards; named lookup is a niceness, not a need.
 
-### Pre-read body-cap enforcement for per-route `max_body` on h2/h3 — medium
+### Pre-read body-cap enforcement for per-route `max_body` on h3 — medium
 
-**What:** The per-route `max_body` override ships, but h2/h3 enforce it *after*
-the body is accumulated (a 413 at dispatch), not during. H1 already rejects
-before reading (it knows the path right after headers). For h2 the path is known
-at `finalize_headers` (before DATA), so the effective cap could move onto the
-stream entry and reject in `on_data` mid-accumulation. h3 decodes the QPACK
-header block only at dispatch today, so it needs an eager header decode at the
-HEADERS frame to know the path during DATA accumulation.
+**What:** h1 and h2 both bound what a request buffers at the matched route's
+`max_body` (h1 before the read, h2 in `on_data` from a cap resolved at
+END_HEADERS). h3 still enforces it *after* the body is accumulated, as a 413 at
+dispatch, because the QPACK header block stays raw until then — so the route's
+path is unknown while DATA accumulates. Closing the gap needs an eager QPACK
+decode at the HEADERS frame, threaded to dispatch.
 
-**Why deferred:** the global `max_content_length` already bounds what h2/h3
-accumulate, so the post-accumulation check is a correct tighter cap; reading up
-to the global before rejecting is an efficiency gap, not a correctness one, and
-matters only for direct (non-proxied) h2/h3 clients. The reverse-proxy path
-(nginx → h1) already gets pre-read rejection.
+**Why deferred:** the global `max_content_length` still bounds what an h3 stream
+accumulates, so the dispatch check is a correct tighter cap; the gap is that a
+route cap tighter than the global one does not reduce buffering on h3. Wants the
+eager-decode plumbing, which also unblocks h3 manual-mode body reading.
 
-**Scope:** medium. h2 is a stream-field + `on_data` change; h3 additionally
-needs eager QPACK decode at the HEADERS frame, threaded to dispatch.
+**Scope:** medium. Eager QPACK decode at the HEADERS frame plus threading the
+decoded block to dispatch, reusing `roadrunner_conn:effective_max_body_for/4`.
 
 ### Nested route groups with shared prefix + middlewares — medium
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -442,23 +442,30 @@ top-level keys add new per-route capabilities without breaking
 existing routes. None of the below is wired up yet; the map shape
 is ready when one of these has a real caller behind it.
 
-### Reuse the dispatch route match for the per-route rate-limit lookup — medium
+### Collapse the per-route override lookups into one route match — medium
 
-**What:** The rate guard runs before route resolution so a refused request skips
-routing entirely. To find a per-route `rate_limit` it therefore does its own
-`path_segments/1` split and its own first-match scan, and dispatch then repeats
-both moments later in `match/3`. A listener with any per-route limit pays
-roughly double the router work per request.
+**What:** The per-route `rate_limit` and `max_body` overrides compile into two
+separate subsets, each looked up independently, and dispatch then matches the
+route a third time in `match/3`. Every lookup repeats the same
+`path_segments/1` split and first-match scan. A listener configuring both
+overrides therefore pays roughly three router matches per request where one
+would do.
 
-**Why deferred:** the duplication only exists when a per-route limit is
-configured (the compiled subset is `undefined` otherwise, and the lookup is
-skipped), and the router match is cheap next to the handler. Collapsing it means
-either routing before the guard (so refused requests pay for routing) or
-threading the matched route from the guard into dispatch, which widens the
-dispatch signature across all three protocol loops.
+They are split because they are consumed at different points: the body cap is
+needed before the body is read, the rate guard runs at dispatch (deliberately
+before route resolution, so a refused request skips routing), and the two were
+built as separate features. Compiling one `route_overrides` subset carrying both
+values, matched once per request and cached on the loop state, collapses all
+three to one.
 
-**Scope:** medium. The win is real but narrow; wants a profile on a
-per-route-limited listener before taking on the plumbing.
+**Why deferred:** each lookup is skipped entirely when its subset is `undefined`
+(the default), so this costs nothing unless per-route overrides are configured,
+and a router match is cheap next to the handler. The fix touches the compile
+step, both persistent_term keys, the loop-state records and the request flow in
+all three protocol loops.
+
+**Scope:** medium. Wants a profile on a listener that configures both overrides
+before taking on the plumbing.
 
 ### Per-route `name => atom()` for telemetry / reverse routing — small
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -70,6 +70,8 @@
     rate_limit_lookup/2,
     rate_limit_apply/2,
     resolve_rate_limit/3,
+    resolve_body_limits/1,
+    effective_max_body/3,
     maybe_put_client_ip/2,
     rate_limited_telemetry/2,
     rate_limit_evict_idle/3,
@@ -504,6 +506,36 @@ maybe_put_client_ip(undefined, Req) ->
     Req;
 maybe_put_client_ip(Prepared, #{headers := Headers} = Req) ->
     Req#{client_ip => roadrunner_real_ip:resolve(Prepared, Headers)}.
+
+%% Read the compiled per-route `max_body` subset for a listener (published by
+%% `roadrunner_listener`), or `undefined` when no route declares one. Read once
+%% per connection at setup and cached on the loop record.
+-doc false.
+-spec resolve_body_limits(proto_opts()) -> roadrunner_router:route_body_limits().
+resolve_body_limits(#{listener_name := ListenerName}) ->
+    persistent_term:get({roadrunner_body_limit_routes, ListenerName}, undefined);
+resolve_body_limits(_ProtoOpts) ->
+    undefined.
+
+%% Resolve the effective request-body cap: the per-route `max_body` when the
+%% request's method+path matches an override, else the listener-global
+%% `Global`. The `undefined` clause (no per-route caps) is the common path and
+%% returns `Global` without touching the request.
+-doc false.
+-spec effective_max_body(
+    roadrunner_router:route_body_limits(), roadrunner_req:request(), non_neg_integer()
+) -> non_neg_integer().
+effective_max_body(undefined, _Req, Global) ->
+    Global;
+effective_max_body(BodyLimits, Req, Global) ->
+    case
+        roadrunner_router:match_body_limit(
+            roadrunner_req:method(Req), roadrunner_req:path(Req), BodyLimits
+        )
+    of
+        nomatch -> Global;
+        MaxBody -> MaxBody
+    end.
 
 %% Resolve a rate-limit-state `Key` to the bucket IP. A baked `IP` keys on
 %% itself; the `client_ip` marker (the `real_ip` opt is set) keys on the

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -72,6 +72,7 @@
     resolve_rate_limit/3,
     resolve_body_limits/1,
     effective_max_body/3,
+    effective_max_body_for/4,
     maybe_put_client_ip/2,
     rate_limited_telemetry/2,
     rate_limit_evict_idle/3,
@@ -528,11 +529,24 @@ resolve_body_limits(_ProtoOpts) ->
 effective_max_body(undefined, _Req, Global) ->
     Global;
 effective_max_body(BodyLimits, Req, Global) ->
-    case
-        roadrunner_router:match_body_limit(
-            roadrunner_req:method(Req), roadrunner_req:path(Req), BodyLimits
-        )
-    of
+    effective_max_body_for(
+        BodyLimits, roadrunner_req:method(Req), roadrunner_req:path(Req), Global
+    ).
+
+%% `effective_max_body/3` keyed on a bare method + path rather than a built
+%% request, for callers that know both before a request map exists. HTTP/2
+%% resolves the cap at END_HEADERS (from the `:method` / `:path` pseudo-headers)
+%% so DATA frames can be capped as they arrive, instead of after the whole body
+%% has accumulated under the global limit. Both entry points funnel through the
+%% same matcher, so the early and late answers cannot disagree.
+-doc false.
+%% Callers gate on a configured subset before reaching here, so there is no
+%% `undefined` clause: the no-per-route-caps case never builds a method + path.
+-spec effective_max_body_for(
+    roadrunner_router:route_body_limits(), binary(), binary(), non_neg_integer()
+) -> non_neg_integer().
+effective_max_body_for(BodyLimits, Method, Path, Global) ->
+    case roadrunner_router:match_body_limit(Method, Path, BodyLimits) of
         nomatch -> Global;
         MaxBody -> MaxBody
     end.

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -135,7 +135,12 @@
     %% (`undefined` when off — the common case). When set,
     %% `handle_request_bytes/2` resolves the client IP per request; the
     %% `undefined` branch adds nothing to the request map.
-    real_ip = undefined :: roadrunner_real_ip:prepared()
+    real_ip = undefined :: roadrunner_real_ip:prepared(),
+    %% Per-route `max_body` subset cached from `proto_opts` at `shoot`
+    %% (`undefined` when no route declares one). When set, `read_body_phase/3`
+    %% caps the body read at the matched route's limit instead of the global
+    %% `max_content_length`.
+    body_limits = undefined :: roadrunner_router:route_body_limits()
 }).
 
 -spec start(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) ->
@@ -264,7 +269,8 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
                     maps:get(http1_max_header_count, ProtoOpts, 100)
                 },
                 rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer, RealIp),
-                real_ip = RealIp
+                real_ip = RealIp,
+                body_limits = roadrunner_conn:resolve_body_limits(ProtoOpts)
             },
             read_request_phase(S)
     end.
@@ -653,7 +659,8 @@ read_body_phase(
         socket = Socket,
         min_rate = MinRate,
         body_buffering = BodyMode,
-        max_content_length = MaxCL,
+        max_content_length = GlobalMaxCL,
+        body_limits = BodyLimits,
         http1_limits = {_ReqLine, MaxHdrLine, MaxHdrBlock, MaxHdrCount}
     } = S,
     Req,
@@ -661,6 +668,9 @@ read_body_phase(
 ) ->
     Recv = roadrunner_conn:make_recv(Socket, Deadline, MinRate),
     Buffered = S#loop_state.buffered,
+    %% Cap the body at the matched route's `max_body` when one is configured,
+    %% else the listener-global `max_content_length` (the common path).
+    MaxCL = roadrunner_conn:effective_max_body(BodyLimits, Req, GlobalMaxCL),
     %% Trailer headers (chunked bodies) obey the same caps as request
     %% headers; the request-line cap doesn't apply to a trailer block.
     TrailerLimits = {MaxHdrLine, MaxHdrBlock, MaxHdrCount},

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -165,6 +165,11 @@
     %% validate against the request's `content-length` header at
     %% END_STREAM (RFC 9113 §8.1.2.6).
     body_len := non_neg_integer(),
+    %% Effective request-body cap for this stream: the listener-global
+    %% `max_content_length` until END_HEADERS, then the matched route's
+    %% `max_body` override when one applies. `on_data/5` enforces it as DATA
+    %% arrives, so an over-cap body is refused without being buffered first.
+    max_body := non_neg_integer(),
     send_window := integer(),
     recv_window := non_neg_integer(),
     worker_pid := undefined | pid(),
@@ -252,9 +257,9 @@
     %% IP per request onto the request map.
     real_ip = undefined :: roadrunner_real_ip:prepared(),
     %% Per-route `max_body` subset cached from proto_opts at `enter/6`
-    %% (`undefined` when no route declares one). When set, `dispatch_stream/2`
-    %% answers 413 for a stream whose accumulated body exceeds the matched
-    %% route's cap (the global `max_content_length` already bounded accumulation).
+    %% (`undefined` when no route declares one). When set, `finalize_headers/2`
+    %% resolves the matched route's cap onto the stream's `max_body` at
+    %% END_HEADERS, and `on_data/5` enforces it as DATA arrives.
     body_limits = undefined :: roadrunner_router:route_body_limits(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
@@ -795,7 +800,8 @@ on_headers(StreamId, Flags, _Priority, Fragment, State) ->
         EndHeaders,
         EndStream,
         State#loop.peer_initial_window,
-        State#loop.stream_recv_window_peak
+        State#loop.stream_recv_window_peak,
+        State#loop.max_content_length
     ),
     State1 = State#loop{
         streams = (State#loop.streams)#{StreamId => Stream},
@@ -811,7 +817,39 @@ on_headers(StreamId, Flags, _Priority, Fragment, State) ->
         true -> frame_loop(State1)
     end.
 
-new_stream(Fragment, EndHeaders, EndStream, SendWindow, RecvWindow) ->
+%% Resolve this stream's effective body cap now that the header block is
+%% decoded. Unlike HTTP/3 (whose QPACK block stays raw until dispatch), h2 has
+%% the `:method` / `:path` pseudo-headers before any DATA frame arrives, so a
+%% per-route `max_body` can bound what the stream buffers rather than only
+%% changing the status after the fact. Falls back to the listener-global cap
+%% when no route declares an override or the pseudo-headers are missing (a
+%% malformed request `roadrunner_http2_request:from_headers/3` rejects at
+%% dispatch anyway).
+-spec stream_max_body(#loop{}, roadrunner_http:headers()) -> non_neg_integer().
+stream_max_body(#loop{body_limits = undefined, max_content_length = Global}, _Headers) ->
+    Global;
+stream_max_body(#loop{body_limits = BodyLimits, max_content_length = Global}, Headers) ->
+    case {find_pseudo(~":method", Headers), find_pseudo(~":path", Headers)} of
+        {undefined, _} ->
+            Global;
+        {_, undefined} ->
+            Global;
+        {Method, Target} ->
+            %% Route matching runs on the `?`-free path. Share
+            %% `roadrunner_req:target_path/1` with `roadrunner_req:path/1`
+            %% rather than re-splitting here, so this early answer uses the
+            %% identical derivation dispatch will.
+            roadrunner_conn:effective_max_body_for(
+                BodyLimits, Method, roadrunner_req:target_path(Target), Global
+            )
+    end.
+
+-spec find_pseudo(binary(), roadrunner_http:headers()) -> binary() | undefined.
+find_pseudo(_Name, []) -> undefined;
+find_pseudo(Name, [{Name, Value} | _]) -> Value;
+find_pseudo(Name, [_ | Rest]) -> find_pseudo(Name, Rest).
+
+new_stream(Fragment, EndHeaders, EndStream, SendWindow, RecvWindow, MaxBody) ->
     #{
         state => open,
         header_fragment => Fragment,
@@ -821,6 +859,7 @@ new_stream(Fragment, EndHeaders, EndStream, SendWindow, RecvWindow) ->
         headers => undefined,
         body => [],
         body_len => 0,
+        max_body => MaxBody,
         send_window => SendWindow,
         recv_window => RecvWindow,
         worker_pid => undefined,
@@ -920,7 +959,11 @@ finalize_headers(
     } = Streams,
     case roadrunner_http2_hpack:decode(iolist_to_binary(Fragment), Dec) of
         {ok, Headers, Dec1} ->
-            Stream1 = Stream#{headers := Headers, header_fragment := <<>>},
+            Stream1 = Stream#{
+                headers := Headers,
+                header_fragment := <<>>,
+                max_body := stream_max_body(State, Headers)
+            },
             %% Commit the mutated HPACK context even if we reject below: the
             %% decode advanced the dynamic table, so dropping it would desync
             %% our decoder from the peer's encoder for every later block.
@@ -972,13 +1015,17 @@ on_data(StreamId, _Flags, _Payload, FlowLen, #loop{streams = Streams} = State) w
     %% discarding them, so the conn window doesn't drift down across resets.
     _ = send_rst_stream(State, StreamId, stream_closed),
     frame_loop(replenish_conn_window(State, FlowLen));
-on_data(
-    StreamId, Flags, Payload, FlowLen, #loop{streams = Streams, max_content_length = MaxCL} = State
-) ->
+on_data(StreamId, Flags, Payload, FlowLen, #loop{streams = Streams} = State) ->
     case Streams of
         #{
             StreamId :=
-                #{state := open, body := Body, body_len := Len, recv_window := RW} = Stream
+                #{
+                    state := open,
+                    body := Body,
+                    body_len := Len,
+                    recv_window := RW,
+                    max_body := MaxCL
+                } = Stream
         } ->
             %% Flow control charges the full on-wire `FlowLen` (RFC 9113
             %% §6.9.1: pad-length byte + padding count). Past the window
@@ -1001,12 +1048,14 @@ on_data(
                     PayloadLen = byte_size(Payload),
                     if
                         Len + PayloadLen > MaxCL ->
-                            %% RFC 9113 §8.1: the request body exceeds
-                            %% `max_content_length`. Answer 413 before the
-                            %% full request, then RST_STREAM(NO_ERROR) to ask
-                            %% the client to stop sending the rest, and drop
-                            %% the stream (no worker was dispatched — dispatch
-                            %% is at END_STREAM).
+                            %% RFC 9113 §8.1: the request body exceeds this
+                            %% stream's cap — the matched route's `max_body`
+                            %% once the header block is decoded, else the
+                            %% listener-global `max_content_length`. Answer 413
+                            %% before the full request, then RST_STREAM(NO_ERROR)
+                            %% to ask the client to stop sending the rest, and
+                            %% drop the stream (no worker was dispatched —
+                            %% dispatch is at END_STREAM).
                             Resp = ~"Payload Too Large",
                             State1 = encode_and_send_response_atomic(
                                 State,
@@ -1126,9 +1175,7 @@ dispatch_stream(
         listener_name = ListenerName,
         max_concurrent_requests = MaxConcReq,
         inflight_counter = InflightCounter,
-        real_ip = RealIp,
-        max_content_length = MaxCL,
-        body_limits = BodyLimits
+        real_ip = RealIp
     } = State
 ) ->
     #{
@@ -1154,40 +1201,23 @@ dispatch_stream(
             },
             case roadrunner_http2_request:from_headers(Headers, BodyIolist, RequestContext) of
                 {ok, Req0} ->
+                    %% No body-cap check here: `on_data/5` already enforced this
+                    %% stream's effective cap (route override or global) as each
+                    %% DATA frame arrived, so an over-cap body never reaches
+                    %% dispatch.
                     Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0),
                     StateBuf = State#loop{req_id_buffer = NewBuf},
-                    case
-                        BodyLimits =/= undefined andalso
-                            BodyLen > roadrunner_conn:effective_max_body(BodyLimits, Req, MaxCL)
-                    of
-                        true ->
-                            %% Per-route `max_body` exceeded: 413 + RST(no_error),
-                            %% no worker. The global cap already bounded what was
-                            %% accumulated; this enforces the tighter route cap.
-                            Resp = ~"Payload Too Large",
-                            State413 = encode_and_send_response_atomic(
-                                StateBuf,
-                                StreamId,
-                                413,
-                                [{~"content-type", ~"text/plain"}],
-                                Resp,
-                                byte_size(Resp)
-                            ),
-                            _ = send_rst_stream(State413, StreamId, no_error),
-                            frame_loop(remove_stream(State413, StreamId));
-                        false ->
-                            dispatch_allowed_stream(
-                                StateBuf,
-                                StreamId,
-                                Req,
-                                Stream,
-                                Streams,
-                                ProtoOpts,
-                                MaxConcReq,
-                                InflightCounter,
-                                ListenerName
-                            )
-                    end;
+                    dispatch_allowed_stream(
+                        StateBuf,
+                        StreamId,
+                        Req,
+                        Stream,
+                        Streams,
+                        ProtoOpts,
+                        MaxConcReq,
+                        InflightCounter,
+                        ListenerName
+                    );
                 {error, _Reason} ->
                     _ = send_rst_stream(State, StreamId, protocol_error),
                     frame_loop(remove_stream(State#loop{req_id_buffer = NewBuf}, StreamId))

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -829,10 +829,8 @@ on_headers(StreamId, Flags, _Priority, Fragment, State) ->
 stream_max_body(#loop{body_limits = undefined, max_content_length = Global}, _Headers) ->
     Global;
 stream_max_body(#loop{body_limits = BodyLimits, max_content_length = Global}, Headers) ->
-    case {find_pseudo(~":method", Headers), find_pseudo(~":path", Headers)} of
-        {undefined, _} ->
-            Global;
-        {_, undefined} ->
+    case route_keys(Headers, undefined, undefined) of
+        undefined ->
             Global;
         {Method, Target} ->
             %% Route matching runs on the `?`-free path. Share
@@ -844,10 +842,24 @@ stream_max_body(#loop{body_limits = BodyLimits, max_content_length = Global}, He
             )
     end.
 
--spec find_pseudo(binary(), roadrunner_http:headers()) -> binary() | undefined.
-find_pseudo(_Name, []) -> undefined;
-find_pseudo(Name, [{Name, Value} | _]) -> Value;
-find_pseudo(Name, [_ | Rest]) -> find_pseudo(Name, Rest).
+%% Pull `:method` and `:path` out of the decoded block in one pass, stopping as
+%% soon as both are bound. RFC 9113 §8.3 requires pseudo-headers to precede the
+%% regular fields, so the scan normally ends within the first few entries rather
+%% than walking the whole list (twice, as two separate lookups would).
+%% `undefined` when either is absent — a malformed request that cannot match a
+%% route, and that `roadrunner_http2_request:from_headers/3` rejects at dispatch.
+-spec route_keys(roadrunner_http:headers(), binary() | undefined, binary() | undefined) ->
+    {binary(), binary()} | undefined.
+route_keys(_Headers, Method, Path) when Method =/= undefined, Path =/= undefined ->
+    {Method, Path};
+route_keys([], _Method, _Path) ->
+    undefined;
+route_keys([{~":method", Method} | Rest], _Method0, Path) ->
+    route_keys(Rest, Method, Path);
+route_keys([{~":path", Path} | Rest], Method, _Path0) ->
+    route_keys(Rest, Method, Path);
+route_keys([_ | Rest], Method, Path) ->
+    route_keys(Rest, Method, Path).
 
 new_stream(Fragment, EndHeaders, EndStream, SendWindow, RecvWindow, MaxBody) ->
     #{

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -251,6 +251,11 @@
     %% (`undefined` when off). When set, `dispatch_stream/2` resolves the client
     %% IP per request onto the request map.
     real_ip = undefined :: roadrunner_real_ip:prepared(),
+    %% Per-route `max_body` subset cached from proto_opts at `enter/6`
+    %% (`undefined` when no route declares one). When set, `dispatch_stream/2`
+    %% answers 413 for a stream whose accumulated body exceeds the matched
+    %% route's cap (the global `max_content_length` already bounded accumulation).
+    body_limits = undefined :: roadrunner_router:route_body_limits(),
     %% Stream table, keyed by stream id.
     streams = #{} :: #{stream_id() => stream_entry()},
     %% Worker monitor ref → stream id, for DOWN correlation.
@@ -345,6 +350,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered) ->
         inflight_counter = InflightCounter,
         rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer, RealIp),
         real_ip = RealIp,
+        body_limits = roadrunner_conn:resolve_body_limits(ProtoOpts),
         handshake_timeout = HandshakeTimeout,
         idle_timeout = IdleTimeout
     },
@@ -1120,7 +1126,9 @@ dispatch_stream(
         listener_name = ListenerName,
         max_concurrent_requests = MaxConcReq,
         inflight_counter = InflightCounter,
-        real_ip = RealIp
+        real_ip = RealIp,
+        max_content_length = MaxCL,
+        body_limits = BodyLimits
     } = State
 ) ->
     #{
@@ -1148,42 +1156,37 @@ dispatch_stream(
                 {ok, Req0} ->
                     Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0),
                     StateBuf = State#loop{req_id_buffer = NewBuf},
-                    case rate_limit_refused(StateBuf, StreamId, Req) of
-                        {refused, State1} ->
-                            %% Per-peer rate exceeded: 429 + RST(no_error) sent,
-                            %% no worker spawned. 429 (not REFUSED_STREAM) so the
-                            %% client backs off per Retry-After instead of
-                            %% retrying the stream immediately.
-                            frame_loop(remove_stream(State1, StreamId));
-                        ok ->
-                            case
-                                roadrunner_conn:try_acquire_request_slot(
-                                    MaxConcReq, InflightCounter
-                                )
-                            of
-                                true ->
-                                    {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
-                                        self(), StreamId, Req, ProtoOpts
-                                    ),
-                                    Stream1 = Stream#{
-                                        worker_pid := WorkerPid,
-                                        worker_ref := MonRef,
-                                        state := half_closed_remote,
-                                        body := []
-                                    },
-                                    frame_loop(StateBuf#loop{
-                                        streams = Streams#{StreamId := Stream1},
-                                        worker_refs =
-                                            (StateBuf#loop.worker_refs)#{MonRef => StreamId}
-                                    });
-                                false ->
-                                    %% Listener-wide in-flight ceiling reached —
-                                    %% refuse with retry-safe REFUSED_STREAM, no
-                                    %% worker spawned.
-                                    ok = throttle_stream(StateBuf, ListenerName),
-                                    _ = send_rst_stream(StateBuf, StreamId, refused_stream),
-                                    frame_loop(remove_stream(StateBuf, StreamId))
-                            end
+                    case
+                        BodyLimits =/= undefined andalso
+                            BodyLen > roadrunner_conn:effective_max_body(BodyLimits, Req, MaxCL)
+                    of
+                        true ->
+                            %% Per-route `max_body` exceeded: 413 + RST(no_error),
+                            %% no worker. The global cap already bounded what was
+                            %% accumulated; this enforces the tighter route cap.
+                            Resp = ~"Payload Too Large",
+                            State413 = encode_and_send_response_atomic(
+                                StateBuf,
+                                StreamId,
+                                413,
+                                [{~"content-type", ~"text/plain"}],
+                                Resp,
+                                byte_size(Resp)
+                            ),
+                            _ = send_rst_stream(State413, StreamId, no_error),
+                            frame_loop(remove_stream(State413, StreamId));
+                        false ->
+                            dispatch_allowed_stream(
+                                StateBuf,
+                                StreamId,
+                                Req,
+                                Stream,
+                                Streams,
+                                ProtoOpts,
+                                MaxConcReq,
+                                InflightCounter,
+                                ListenerName
+                            )
                     end;
                 {error, _Reason} ->
                     _ = send_rst_stream(State, StreamId, protocol_error),
@@ -1194,6 +1197,55 @@ dispatch_stream(
             %% mismatch is a stream-error PROTOCOL_ERROR.
             _ = send_rst_stream(State, StreamId, protocol_error),
             frame_loop(remove_stream(State, StreamId))
+    end.
+
+%% A request that passed the body-size cap: run the per-peer rate-limit gate,
+%% then acquire the listener-wide in-flight slot and spawn the stream worker, or
+%% refuse (429 on rate, REFUSED_STREAM at the ceiling). No worker is spawned on a
+%% refusal.
+-spec dispatch_allowed_stream(
+    #loop{},
+    stream_id(),
+    roadrunner_req:request(),
+    stream_entry(),
+    #{stream_id() => stream_entry()},
+    roadrunner_conn:proto_opts(),
+    infinity | pos_integer(),
+    counters:counters_ref() | undefined,
+    atom()
+) -> no_return().
+dispatch_allowed_stream(
+    StateBuf, StreamId, Req, Stream, Streams, ProtoOpts, MaxConcReq, InflightCounter, ListenerName
+) ->
+    case rate_limit_refused(StateBuf, StreamId, Req) of
+        {refused, State1} ->
+            %% Per-peer rate exceeded: 429 + RST(no_error) sent, no worker
+            %% spawned. 429 (not REFUSED_STREAM) so the client backs off per
+            %% Retry-After instead of retrying the stream immediately.
+            frame_loop(remove_stream(State1, StreamId));
+        ok ->
+            case roadrunner_conn:try_acquire_request_slot(MaxConcReq, InflightCounter) of
+                true ->
+                    {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(
+                        self(), StreamId, Req, ProtoOpts
+                    ),
+                    Stream1 = Stream#{
+                        worker_pid := WorkerPid,
+                        worker_ref := MonRef,
+                        state := half_closed_remote,
+                        body := []
+                    },
+                    frame_loop(StateBuf#loop{
+                        streams = Streams#{StreamId := Stream1},
+                        worker_refs = (StateBuf#loop.worker_refs)#{MonRef => StreamId}
+                    });
+                false ->
+                    %% Listener-wide in-flight ceiling reached — refuse with
+                    %% retry-safe REFUSED_STREAM, no worker spawned.
+                    ok = throttle_stream(StateBuf, ListenerName),
+                    _ = send_rst_stream(StateBuf, StreamId, refused_stream),
+                    frame_loop(remove_stream(StateBuf, StreamId))
+            end
     end.
 
 %% Verify that any client-supplied `content-length` header matches

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -151,7 +151,13 @@
     %% Compiled `real_ip` config cached from proto_opts at conn start
     %% (`undefined` when off). When set, `dispatch_decoded/4` resolves the
     %% client IP per request onto the request map.
-    real_ip = undefined :: roadrunner_real_ip:prepared()
+    real_ip = undefined :: roadrunner_real_ip:prepared(),
+    %% Per-route `max_body` subset cached from proto_opts at conn start
+    %% (`undefined` when no route declares one). When set, `dispatch_decoded/4`
+    %% answers 413 for a request whose body exceeds the matched route's cap (the
+    %% global `max_content_length` already bounded accumulation; h3 decodes the
+    %% header path only here, so the cap is a post-accumulation check).
+    body_limits = undefined :: roadrunner_router:route_body_limits()
 }).
 
 -doc """
@@ -218,7 +224,8 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
         max_concurrent_requests = maps:get(max_concurrent_requests, ProtoOpts, infinity),
         inflight_counter = maps:get(inflight_counter, ProtoOpts, undefined),
         rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer, RealIp),
-        real_ip = RealIp
+        real_ip = RealIp,
+        body_limits = roadrunner_conn:resolve_body_limits(ProtoOpts)
     }).
 
 -spec loop(#h3{}) -> ok.
@@ -779,9 +786,12 @@ respond_field_section_too_large(#h3{conn = Conn} = State, StreamId) ->
 dispatch_decoded(
     #h3{
         peer = Peer,
+        conn = Conn,
         listener_name = ListenerName,
         req_id_buffer = ReqIdBuffer,
-        real_ip = RealIp
+        real_ip = RealIp,
+        max_content_length = MaxCL,
+        body_limits = BodyLimits
     } = State,
     StreamId,
     Headers,
@@ -803,14 +813,32 @@ dispatch_decoded(
             reset_and_drop(State1, StreamId, ?H3_MESSAGE_ERROR);
         {ok, Req0} ->
             Req = roadrunner_conn:maybe_put_client_ip(RealIp, Req0),
-            case rate_limit_refused(State1, StreamId, Req) of
-                {refused, State2} ->
-                    %% Per-peer rate exceeded: 429 + Retry-After sent, stream
-                    %% dropped. 429 (not H3_REQUEST_REJECTED) so the client backs
-                    %% off per Retry-After instead of retrying immediately.
-                    State2;
-                ok ->
-                    dispatch_with_slot(State1, StreamId, Req)
+            case
+                BodyLimits =/= undefined andalso
+                    iolist_size(Body) > roadrunner_conn:effective_max_body(BodyLimits, Req, MaxCL)
+            of
+                true ->
+                    %% Per-route `max_body` exceeded: 413, stream dropped. The
+                    %% global cap already bounded accumulation; h3 decodes the
+                    %% header path only here, so this is a post-accumulation check.
+                    ok = roadrunner_http3_stream_worker:send_buffered(
+                        Conn,
+                        StreamId,
+                        413,
+                        [{~"content-type", ~"text/plain"}],
+                        ~"Payload Too Large"
+                    ),
+                    drop_stream(State1, StreamId);
+                false ->
+                    case rate_limit_refused(State1, StreamId, Req) of
+                        {refused, State2} ->
+                            %% Per-peer rate exceeded: 429 + Retry-After sent,
+                            %% stream dropped. 429 (not H3_REQUEST_REJECTED) so the
+                            %% client backs off per Retry-After instead of retrying.
+                            State2;
+                        ok ->
+                            dispatch_with_slot(State1, StreamId, Req)
+                    end
             end
     end.
 

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -919,7 +919,8 @@ publish_routes(ListenerName, #{routes := Routes} = Opts) when is_list(Routes) ->
         {roadrunner_routes, ListenerName},
         roadrunner_router:compile(Routes, ListenerMws)
     ),
-    publish_rate_limit_routes(ListenerName, Routes);
+    ok = publish_rate_limit_routes(ListenerName, Routes),
+    publish_body_limit_routes(ListenerName, Routes);
 publish_routes(_ListenerName, _Opts) ->
     ok.
 
@@ -930,6 +931,19 @@ publish_routes(_ListenerName, _Opts) ->
 publish_rate_limit_routes(ListenerName, Routes) ->
     Key = {roadrunner_rate_limit_routes, ListenerName},
     case roadrunner_router:compile_rate_limits(Routes) of
+        undefined ->
+            _ = persistent_term:erase(Key),
+            ok;
+        Limits ->
+            persistent_term:put(Key, Limits)
+    end.
+
+%% Publish the compiled per-route `max_body` subset (or remove it when none),
+%% read per-connection by the conn loops to resolve the effective body cap.
+-spec publish_body_limit_routes(atom(), roadrunner_router:routes()) -> ok.
+publish_body_limit_routes(ListenerName, Routes) ->
+    Key = {roadrunner_body_limit_routes, ListenerName},
+    case roadrunner_router:compile_body_limits(Routes) of
         undefined ->
             _ = persistent_term:erase(Key),
             ok;
@@ -1702,6 +1716,7 @@ do_reload_routes(
         roadrunner_router:compile(Routes, ListenerMws)
     ),
     ok = publish_rate_limit_routes(Name, Routes),
+    ok = publish_body_limit_routes(Name, Routes),
     ok;
 do_reload_routes(#state{proto_opts = #{dispatch := {handler, _, _, _}}}, _Routes) ->
     {error, no_routes}.

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -167,6 +167,7 @@ to absorb a chunk's payload across multiple length-bounded calls.
     method/1,
     method_is/2,
     path/1,
+    target_path/1,
     qs/1,
     version/1,
     headers/1,
@@ -224,7 +225,15 @@ path(#{path := P}) ->
     P;
 path(#{target := T}) ->
     %% Fallback for h2/h3 and manually-built maps that carry no `path`.
-    case binary:split(T, persistent_term:get(?QMARK_CP_KEY)) of
+    target_path(T).
+
+%% Slice the `?`-free path out of a raw request-target. Shared with `path/1` so
+%% callers holding only a target (HTTP/2 resolves a route before a request map
+%% exists, from the `:path` pseudo-header) derive the path identically.
+-doc false.
+-spec target_path(binary()) -> binary().
+target_path(Target) ->
+    case binary:split(Target, persistent_term:get(?QMARK_CP_KEY)) of
         [P, _Q] -> P;
         [P] -> P
     end.

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -50,9 +50,18 @@ opaque `compiled()` shape is a list of pre-parsed segment patterns;
 swapping to a trie/DAG later is a non-breaking change for callers.
 """.
 
--export([compile/2, match/3, compile_rate_limits/1, match_rate_limit/3]).
+-export([
+    compile/2,
+    match/3,
+    compile_rate_limits/1,
+    match_rate_limit/3,
+    compile_body_limits/1,
+    match_body_limit/3
+]).
 
--export_type([route/0, routes/0, compiled/0, bindings/0, methods/0, route_rate_limits/0]).
+-export_type([
+    route/0, routes/0, compiled/0, bindings/0, methods/0, route_rate_limits/0, route_body_limits/0
+]).
 
 -doc """
 A single route entry. Three shapes are accepted:
@@ -80,7 +89,8 @@ unset → every method.
         state => term(),
         middlewares => roadrunner_middleware:middleware_list(),
         methods => methods(),
-        rate_limit => map()
+        rate_limit => map(),
+        max_body => non_neg_integer()
     }.
 
 -doc """
@@ -149,6 +159,17 @@ path, so this is a plain (non-opaque) type.
 """.
 -type route_rate_limits() ::
     [{[segment()], method_lookup(), {pos_integer(), pos_integer(), pos_integer()}, binary()}]
+    | undefined.
+
+-doc """
+The compiled per-route `max_body` overrides `match_body_limit/3` consumes: a
+path+method-keyed subset of the routes that declare a `max_body`, each with its
+byte cap. `undefined` when no route declares one (so the body path pays
+nothing). A plain (non-opaque) type — the conn loops match `undefined` to take
+the global-limit fast path.
+""".
+-type route_body_limits() ::
+    [{[segment()], method_lookup(), non_neg_integer()}]
     | undefined.
 
 -doc """
@@ -417,6 +438,63 @@ match_rate_limit_1(Method, Segments, [{Pattern, Methods, Units, Key} | Rest]) ->
                     {Rate, Cap, Cost, Key};
                 false ->
                     match_rate_limit_1(Method, Segments, Rest)
+            end
+    end.
+
+-doc """
+Compile the per-route `max_body` overrides out of a route list.
+
+Keeps only the map-form routes that carry a `max_body` key, pairing each route's
+compiled path + method allowlist with its byte cap. Returns `undefined` when no
+route declares one, so the caller can bake an absent subset and keep the global
+limit. Raises `{invalid_route_max_body, Path, Value}` on a non-`non_neg_integer`
+cap, at listener init.
+""".
+-spec compile_body_limits(routes()) -> route_body_limits().
+compile_body_limits(Routes) when is_list(Routes) ->
+    case [compile_body_limit(R) || R <- Routes, is_body_limited(R)] of
+        [] -> undefined;
+        Limits -> Limits
+    end.
+
+-spec is_body_limited(route()) -> boolean().
+is_body_limited(#{max_body := _}) -> true;
+is_body_limited(_) -> false.
+
+-spec compile_body_limit(map()) -> {[segment()], method_lookup(), non_neg_integer()}.
+compile_body_limit(#{path := Path, max_body := MaxBody} = Route) when
+    is_binary(Path), is_integer(MaxBody), MaxBody >= 0
+->
+    {compile_path(Path), compile_methods(maps:get(methods, Route, undefined)), MaxBody};
+compile_body_limit(#{path := Path, max_body := MaxBody}) ->
+    error({invalid_route_max_body, Path, MaxBody}).
+
+-doc """
+Find the per-route `max_body` byte cap for a request method + path, or `nomatch`.
+
+First-match-wins over the compiled subset, reusing the same path + method
+matchers as `match/3`; a path-match whose method is not in the route's allowlist
+keeps scanning. `nomatch` means the caller keeps the listener-global
+`max_content_length`.
+""".
+-spec match_body_limit(binary(), binary(), route_body_limits()) ->
+    non_neg_integer() | nomatch.
+match_body_limit(_Method, _Path, undefined) ->
+    nomatch;
+match_body_limit(Method, Path, Limits) when is_binary(Method), is_binary(Path) ->
+    match_body_limit_1(Method, path_segments(Path), Limits).
+
+-spec match_body_limit_1(binary(), [binary()], [tuple()]) -> non_neg_integer() | nomatch.
+match_body_limit_1(_Method, _Segments, []) ->
+    nomatch;
+match_body_limit_1(Method, Segments, [{Pattern, Methods, MaxBody} | Rest]) ->
+    case match_pattern(Pattern, Segments, #{}) of
+        no_match ->
+            match_body_limit_1(Method, Segments, Rest);
+        _Bindings ->
+            case method_allowed(Method, Methods) of
+                true -> MaxBody;
+                false -> match_body_limit_1(Method, Segments, Rest)
             end
     end.
 

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -476,6 +476,14 @@ First-match-wins over the compiled subset, reusing the same path + method
 matchers as `match/3`; a path-match whose method is not in the route's allowlist
 keeps scanning. `nomatch` means the caller keeps the listener-global
 `max_content_length`.
+
+Where the cap takes effect differs by protocol. HTTP/1 and HTTP/2 bound what the
+request buffers: h1 caps the body read, h2 resolves the route's cap once the
+header block is decoded and enforces it as DATA frames arrive. HTTP/3 keeps its
+QPACK header block raw until dispatch, so it cannot know the path while the body
+accumulates; there the route cap is applied after accumulation (bounded by the
+listener-global `max_content_length`) and changes the response rather than the
+buffering.
 """.
 -spec match_body_limit(binary(), binary(), route_body_limits()) ->
     non_neg_integer() | nomatch.

--- a/test/roadrunner_body_limit_listener_tests.erl
+++ b/test/roadrunner_body_limit_listener_tests.erl
@@ -2,6 +2,9 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% RFC 9113 §6.4 frame type.
+-define(RST_STREAM, 3).
+
 %% =============================================================================
 %% Opt validation.
 %% =============================================================================
@@ -51,7 +54,8 @@ h1_uncapped_route_uses_global_test() ->
     end).
 
 %% =============================================================================
-%% HTTP/2 (h2c): the route cap is enforced at dispatch (post-accumulation 413).
+%% HTTP/2 (h2c): the route cap is resolved at END_HEADERS and enforced as DATA
+%% arrives, so an over-cap body is refused without being buffered.
 %% =============================================================================
 
 h2c_over_route_cap_413_test() ->
@@ -66,6 +70,63 @@ h2c_over_route_cap_413_test() ->
         %% The 413 response body is "Payload Too Large" (a DATA frame payload).
         ?assertMatch({match, _}, re:run(Reply, ~"Payload Too Large"))
     end).
+
+h2c_over_route_cap_rejects_before_end_stream_test() ->
+    %% The route cap must bound what the stream buffers, not just change the
+    %% status once the whole body has landed. Send HEADERS then a single
+    %% over-cap DATA frame WITHOUT END_STREAM: a post-accumulation check would
+    %% still be waiting for the client to finish, so a 413 here proves the cap
+    %% is enforced as DATA arrives.
+    Routes = [#{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 10}],
+    with_route_listener([http2], Routes, fun(Port, _Name) ->
+        {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        Preface = ~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+        EmptySettings = <<0:24, 4, 0, 0:32>>,
+        {Headers, Data} = h2_post_open_frames(~"/upload", 20),
+        ok = gen_tcp:send(Sock, [Preface, EmptySettings, Headers, Data]),
+        Reply = recv_for(Sock, <<>>, 800),
+        ok = gen_tcp:close(Sock),
+        ?assertMatch({match, _}, re:run(Reply, ~"Payload Too Large"))
+    end).
+
+h2c_under_route_cap_still_dispatches_test() ->
+    %% The mirror of the above: a body inside the route cap must reach the
+    %% handler, so the earlier enforcement point cannot reject valid requests.
+    Routes = [#{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 64}],
+    with_route_listener([http2], Routes, fun(Port, _Name) ->
+        {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        Preface = ~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+        EmptySettings = <<0:24, 4, 0, 0:32>>,
+        ok = gen_tcp:send(Sock, [Preface, EmptySettings | h2_post_frames(~"/upload", 20)]),
+        Reply = recv_for(Sock, <<>>, 800),
+        ok = gen_tcp:close(Sock),
+        ?assertMatch(nomatch, re:run(Reply, ~"Payload Too Large"))
+    end).
+
+h2c_query_string_still_matches_route_cap_test() ->
+    %% The early resolution reads the `:path` pseudo-header, which carries the
+    %% query string; route matching must run on the `?`-free path.
+    Routes = [#{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 10}],
+    with_route_listener([http2], Routes, fun(Port, _Name) ->
+        {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        Preface = ~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+        EmptySettings = <<0:24, 4, 0, 0:32>>,
+        {Headers, Data} = h2_post_open_frames(~"/upload?a=1", 20),
+        ok = gen_tcp:send(Sock, [Preface, EmptySettings, Headers, Data]),
+        Reply = recv_for(Sock, <<>>, 800),
+        ok = gen_tcp:close(Sock),
+        ?assertMatch({match, _}, re:run(Reply, ~"Payload Too Large"))
+    end).
+
+h2c_missing_path_pseudo_header_is_reset_test() ->
+    %% Resolving the route cap at END_HEADERS reads the `:path` pseudo-header.
+    %% A block without one cannot match a route, so the stream keeps the global
+    %% cap and is reset as malformed at dispatch (RFC 9113 §8.3.1).
+    ?assert(lists:member(?RST_STREAM, h2_malformed_reply_frames([{~":method", ~"POST"}]))).
+
+h2c_missing_method_pseudo_header_is_reset_test() ->
+    %% Same for `:method`: no method means no route match, global cap, reset.
+    ?assert(lists:member(?RST_STREAM, h2_malformed_reply_frames([{~":path", ~"/upload"}]))).
 
 %% --- helpers ---
 
@@ -124,3 +185,44 @@ h2_post_frames(Path, BodyLen) ->
     Payload = binary:copy(~"x", BodyLen),
     Data = <<BodyLen:24, 0:8, 16#01:8, 0:1, 1:31, Payload/binary>>,
     [Headers, Data].
+
+%% Drive a body-limited h2c listener with a header block missing a pseudo-header,
+%% followed by an over-cap DATA frame, and return the frame types the server
+%% sent back.
+h2_malformed_reply_frames(Pseudo) ->
+    Routes = [#{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 10}],
+    with_route_listener([http2], Routes, fun(Port, _Name) ->
+        {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        {Block, _Enc} = roadrunner_http2_hpack:encode(
+            [{~":scheme", ~"http"}, {~":authority", ~"x"} | Pseudo],
+            roadrunner_http2_hpack:new_encoder(4096)
+        ),
+        Headers = roadrunner_http2_frame:encode(
+            {headers, 1, 16#04, undefined, iolist_to_binary(Block)}
+        ),
+        Payload = binary:copy(~"x", 20),
+        Data = <<20:24, 0:8, 16#01:8, 0:1, 1:31, Payload/binary>>,
+        Preface = ~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+        EmptySettings = <<0:24, 4, 0, 0:32>>,
+        ok = gen_tcp:send(Sock, [Preface, EmptySettings, Headers, Data]),
+        Reply = recv_for(Sock, <<>>, 800),
+        ok = gen_tcp:close(Sock),
+        h2_frame_types(Reply)
+    end).
+
+%% Frame types present in a raw h2 byte stream, in order.
+h2_frame_types(<<Len:24, Type:8, _Flags:8, _R:1, _StreamId:31, Rest/binary>>) when
+    byte_size(Rest) >= Len
+->
+    <<_Payload:Len/binary, Tail/binary>> = Rest,
+    [Type | h2_frame_types(Tail)];
+h2_frame_types(_) ->
+    [].
+
+%% Same as `h2_post_frames/2` but the DATA frame carries no END_STREAM, so the
+%% request is still open when the server sees it.
+h2_post_open_frames(Path, BodyLen) ->
+    [Headers, _EndStreamData] = h2_post_frames(Path, BodyLen),
+    Payload = binary:copy(~"x", BodyLen),
+    Data = <<BodyLen:24, 0:8, 0:8, 0:1, 1:31, Payload/binary>>,
+    {Headers, Data}.

--- a/test/roadrunner_body_limit_listener_tests.erl
+++ b/test/roadrunner_body_limit_listener_tests.erl
@@ -1,0 +1,126 @@
+-module(roadrunner_body_limit_listener_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% =============================================================================
+%% Opt validation.
+%% =============================================================================
+
+valid_max_body_starts_test() ->
+    Routes = [#{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 1024}],
+    with_route_listener([http1], Routes, fun(_Port, Name) ->
+        ?assert(is_integer(roadrunner_listener:port(Name)))
+    end).
+
+rejects_bad_max_body_test() ->
+    process_flag(trap_exit, true),
+    Routes = [#{path => ~"/x", handler => roadrunner_hello_handler, max_body => -1}],
+    R = roadrunner_listener:start_link(unique(bl_bad), #{
+        port => 0, protocols => [http1], routes => Routes
+    }),
+    ?assertMatch({error, {{invalid_route_max_body, ~"/x", -1}, _}}, R).
+
+%% =============================================================================
+%% HTTP/1: the route cap is enforced before the body is read (413 / 200).
+%% =============================================================================
+
+h1_over_route_cap_413_test() ->
+    Routes = [#{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 10}],
+    with_route_listener([http1], Routes, fun(Port, _Name) ->
+        %% 20-byte body to a 10-byte-capped route → 413 (rejected before read).
+        ?assertMatch(
+            <<"HTTP/1.1 413", _/binary>>, h1_post(Port, ~"/upload", binary:copy(~"x", 20))
+        ),
+        %% 5-byte body is under the cap → reaches the handler.
+        ?assertMatch(
+            <<"HTTP/1.1 200", _/binary>>, h1_post(Port, ~"/upload", binary:copy(~"x", 5))
+        )
+    end).
+
+h1_uncapped_route_uses_global_test() ->
+    %% A route with no `max_body` rides the (large) global `max_content_length`,
+    %% so a 20-byte body is fine even when a sibling route caps at 10.
+    Routes = [
+        #{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 10},
+        #{path => ~"/open", handler => roadrunner_hello_handler}
+    ],
+    with_route_listener([http1], Routes, fun(Port, _Name) ->
+        ?assertMatch(
+            <<"HTTP/1.1 200", _/binary>>, h1_post(Port, ~"/open", binary:copy(~"x", 20))
+        )
+    end).
+
+%% =============================================================================
+%% HTTP/2 (h2c): the route cap is enforced at dispatch (post-accumulation 413).
+%% =============================================================================
+
+h2c_over_route_cap_413_test() ->
+    Routes = [#{path => ~"/upload", handler => roadrunner_hello_handler, max_body => 10}],
+    with_route_listener([http2], Routes, fun(Port, _Name) ->
+        {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+        Preface = ~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+        EmptySettings = <<0:24, 4, 0, 0:32>>,
+        ok = gen_tcp:send(Sock, [Preface, EmptySettings | h2_post_frames(~"/upload", 20)]),
+        Reply = recv_for(Sock, <<>>, 800),
+        ok = gen_tcp:close(Sock),
+        %% The 413 response body is "Payload Too Large" (a DATA frame payload).
+        ?assertMatch({match, _}, re:run(Reply, ~"Payload Too Large"))
+    end).
+
+%% --- helpers ---
+
+with_route_listener(Protocols, Routes, Fun) ->
+    Name = unique(bl_it),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0, protocols => Protocols, routes => Routes
+    }),
+    Port = roadrunner_listener:port(Name),
+    try
+        Fun(Port, Name)
+    after
+        ok = roadrunner_listener:stop(Name)
+    end.
+
+unique(Prefix) ->
+    list_to_atom(atom_to_list(Prefix) ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
+
+h1_post(Port, Path, Body) ->
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    CL = integer_to_binary(byte_size(Body)),
+    Req = [
+        ~"POST ",
+        Path,
+        ~" HTTP/1.1\r\nHost: x\r\nContent-Length: ",
+        CL,
+        ~"\r\nConnection: close\r\n\r\n",
+        Body
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    Reply = recv_for(Sock, <<>>, 1000),
+    ok = gen_tcp:close(Sock),
+    Reply.
+
+recv_for(Sock, Acc, Timeout) ->
+    case gen_tcp:recv(Sock, 0, Timeout) of
+        {ok, Data} -> recv_for(Sock, <<Acc/binary, Data/binary>>, Timeout);
+        {error, _} -> Acc
+    end.
+
+%% A POST request on stream 1: HEADERS (END_HEADERS, no END_STREAM) then a DATA
+%% frame of `BodyLen` bytes (END_STREAM).
+h2_post_frames(Path, BodyLen) ->
+    {Block, _Enc} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"POST"},
+            {~":scheme", ~"http"},
+            {~":authority", ~"x"},
+            {~":path", Path}
+        ],
+        roadrunner_http2_hpack:new_encoder(4096)
+    ),
+    Headers = roadrunner_http2_frame:encode(
+        {headers, 1, 16#04, undefined, iolist_to_binary(Block)}
+    ),
+    Payload = binary:copy(~"x", BodyLen),
+    Data = <<BodyLen:24, 0:8, 16#01:8, 0:1, 1:31, Payload/binary>>,
+    [Headers, Data].

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -2285,3 +2285,35 @@ maybe_put_client_ip_unknown_peer_skips_field_test() ->
             roadrunner_real_ip:prepare(Cfg, undefined), Req
         )
     ).
+
+%% --- resolve_body_limits/1 ---
+
+resolve_body_limits_unset_test() ->
+    %% No subset published for this listener → undefined.
+    ?assertEqual(
+        undefined,
+        roadrunner_conn:resolve_body_limits(#{listener_name => body_limits_unset_test})
+    ).
+
+resolve_body_limits_no_listener_name_test() ->
+    ?assertEqual(undefined, roadrunner_conn:resolve_body_limits(#{})).
+
+%% --- effective_max_body/3 ---
+
+effective_max_body_off_returns_global_test() ->
+    Req = #{method => ~"POST", path => ~"/login"},
+    ?assertEqual(1000, roadrunner_conn:effective_max_body(undefined, Req, 1000)).
+
+effective_max_body_route_match_test() ->
+    Limits = roadrunner_router:compile_body_limits([
+        #{path => ~"/login", handler => h, max_body => 64}
+    ]),
+    Req = #{method => ~"POST", path => ~"/login"},
+    ?assertEqual(64, roadrunner_conn:effective_max_body(Limits, Req, 1000)).
+
+effective_max_body_route_miss_returns_global_test() ->
+    Limits = roadrunner_router:compile_body_limits([
+        #{path => ~"/login", handler => h, max_body => 64}
+    ]),
+    Req = #{method => ~"GET", path => ~"/other"},
+    ?assertEqual(1000, roadrunner_conn:effective_max_body(Limits, Req, 1000)).

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -25,6 +25,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     crash_500/1,
     interim_response_500/1,
     rate_limited/1,
+    per_route_body_limit_413/1,
     forbidden_response_header_stripped/1,
     unsafe_response_header_500/1,
     unsupported_shapes_501/1,
@@ -98,6 +99,7 @@ all() ->
         crash_500,
         interim_response_500,
         rate_limited,
+        per_route_body_limit_413,
         forbidden_response_header_stripped,
         unsafe_response_header_500,
         unsupported_shapes_501,
@@ -190,6 +192,7 @@ end_per_suite(_Config) ->
 init_per_testcase(Case, Config) when
     Case =:= not_found;
     Case =:= rate_limited;
+    Case =:= per_route_body_limit_413;
     Case =:= oversized_413;
     Case =:= protocols_tuple_form;
     Case =:= certfile_keyfile;
@@ -311,6 +314,27 @@ rate_limited(_Config) ->
         ?assertMatch({200, _}, status_body(get(Conn, ~"/"))),
         {429, Headers, _} = get(Conn, ~"/"),
         ?assertEqual(~"1", proplists:get_value(~"retry-after", Headers))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+per_route_body_limit_413(_Config) ->
+    %% Per-route `max_body` over h3: a body exceeding the matched route's cap is
+    %% answered 413 at dispatch (h3 decodes the path only there, so the global
+    %% cap bounds accumulation and this is a post-accumulation check); a body
+    %% under the cap reaches the handler.
+    Name = listener_name(per_route_body_limit_413),
+    Routes = [#{path => ~"/echo", handler => roadrunner_h3_test_handler, max_body => 10}],
+    {ok, _} = start_h3(Name, #{routes => Routes}),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        {ok, S1} = roadrunner_quic_test_h3:open_request(Conn, headers(~"POST", ~"/echo"), false),
+        ok = roadrunner_quic_test_h3:send_data(Conn, S1, binary:copy(<<"x">>, 20), true),
+        ?assertMatch({413, _, _}, collect(Conn, S1)),
+        {ok, S2} = roadrunner_quic_test_h3:open_request(Conn, headers(~"POST", ~"/echo"), false),
+        ok = roadrunner_quic_test_h3:send_data(Conn, S2, binary:copy(<<"x">>, 5), true),
+        ?assertMatch({200, _, _}, collect(Conn, S2))
     after
         close(Conn),
         roadrunner_listener:stop(Name)

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -706,3 +706,60 @@ rate_limits_bad_config_raises_test() ->
             #{path => ~"/x", handler => h, rate_limit => #{rate => 0}}
         ])
     ).
+
+%% =============================================================================
+%% compile_body_limits/1 + match_body_limit/3 — per-route body-size overrides
+%% =============================================================================
+
+body_limits_none_is_undefined_test() ->
+    ?assertEqual(
+        undefined,
+        roadrunner_router:compile_body_limits([{~"/", h}, #{path => ~"/x", handler => h}])
+    ).
+
+body_limits_match_hit_test() ->
+    Limits = roadrunner_router:compile_body_limits([
+        #{path => ~"/login", handler => h, max_body => 65536}
+    ]),
+    ?assertEqual(65536, roadrunner_router:match_body_limit(~"POST", ~"/login", Limits)).
+
+body_limits_match_miss_test() ->
+    Limits = roadrunner_router:compile_body_limits([
+        #{path => ~"/login", handler => h, max_body => 65536}
+    ]),
+    ?assertEqual(nomatch, roadrunner_router:match_body_limit(~"GET", ~"/other", Limits)).
+
+body_limits_undefined_subset_is_nomatch_test() ->
+    ?assertEqual(nomatch, roadrunner_router:match_body_limit(~"GET", ~"/login", undefined)).
+
+body_limits_method_specific_test() ->
+    Limits = roadrunner_router:compile_body_limits([
+        #{path => ~"/upload", handler => h, methods => [~"POST"], max_body => 1024}
+    ]),
+    ?assertEqual(1024, roadrunner_router:match_body_limit(~"POST", ~"/upload", Limits)),
+    ?assertEqual(nomatch, roadrunner_router:match_body_limit(~"GET", ~"/upload", Limits)).
+
+body_limits_zero_allowed_test() ->
+    %% max_body => 0 (reject any body) is valid.
+    Limits = roadrunner_router:compile_body_limits([
+        #{path => ~"/nobody", handler => h, max_body => 0}
+    ]),
+    ?assertEqual(0, roadrunner_router:match_body_limit(~"GET", ~"/nobody", Limits)).
+
+body_limits_param_path_test() ->
+    Limits = roadrunner_router:compile_body_limits([
+        #{path => ~"/users/:id", handler => h, max_body => 4096}
+    ]),
+    ?assertEqual(4096, roadrunner_router:match_body_limit(~"PUT", ~"/users/7", Limits)).
+
+body_limits_bad_value_raises_test() ->
+    ?assertError(
+        {invalid_route_max_body, ~"/x", -1},
+        roadrunner_router:compile_body_limits([#{path => ~"/x", handler => h, max_body => -1}])
+    ).
+
+body_limits_non_integer_raises_test() ->
+    ?assertError(
+        {invalid_route_max_body, ~"/x", big},
+        roadrunner_router:compile_body_limits([#{path => ~"/x", handler => h, max_body => big}])
+    ).


### PR DESCRIPTION
# Description

`max_content_length` is listener-global, so an endpoint that accepts a large upload forces the same ceiling on every other route. A `max_body` key on a map-form route now overrides it for that path, letting an upload endpoint accept more while the rest of the listener stays tight. Routes that declare no override keep the listener-global cap, and when no route declares one the compiled subset is `undefined` and the body path is unchanged. Matching reuses the dispatch path and method matchers, first-match-wins in declaration order.

```erlang
Routes = [
    #{path => ~"/api/*rest", handler => api_h},
    #{path => ~"/upload", handler => upload_h, methods => [~"POST"],
      max_body => 50 * 1024 * 1024}
].
```

Enforcement differs by protocol, and the difference matters when the override is used to *tighten* a route rather than loosen it. On HTTP/1 the route cap bounds the body read itself, so an oversized request never gets buffered. On HTTP/2 and HTTP/3 the cap is applied after the body has accumulated under the listener-global `max_content_length`, and answers 413 at dispatch: a route cap tighter than the global one changes the response, but does not bound how much the connection buffers first. Use a tight listener-global `max_content_length` with per-route overrides that raise it, rather than a loose global that per-route caps are expected to tighten.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)