### PR TITLE
Keep the acceptor accepting through transient accept errors

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -218,6 +218,29 @@ lot of them.
 
 ## Other
 
+### Bound and parallelize the TLS handshake in the accept path
+
+**What:** `roadrunner_transport:accept/1` for TLS runs
+`ssl:handshake/1` inside the acceptor with no timeout. Two
+consequences: a client that connects and never sends a ClientHello
+parks that acceptor indefinitely (a trivial slow-loris against the
+accept pool — `num_acceptors` such clients and the listener stops
+accepting), and handshake time serializes across the pool, capping
+TLS connection-establishment throughput at
+`num_acceptors / handshake_time`. The fixes are separable: pass a
+`handshake_timeout` to `ssl:handshake/2` (small), and move the
+handshake out of the acceptor into the connection process —
+`ssl:transport_accept` in the acceptor, handshake after the handoff —
+so slow handshakes cost only their own connection (medium; changes
+the `roadrunner_conn` startup contract, which expects a
+handshake-complete socket at `shoot`).
+
+**Why deferred:** surfaced while auditing the acceptor
+transient-error fix; that fix makes handshake FAILURES harmless but
+doesn't bound handshake TIME.
+
+**Scope:** small (timeout) / medium (handshake in the conn process).
+
 ### Connection-process memory tuning follow-ups
 
 **What:** The `handler_spawn` listener opt already exposes the full

--- a/src/roadrunner_acceptor.erl
+++ b/src/roadrunner_acceptor.erl
@@ -6,21 +6,28 @@
 %%
 %% Spawn-linked to the owning `roadrunner_listener`: a listener stop closes
 %% the listen socket, the acceptor's `accept/1` returns `{error, closed}`,
-%% and the acceptor exits cleanly. A transient accept error instead
-%% (`emfile`/`enfile`/`system_limit` descriptor exhaustion when `max_clients`
-%% sits above the OS `ulimit -n`, or a connection aborted before accept
-%% completed) is reported via telemetry and retried after a short back-off,
-%% so the pool never silently drains. Unrelated acceptor crashes propagate
-%% back via the link, taking the listener down for supervisor restart.
-%% Connection workers are spawned **without** a link so that a crash
-%% in one connection does not bring down the acceptor.
+%% and the acceptor exits cleanly. Every other accept error is reported
+%% via telemetry and retried, so the pool never silently drains (the
+%% listener doesn't supervise acceptors — a quiet exit would leave it
+%% permanently down one acceptor). How the retry paces depends on the
+%% error class (`accept_error_class/1`): per-connection failures — an
+%% aborted connection, a failed TLS handshake — retry immediately, since
+%% they arrive at connection rate and sleeping per event would throttle
+%% the whole pool; resource errors (`emfile`/`enfile`/`system_limit`
+%% descriptor exhaustion when `max_clients` sits above the OS
+%% `ulimit -n`, and anything unrecognized) back off briefly first.
+%% Unrelated acceptor crashes propagate back via the link, taking the
+%% listener down for supervisor restart. Connection workers are spawned
+%% **without** a link so that a crash in one connection does not bring
+%% down the acceptor.
 
-%% Back-off between retries after a transient accept error. Bounds the
-%% retry/telemetry rate and gives the box a moment to reclaim descriptors
-%% before the next `accept/1`.
+%% Back-off between retries after a resource-class accept error. Bounds
+%% the retry/telemetry rate and gives the box a moment to reclaim
+%% descriptors before the next `accept/1`.
 -define(ACCEPT_ERROR_BACKOFF_MS, 100).
 
 -export([start_link/3]).
+-export([accept_error_class/1]).
 
 -doc """
 Spawn-link an acceptor process bound to `LSocket` with the given
@@ -51,21 +58,46 @@ loop(LSocket, ProtoOpts) ->
             %% cleanly; the linked listener tears the rest of the pool down.
             ok;
         {error, Reason} ->
-            %% Any other accept error is transient: descriptor exhaustion
-            %% (`emfile`/`enfile`/`system_limit`) when `max_clients` sits
-            %% above the OS `ulimit -n`, or a connection aborted before
-            %% accept completed. Surface it and back off, then keep
-            %% accepting — exiting here would silently drain the pool and
-            %% leave the listener permanently deaf with no diagnostic.
+            %% Any other accept error: surface it and keep accepting —
+            %% exiting here would silently drain the pool and leave the
+            %% listener permanently deaf with no diagnostic. Pacing is
+            %% per error class; see `accept_error_class/1`.
             ok = roadrunner_telemetry:listener_accept_error(#{
                 listener_name => maps:get(listener_name, ProtoOpts, undefined),
                 reason => Reason
             }),
-            receive
-            after ?ACCEPT_ERROR_BACKOFF_MS -> ok
-            end,
+            ok =
+                case accept_error_class(Reason) of
+                    retry ->
+                        ok;
+                    backoff ->
+                        receive
+                        after ?ACCEPT_ERROR_BACKOFF_MS -> ok
+                        end
+                end,
             loop(LSocket, ProtoOpts)
     end.
+
+%% Classify a non-`closed` accept error for retry pacing. Exported for
+%% exhaustive unit coverage; not part of any public API.
+%%
+%% `retry` — per-connection events that arrive at connection rate:
+%% `econnaborted` (peer reset between the kernel queue and our accept;
+%% bursts under SYN-flood conditions) and `{handshake, _}` (a garbage or
+%% aborted TLS handshake — routine internet background noise on a TLS
+%% port). Sleeping on these would let plain noise cap the whole accept
+%% pool at `acceptors / backoff` accepts per second.
+%%
+%% `backoff` — resource exhaustion (`emfile`/`enfile`/`system_limit`),
+%% where hammering `accept/1` cannot help until the box reclaims
+%% descriptors, and any error this module doesn't recognize, where a
+%% brief pause bounds the retry/telemetry rate if it turns out to be
+%% persistent.
+-doc false.
+-spec accept_error_class(term()) -> retry | backoff.
+accept_error_class(econnaborted) -> retry;
+accept_error_class({handshake, _}) -> retry;
+accept_error_class(_Resource) -> backoff.
 
 -spec handle_accepted(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) -> ok.
 handle_accepted(Socket, ProtoOpts) ->

--- a/src/roadrunner_acceptor.erl
+++ b/src/roadrunner_acceptor.erl
@@ -5,11 +5,20 @@
 %% and hands each accepted connection off to a `roadrunner_conn` worker.
 %%
 %% Spawn-linked to the owning `roadrunner_listener`: a listener stop closes
-%% the listen socket, the acceptor's `accept/1` returns `{error, _}`,
-%% and the acceptor exits cleanly. Unrelated acceptor crashes propagate
+%% the listen socket, the acceptor's `accept/1` returns `{error, closed}`,
+%% and the acceptor exits cleanly. A transient accept error instead
+%% (`emfile`/`enfile`/`system_limit` descriptor exhaustion when `max_clients`
+%% sits above the OS `ulimit -n`, or a connection aborted before accept
+%% completed) is reported via telemetry and retried after a short back-off,
+%% so the pool never silently drains. Unrelated acceptor crashes propagate
 %% back via the link, taking the listener down for supervisor restart.
 %% Connection workers are spawned **without** a link so that a crash
 %% in one connection does not bring down the acceptor.
+
+%% Back-off between retries after a transient accept error. Bounds the
+%% retry/telemetry rate and gives the box a moment to reclaim descriptors
+%% before the next `accept/1`.
+-define(ACCEPT_ERROR_BACKOFF_MS, 100).
 
 -export([start_link/3]).
 
@@ -37,10 +46,25 @@ loop(LSocket, ProtoOpts) ->
         {ok, Socket} ->
             handle_accepted(Socket, ProtoOpts),
             loop(LSocket, ProtoOpts);
-        {error, _} ->
-            %% Listen socket was closed (or another transport error) —
-            %% terminate cleanly; the linked listener will tear us down.
-            ok
+        {error, closed} ->
+            %% Listen socket was closed — the listener is stopping. Exit
+            %% cleanly; the linked listener tears the rest of the pool down.
+            ok;
+        {error, Reason} ->
+            %% Any other accept error is transient: descriptor exhaustion
+            %% (`emfile`/`enfile`/`system_limit`) when `max_clients` sits
+            %% above the OS `ulimit -n`, or a connection aborted before
+            %% accept completed. Surface it and back off, then keep
+            %% accepting — exiting here would silently drain the pool and
+            %% leave the listener permanently deaf with no diagnostic.
+            ok = roadrunner_telemetry:listener_accept_error(#{
+                listener_name => maps:get(listener_name, ProtoOpts, undefined),
+                reason => Reason
+            }),
+            receive
+            after ?ACCEPT_ERROR_BACKOFF_MS -> ok
+            end,
+            loop(LSocket, ProtoOpts)
     end.
 
 -spec handle_accepted(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) -> ok.

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -76,6 +76,16 @@
 %%   - **Measurements:** `system_time`.
 %%   - **Metadata:** `listener_name`, `reason` (`max_clients`).
 %%
+%% - `[roadrunner, listener, accept_error]` — fired when an acceptor's
+%%   `accept/1` returns a transient error: file-descriptor exhaustion
+%%   (`emfile`/`enfile`/`system_limit`, usually `max_clients` above the OS
+%%   `ulimit -n`) or a connection aborted before accept completed. The
+%%   acceptor backs off and keeps accepting instead of exiting, so this is
+%%   the signal that the box is out of descriptors — raise `ulimit -n`.
+%%
+%%   - **Measurements:** `system_time`.
+%%   - **Metadata:** `listener_name`, `reason` (the accept error).
+%%
 %% - `[roadrunner, request, throttled]` — fired before any handler runs when a
 %%   request is refused at a listener limit, for one of two reasons:
 %%     - `max_concurrent_requests`: an HTTP/2 or HTTP/3 stream over the
@@ -169,6 +179,7 @@
     listener_accept/1,
     listener_conn_close/2,
     listener_conn_rejected/1,
+    listener_accept_error/1,
     request_rejected/1,
     request_throttled/1,
     slots_reconciled/1,
@@ -305,6 +316,25 @@ to stay cheap under a connection flood.
 listener_conn_rejected(Metadata) ->
     telemetry:execute(
         [roadrunner, listener, conn_rejected],
+        #{system_time => erlang:system_time()},
+        Metadata
+    ),
+    ok.
+
+-doc """
+Emit `[roadrunner, listener, accept_error]` when an acceptor's `accept/1`
+fails with a transient error — file-descriptor exhaustion
+(`emfile`/`enfile`/`system_limit`, typically `max_clients` sitting above
+the OS `ulimit -n`) or a connection aborted before accept completed. The
+acceptor reports it here, backs off, and keeps accepting rather than
+exiting, so this event is the signal that the box is out of descriptors.
+`Metadata` should include `listener_name` and `reason` (the accept
+error). Carries no `peer`: there is no connection to name.
+""".
+-spec listener_accept_error(map()) -> ok.
+listener_accept_error(Metadata) ->
+    telemetry:execute(
+        [roadrunner, listener, accept_error],
         #{system_time => erlang:system_time()},
         Metadata
     ),

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -77,11 +77,15 @@
 %%   - **Metadata:** `listener_name`, `reason` (`max_clients`).
 %%
 %% - `[roadrunner, listener, accept_error]` — fired when an acceptor's
-%%   `accept/1` returns a transient error: file-descriptor exhaustion
-%%   (`emfile`/`enfile`/`system_limit`, usually `max_clients` above the OS
-%%   `ulimit -n`) or a connection aborted before accept completed. The
-%%   acceptor backs off and keeps accepting instead of exiting, so this is
-%%   the signal that the box is out of descriptors — raise `ulimit -n`.
+%%   `accept/1` returns any error other than the listen socket closing,
+%%   and the acceptor keeps accepting instead of exiting. Two classes
+%%   share the event, told apart by `reason`: per-connection failures
+%%   (`econnaborted`, or `{handshake, HsReason}` for a failed TLS
+%%   handshake — routine noise on an internet-facing TLS port) retry
+%%   immediately; resource errors (`emfile`/`enfile`/`system_limit`
+%%   descriptor exhaustion, usually `max_clients` above the OS
+%%   `ulimit -n`) retry after a short back-off. A sustained stream of
+%%   descriptor-exhaustion reasons is the signal to raise `ulimit -n`.
 %%
 %%   - **Measurements:** `system_time`.
 %%   - **Metadata:** `listener_name`, `reason` (the accept error).
@@ -323,11 +327,14 @@ listener_conn_rejected(Metadata) ->
 
 -doc """
 Emit `[roadrunner, listener, accept_error]` when an acceptor's `accept/1`
-fails with a transient error — file-descriptor exhaustion
+fails with anything other than the listen socket closing — a
+per-connection failure (`econnaborted`, a failed TLS handshake as
+`{handshake, _}`) or descriptor exhaustion
 (`emfile`/`enfile`/`system_limit`, typically `max_clients` sitting above
-the OS `ulimit -n`) or a connection aborted before accept completed. The
-acceptor reports it here, backs off, and keeps accepting rather than
-exiting, so this event is the signal that the box is out of descriptors.
+the OS `ulimit -n`). The acceptor reports it here and keeps accepting
+rather than exiting (immediately for per-connection failures, after a
+short back-off for resource errors), so a sustained stream of
+descriptor-exhaustion reasons is the signal to raise `ulimit -n`.
 `Metadata` should include `listener_name` and `reason` (the accept
 error). Carries no `peer`: there is no connection to name.
 """.

--- a/src/roadrunner_transport.erl
+++ b/src/roadrunner_transport.erl
@@ -91,7 +91,19 @@ listen_tls(Port, Opts) ->
         {error, _} = Err -> Err
     end.
 
--doc "Accept the next pending connection. For TLS, runs the handshake before returning.".
+-doc """
+Accept the next pending connection. For TLS, runs the handshake before
+returning.
+
+TLS failures are two different events and come back distinguishably:
+a `ssl:transport_accept/1` error is about the LISTEN socket (`closed`
+means the listener is going away), while a failed `ssl:handshake/1` is
+about that one connection — a garbage ClientHello, a TLS alert, or the
+peer disconnecting mid-handshake (which `ssl` also reports as `closed`).
+Handshake failures are wrapped as `{error, {handshake, Reason}}` so an
+acceptor can keep accepting through per-connection noise and reserve
+the bare `{error, closed}` for the listener actually stopping.
+""".
 -spec accept(socket()) -> {ok, socket()} | {error, term()}.
 accept({gen_tcp, LSock}) ->
     case gen_tcp:accept(LSock) of
@@ -101,8 +113,10 @@ accept({gen_tcp, LSock}) ->
 accept({ssl, LSock}) ->
     maybe
         {ok, Pre} ?= ssl:transport_accept(LSock),
-        {ok, S} ?= ssl:handshake(Pre),
-        {ok, {ssl, S}}
+        case ssl:handshake(Pre) of
+            {ok, S} -> {ok, {ssl, S}};
+            {error, HsReason} -> {error, {handshake, HsReason}}
+        end
     end.
 
 -doc "Hand the controlling process for the underlying socket.".

--- a/test/roadrunner_acceptor_tests.erl
+++ b/test/roadrunner_acceptor_tests.erl
@@ -105,6 +105,47 @@ conn_process_carries_listener_name_and_peer_label_test_() ->
             end}
         end}.
 
+acceptor_retries_on_transient_accept_error_test() ->
+    %% Accepting on a connected (non-listen) socket fails with a transient
+    %% error (einval here, standing in for emfile descriptor exhaustion). The
+    %% acceptor must report it via telemetry and keep looping, NOT exit and
+    %% leave the listener silently deaf. Closing the socket then yields
+    %% {error, closed}, which ends the loop cleanly.
+    {ok, LSock} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(LSock),
+    {ok, CSock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    HandlerId = {?MODULE, make_ref()},
+    ok = telemetry:attach(
+        HandlerId,
+        [roadrunner, listener, accept_error],
+        fun(_Event, _Measure, Meta, _Cfg) -> Self ! {accept_error, Meta} end,
+        undefined
+    ),
+    {ok, Pid} = roadrunner_acceptor:start_link(
+        {gen_tcp, CSock}, #{listener_name => acceptor_test_accept_error}, 1
+    ),
+    receive
+        {accept_error, Meta} ->
+            ?assertEqual(acceptor_test_accept_error, maps:get(listener_name, Meta)),
+            ?assertNotEqual(closed, maps:get(reason, Meta))
+    after 2000 ->
+        error(no_accept_error_telemetry)
+    end,
+    %% Survived the transient error.
+    ?assert(is_process_alive(Pid)),
+    %% Closing the socket turns the next accept into {error, closed} → exit.
+    MRef = erlang:monitor(process, Pid),
+    ok = gen_tcp:close(CSock),
+    receive
+        {'DOWN', MRef, process, Pid, normal} -> ok
+    after 2000 ->
+        error(acceptor_did_not_stop)
+    end,
+    ok = telemetry:detach(HandlerId),
+    ok = gen_tcp:close(LSock).
+
 %% --- helpers ---
 
 %% Poll until we see a refined `{roadrunner_conn, Name, Peer}` label or run

--- a/test/roadrunner_acceptor_tests.erl
+++ b/test/roadrunner_acceptor_tests.erl
@@ -146,6 +146,70 @@ acceptor_retries_on_transient_accept_error_test() ->
     ok = telemetry:detach(HandlerId),
     ok = gen_tcp:close(LSock).
 
+accept_error_class_test() ->
+    %% Per-connection failures retry immediately; resource exhaustion
+    %% and unknowns back off. Exhaustive over the classifier's clauses.
+    ?assertEqual(retry, roadrunner_acceptor:accept_error_class(econnaborted)),
+    ?assertEqual(retry, roadrunner_acceptor:accept_error_class({handshake, closed})),
+    ?assertEqual(
+        retry,
+        roadrunner_acceptor:accept_error_class(
+            {handshake, {tls_alert, {handshake_failure, "reason"}}}
+        )
+    ),
+    ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(emfile)),
+    ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(enfile)),
+    ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(system_limit)),
+    ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(einval)).
+
+acceptor_survives_failed_tls_handshake_test() ->
+    %% A garbage ClientHello on a TLS listener fails `ssl:handshake/1`
+    %% inside `roadrunner_transport:accept/1`. The acceptor must treat
+    %% that as per-connection noise — telemetry with a `{handshake, _}`
+    %% reason, keep accepting — and reserve plain `closed` (the listen
+    %% socket going away) for its clean exit. Before the transport
+    %% tagged handshake errors, a peer disconnecting mid-handshake also
+    %% surfaced as `closed` and silently killed the acceptor.
+    {ok, _} = application:ensure_all_started(ssl),
+    {ok, _} = application:ensure_all_started(telemetry),
+    ServerOpts =
+        roadrunner_test_certs:server_opts() ++
+            [binary, {active, false}, {reuseaddr, true}],
+    {ok, LSock} = roadrunner_transport:listen_tls(0, ServerOpts),
+    {ok, Port} = roadrunner_transport:port(LSock),
+    Self = self(),
+    HandlerId = {?MODULE, make_ref()},
+    ok = telemetry:attach(
+        HandlerId,
+        [roadrunner, listener, accept_error],
+        fun(_Event, _Measure, Meta, _Cfg) -> Self ! {accept_error, Meta} end,
+        undefined
+    ),
+    {ok, Pid} = roadrunner_acceptor:start_link(
+        LSock, #{listener_name => acceptor_test_tls_noise}, 1
+    ),
+    %% Plain-HTTP bytes can't form a TLS hello — the handshake fails.
+    {ok, Noise} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Noise, ~"GET / HTTP/1.1\r\n\r\n"),
+    receive
+        {accept_error, Meta} ->
+            ?assertMatch({handshake, _}, maps:get(reason, Meta))
+    after 5000 ->
+        error(no_handshake_error_telemetry)
+    end,
+    ok = gen_tcp:close(Noise),
+    %% Survived the noise connection.
+    ?assert(is_process_alive(Pid)),
+    %% Closing the listen socket ends the loop cleanly.
+    MRef = erlang:monitor(process, Pid),
+    ok = roadrunner_transport:close(LSock),
+    receive
+        {'DOWN', MRef, process, Pid, normal} -> ok
+    after 2000 ->
+        error(acceptor_did_not_stop)
+    end,
+    ok = telemetry:detach(HandlerId).
+
 %% --- helpers ---
 
 %% Poll until we see a refined `{roadrunner_conn, Name, Peer}` label or run

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -163,7 +163,9 @@ accept_handshake_failure_returns_error_test() ->
             {accept_result, R} -> R
         after 5000 -> error(accept_timeout)
         end,
-    ?assertMatch({error, _}, Result),
+    %% Handshake failures come back tagged, distinguishing this
+    %% per-connection event from the listen socket's own `closed`.
+    ?assertMatch({error, {handshake, _}}, Result),
     roadrunner_transport:close(LSocket),
     gen_tcp:close(Client).
 


### PR DESCRIPTION
# Description

An acceptor exited on any `accept/1` error, and the listener doesn't supervise acceptors — so descriptor exhaustion, an aborted connection, or (worst) any failed TLS handshake permanently and silently shrank the accept pool; ten noise connections could leave a TLS listener deaf. Errors are now reported via a new `[roadrunner, listener, accept_error]` event and retried, paced by class: per-connection failures (`econnaborted`, failed handshakes — which the transport now tags as `{handshake, Reason}` so a peer closing mid-handshake is no longer mistaken for the listen socket closing) retry immediately, while resource errors (`emfile`/`enfile`/`system_limit`) back off 100 ms so the box can reclaim descriptors. Only the listen socket's own `closed` ends the loop. Tests cover the classifier exhaustively plus live acceptor survival through both an einval-class error and a real failed TLS handshake.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)