### PR TITLE
Return route-validation failures from reload_routes instead of crashing

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -434,26 +434,6 @@ Revisit only if a real workload reports false `slow_client` drops.
 
 **Scope:** small.
 
-### Return route-validation failures from `reload_routes/2` — small
-
-**What:** `roadrunner_router:compile/2` raises on a table that cannot work
-(`invalid_route_methods`, `invalid_route_path`, `unreachable_route`).
-`roadrunner_listener:do_reload_routes/2` calls it straight from `handle_call`, so
-a bad table handed to `reload_routes/2` crashes the listener instead of coming
-back as `{error, Reason}`. The supervisor restarts it with the last-known-good
-routes from its own opts, so the table stays correct, but live connections drop
-for what is only a validation failure. Widening the return to
-`ok | {error, no_routes} | {error, term()}` and validating before the
-`persistent_term` swap would reject the table without touching the running one.
-
-**Why deferred:** the crash predates the reachability check (`compile_methods/1`
-already raised the same way) and is loud rather than silent, which is the safer
-default of the two. Boot-time validation is the common path; `reload_routes/2` is
-a deliberate deploy-time call whose input is usually the same table that already
-booted.
-
-**Scope:** small.
-
 ## Per-route framework knobs the map shape unlocks
 
 The map-shape route entry (`#{path => ..., handler => ..., state =>

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -629,9 +629,16 @@ re-baked) and published to `persistent_term`;
 in-flight conns keep using whatever they read at request-resolve
 time, but every subsequent dispatch sees the new table.
 
-Returns `ok` on success or `{error, no_routes}` if the listener was
+Returns `ok` on success, `{error, no_routes}` if the listener was
 started in single-handler mode (`routes => Module` or no `routes`
-opt) — there's no router table to reload.
+opt) since there's no router table to reload, or
+`{error, Reason}` carrying a `t:roadrunner_router:validation_error/0`
+if the replacement table cannot work. A rejected table is refused
+whole: the listener keeps serving the routes it already had, and
+nothing about the running table changes. That covers everything
+decidable from the table itself; a per-route middleware that crashes
+in its own `init/1` still fails the reload the loud way, the same as
+it would at listener start.
 
 Each call performs one global `persistent_term` swap, which scans every
 process heap to reclaim the old table. That cost is acceptable for a
@@ -639,7 +646,7 @@ whole-table swap at deploy time, but callers should batch route changes
 into a single `reload_routes/2` rather than calling it per route.
 """.
 -spec reload_routes(Name :: atom(), roadrunner_router:routes()) ->
-    ok | {error, no_routes}.
+    ok | {error, no_routes} | {error, roadrunner_router:validation_error()}.
 reload_routes(Name, Routes) ->
     gen_server:call(Name, {reload_routes, Routes}).
 
@@ -1649,16 +1656,25 @@ handle_call(info, _From, #state{proto_opts = ProtoOpts} = State) ->
     {reply, Reply, State}.
 
 -spec do_reload_routes(#state{}, roadrunner_router:routes()) ->
-    ok | {error, no_routes}.
+    ok | {error, no_routes} | {error, roadrunner_router:validation_error()}.
 do_reload_routes(
     #state{proto_opts = #{dispatch := {router, Name}, middlewares := ListenerMws}},
     Routes
 ) ->
-    persistent_term:put(
-        {roadrunner_routes, Name},
-        roadrunner_router:compile(Routes, ListenerMws)
-    ),
-    ok;
+    %% Check the replacement before touching anything. `compile/2` raises on a
+    %% table that cannot work, and raising from here would take down a listener
+    %% (and the caller) that has a perfectly good table already published, so
+    %% the verdict comes back as a value and a bad table is simply refused.
+    case roadrunner_router:validate(Routes) of
+        ok ->
+            persistent_term:put(
+                {roadrunner_routes, Name},
+                roadrunner_router:compile(Routes, ListenerMws)
+            ),
+            ok;
+        {error, _Reason} = Error ->
+            Error
+    end;
 do_reload_routes(#state{proto_opts = #{dispatch := {handler, _, _, _}}}, _Routes) ->
     {error, no_routes}.
 

--- a/src/roadrunner_router.erl
+++ b/src/roadrunner_router.erl
@@ -61,9 +61,11 @@ patterns; swapping to a trie/DAG later is a non-breaking change for
 callers.
 """.
 
--export([compile/2, match/3]).
+-export([compile/2, validate/1, match/3]).
 
--export_type([route/0, routes/0, compiled/0, bindings/0, methods/0]).
+-export_type([
+    route/0, routes/0, compiled/0, bindings/0, methods/0, validation_error/0
+]).
 
 -doc """
 A single route entry. Three shapes are accepted:
@@ -108,6 +110,27 @@ raises `{invalid_route_methods, _}` on an empty list or non-binary
 entries (both would otherwise silently reject every request).
 """.
 -type methods() :: [binary()] | undefined.
+
+-doc """
+Why a route table was rejected, as returned by `validate/1` and raised by
+`compile/2`.
+
+- `{invalid_route, Route}` — the entry is not one of the accepted shapes, or
+  its path is not a binary / its handler is not a module atom.
+- `{invalid_route_methods, Methods}` — a `methods` key that is not a non-empty
+  list of binaries.
+- `{invalid_route_path, Path, wildcard_not_last}` — a segment after the
+  pattern's `*wildcard`, which no request could ever reach.
+- `{unreachable_route, Position, Path, ShadowedBy}` — the entries above this
+  one already answer its path for every method it declares. `Position` is the
+  1-based index in the table and `ShadowedBy` lists the `{Position, Path}` of
+  every earlier route taking work away from it.
+""".
+-type validation_error() ::
+    {invalid_route, route()}
+    | {invalid_route_methods, term()}
+    | {invalid_route_path, binary(), wildcard_not_last}
+    | {unreachable_route, pos_integer(), binary(), [{pos_integer(), binary()}]}.
 
 %% The compiled form of `methods()`: a set-as-map for O(1) membership,
 %% or `undefined` for a route that answers every method.
@@ -155,14 +178,9 @@ Compile a list of routes into the lookup form `match/3` expects.
 Each path is split on `/` (empty leading/trailing segments dropped),
 and segments starting with `:` are recorded as named captures.
 
-Raises, before any middleware `init/1` runs, when the table cannot
-work as written: `{invalid_route_path, Path, wildcard_not_last}` for
-a pattern carrying a segment after its `*wildcard`, and
-`{unreachable_route, Position, Path, ShadowedBy}` for a route whose
-path and methods the entries above it already answer in full.
-`Position` is the route's 1-based index in `Routes`, and
-`ShadowedBy` lists the `{Position, Path}` of every earlier route
-taking work away from it.
+Raises any `t:validation_error/0` before running a middleware
+`init/1`, so a table that cannot work never has side effects. Call
+`validate/1` first to get the same verdict as a value instead.
 
 Only a route left with nothing to answer is unreachable. Two routes
 on the same path declaring disjoint `methods` both stay reachable,
@@ -178,9 +196,34 @@ when compiling routes outside a listener (typically only in tests).
 """.
 -spec compile(routes(), roadrunner_middleware:middleware_list()) -> compiled().
 compile(Routes, ListenerMws) when is_list(Routes), is_list(ListenerMws) ->
-    ok = check_shadowing(route_specs(Routes, 1)),
-    ResolvedListener = roadrunner_middleware:resolve(ListenerMws),
-    [compile_route(R, ResolvedListener) || R <- Routes].
+    case validate(Routes) of
+        ok ->
+            ResolvedListener = roadrunner_middleware:resolve(ListenerMws),
+            [compile_route(R, ResolvedListener) || R <- Routes];
+        {error, Reason} ->
+            error(Reason)
+    end.
+
+-doc """
+Check a route table without building it, returning the verdict as a value.
+
+`compile/2` runs exactly this and raises on `{error, Reason}`, so a
+table `validate/1` accepts is one `compile/2` will not reject. Use it
+where raising is the wrong answer: `roadrunner_listener:reload_routes/2`
+validates a replacement table this way so a bad one is refused without
+disturbing the table already serving.
+
+Covers everything decidable from the table itself: entry shapes, method
+allowlists, wildcard placement, and whether every route can be reached.
+It does not run middleware `init/1`, so a per-route middleware that
+crashes on init still surfaces at `compile/2` time.
+""".
+-spec validate(routes()) -> ok | {error, validation_error()}.
+validate(Routes) when is_list(Routes) ->
+    maybe
+        {ok, Specs} ?= route_specs(Routes, 1),
+        check_shadowing(Specs)
+    end.
 
 -spec compile_route(route(), [roadrunner_middleware:resolved()]) ->
     {[segment()], module(), roadrunner_middleware:next(), term(), method_lookup()}.
@@ -229,20 +272,28 @@ compile_segment(Lit) -> {literal, Lit}.
 
 %% Compile a route's `methods` allowlist into a set-map for O(1) match-time
 %% membership; `undefined` (no allowlist) passes through to answer every method.
-%% A present `methods` must be a non-empty list of binaries -- an empty list
-%% (a route that answers nothing) or non-binary entries (which could never
-%% match the binary wire method) are config errors, raised loudly rather than
-%% silently 405-ing every request.
+%% `check_methods/1` has already rejected every shape this cannot handle, so
+%% there is nothing left to guard.
 -spec compile_methods(methods()) -> method_lookup().
 compile_methods(undefined) ->
     undefined;
-compile_methods(Methods) when is_list(Methods), Methods =/= [] ->
-    case lists:all(fun is_binary/1, Methods) of
-        true -> maps:from_keys(Methods, true);
-        false -> error({invalid_route_methods, Methods})
-    end;
 compile_methods(Methods) ->
-    error({invalid_route_methods, Methods}).
+    maps:from_keys(Methods, true).
+
+%% A present `methods` must be a non-empty list of binaries -- an empty list
+%% (a route that answers nothing) or non-binary entries (which could never match
+%% the binary wire method) are config errors, reported rather than left to
+%% silently 405 every request.
+-spec check_methods(methods()) -> ok | {error, validation_error()}.
+check_methods(undefined) ->
+    ok;
+check_methods(Methods) when is_list(Methods), Methods =/= [] ->
+    case lists:all(fun is_binary/1, Methods) of
+        true -> ok;
+        false -> {error, {invalid_route_methods, Methods}}
+    end;
+check_methods(Methods) ->
+    {error, {invalid_route_methods, Methods}}.
 
 %% The per-route facts the reachability check works from: the route's 1-based
 %% position in the table (so the error can point at a line), the path as the
@@ -254,45 +305,64 @@ compile_methods(Methods) ->
 %% `any` for a route declaring no allowlist, otherwise the remaining set.
 -type uncovered() :: any | #{binary() => true}.
 
-%% Build the reachability facts for every route, rejecting a misplaced wildcard
-%% on the way past. The pattern and the method set are re-derived here rather
-%% than read back off the compiled routes so the whole table is validated before
-%% `compile/2` resolves any middleware -- a table that cannot work never runs a
-%% middleware `init/1`.
--spec route_specs(routes(), pos_integer()) -> [route_spec()].
+%% Build the reachability facts for every route, checking each entry on the way
+%% past and stopping at the first bad one. The pattern and the method set are
+%% derived here rather than read back off the compiled routes so the whole table
+%% is checked before `compile/2` resolves any middleware -- a table that cannot
+%% work never runs a middleware `init/1`.
+-spec route_specs(routes(), pos_integer()) -> {ok, [route_spec()]} | {error, validation_error()}.
 route_specs([], _Pos) ->
-    [];
+    {ok, []};
 route_specs([Route | Rest], Pos) ->
-    Path = route_path(Route),
-    Pattern = compile_path(Path),
-    ok = check_wildcard_last(Pattern, Path),
-    [{Pos, Path, Pattern, route_methods(Route)} | route_specs(Rest, Pos + 1)].
+    maybe
+        {ok, Spec} ?= route_spec(Route, Pos),
+        {ok, Specs} ?= route_specs(Rest, Pos + 1),
+        {ok, [Spec | Specs]}
+    end.
 
--spec route_path(route()) -> binary().
-route_path({Path, _Handler}) when is_binary(Path) ->
-    Path;
-route_path({Path, _Handler, _State}) when is_binary(Path) ->
-    Path;
-route_path(#{path := Path}) when is_binary(Path) ->
-    Path.
+-spec route_spec(route(), pos_integer()) -> {ok, route_spec()} | {error, validation_error()}.
+route_spec(Route, Pos) ->
+    maybe
+        {ok, Path} ?= route_path(Route),
+        Pattern = compile_path(Path),
+        ok ?= check_wildcard_last(Pattern, Path),
+        {ok, Methods} ?= route_methods(Route),
+        {ok, {Pos, Path, Pattern, Methods}}
+    end.
 
--spec route_methods(route()) -> method_lookup().
+%% The accepted entry shapes, and the only place they are checked. These clauses
+%% mirror `compile_route/2`'s heads exactly: a table this accepts is one the
+%% build pass can destructure without a surprise.
+-spec route_path(route()) -> {ok, binary()} | {error, validation_error()}.
+route_path({Path, Handler}) when is_binary(Path), is_atom(Handler) ->
+    {ok, Path};
+route_path({Path, Handler, _State}) when is_binary(Path), is_atom(Handler) ->
+    {ok, Path};
+route_path(#{path := Path, handler := Handler}) when is_binary(Path), is_atom(Handler) ->
+    {ok, Path};
+route_path(Route) ->
+    {error, {invalid_route, Route}}.
+
+-spec route_methods(route()) -> {ok, method_lookup()} | {error, validation_error()}.
 route_methods(#{methods := Methods}) ->
-    compile_methods(Methods);
+    maybe
+        ok ?= check_methods(Methods),
+        {ok, compile_methods(Methods)}
+    end;
 route_methods(_Route) ->
-    undefined.
+    {ok, undefined}.
 
 %% `match_pattern/3` consumes a wildcard only as a pattern's final segment, so a
 %% route carrying anything after its `*` can never answer a request. That is a
-%% typo in the table rather than a route: raise instead of registering an entry
-%% guaranteed to be dead.
--spec check_wildcard_last([segment()], binary()) -> ok.
+%% typo in the table rather than a route: reject it instead of registering an
+%% entry guaranteed to be dead.
+-spec check_wildcard_last([segment()], binary()) -> ok | {error, validation_error()}.
 check_wildcard_last([], _Path) ->
     ok;
 check_wildcard_last([{wildcard, _Name}], _Path) ->
     ok;
 check_wildcard_last([{wildcard, _Name} | _Rest], Path) ->
-    error({invalid_route_path, Path, wildcard_not_last});
+    {error, {invalid_route_path, Path, wildcard_not_last}};
 check_wildcard_last([_Segment | Rest], Path) ->
     check_wildcard_last(Rest, Path).
 
@@ -302,17 +372,17 @@ check_wildcard_last([_Segment | Rest], Path) ->
 %% at boot to explain it -- and the wildcard doing the swallowing is often one a
 %% framework generated rather than one the author typed. O(n^2) over the table,
 %% once, on a list of a handful of routes.
--spec check_shadowing([route_spec()]) -> ok.
+-spec check_shadowing([route_spec()]) -> ok | {error, validation_error()}.
 check_shadowing(Specs) ->
     check_shadowing(Specs, Specs).
 
--spec check_shadowing([route_spec()], [route_spec()]) -> ok.
+-spec check_shadowing([route_spec()], [route_spec()]) -> ok | {error, validation_error()}.
 check_shadowing([], _All) ->
     ok;
 check_shadowing([{Pos, Path, Pattern, Methods} | Rest], All) ->
     case shadowed_by(All, Pos, Pattern, uncovered(Methods)) of
         reachable -> check_shadowing(Rest, All);
-        {shadowed, By} -> error({unreachable_route, Pos, Path, By})
+        {shadowed, By} -> {error, {unreachable_route, Pos, Path, By}}
     end.
 
 -spec uncovered(method_lookup()) -> uncovered().

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -961,6 +961,47 @@ reload_routes_swaps_dispatch_table_test_() ->
             end}
         end}.
 
+reload_routes_refuses_an_unworkable_table_test_() ->
+    %% A replacement table that cannot work comes back as a value. Raising here
+    %% would take down a listener (and the caller) that has a perfectly good
+    %% table already published, so the running one is left exactly as it was.
+    {setup,
+        fun() ->
+            ok = ensure_pg_started(),
+            Name = listener_test_reload_reject,
+            {ok, _} = roadrunner_listener:start_link(Name, #{
+                port => 0,
+                routes => [{~"/old", roadrunner_hello_handler, #{}}]
+            }),
+            {Name, roadrunner_listener:port(Name)}
+        end,
+        fun({Name, _Port}) -> ok = roadrunner_listener:stop(Name) end, fun({Name, Port}) ->
+            {"reload_routes/2 rejects a bad table and keeps serving the old one", fun() ->
+                ?assertEqual(
+                    {error, {unreachable_route, 2, ~"/old", [{1, ~"/old"}]}},
+                    roadrunner_listener:reload_routes(Name, [
+                        {~"/old", roadrunner_hello_handler, #{}},
+                        {~"/old", roadrunner_hello_handler, #{}}
+                    ])
+                ),
+                %% Still up, and the table it booted with still answers.
+                ?assertEqual(accepting, roadrunner_listener:status(Name)),
+                ?assertMatch(
+                    <<"HTTP/1.1 200 OK", _/binary>>, http_get_close(Port, ~"/old")
+                ),
+                %% And a workable table still swaps in afterwards.
+                ?assertEqual(
+                    ok,
+                    roadrunner_listener:reload_routes(
+                        Name, [{~"/new", roadrunner_hello_handler, #{}}]
+                    )
+                ),
+                ?assertMatch(
+                    <<"HTTP/1.1 200 OK", _/binary>>, http_get_close(Port, ~"/new")
+                )
+            end}
+        end}.
+
 reload_routes_rebakes_listener_middlewares_test_() ->
     %% reload_routes/2 must re-bake the listener's `middlewares` opt
     %% onto the new route cfg. Regression guard for `do_reload_routes/2`

--- a/test/roadrunner_router_tests.erl
+++ b/test/roadrunner_router_tests.erl
@@ -861,6 +861,82 @@ compile_allows_all_methods_route_below_method_specific_ones_test() ->
     ?assertEqual({ok, get_handler, #{}, #{}}, match_no_pipeline(~"GET", ~"/x", Compiled)),
     ?assertEqual({ok, catch_all_handler, #{}, #{}}, match_no_pipeline(~"DELETE", ~"/x", Compiled)).
 
+%% =============================================================================
+%% validate/1 — the same check as a value, for callers that cannot raise
+%% =============================================================================
+
+validate_accepts_a_workable_table_test() ->
+    ?assertEqual(
+        ok,
+        roadrunner_router:validate([
+            {~"/users/me", me_handler},
+            {~"/users/:id", users_handler},
+            #{path => ~"/x", handler => get_handler, methods => [~"GET"]},
+            #{path => ~"/x", handler => post_handler, methods => [~"POST"]},
+            {~"/static/*path", static_handler}
+        ])
+    ).
+
+validate_accepts_an_explicit_undefined_methods_test() ->
+    %% `methods()` includes `undefined`, so spelling it out is the same as
+    %% leaving the key off: the route answers every method.
+    Routes = [#{path => ~"/x", handler => h, methods => undefined}],
+    ?assertEqual(ok, roadrunner_router:validate(Routes)),
+    Compiled = roadrunner_router:compile(Routes, []),
+    ?assertEqual({ok, h, #{}, #{}}, match_no_pipeline(~"DELETE", ~"/x", Compiled)).
+
+validate_reports_an_unreachable_route_test() ->
+    ?assertEqual(
+        {error, {unreachable_route, 2, ~"/a", [{1, ~"/a"}]}},
+        roadrunner_router:validate([{~"/a", first_handler}, {~"/a", second_handler}])
+    ).
+
+validate_reports_a_misplaced_wildcard_test() ->
+    ?assertEqual(
+        {error, {invalid_route_path, ~"/foo/*rest/bar", wildcard_not_last}},
+        roadrunner_router:validate([{~"/foo/*rest/bar", weird_handler}])
+    ).
+
+validate_reports_bad_methods_test() ->
+    ?assertEqual(
+        {error, {invalid_route_methods, []}},
+        roadrunner_router:validate([#{path => ~"/x", handler => h, methods => []}])
+    ).
+
+validate_reports_a_non_binary_path_test() ->
+    ?assertEqual(
+        {error, {invalid_route, {123, h}}},
+        roadrunner_router:validate([{123, h}])
+    ).
+
+validate_reports_a_non_module_handler_test() ->
+    %% A handler has to be a module atom; anything else could never be called.
+    ?assertEqual(
+        {error, {invalid_route, {~"/x", "handler"}}},
+        roadrunner_router:validate([{~"/x", "handler"}])
+    ).
+
+validate_reports_a_map_entry_missing_its_handler_test() ->
+    ?assertEqual(
+        {error, {invalid_route, #{path => ~"/x"}}},
+        roadrunner_router:validate([#{path => ~"/x"}])
+    ).
+
+validate_stops_at_the_first_bad_entry_test() ->
+    %% Two problems in one table: the earlier entry is the one reported, so the
+    %% caller fixes the table top down rather than chasing a later symptom.
+    ?assertEqual(
+        {error, {invalid_route_path, ~"/a/*x/y", wildcard_not_last}},
+        roadrunner_router:validate([{~"/a/*x/y", h1}, {~"/b", h2}, {~"/b", h3}])
+    ).
+
+compile_raises_what_validate_reports_test() ->
+    %% `compile/2` runs exactly `validate/1` and raises its reason, so the two
+    %% never disagree about which tables are workable.
+    Routes = [{123, h}],
+    ?assertEqual({error, {invalid_route, {123, h}}}, roadrunner_router:validate(Routes)),
+    ?assertError({invalid_route, {123, h}}, roadrunner_router:compile(Routes, [])).
+
 %% --- helpers ---
 
 %% Drop the pipeline (4th element) and state (5th) so the handler


### PR DESCRIPTION
# Description

`roadrunner_listener:reload_routes/2` compiled the replacement table inside `handle_call`, and `roadrunner_router:compile/2` raises on a table that cannot work. One typo in a route list therefore took down the listener, dropping every live connection, and took the calling process with it, all while the table already serving was perfectly fine. The check now runs as `roadrunner_router:validate/1`, which returns the same verdict as a value, so a bad table is refused whole and the running one is untouched. `compile/2` calls the same function and raises what it returns, so boot still fails fast and the two can never disagree about which tables are workable.

```erlang
roadrunner_listener:reload_routes(Name, [{~"/old", h}, {~"/old", h}]).
%% before: listener terminates, caller exits with it
%% after:  {error, {unreachable_route, 2, ~"/old", [{1, ~"/old"}]}}, listener keeps serving /old
```

`validate/1` covers everything decidable from the table itself: entry shapes, method allowlists, wildcard placement and reachability. A malformed entry now reports `{invalid_route, Route}` rather than a bare `function_clause`, and the reasons are named as an exported `t:roadrunner_router:validation_error/0`. A per-route middleware that crashes in its own `init/1` still fails the loud way, the same as at listener start, and the docs say so.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)