### PR TITLE
Raise default max_clients to 16384, add a recv_buffer option

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -108,7 +108,8 @@ so there is no dynamic-table memory to bound yet.
 | Limit | Default | Configurable | Purpose |
 |---|---|---|---|
 | `socket_backlog` | 1024 | yes | TCP listen backlog (kernel SYN/accept queue depth) |
-| `max_clients` | 150 | yes | concurrent connection cap per listener |
+| `recv_buffer` | 64 KB | yes | per-connection inbound TCP buffer (body-path throughput vs memory at scale) |
+| `max_clients` | 16384 | yes | concurrent connection cap per listener |
 | `max_concurrent_requests` | `infinity` | yes | concurrent in-flight request cap per listener (HTTP/2 and HTTP/3) |
 | `request_timeout` | 30 s | yes | header-read timeout on a fresh connection |
 | `keep_alive_timeout` | 60 s | yes | idle timeout between requests |
@@ -116,11 +117,21 @@ so there is no dynamic-table memory to bound yet.
 | `min_bytes_per_second` | 100 | yes (0 disables) | slow-loris guard on the request-read phase |
 | `rate_limit` | off | opt-in | per-peer request-rate cap (`429` + `Retry-After`) |
 
+`max_clients`'s effective cap is `min(max_clients, the OS file-descriptor
+limit)`. With the 16384 default above a stock `ulimit -n` of 1024, the
+acceptors hit `emfile` at the descriptor ceiling — each emits
+`[roadrunner, listener, accept_error]` and keeps accepting after a short
+back-off rather than going silent — so raise `ulimit -n` (and the systemd
+`LimitNOFILE`) for high concurrency. Saturation recv-buffer memory scales
+as `max_clients × recv_buffer`, so lower either for a tighter bound.
+
 `max_clients` bounds connections and the HTTP/2 / HTTP/3
 `max_concurrent_streams` bounds streams per connection, but their product
 (the worst-case number of concurrent handler processes) is otherwise
-unbounded. A high `max_clients`, set for burst tolerance, can let
-concurrent handler memory grow without limit under heavy multiplexing.
+unbounded. At the defaults that product (`16384 × 100` ≈ 1.6M) exceeds the
+BEAM process limit (`+P`, default 262144), so under heavy multiplexing it
+can exhaust the VM-global process table — failing spawns everywhere, not
+just this listener — on top of unbounded handler memory.
 `max_concurrent_requests` caps that product directly: a listener-wide
 ceiling on live handler processes for the multiplexed protocols. Over the
 ceiling, a new HTTP/2 or HTTP/3 stream is refused with `REFUSED_STREAM` /

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -104,7 +104,8 @@
     ws_max_frame_size := non_neg_integer(),
     ws_max_message_size := non_neg_integer(),
     %% inet `buffer` applied to the socket on WebSocket upgrade;
-    %% `undefined` inherits the listener socket's 64 KB.
+    %% `undefined` inherits the listener socket's `recv_buffer`
+    %% (64 KB default).
     ws_buffer := pos_integer() | undefined,
     %% Idle ms after which a WebSocket session hibernates; `infinity`
     %% (the default) never hibernates on idle.

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -118,7 +118,7 @@ Optional middleware and timing knobs (durations in milliseconds):
   `t:ws_opts/0`): `max_frame_size` (per-frame payload cap) and
   `max_message_size` (reassembled + decompressed message cap), both
   defaulting to 10 MB with over-cap closing the connection with code
-  1009, plus `buffer` (per-session inet `buffer` override — bounds
+  1009, plus `recv_buffer` (per-session inet `buffer` override — bounds
   per-connection memory at high WebSocket concurrency; inherits the
   listener's `recv_buffer` when unset) and `hibernate_after` (idle-session
   hibernation timeout in milliseconds; off when unset).
@@ -510,9 +510,10 @@ WebSocket session tunables (under `ws` in the listener opts).
   running fragment total, and the decompressed size when
   permessage-deflate is negotiated. Over-cap closes with 1009. Must
   be `>= max_frame_size`. Default 10 MB.
-- `buffer` — inet `buffer` (user-space receive buffer, bytes)
+- `recv_buffer` — inet `buffer` (user-space receive buffer, bytes)
   applied to the socket when a connection upgrades to a WebSocket
-  session. The emulator keeps a buffer of this size alive per
+  session — the session-level override of the top-level
+  `recv_buffer` listener opt. The emulator keeps a buffer of this size alive per
   socket, so it bounds how many bytes one `{tcp, _, Data}` delivery
   carries AND what every connection pays in resident memory. Unset
   (the default) inherits the listener socket's `recv_buffer` (64 KB
@@ -539,7 +540,7 @@ WebSocket session tunables (under `ws` in the listener opts).
 -type ws_opts() :: #{
     max_frame_size => 0..16#7FFFFFFF,
     max_message_size => 0..16#7FFFFFFF,
-    buffer => 1..16#7FFFFFFF,
+    recv_buffer => 1..16#7FFFFFFF,
     hibernate_after => 1..16#7FFFFFFF
 }.
 
@@ -1136,7 +1137,7 @@ build_proto_opts(Opts, ListenerName) ->
     #{
         max_frame_size := WsFrame,
         max_message_size := WsMsg,
-        buffer := WsBuffer,
+        recv_buffer := WsBuffer,
         hibernate_after := WsHibernateAfter
     } =
         validate_ws_opts(maps:get(ws, Opts, #{})),
@@ -1550,7 +1551,7 @@ flatten_http3_opts(Entries) ->
     #{
         max_frame_size := non_neg_integer(),
         max_message_size := non_neg_integer(),
-        buffer := undefined,
+        recv_buffer := undefined,
         hibernate_after := infinity
     }.
 ws_defaults() ->
@@ -1559,7 +1560,7 @@ ws_defaults() ->
         max_message_size => ?DEFAULT_WS_MAX_MESSAGE_SIZE,
         %% `undefined` = no setopts on upgrade; the session keeps the
         %% listener socket's inherited `recv_buffer`.
-        buffer => undefined,
+        recv_buffer => undefined,
         %% `infinity` = the session's receive never times out into a
         %% hibernate — the `after infinity` clause is dead by the
         %% receive's own semantics, so the default costs nothing.
@@ -1575,7 +1576,7 @@ ws_defaults() ->
     #{
         max_frame_size := non_neg_integer(),
         max_message_size := non_neg_integer(),
-        buffer := pos_integer() | undefined,
+        recv_buffer := pos_integer() | undefined,
         hibernate_after := pos_integer() | infinity
     }.
 validate_ws_opts(Opts) when is_map(Opts) ->
@@ -1598,12 +1599,12 @@ validate_ws_opts(Other) ->
     error({invalid_listener_opt, ws, Other}).
 
 %% Per-key range check for the `ws` sub-opts. The size caps allow 0
-%% (reject every frame / message); `buffer` and `hibernate_after` are
-%% a buffer size and an idle interval, so zero is meaningless and
+%% (reject every frame / message); `recv_buffer` and `hibernate_after`
+%% are a buffer size and an idle interval, so zero is meaningless and
 %% rejected for both.
--spec valid_ws_opt(max_frame_size | max_message_size | buffer | hibernate_after, term()) ->
+-spec valid_ws_opt(max_frame_size | max_message_size | recv_buffer | hibernate_after, term()) ->
     boolean().
-valid_ws_opt(buffer, V) ->
+valid_ws_opt(recv_buffer, V) ->
     is_integer(V) andalso V >= 1 andalso V =< 16#7FFFFFFF;
 valid_ws_opt(hibernate_after, V) ->
     is_integer(V) andalso V >= 1 andalso V =< 16#7FFFFFFF;
@@ -1613,7 +1614,7 @@ valid_ws_opt(_SizeCap, V) ->
 %% Validate the `recv_buffer` opt (an inet buffer size — zero is
 %% meaningless) rather than passing a bad value into `gen_tcp:listen/2`,
 %% where it would surface as an opaque `{listen_failed, _}`. Mirrors the
-%% strict `ws.buffer` validation.
+%% strict `ws.recv_buffer` validation.
 -spec validate_recv_buffer(map()) -> pos_integer().
 validate_recv_buffer(Opts) ->
     case maps:get(recv_buffer, Opts, ?DEFAULT_RECV_BUFFER) of

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -120,7 +120,7 @@ Optional middleware and timing knobs (durations in milliseconds):
   defaulting to 10 MB with over-cap closing the connection with code
   1009, plus `buffer` (per-session inet `buffer` override — bounds
   per-connection memory at high WebSocket concurrency; inherits the
-  listener's 64 KB when unset) and `hibernate_after` (idle-session
+  listener's `recv_buffer` when unset) and `hibernate_after` (idle-session
   hibernation timeout in milliseconds; off when unset).
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
@@ -515,8 +515,9 @@ WebSocket session tunables (under `ws` in the listener opts).
   session. The emulator keeps a buffer of this size alive per
   socket, so it bounds how many bytes one `{tcp, _, Data}` delivery
   carries AND what every connection pays in resident memory. Unset
-  (the default) inherits the listener socket's 64 KB — sized for
-  HTTP request flow, where bodies arrive in bulk. Long-lived
+  (the default) inherits the listener socket's `recv_buffer` (64 KB
+  default) — sized for HTTP request flow, where bodies arrive in
+  bulk. Long-lived
   WebSocket sessions that exchange small messages should set this
   lower in production: at high connection counts the inherited
   64 KB dominates per-connection memory (64 KB × connections),
@@ -1052,7 +1053,7 @@ base_listen_opts(Opts) ->
         {packet, raw},
         {nodelay, true},
         {backlog, maps:get(socket_backlog, Opts, ?DEFAULT_SOCKET_BACKLOG)},
-        {buffer, maps:get(recv_buffer, Opts, ?DEFAULT_RECV_BUFFER)}
+        {buffer, validate_recv_buffer(Opts)}
     ],
     %% Prepend `{ip, IP}` only when the caller set it, so the default
     %% list (and the default all-interfaces bind) is unchanged. Both
@@ -1557,7 +1558,7 @@ ws_defaults() ->
         max_frame_size => ?DEFAULT_WS_MAX_FRAME_SIZE,
         max_message_size => ?DEFAULT_WS_MAX_MESSAGE_SIZE,
         %% `undefined` = no setopts on upgrade; the session keeps the
-        %% listener socket's inherited 64 KB `buffer`.
+        %% listener socket's inherited `recv_buffer`.
         buffer => undefined,
         %% `infinity` = the session's receive never times out into a
         %% hibernate — the `after infinity` clause is dead by the
@@ -1608,6 +1609,17 @@ valid_ws_opt(hibernate_after, V) ->
     is_integer(V) andalso V >= 1 andalso V =< 16#7FFFFFFF;
 valid_ws_opt(_SizeCap, V) ->
     is_integer(V) andalso V >= 0 andalso V =< 16#7FFFFFFF.
+
+%% Validate the `recv_buffer` opt (an inet buffer size — zero is
+%% meaningless) rather than passing a bad value into `gen_tcp:listen/2`,
+%% where it would surface as an opaque `{listen_failed, _}`. Mirrors the
+%% strict `ws.buffer` validation.
+-spec validate_recv_buffer(map()) -> pos_integer().
+validate_recv_buffer(Opts) ->
+    case maps:get(recv_buffer, Opts, ?DEFAULT_RECV_BUFFER) of
+        N when is_integer(N), N >= 1, N =< 16#7FFFFFFF -> N;
+        Bad -> error({invalid_listener_opt, recv_buffer, Bad})
+    end.
 
 %% Validate the `rate_limit` opt and, when set, create its per-listener ETS
 %% bucket store. `undefined` (the default) skips the guard entirely.

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -48,13 +48,16 @@ All duration and interval values in `opts()` are in milliseconds —
 -define(DEFAULT_KEEP_ALIVE_TIMEOUT, 60000).
 -define(DEFAULT_NUM_ACCEPTORS, 10).
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
--define(DEFAULT_MAX_CLIENTS, 150).
+-define(DEFAULT_MAX_CLIENTS, 16384).
 -define(DEFAULT_MAX_CONCURRENT_REQUESTS, infinity).
 -define(DEFAULT_MIN_BYTES_PER_SECOND, 100).
 %% TCP listen backlog (kernel SYN/accept queue depth). OTP defaults to 5,
 %% which a burst of concurrent connects overflows; 1024 matches cowboy.
 %% Linux clamps the effective value at `net.core.somaxconn`.
 -define(DEFAULT_SOCKET_BACKLOG, 1024).
+%% Emulator user-space recv buffer per accepted socket (see the `buffer`
+%% note in `base_listen_opts/1` for the throughput/memory trade-off).
+-define(DEFAULT_RECV_BUFFER, 65536).
 %% Spawn config for every handler-running process (connection process +
 %% HTTP/2/3 stream workers). `fullsweep_after, 0` reclaims the per-connection
 %% heap that grows building a response (e.g. a JSON encoder's transient iolist)
@@ -131,22 +134,33 @@ Optional middleware and timing knobs (durations in milliseconds):
 - `num_acceptors` — size of the acceptor pool. Default 10.
 - `max_keep_alive_requests` — requests served per conn before
   forced close. Default 1000.
-- `max_clients` — concurrent connection cap. Default 150. Connections
-  accepted while already at the cap are closed immediately without a
-  response. The default bounds memory (the recv `buffer` alone is
-  `max_clients × 64 KB`), so high-concurrency deployments should raise
-  it. Rejections are observable: each one emits
-  `[roadrunner, listener, conn_rejected]` and increments the `rejected`
-  count from `info/1`, so a rising `rejected` is the signal that the
-  cap is the binding limit.
+- `max_clients` — concurrent connection cap. Default 16384 (the modern
+  Erlang/Elixir HTTP-server norm). Connections accepted while already at
+  the cap are closed immediately without a response. The effective cap is
+  `min(max_clients, the OS file-descriptor limit)` — raise `ulimit -n`
+  (and the systemd `LimitNOFILE`) for high concurrency, otherwise the
+  acceptors hit `emfile` at the descriptor ceiling and emit
+  `[roadrunner, listener, accept_error]`. Saturation memory scales as
+  `max_clients × recv_buffer`, so memory-constrained deployments lower the
+  cap or `recv_buffer`. Rejections are observable:
+  each one emits `[roadrunner, listener, conn_rejected]` and increments
+  the `rejected` count from `info/1`, so a rising `rejected` is the
+  signal that the cap is the binding limit. For HTTP/2 and HTTP/3 the
+  worst-case live-handler count is `max_clients × max_concurrent_streams`;
+  bound it with `max_concurrent_requests` (default `infinity`) if heavy
+  multiplexing memory is a concern.
 - `max_concurrent_requests` — cap on concurrent in-flight requests
   (live handler processes) across the whole listener, for the
   multiplexed protocols (HTTP/2 and HTTP/3). Default `infinity` (off).
   `max_clients` bounds connections and `max_concurrent_streams` bounds
   streams per connection, but their product (the worst-case live-handler
-  count) is otherwise unbounded; a high `max_clients` set for burst
-  tolerance can let concurrent handler memory grow without limit under
-  heavy multiplexing. This caps the product directly. Over-limit streams
+  count) is otherwise unbounded; at the defaults that product
+  (`16384 × 100` ≈ 1.6M) exceeds the BEAM process limit (`+P`, default
+  262144), so under heavy multiplexing it can exhaust the VM-global
+  process table — failing spawns everywhere, not just this listener — on
+  top of unbounded handler memory. This caps the product directly; set it
+  to a finite value when enabling HTTP/2 or HTTP/3 under a high
+  `max_clients`. Over-limit streams
   are refused with `REFUSED_STREAM` (h2) / `H3_REQUEST_REJECTED` (h3),
   which RFC 9113 §8.7 marks safe to retry; each refusal emits
   `[roadrunner, request, throttled]` and increments the `throttled`
@@ -162,6 +176,11 @@ Optional middleware and timing knobs (durations in milliseconds):
   dev/admin/metrics endpoint that must not be reachable from the LAN.
   Applies to every socket the listener binds: plain TCP, TLS, and the
   HTTP/3 UDP socket.
+- `recv_buffer` — emulator user-space buffer (bytes) for inbound TCP
+  data, per accepted connection. Default 64 KB. Larger values cut the
+  per-body message count on high-MTU paths; smaller values cut
+  per-connection memory at scale. See the `buffer` note in
+  `base_listen_opts/1`.
 - `min_bytes_per_second` — slow-loris guard on the request-read
   phase (0 disables). Default 100.
 - `rate_check_interval` — how often the rate guard re-checks
@@ -222,6 +241,7 @@ ops-tuning rationale.
     %% (`0.0.0.0` / `::`). Set to `{127,0,0,1}` to restrict the
     %% listener to loopback.
     ip => inet:ip_address(),
+    recv_buffer => pos_integer(),
     min_bytes_per_second => non_neg_integer(),
     %% How often `reading_request` re-checks the running
     %% bytes-per-second average against `min_bytes_per_second`.
@@ -1019,11 +1039,12 @@ base_listen_opts(Opts) ->
     %% (1460-byte chunks) this can result in many small messages
     %% per request body, each paying the message-passing tax. 64 KB
     %% is enough to carry 4 default-sized HTTP/2 DATA frames or a
-    %% typical request, comfortably above the per-MTU floor without
-    %% wasting memory at scale (`max_clients × 64KB` ≈ 10 MB at the
-    %% default `max_clients = 150`). See `erlang/otp#9423` and
-    %% `ninenines/cowlib#143` for the upstream context that prompted
-    %% this tuning.
+    %% typical request, comfortably above the per-MTU floor. Saturation
+    %% memory scales as `max_clients × this buffer`, so it is the
+    %% `recv_buffer` listener opt — lower it to trade body-path
+    %% throughput for per-connection memory at a high `max_clients`. See
+    %% `erlang/otp#9423` and `ninenines/cowlib#143` for the upstream
+    %% context that prompted this tuning.
     Base = [
         binary,
         {active, false},
@@ -1031,7 +1052,7 @@ base_listen_opts(Opts) ->
         {packet, raw},
         {nodelay, true},
         {backlog, maps:get(socket_backlog, Opts, ?DEFAULT_SOCKET_BACKLOG)},
-        {buffer, 65536}
+        {buffer, maps:get(recv_buffer, Opts, ?DEFAULT_RECV_BUFFER)}
     ],
     %% Prepend `{ip, IP}` only when the caller set it, so the default
     %% list (and the default all-interfaces bind) is unchanged. Both

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -299,8 +299,9 @@ start_session(
 %% Apply the `ws.buffer` listener opt: resize the socket's inet
 %% `buffer` for the session's lifetime, before the 101 goes out. The
 %% conn still owns the socket here. `undefined` (the default) keeps the
-%% listener socket's inherited 64 KB — sized for HTTP request flow;
-%% high-concurrency small-message deployments set it lower because the
+%% listener socket's inherited `recv_buffer` (64 KB default), sized
+%% for HTTP request flow; high-concurrency small-message deployments
+%% set it lower because the
 %% emulator holds a live buffer of this size per socket. A setopts
 %% failure means the socket already died; the session discovers that on
 %% its first receive, so the result is ignored rather than special-cased.

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -296,7 +296,7 @@ start_session(
             rejected
     end.
 
-%% Apply the `ws.buffer` listener opt: resize the socket's inet
+%% Apply the `ws.recv_buffer` listener opt: resize the socket's inet
 %% `buffer` for the session's lifetime, before the 101 goes out. The
 %% conn still owns the socket here. `undefined` (the default) keeps the
 %% listener socket's inherited `recv_buffer` (64 KB default), sized

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1752,7 +1752,7 @@ ws_sink_loop(Logger, Tag, UpgradeBytes, Delivered) ->
             ConnPid ! {roadrunner_fake_recv_reply, {ok, UpgradeBytes}},
             ws_sink_loop(Logger, Tag, UpgradeBytes, true);
         {roadrunner_fake_setopts, ArmingPid, Opts} ->
-            %% Only report active-once arms — the session's `ws.buffer`
+            %% Only report active-once arms — the session's `ws.recv_buffer`
             %% setopts (when configured) would otherwise be mistaken for
             %% an arm.
             case lists:member({active, once}, Opts) of

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -599,13 +599,13 @@ listener_rejects_invalid_ws_opt_test() ->
             #{max_frame_size => -1},
             #{max_frame_size => bad},
             not_a_map,
-            %% `buffer` is an inet buffer size and `hibernate_after` an
+            %% `recv_buffer` is an inet buffer size and `hibernate_after` an
             %% idle interval — zero, negative, non-integer, and
             %% over-range all reject.
-            #{buffer => 0},
-            #{buffer => -1},
-            #{buffer => bad},
-            #{buffer => 16#80000000},
+            #{recv_buffer => 0},
+            #{recv_buffer => -1},
+            #{recv_buffer => bad},
+            #{recv_buffer => 16#80000000},
             #{hibernate_after => 0},
             #{hibernate_after => -1},
             #{hibernate_after => bad},
@@ -614,12 +614,12 @@ listener_rejects_invalid_ws_opt_test() ->
     ).
 
 listener_accepts_ws_session_opts_test() ->
-    %% Valid `ws.buffer` / `ws.hibernate_after` pass validation and the
+    %% Valid `ws.recv_buffer` / `ws.hibernate_after` pass validation and the
     %% listener starts; the session-side application of each is covered
     %% in `roadrunner_ws_session_tests`.
     {ok, Pid} = roadrunner_listener:start_link(listener_test_ws_session_opts_ok, #{
         port => 0,
-        ws => #{buffer => 2048, hibernate_after => 15000},
+        ws => #{recv_buffer => 2048, hibernate_after => 15000},
         routes => roadrunner_hello_handler
     }),
     ?assert(is_process_alive(Pid)),

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -625,6 +625,23 @@ listener_accepts_ws_session_opts_test() ->
     ?assert(is_process_alive(Pid)),
     ok = roadrunner_listener:stop(listener_test_ws_session_opts_ok).
 
+listener_rejects_invalid_recv_buffer_test() ->
+    %% `recv_buffer` is an inet buffer size — zero, negative,
+    %% non-integer, and over-range reject at `init/1` instead of
+    %% surfacing as an opaque `{listen_failed, _}` from `gen_tcp:listen`.
+    process_flag(trap_exit, true),
+    lists:foreach(
+        fun(Bad) ->
+            R = roadrunner_listener:start_link(listener_test_recv_buffer_invalid, #{
+                port => 0,
+                recv_buffer => Bad,
+                routes => roadrunner_hello_handler
+            }),
+            ?assertMatch({error, {{invalid_listener_opt, recv_buffer, _}, _Stack}}, R)
+        end,
+        [0, -1, bad, 16#80000000]
+    ).
+
 listener_rejects_invalid_handler_spawn_test() ->
     %% `handler_spawn` must be a map; `opts` a list that does not carry the
     %% roadrunner-owned linkage (`link` / `monitor` / `{monitor, _}`,

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -140,6 +140,25 @@ listener_honors_ip_opt_test() ->
     ok = gen_tcp:close(Sock),
     ok = roadrunner_listener:stop(Name).
 
+listener_honors_recv_buffer_opt_test() ->
+    %% A custom `recv_buffer` must flow into `gen_tcp:listen` as the socket
+    %% `buffer` (the default path is exercised by every other listener test).
+    %% Bind with an explicit buffer and serve one request through the socket
+    %% to prove the listen option was accepted, not just stored.
+    Name = listener_test_recv_buffer,
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        recv_buffer => 16384,
+        routes => roadrunner_hello_handler
+    }),
+    Port = roadrunner_listener:port(Name),
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"),
+    {ok, Reply} = gen_tcp:recv(Sock, 0, 1000),
+    ?assertMatch(<<"HTTP/1.1 200 ", _/binary>>, Reply),
+    ok = gen_tcp:close(Sock),
+    ok = roadrunner_listener:stop(Name).
+
 %% =============================================================================
 %% notify_drain/2 (soft drain — broadcast without stopping the listener)
 %% =============================================================================

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -46,7 +46,7 @@ start_with_bad_handshake_still_returns_400_test() ->
     ?assertEqual(nomatch, binary:match(Sent, ~"101")).
 
 ws_buffer_opt_applied_before_101_test() ->
-    %% `ws.buffer` set: the session must resize the socket's inet
+    %% `ws.recv_buffer` set: the session must resize the socket's inet
     %% `buffer` while the conn still owns the socket — i.e. the setopts
     %% must land BEFORE the 101 goes out. The events sink logs setopts
     %% and sends into one ordered stream; a seeded close frame ends the
@@ -2536,7 +2536,7 @@ spawn_send_log_sink(Logger, Tag) ->
 
 %% Events sink: like the send-log sink, but logs `setopts` calls too,
 %% into the same ordered stream — for tests that assert on the ORDER
-%% of socket operations (e.g. `ws.buffer` applied before the 101).
+%% of socket operations (e.g. `ws.recv_buffer` applied before the 101).
 spawn_events_sink(Logger, Tag) ->
     spawn(fun() -> events_sink_loop(Logger, Tag) end).
 


### PR DESCRIPTION
# Description

Raises the default `max_clients` from 150 to 16384 — the norm across modern Erlang/Elixir HTTP servers — and exposes the previously hard-coded 64 KB per-connection inbound buffer as a `recv_buffer` listener opt (strictly validated, like `ws.buffer`), so saturation memory (`max_clients × recv_buffer`) is tunable in both directions. The docs carry the operational story: the effective cap is `min(max_clients, ulimit -n)` and acceptors now ride out `emfile` with telemetry instead of going silent, and at the new default the HTTP/2 and HTTP/3 worst-case handler product (16384 × 100 streams) exceeds the BEAM process limit, so `max_concurrent_requests` is called out as the bound to set under heavy multiplexing.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)