### PR TITLE
Reject unreachable routes when compiling a route table

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ routes => [
 ]
 ```
 
+Routes are tried top to bottom and the first match wins, so the specific route
+goes above the general one. When a route can never be reached because the
+entries above it already answer its path and its methods, the listener refuses
+to start and names both lines. A mis-ordered table shows up at boot with the
+line to move, instead of as a 404 in production.
+
 Restrict a route to specific HTTP methods with the **map form**'s `methods` key
 (a non-empty list of uppercase method binaries). A request whose path matches a
 route but whose method is not listed gets `405 Method Not Allowed` with an `Allow`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -434,6 +434,26 @@ Revisit only if a real workload reports false `slow_client` drops.
 
 **Scope:** small.
 
+### Return route-validation failures from `reload_routes/2` — small
+
+**What:** `roadrunner_router:compile/2` raises on a table that cannot work
+(`invalid_route_methods`, `invalid_route_path`, `unreachable_route`).
+`roadrunner_listener:do_reload_routes/2` calls it straight from `handle_call`, so
+a bad table handed to `reload_routes/2` crashes the listener instead of coming
+back as `{error, Reason}`. The supervisor restarts it with the last-known-good
+routes from its own opts, so the table stays correct, but live connections drop
+for what is only a validation failure. Widening the return to
+`ok | {error, no_routes} | {error, term()}` and validating before the
+`persistent_term` swap would reject the table without touching the running one.
+
+**Why deferred:** the crash predates the reachability check (`compile_methods/1`
+already raised the same way) and is loud rather than silent, which is the safer
+default of the two. Boot-time validation is the common path; `reload_routes/2` is
+a deliberate deploy-time call whose input is usually the same table that already
+booted.
+
+**Scope:** small.
+
 ## Per-route framework knobs the map shape unlocks
 
 The map-shape route entry (`#{path => ..., handler => ..., state =>

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -96,7 +96,10 @@ Routing (pick one):
 - `routes => roadrunner_router:routes()` — list of route entries;
   each entry is either a `{Path, Handler}` / `{Path, Handler, State}`
   tuple or a `#{path := Path, handler := Handler, state => ...,
-  middlewares => [...]}` map. First match wins.
+  middlewares => [...]}` map. First match wins, so the specific
+  route goes above the general one; a route the entries above it
+  already answer in full is a config error and raises at listener
+  start rather than turning into a runtime 404.
 
 Optional middleware and timing knobs (durations in milliseconds):
 - `middlewares` — listener-wide pipeline applied to every request.

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -40,14 +40,25 @@ binary on the wire" rule we already use for header names.
 Segments starting with `*` (e.g. `/static/*path`) are wildcard
 captures: they consume all remaining path segments and bind them as
 a list under the given name. A wildcard must be the last segment in
-a pattern; anything after it never matches.
+a pattern; a segment after it could never match, so `compile/2`
+raises `{invalid_route_path, Path, wildcard_not_last}` rather than
+registering a route that can never answer.
 
 Literal segments must match byte-exactly; comparison is
 case-sensitive per RFC 3986.
 
-Routes are tried in declaration order — earlier entries win. The
-opaque `compiled()` shape is a list of pre-parsed segment patterns;
-swapping to a trie/DAG later is a non-breaking change for callers.
+Routes are tried in declaration order, earlier entries win, and
+nothing is reordered by specificity. To keep that rule from failing
+silently, `compile/2` rejects a route the entries above it already
+answer in full: write `/static/*path` above `/static/assets/*path`
+and the second one can never be reached, so compiling raises
+`{unreachable_route, Position, Path, ShadowedBy}` naming both.
+Ordering stays the caller's to choose; getting it wrong stops the
+listener from booting instead of turning into a 404 in production.
+
+The opaque `compiled()` shape is a list of pre-parsed segment
+patterns; swapping to a trie/DAG later is a non-breaking change for
+callers.
 """.
 
 -export([compile/2, match/3]).
@@ -144,6 +155,19 @@ Compile a list of routes into the lookup form `match/3` expects.
 Each path is split on `/` (empty leading/trailing segments dropped),
 and segments starting with `:` are recorded as named captures.
 
+Raises, before any middleware `init/1` runs, when the table cannot
+work as written: `{invalid_route_path, Path, wildcard_not_last}` for
+a pattern carrying a segment after its `*wildcard`, and
+`{unreachable_route, Position, Path, ShadowedBy}` for a route whose
+path and methods the entries above it already answer in full.
+`Position` is the route's 1-based index in `Routes`, and
+`ShadowedBy` lists the `{Position, Path}` of every earlier route
+taking work away from it.
+
+Only a route left with nothing to answer is unreachable. Two routes
+on the same path declaring disjoint `methods` both stay reachable,
+which is how same-path method dispatch works.
+
 `ListenerMws` is the listener-wide middleware list; it is resolved
 **once** (running each module's `init/1` a single time) and reused
 across every route, composed outermost around each route's own
@@ -154,6 +178,7 @@ when compiling routes outside a listener (typically only in tests).
 """.
 -spec compile(routes(), roadrunner_middleware:middleware_list()) -> compiled().
 compile(Routes, ListenerMws) when is_list(Routes), is_list(ListenerMws) ->
+    ok = check_shadowing(route_specs(Routes, 1)),
     ResolvedListener = roadrunner_middleware:resolve(ListenerMws),
     [compile_route(R, ResolvedListener) || R <- Routes].
 
@@ -218,6 +243,146 @@ compile_methods(Methods) when is_list(Methods), Methods =/= [] ->
     end;
 compile_methods(Methods) ->
     error({invalid_route_methods, Methods}).
+
+%% The per-route facts the reachability check works from: the route's 1-based
+%% position in the table (so the error can point at a line), the path as the
+%% caller wrote it, its compiled segment pattern, and its compiled method
+%% allowlist.
+-type route_spec() :: {pos_integer(), binary(), [segment()], method_lookup()}.
+
+%% The methods a route can still answer that no earlier route has taken:
+%% `any` for a route declaring no allowlist, otherwise the remaining set.
+-type uncovered() :: any | #{binary() => true}.
+
+%% Build the reachability facts for every route, rejecting a misplaced wildcard
+%% on the way past. The pattern and the method set are re-derived here rather
+%% than read back off the compiled routes so the whole table is validated before
+%% `compile/2` resolves any middleware -- a table that cannot work never runs a
+%% middleware `init/1`.
+-spec route_specs(routes(), pos_integer()) -> [route_spec()].
+route_specs([], _Pos) ->
+    [];
+route_specs([Route | Rest], Pos) ->
+    Path = route_path(Route),
+    Pattern = compile_path(Path),
+    ok = check_wildcard_last(Pattern, Path),
+    [{Pos, Path, Pattern, route_methods(Route)} | route_specs(Rest, Pos + 1)].
+
+-spec route_path(route()) -> binary().
+route_path({Path, _Handler}) when is_binary(Path) ->
+    Path;
+route_path({Path, _Handler, _State}) when is_binary(Path) ->
+    Path;
+route_path(#{path := Path}) when is_binary(Path) ->
+    Path.
+
+-spec route_methods(route()) -> method_lookup().
+route_methods(#{methods := Methods}) ->
+    compile_methods(Methods);
+route_methods(_Route) ->
+    undefined.
+
+%% `match_pattern/3` consumes a wildcard only as a pattern's final segment, so a
+%% route carrying anything after its `*` can never answer a request. That is a
+%% typo in the table rather than a route: raise instead of registering an entry
+%% guaranteed to be dead.
+-spec check_wildcard_last([segment()], binary()) -> ok.
+check_wildcard_last([], _Path) ->
+    ok;
+check_wildcard_last([{wildcard, _Name}], _Path) ->
+    ok;
+check_wildcard_last([{wildcard, _Name} | _Rest], Path) ->
+    error({invalid_route_path, Path, wildcard_not_last});
+check_wildcard_last([_Segment | Rest], Path) ->
+    check_wildcard_last(Rest, Path).
+
+%% Reject any route the entries above it already answer in full. First-match
+%% wins is the documented rule, so a route the scan can never reach is dead
+%% weight that surfaces at runtime as a 404 (or the wrong handler) with nothing
+%% at boot to explain it -- and the wildcard doing the swallowing is often one a
+%% framework generated rather than one the author typed. O(n^2) over the table,
+%% once, on a list of a handful of routes.
+-spec check_shadowing([route_spec()]) -> ok.
+check_shadowing(Specs) ->
+    check_shadowing(Specs, Specs).
+
+-spec check_shadowing([route_spec()], [route_spec()]) -> ok.
+check_shadowing([], _All) ->
+    ok;
+check_shadowing([{Pos, Path, Pattern, Methods} | Rest], All) ->
+    case shadowed_by(All, Pos, Pattern, uncovered(Methods)) of
+        reachable -> check_shadowing(Rest, All);
+        {shadowed, By} -> error({unreachable_route, Pos, Path, By})
+    end.
+
+-spec uncovered(method_lookup()) -> uncovered().
+uncovered(undefined) ->
+    any;
+uncovered(Methods) ->
+    Methods.
+
+%% Walk the table from the top narrowing the methods the route at `Pos` can
+%% still answer, stopping when the walk reaches that route itself. Returns the
+%% earlier routes that took methods away from it once nothing is left, or
+%% `reachable`. A covering route contributing no method the later one declares
+%% is stepped over, so the error names only the entries actually in the way.
+-spec shadowed_by([route_spec()], pos_integer(), [segment()], uncovered()) ->
+    reachable | {shadowed, [{pos_integer(), binary()}]}.
+shadowed_by([{Pos, _Path, _Pattern, _Methods} | _Rest], Pos, _Later, _Uncovered) ->
+    reachable;
+shadowed_by(
+    [{EarlierPos, EarlierPath, EarlierPattern, EarlierMethods} | Rest], Pos, Later, Uncovered
+) ->
+    case covers(EarlierPattern, Later) of
+        false ->
+            shadowed_by(Rest, Pos, Later, Uncovered);
+        true ->
+            case take_methods(EarlierMethods, Uncovered) of
+                empty ->
+                    {shadowed, [{EarlierPos, EarlierPath}]};
+                Uncovered ->
+                    shadowed_by(Rest, Pos, Later, Uncovered);
+                Narrowed ->
+                    case shadowed_by(Rest, Pos, Later, Narrowed) of
+                        reachable -> reachable;
+                        {shadowed, By} -> {shadowed, [{EarlierPos, EarlierPath} | By]}
+                    end
+            end
+    end.
+
+%% Narrow the methods a later route can still answer by the ones an earlier,
+%% path-covering route takes. An earlier route with no allowlist answers every
+%% method and leaves nothing. A later route with no allowlist (`any`) answers
+%% every method, which no finite set of earlier allowlists can exhaust.
+-spec take_methods(method_lookup(), uncovered()) -> uncovered() | empty.
+take_methods(undefined, _Uncovered) ->
+    empty;
+take_methods(_Methods, any) ->
+    any;
+take_methods(Methods, Uncovered) ->
+    case maps:without(maps:keys(Methods), Uncovered) of
+        Emptied when map_size(Emptied) =:= 0 -> empty;
+        Narrowed -> Narrowed
+    end.
+
+%% Does `Earlier` match every path `Later` matches? Both patterns are
+%% well-formed by here (any wildcard is the final segment), so a positional walk
+%% decides it: an earlier wildcard absorbs whatever remains, a `:param` covers
+%% any single segment a literal or another param could take, and a literal
+%% covers only the same literal.
+-spec covers([segment()], [segment()]) -> boolean().
+covers([{wildcard, _Name}], _Later) ->
+    true;
+covers([{literal, S} | Earlier], [{literal, S} | Later]) ->
+    covers(Earlier, Later);
+covers([{param, _Name} | Earlier], [{literal, _S} | Later]) ->
+    covers(Earlier, Later);
+covers([{param, _Name} | Earlier], [{param, _Other} | Later]) ->
+    covers(Earlier, Later);
+covers([], []) ->
+    true;
+covers(_Earlier, _Later) ->
+    false.
 
 -doc """
 Look up the handler for a given request method + path.

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -914,6 +914,26 @@ parse_cl(Head) ->
     ),
     binary_to_integer(Cl).
 
+unreachable_route_stops_the_listener_from_starting_test_() ->
+    %% The reachability check runs in `init/1`, so a table with a dead route
+    %% fails the boot instead of registering a listener that 404s the route.
+    %% Spawned: the linked `init/1` failure sends this process an `'EXIT'` that
+    %% must not bleed into the next test in the module.
+    {spawn, fun() ->
+        process_flag(trap_exit, true),
+        Result = roadrunner_listener:start_link(listener_test_unreachable_route, #{
+            port => 0,
+            routes => [
+                {~"/static/*path", roadrunner_hello_handler, #{}},
+                {~"/static/assets/*path", roadrunner_hello_handler, #{}}
+            ]
+        }),
+        ?assertMatch(
+            {error, {{unreachable_route, 2, ~"/static/assets/*path", [{1, ~"/static/*path"}]}, _}},
+            Result
+        )
+    end}.
+
 reload_routes_swaps_dispatch_table_test_() ->
     {setup,
         fun() ->

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -311,19 +311,18 @@ match_mixed_tuple_and_map_routes_test() ->
         match_no_pipeline(~"/api/users", Compiled)
     ).
 
-match_wildcard_not_last_falls_through_test() ->
-    %% A wildcard mid-pattern doesn't match — extra literal after it never
-    %% reaches a matching clause, and a fallback route still works.
-    Compiled = roadrunner_router:compile(
-        [
-            {~"/foo/*rest/bar", weird_handler},
-            {~"/foo/*rest", normal_handler}
-        ],
-        []
-    ),
-    ?assertEqual(
-        {ok, normal_handler, #{~"rest" => [~"x", ~"y"]}, #{}},
-        match_no_pipeline(~"/foo/x/y", Compiled)
+compile_rejects_wildcard_followed_by_a_literal_test() ->
+    %% A segment after the wildcard is never reached by the match clauses, so
+    %% the route could only ever be dead weight in the table.
+    ?assertError(
+        {invalid_route_path, ~"/foo/*rest/bar", wildcard_not_last},
+        roadrunner_router:compile(
+            [
+                {~"/foo/*rest/bar", weird_handler},
+                {~"/foo/*rest", normal_handler}
+            ],
+            []
+        )
     ).
 
 %% =============================================================================
@@ -416,19 +415,23 @@ match_duplicate_param_names_keep_last_binding_test() ->
         match_no_pipeline(~"/first/second", Compiled)
     ).
 
-match_multiple_wildcards_pattern_does_not_match_test() ->
-    %% Wildcard match clause requires the wildcard segment to be last.
-    %% A pattern with two wildcards therefore can never match — the
-    %% second is treated as a literal. Document so a future change to
-    %% allow nested wildcards is intentional.
-    Compiled = roadrunner_router:compile([{~"/*a/*b", h}], []),
-    ?assertEqual(not_found, match_no_pipeline(~"/x/y/z", Compiled)).
+compile_rejects_multiple_wildcards_test() ->
+    %% The wildcard match clause requires the wildcard segment to be last, so
+    %% the second `*b` could only ever be read as a literal sitting after a
+    %% wildcard. Rejected rather than registered as a route that never matches;
+    %% allowing nested wildcards later stays a deliberate change.
+    ?assertError(
+        {invalid_route_path, ~"/*a/*b", wildcard_not_last},
+        roadrunner_router:compile([{~"/*a/*b", h}], [])
+    ).
 
-match_wildcard_followed_by_literal_does_not_match_test() ->
-    %% Same constraint: anything declared after a wildcard segment is
-    %% unreachable.
-    Compiled = roadrunner_router:compile([{~"/*tail/post", h}], []),
-    ?assertEqual(not_found, match_no_pipeline(~"/a/b/post", Compiled)).
+compile_rejects_root_wildcard_followed_by_a_literal_test() ->
+    %% Same constraint from the root: anything declared after a wildcard
+    %% segment is unreachable.
+    ?assertError(
+        {invalid_route_path, ~"/*tail/post", wildcard_not_last},
+        roadrunner_router:compile([{~"/*tail/post", h}], [])
+    ).
 
 match_nul_byte_in_segment_is_captured_raw_test() ->
     %% NUL is just a byte to the router — the request-line parser
@@ -604,24 +607,259 @@ compile_rejects_non_binary_methods_test() ->
         roadrunner_router:compile([#{path => ~"/x", handler => h, methods => [get, post]}], [])
     ).
 
-match_all_methods_route_shadows_later_specific_test() ->
-    %% Declaration order wins: an all-methods route on a path short-circuits
-    %% before a later same-path method-specific route is considered.
+compile_rejects_method_specific_route_below_an_all_methods_one_test() ->
+    %% An all-methods route short-circuits every method on its path, so a later
+    %% same-path method-specific route never gets a request.
+    ?assertError(
+        {unreachable_route, 2, ~"/x", [{1, ~"/x"}]},
+        roadrunner_router:compile(
+            [
+                #{path => ~"/x", handler => catch_all},
+                #{path => ~"/x", handler => only_post, methods => [~"POST"]}
+            ],
+            []
+        )
+    ).
+
+%% =============================================================================
+%% Route reachability — compile/2 rejects a route the entries above it already
+%% answer in full, so a mis-ordered table fails at boot instead of 404-ing.
+%% =============================================================================
+
+compile_rejects_duplicate_path_test() ->
+    ?assertError(
+        {unreachable_route, 2, ~"/a", [{1, ~"/a"}]},
+        roadrunner_router:compile([{~"/a", first_handler}, {~"/a", second_handler}], [])
+    ).
+
+compile_rejects_duplicate_root_path_test() ->
+    %% Both compile to an empty segment list, so the walk bottoms out on two
+    %% empty patterns and still reports the shadow.
+    ?assertError(
+        {unreachable_route, 2, ~"////", [{1, ~"/"}]},
+        roadrunner_router:compile([{~"/", home_handler}, {~"////", root_handler}], [])
+    ).
+
+compile_rejects_route_swallowed_by_an_earlier_wildcard_test() ->
+    %% The wildcard is often generated rather than typed (a framework expanding
+    %% an asset route to `<Path>/*path`), so someone reordering two lines gets
+    %% no visual cue that the one above carries a catch-all.
+    ?assertError(
+        {unreachable_route, 2, ~"/static/assets/*path", [{1, ~"/static/*path"}]},
+        roadrunner_router:compile(
+            [
+                {~"/static/*path", site_handler},
+                {~"/static/assets/*path", assets_handler}
+            ],
+            []
+        )
+    ).
+
+compile_rejects_route_shadowed_by_a_non_adjacent_earlier_route_test() ->
+    %% The shadower is two lines up with an unrelated route between them, and
+    %% carries state, so the reported positions have to come from the table
+    %% rather than from adjacency.
+    ?assertError(
+        {unreachable_route, 3, ~"/a", [{1, ~"/a"}]},
+        roadrunner_router:compile(
+            [
+                {~"/a", first_handler, #{tier => primary}},
+                {~"/b", second_handler},
+                {~"/a", third_handler}
+            ],
+            []
+        )
+    ).
+
+compile_rejects_trailing_slash_duplicate_test() ->
+    %% `/a` and `/a/` compile to the same segment list, so the second is a
+    %% duplicate rather than a route on a distinct path. The error says so.
+    ?assertError(
+        {unreachable_route, 2, ~"/a/", [{1, ~"/a"}]},
+        roadrunner_router:compile([{~"/a", first_handler}, {~"/a/", second_handler}], [])
+    ).
+
+compile_rejects_method_route_below_a_covering_wildcard_test() ->
+    %% Path coverage and method coverage compose: the wildcard answers every
+    %% path below `/api` for every method, which includes this route's GET.
+    ?assertError(
+        {unreachable_route, 2, ~"/api/users", [{1, ~"/api/*p"}]},
+        roadrunner_router:compile(
+            [
+                {~"/api/*p", api_handler},
+                #{path => ~"/api/users", handler => users_handler, methods => [~"GET"]}
+            ],
+            []
+        )
+    ).
+
+compile_rejects_method_union_across_different_path_shapes_test() ->
+    %% The two routes above cover this one's path in different ways (a literal
+    %% prefix with a capture, then two captures) and take one method each
+    %% between them.
+    ?assertError(
+        {unreachable_route, 3, ~"/x/y", [{1, ~"/x/:id"}, {2, ~"/:a/:b"}]},
+        roadrunner_router:compile(
+            [
+                #{path => ~"/x/:id", handler => get_handler, methods => [~"GET"]},
+                #{path => ~"/:a/:b", handler => post_handler, methods => [~"POST"]},
+                #{path => ~"/x/y", handler => rw_handler, methods => [~"GET", ~"POST"]}
+            ],
+            []
+        )
+    ).
+
+compile_allows_route_a_covering_path_leaves_a_method_open_test() ->
+    %% `/x/:id` covers `/x/y` but only answers GET, so the POST on the deeper
+    %% route keeps it alive.
     Compiled = roadrunner_router:compile(
         [
-            #{path => ~"/x", handler => catch_all},
-            #{path => ~"/x", handler => only_post, methods => [~"POST"]}
+            #{path => ~"/x/:id", handler => get_handler, methods => [~"GET"]},
+            #{path => ~"/x/y", handler => rw_handler, methods => [~"GET", ~"POST"]}
+        ],
+        []
+    ),
+    ?assertEqual({ok, rw_handler, #{}, #{}}, match_no_pipeline(~"POST", ~"/x/y", Compiled)),
+    ?assertEqual(
+        {ok, get_handler, #{~"id" => ~"y"}, #{}}, match_no_pipeline(~"GET", ~"/x/y", Compiled)
+    ).
+
+compile_rejects_literal_below_a_covering_param_test() ->
+    ?assertError(
+        {unreachable_route, 2, ~"/users/me", [{1, ~"/users/:id"}]},
+        roadrunner_router:compile(
+            [{~"/users/:id", users_handler}, {~"/users/me", me_handler}],
+            []
+        )
+    ).
+
+compile_rejects_param_below_a_covering_param_test() ->
+    %% Capture names narrow nothing — `/:a` and `/:b` match the same paths.
+    ?assertError(
+        {unreachable_route, 2, ~"/:b", [{1, ~"/:a"}]},
+        roadrunner_router:compile([{~"/:a", first_handler}, {~"/:b", second_handler}], [])
+    ).
+
+compile_rejects_everything_below_a_root_wildcard_test() ->
+    ?assertError(
+        {unreachable_route, 2, ~"/", [{1, ~"/*all"}]},
+        roadrunner_router:compile([{~"/*all", catchall_handler}, {~"/", home_handler}], [])
+    ).
+
+compile_rejects_wildcard_prefix_below_its_own_wildcard_test() ->
+    %% `/static/*path` matches `/static` itself (empty remainder), so a bare
+    %% `/static` written below it never gets there.
+    ?assertError(
+        {unreachable_route, 2, ~"/static", [{1, ~"/static/*path"}]},
+        roadrunner_router:compile(
+            [{~"/static/*path", static_handler}, {~"/static", index_handler}],
+            []
+        )
+    ).
+
+compile_allows_specific_route_above_a_wildcard_test() ->
+    %% The same two routes in the working order: the specific one is reachable.
+    Compiled = roadrunner_router:compile(
+        [
+            {~"/static/assets/*path", assets_handler},
+            {~"/static/*path", site_handler}
         ],
         []
     ),
     ?assertEqual(
-        {ok, catch_all, #{}, #{}},
-        match_no_pipeline(~"POST", ~"/x", Compiled)
+        {ok, assets_handler, #{~"path" => [~"app.js"]}, #{}},
+        match_no_pipeline(~"/static/assets/app.js", Compiled)
     ),
     ?assertEqual(
-        {ok, catch_all, #{}, #{}},
-        match_no_pipeline(~"GET", ~"/x", Compiled)
+        {ok, site_handler, #{~"path" => [~"logo.png"]}, #{}},
+        match_no_pipeline(~"/static/logo.png", Compiled)
     ).
+
+compile_allows_sibling_literals_test() ->
+    Compiled = roadrunner_router:compile([{~"/a", a_handler}, {~"/b", b_handler}], []),
+    ?assertEqual({ok, b_handler, #{}, #{}}, match_no_pipeline(~"/b", Compiled)).
+
+compile_allows_deeper_route_below_a_shorter_one_test() ->
+    Compiled = roadrunner_router:compile([{~"/a", a_handler}, {~"/a/b", ab_handler}], []),
+    ?assertEqual({ok, ab_handler, #{}, #{}}, match_no_pipeline(~"/a/b", Compiled)).
+
+compile_allows_wildcard_below_a_sibling_param_test() ->
+    %% `/:a` takes exactly one segment; `/*p` also answers `/` and deeper
+    %% paths, so it keeps work of its own.
+    Compiled = roadrunner_router:compile(
+        [{~"/:a", param_handler}, {~"/*p", catchall_handler}],
+        []
+    ),
+    ?assertEqual({ok, param_handler, #{~"a" => ~"x"}, #{}}, match_no_pipeline(~"/x", Compiled)),
+    ?assertEqual(
+        {ok, catchall_handler, #{~"p" => [~"x", ~"y"]}, #{}},
+        match_no_pipeline(~"/x/y", Compiled)
+    ).
+
+compile_allows_same_path_with_disjoint_methods_test() ->
+    %% Same-path method dispatch: neither route can answer the other's method.
+    Compiled = roadrunner_router:compile(
+        [
+            #{path => ~"/x", handler => get_handler, methods => [~"GET"]},
+            #{path => ~"/x", handler => post_handler, methods => [~"POST"]}
+        ],
+        []
+    ),
+    ?assertEqual({ok, get_handler, #{}, #{}}, match_no_pipeline(~"GET", ~"/x", Compiled)),
+    ?assertEqual({ok, post_handler, #{}, #{}}, match_no_pipeline(~"POST", ~"/x", Compiled)).
+
+compile_rejects_same_path_with_a_method_subset_test() ->
+    ?assertError(
+        {unreachable_route, 2, ~"/x", [{1, ~"/x"}]},
+        roadrunner_router:compile(
+            [
+                #{path => ~"/x", handler => rw_handler, methods => [~"GET", ~"POST"]},
+                #{path => ~"/x", handler => ro_handler, methods => [~"GET"]}
+            ],
+            []
+        )
+    ).
+
+compile_rejects_route_whose_methods_earlier_routes_cover_between_them_test() ->
+    %% No single earlier route covers the third one, but the two above it do
+    %% between them, so both are named.
+    ?assertError(
+        {unreachable_route, 3, ~"/x", [{1, ~"/x"}, {2, ~"/x"}]},
+        roadrunner_router:compile(
+            [
+                #{path => ~"/x", handler => get_handler, methods => [~"GET"]},
+                #{path => ~"/x", handler => post_handler, methods => [~"POST"]},
+                #{path => ~"/x", handler => rw_handler, methods => [~"GET", ~"POST"]}
+            ],
+            []
+        )
+    ).
+
+compile_allows_route_with_a_method_earlier_routes_leave_open_test() ->
+    %% Same shape, but the last route also declares PUT — nothing above answers
+    %% it, so it stays reachable.
+    Compiled = roadrunner_router:compile(
+        [
+            #{path => ~"/x", handler => get_handler, methods => [~"GET"]},
+            #{path => ~"/x", handler => post_handler, methods => [~"POST"]},
+            #{path => ~"/x", handler => put_handler, methods => [~"GET", ~"PUT"]}
+        ],
+        []
+    ),
+    ?assertEqual({ok, put_handler, #{}, #{}}, match_no_pipeline(~"PUT", ~"/x", Compiled)).
+
+compile_allows_all_methods_route_below_method_specific_ones_test() ->
+    %% A route with no allowlist answers every method, and no finite set of
+    %% earlier allowlists can exhaust that.
+    Compiled = roadrunner_router:compile(
+        [
+            #{path => ~"/x", handler => get_handler, methods => [~"GET"]},
+            {~"/x", catch_all_handler}
+        ],
+        []
+    ),
+    ?assertEqual({ok, get_handler, #{}, #{}}, match_no_pipeline(~"GET", ~"/x", Compiled)),
+    ?assertEqual({ok, catch_all_handler, #{}, #{}}, match_no_pipeline(~"DELETE", ~"/x", Compiled)).
 
 %% --- helpers ---
 


### PR DESCRIPTION
# Description

Route matching is first-match-wins in declaration order, so a route the entries above it already answer never runs. Until now that failed silently, as a 404 or the wrong handler with nothing at boot to explain it, which is easiest to hit when the swallowing wildcard was generated rather than typed. `roadrunner_router:compile/2` now rejects such a table, before any middleware `init/1` runs, and names the line to move. A wildcard that is not the last segment is rejected the same way, since that route could never match anything either. Ordering stays the caller's to choose, and two routes sharing a path with disjoint `methods` both stay reachable.

```erlang
routes => [
    {~"/static/*path", site_handler},
    {~"/static/assets/*path", assets_handler}
]
%% ** {unreachable_route, 2, ~"/static/assets/*path", [{1, ~"/static/*path"}]}
```

A route is unreachable only when the entries above it cover every method it declares, so the check accumulates method coverage instead of comparing pairs: three same-path routes declaring `[GET]`, `[POST]` and `[GET, POST]` make the third one dead even though neither of the first two kills it alone, and `ShadowedBy` then names both.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)