### PR TITLE
Answer 405 instead of crashing the stream worker on HTTP/2 and HTTP/3

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -474,19 +474,6 @@ to a path.
 `(listener_name, method, path)` is already enough to identify a
 route in dashboards; named lookup is a niceness, not a need.
 
-### Per-route `methods => [binary()]` allowlist with automatic 405 — small
-
-**What:** `methods => [~"GET", ~"PUT"]` on a route map means the
-framework returns `405 Method Not Allowed` (with the right `Allow`
-header) for any other method on that path. Eliminates the
-boilerplate every handler currently writes to gate on
-`roadrunner_req:method/1`.
-
-**Why deferred:** simple to bolt on once a couple of real handlers
-demonstrate the pattern they want. The single-route equality check
-is the wrong model for catch-all routes (`/api/*path`) that
-multiplex methods downstream.
-
 ### Nested route groups with shared prefix + middlewares — medium
 
 **What:** Phoenix-style scope / pipeline:

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -74,6 +74,7 @@
     send_not_found/1,
     send_method_not_allowed/2,
     resolve_handler/2,
+    allow_header_value/1,
     response_status/1,
     response_kind/1,
     head_response/2
@@ -602,6 +603,15 @@ resolve_handler({router, ListenerName}, Req) ->
     %% atomically swap the table without bouncing the listener.
     Compiled = persistent_term:get({roadrunner_routes, ListenerName}),
     roadrunner_router:match(roadrunner_req:method(Req), roadrunner_req:path(Req), Compiled).
+
+%% The `Allow` header value for a `405`, built from the methods
+%% `roadrunner_router:match/3` reports as accepted on the path. Flattened here
+%% because the HPACK and QPACK encoders size header values with `byte_size/1`,
+%% so h2 and h3 need a binary rather than the iodata the HTTP/1 writer takes.
+-doc false.
+-spec allow_header_value([binary()]) -> binary().
+allow_header_value(Allowed) ->
+    iolist_to_binary(lists:join(~", ", Allowed)).
 
 -doc false.
 -spec read_body(

--- a/src/roadrunner_http2_stream_worker.erl
+++ b/src/roadrunner_http2_stream_worker.erl
@@ -101,6 +101,21 @@ run_handler(ConnPid, StreamId, Req, Dispatch) ->
                 Metadata,
                 ReqStart
             );
+        {method_not_allowed, Allowed} ->
+            %% Path matched but no route on it answers this method: 405 plus the
+            %% `Allow` union, decided before any pipeline runs because the
+            %% method gate is a routing decision rather than handler work.
+            send_buffered(
+                ConnPid,
+                StreamId,
+                405,
+                [
+                    {~"content-type", ~"text/plain"},
+                    {~"allow", roadrunner_conn:allow_header_value(Allowed)}
+                ],
+                ~"Method Not Allowed"
+            ),
+            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, 405, buffered);
         not_found ->
             send_buffered(
                 ConnPid, StreamId, 404, [{~"content-type", ~"text/plain"}], ~"Not Found"

--- a/src/roadrunner_http3_stream_worker.erl
+++ b/src/roadrunner_http3_stream_worker.erl
@@ -87,6 +87,21 @@ run_handler(Conn, StreamId, Req, Dispatch) ->
             invoke(
                 Conn, StreamId, Handler, Pipeline, Req#{bindings => Bindings}, Metadata, ReqStart
             );
+        {method_not_allowed, Allowed} ->
+            %% Path matched but no route on it answers this method: 405 plus the
+            %% `Allow` union, decided before any pipeline runs because the
+            %% method gate is a routing decision rather than handler work.
+            send_buffered(
+                Conn,
+                StreamId,
+                405,
+                [
+                    {~"content-type", ~"text/plain"},
+                    {~"allow", roadrunner_conn:allow_header_value(Allowed)}
+                ],
+                ~"Method Not Allowed"
+            ),
+            ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, 405, buffered);
         not_found ->
             send_buffered(Conn, StreamId, 404, [{~"content-type", ~"text/plain"}], ~"Not Found"),
             ok = roadrunner_telemetry:request_stop(ReqStart, Metadata, 404, buffered)

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -64,6 +64,7 @@ all_test_() ->
         fun middleware_chain_runs/0,
         fun rst_stream_cancels_active_stream/0,
         fun router_404_returns_not_found/0,
+        fun router_405_returns_method_not_allowed/0,
         fun data_without_end_stream_continues_loop/0,
         fun continuation_without_end_headers_continues_loop/0,
         fun idle_timeout_emits_goaway/0,
@@ -1307,6 +1308,70 @@ router_404_returns_not_found() ->
         roadrunner_http2_frame:parse(Resp, 16384),
     {ok, RespHeaders, _} = roadrunner_http2_hpack:decode(RespHpack, Dec0),
     ?assertEqual(~"404", proplists:get_value(~":status", RespHeaders)),
+    cleanup(Pid, Ref).
+
+router_405_returns_method_not_allowed() ->
+    %% Path matches but the route's `methods` allowlist rejects the method:
+    %% routing answers 405 with the accepted methods in `Allow`, without
+    %% reaching the handler.
+    {ok, _} = application:ensure_all_started(telemetry),
+    drain_mailbox(),
+    persistent_term:put(
+        {roadrunner_routes, h2_405_listener},
+        roadrunner_router:compile(
+            [#{path => ~"/only-get", handler => roadrunner_hello_handler, methods => [~"GET"]}],
+            []
+        )
+    ),
+    Self = self(),
+    Counter = counters:new(1, [write_concurrency]),
+    ok = counters:add(Counter, 1, 1),
+    ProtoOpts = #{
+        handler_spawn_opts => [{fullsweep_after, 0}],
+        handler_start_timeout => infinity,
+        max_concurrent_requests => infinity,
+        client_counter => Counter,
+        listener_name => h2_405_listener,
+        dispatch => {router, h2_405_listener},
+        middlewares => []
+    },
+    Sock = {fake, Self},
+    Pid = spawn(fun() ->
+        receive
+            ready -> ok
+        end,
+        roadrunner_conn_loop_http2:enter(
+            Sock, ProtoOpts, h2_405_listener, undefined, erlang:monotonic_time(), <<>>
+        )
+    end),
+    Ref = monitor(process, Pid),
+    Pid ! ready,
+    _ = expect_send(),
+    serve_recv(Pid, ?PREFACE),
+    serve_recv(Pid, ?EMPTY_SETTINGS_FRAME),
+    _ = expect_send(),
+    Enc = roadrunner_http2_hpack:new_encoder(4096),
+    {Hpack, _} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"POST"},
+            {~":scheme", ~"https"},
+            {~":authority", ~"x"},
+            {~":path", ~"/only-get"}
+        ],
+        Enc
+    ),
+    HpackBin = iolist_to_binary(Hpack),
+    Hf = iolist_to_binary(
+        roadrunner_http2_frame:encode({headers, 1, 16#04 bor 16#01, undefined, HpackBin})
+    ),
+    serve_recv(Pid, Hf),
+    Resp = expect_send(),
+    Dec0 = roadrunner_http2_hpack:new_decoder(4096),
+    {ok, {headers, 1, _, _, RespHpack}, _} =
+        roadrunner_http2_frame:parse(Resp, 16384),
+    {ok, RespHeaders, _} = roadrunner_http2_hpack:decode(RespHpack, Dec0),
+    ?assertEqual(~"405", proplists:get_value(~":status", RespHeaders)),
+    ?assertEqual(~"GET", proplists:get_value(~"allow", RespHeaders)),
     cleanup(Pid, Ref).
 
 data_without_end_stream_continues_loop() ->

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -22,6 +22,7 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     head_request/1,
     large_post/1,
     not_found/1,
+    method_not_allowed/1,
     crash_500/1,
     interim_response_500/1,
     rate_limited/1,
@@ -95,6 +96,7 @@ all() ->
         head_request,
         large_post,
         not_found,
+        method_not_allowed,
         crash_500,
         interim_response_500,
         rate_limited,
@@ -189,6 +191,7 @@ end_per_suite(_Config) ->
 %% max_clients, no TLS) start their own and skip this one.
 init_per_testcase(Case, Config) when
     Case =:= not_found;
+    Case =:= method_not_allowed;
     Case =:= rate_limited;
     Case =:= oversized_413;
     Case =:= protocols_tuple_form;
@@ -282,6 +285,27 @@ not_found(_Config) ->
     Conn = connect(roadrunner_listener:port(Name)),
     try
         ?assertMatch({404, _}, status_body(get(Conn, ~"/missing")))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+method_not_allowed(_Config) ->
+    %% The path matches but the route's `methods` allowlist does not answer
+    %% POST, so routing decides a 405 and carries the accepted methods in
+    %% `Allow` rather than reaching the handler.
+    Name = listener_name(method_not_allowed),
+    {ok, _} = start_h3(Name, #{
+        routes => [
+            #{path => ~"/only-get", handler => roadrunner_h3_test_handler, methods => [~"GET"]}
+        ]
+    }),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        {Status, Headers, _Body} = post(Conn, ~"/only-get", ~""),
+        ?assertEqual(405, Status),
+        ?assertEqual(~"GET", proplists:get_value(~"allow", Headers)),
+        ?assertMatch({200, _}, status_body(get(Conn, ~"/only-get")))
     after
         close(Conn),
         roadrunner_listener:stop(Name)


### PR DESCRIPTION
# Description

`roadrunner_conn:resolve_handler/2` returns `{method_not_allowed, Allowed}` when a route's `methods` allowlist rejects the request method, and the HTTP/1 loop turns that into a `405` with an `Allow` header. The HTTP/2 and HTTP/3 stream workers matched only `{ok, ...}` and `not_found`, so the same request killed the worker with a `case_clause` instead of answering. Both now send the `405` with the accepted methods, ahead of any pipeline, because the method gate is a routing decision rather than handler work. The `Allow` value is flattened to a binary in one shared helper since HPACK and QPACK size header values with `byte_size/1`.

```erlang
routes => [#{path => ~"/only-get", handler => h, methods => [~"GET"]}]
%% POST /only-get over h2 or h3, before: {case_clause, {method_not_allowed, [~"GET"]}}
%% after: 405, allow: GET
```

Covered by a fake-socket test on the HTTP/2 conn loop and a live-QUIC testcase in the HTTP/3 suite, both asserting the status and the `Allow` header. The roadmap entry proposing this feature is dropped, since it is now real on every protocol.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)