### PR TITLE
Skip redundant lowercase scans on the header hot path

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -450,8 +450,10 @@ more machinery than the surrounding hot-path work shipped so far. The
 measurement supports it: paired microbench, median of 15 rounds, shows a
 hit at 9-13 ns against 71 ns (`Host`), 195 ns (`Accept-Encoding`) and 431 ns
 (`Access-Control-Request-Headers`), while a miss costs 9-14 ns and, tested
-at 36 entries, does not grow with table size. HTTP/1 clients send
-Title-Case names, so a typical request is mostly hits.
+at 36 hand-written entries, does not grow with table size. Re-check that
+last point once the table is generated: a larger generated set is a
+different input to the compiler's trie construction than the one measured.
+HTTP/1 clients send Title-Case names, so a typical request is mostly hits.
 
 **Careful:** this is not the validate-plus-lowercase *fusion* that was
 measured and reverted (that one lost 667 ns/call on Title-Case names). The

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -434,6 +434,38 @@ Revisit only if a real workload reports false `slow_client` drops.
 
 **Scope:** small.
 
+### Intern common header names in the h1 name parser
+
+**What:** Give `roadrunner_http1:validate_and_lowercase_name/1` a table of
+literal clause heads for the canonical casing of the common request header
+names (`Host`, `Connection`, `Accept-Encoding`, ...), each returning the
+lowercase literal directly, ahead of the existing `scan_name_lower/1` walk.
+A hit replaces the validate walk plus the lowercase walk plus the
+`iolist_to_binary` copy with a single comparison, and hands back a shared
+literal instead of a freshly allocated sub-binary of the request buffer.
+
+**Why deferred:** it needs a generated table plus a property test asserting
+every entry equals roadrunner_bin:ascii_lowercase/1 of its key, which is
+more machinery than the surrounding hot-path work shipped so far. The
+measurement supports it: paired microbench, median of 15 rounds, shows a
+hit at 9-13 ns against 71 ns (`Host`), 195 ns (`Accept-Encoding`) and 431 ns
+(`Access-Control-Request-Headers`), while a miss costs 9-14 ns and, tested
+at 36 entries, does not grow with table size. HTTP/1 clients send
+Title-Case names, so a typical request is mostly hits.
+
+**Careful:** this is not the validate-plus-lowercase *fusion* that was
+measured and reverted (that one lost 667 ns/call on Title-Case names). The
+two-pass scan stays exactly as it is; the table only sits in front of it.
+
+**Related, smaller:** `roadrunner_bin:has_uppercase/1` walks one byte per
+call. A 32-bit SWAR word-at-a-time scan measured 23-37% faster on
+lowercase inputs and 1.2 ns slower on an early uppercase exit, which would
+speed up every remaining ascii_lowercase/1 caller including the public
+`roadrunner_req:header/2`. Worth it only if the interning work does not
+already remove the calls that matter.
+
+**Scope:** medium.
+
 ## Per-route framework knobs the map shape unlocks
 
 The map-shape route entry (`#{path => ..., handler => ..., state =>

--- a/src/roadrunner_compress.erl
+++ b/src/roadrunner_compress.erl
@@ -238,7 +238,7 @@ encoding_token(deflate) -> ~"deflate".
 %% effective q > 0.
 -spec negotiate_encoding(roadrunner_req:request()) -> encoding().
 negotiate_encoding(Req) ->
-    case roadrunner_req:header(~"accept-encoding", Req) of
+    case roadrunner_req:header_normalized(~"accept-encoding", Req) of
         undefined ->
             none;
         Value ->

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -670,7 +670,7 @@ has_continue_expectation(#{cached_decisions := #{expects_continue := EC}}) ->
 has_continue_expectation(Req) ->
     %% Manually-built request maps (tests, middleware) skip the parse-time
     %% precompute — fall back to the lowercase-and-compare path.
-    case roadrunner_req:header(~"expect", Req) of
+    case roadrunner_req:header_normalized(~"expect", Req) of
         undefined -> false;
         Value -> roadrunner_bin:ascii_lowercase(Value) =:= ~"100-continue"
     end.
@@ -718,7 +718,7 @@ body_framing(#{cached_decisions := #{content_length := CL}}) ->
     end;
 body_framing(Req) ->
     %% Manually-built request maps without cached_decisions — full path.
-    case roadrunner_req:header(~"transfer-encoding", Req) of
+    case roadrunner_req:header_normalized(~"transfer-encoding", Req) of
         undefined ->
             case content_length(Req) of
                 none -> none;
@@ -1062,7 +1062,7 @@ fill_iolist(Need, Recv) ->
 -spec content_length(roadrunner_req:request()) ->
     none | {ok, non_neg_integer()} | {error, bad_content_length}.
 content_length(Req) ->
-    case roadrunner_req:header(~"content-length", Req) of
+    case roadrunner_req:header_normalized(~"content-length", Req) of
         undefined ->
             none;
         Bin ->
@@ -1185,7 +1185,7 @@ keep_alive_decision_full(Req, RespHeaders) ->
 req_connection_lower(#{cached_decisions := #{connection_lower := V}}) ->
     V;
 req_connection_lower(Req) ->
-    case roadrunner_req:header(~"connection", Req) of
+    case roadrunner_req:header_normalized(~"connection", Req) of
         undefined -> ~"";
         V -> roadrunner_bin:ascii_lowercase(V)
     end.

--- a/src/roadrunner_cors.erl
+++ b/src/roadrunner_cors.erl
@@ -129,7 +129,7 @@ compile_allow_headers(Config) ->
 -spec call(roadrunner_req:request(), roadrunner_middleware:next(), state()) ->
     roadrunner_handler:result().
 call(Req, Next, #cors{} = State) ->
-    case roadrunner_req:header(~"origin", Req) of
+    case roadrunner_req:header_normalized(~"origin", Req) of
         undefined ->
             %% Not a CORS request — nothing to do.
             Next(Req);
@@ -149,7 +149,7 @@ call(Req, Next, #cors{} = State) ->
 -spec is_preflight(roadrunner_req:request()) -> boolean().
 is_preflight(Req) ->
     roadrunner_req:method(Req) =:= ~"OPTIONS" andalso
-        roadrunner_req:header(~"access-control-request-method", Req) =/= undefined.
+        roadrunner_req:header_normalized(~"access-control-request-method", Req) =/= undefined.
 
 %% =============================================================================
 %% Preflight (204)
@@ -183,7 +183,7 @@ preflight_response(#cors{origins = Origins} = State, Origin, Req) ->
 preflight_headers(#cors{reflect_headers = false, preflight_static = Static}, _Req) ->
     Static;
 preflight_headers(#cors{reflect_headers = true, preflight_static = Static}, Req) ->
-    case roadrunner_req:header(~"access-control-request-headers", Req) of
+    case roadrunner_req:header_normalized(~"access-control-request-headers", Req) of
         undefined ->
             Static;
         Requested ->

--- a/src/roadrunner_etag.erl
+++ b/src/roadrunner_etag.erl
@@ -71,7 +71,7 @@ conditional_method(_) -> false.
     roadrunner_handler:response().
 conditional(Req, Headers, Body) ->
     ETag = etag(Headers, Body),
-    case roadrunner_req:header(~"if-none-match", Req) of
+    case roadrunner_req:header_normalized(~"if-none-match", Req) of
         undefined ->
             {200, with_etag(Headers, ETag), Body};
         IfNoneMatch ->

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -620,6 +620,14 @@ compute_cached_decisions(Headers) ->
     roadrunner_req:cached_decisions().
 compute_cached_decisions_loop([], Acc) ->
     Acc;
+%% Each field's canonical lowercase value gets a literal clause ahead
+%% of that field's general clause. The literal is its own lowercase, so
+%% `ascii_lowercase/1` would walk it only to hand back the same term;
+%% matching the clause head compares it once instead.
+compute_cached_decisions_loop([{~"transfer-encoding", ~"chunked"} | Rest], Acc) ->
+    compute_cached_decisions_loop(Rest, Acc#{
+        has_transfer_encoding := true, is_chunked := true
+    });
 compute_cached_decisions_loop([{~"transfer-encoding", V} | Rest], Acc) ->
     %% Set both keys in a single map update on the chunked path — two
     %% sequential `:=` updates would allocate two map terms.
@@ -629,6 +637,8 @@ compute_cached_decisions_loop([{~"transfer-encoding", V} | Rest], Acc) ->
             _ -> Acc#{has_transfer_encoding := true}
         end,
     compute_cached_decisions_loop(Rest, Acc1);
+compute_cached_decisions_loop([{~"expect", ~"100-continue"} | Rest], Acc) ->
+    compute_cached_decisions_loop(Rest, Acc#{expects_continue := true});
 compute_cached_decisions_loop([{~"expect", V} | Rest], Acc) ->
     Acc1 =
         case roadrunner_bin:ascii_lowercase(V) of
@@ -636,6 +646,10 @@ compute_cached_decisions_loop([{~"expect", V} | Rest], Acc) ->
             _ -> Acc
         end,
     compute_cached_decisions_loop(Rest, Acc1);
+compute_cached_decisions_loop([{~"connection", ~"keep-alive"} | Rest], Acc) ->
+    compute_cached_decisions_loop(Rest, Acc#{connection_lower := ~"keep-alive"});
+compute_cached_decisions_loop([{~"connection", ~"close"} | Rest], Acc) ->
+    compute_cached_decisions_loop(Rest, Acc#{connection_lower := ~"close"});
 compute_cached_decisions_loop([{~"connection", V} | Rest], Acc) ->
     compute_cached_decisions_loop(
         Rest, Acc#{connection_lower := roadrunner_bin:ascii_lowercase(V)}

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -166,6 +166,7 @@ to absorb a chunk's payload across multiple length-bounded calls.
     version/1,
     headers/1,
     header/2,
+    header_normalized/2,
     has_header/2,
     parse_qs/1,
     parse_cookies/1,
@@ -255,6 +256,24 @@ before searching.
 header(Name, #{headers := H}) when is_binary(Name) ->
     Lower = roadrunner_bin:ascii_lowercase(Name),
     case lists:keyfind(Lower, 1, H) of
+        {_, Value} -> Value;
+        false -> undefined
+    end.
+
+%% Look up a header by a name that is already lowercase — the form
+%% `roadrunner_http1:parse_header/1` stores and the form every
+%% framework-internal call site passes as a literal. Skips the
+%% case-normalizing scan `header/2` runs per call, which is dead work
+%% on a name that is its own lowercase. Handler code wants `header/2`,
+%% which accepts any casing.
+%%
+%% The lookup is spelled out rather than shared with `header/2`: a
+%% common helper adds a call to both, and `header/2` is hot enough for
+%% handlers that the indirection measured as a ~2 % regression there.
+-doc false.
+-spec header_normalized(binary(), request()) -> binary() | undefined.
+header_normalized(Name, #{headers := H}) when is_binary(Name) ->
+    case lists:keyfind(Name, 1, H) of
         {_, Value} -> Value;
         false -> undefined
     end.

--- a/src/roadrunner_req.erl
+++ b/src/roadrunner_req.erl
@@ -463,6 +463,13 @@ read_form(Req) ->
             dispatch_form(content_type_kind(ContentType), ContentType, Req)
     end.
 
+%% Split the parameters off before lowercasing, never after. Only the
+%% type token is case-insensitive (RFC 9110 §8.3.1); the parameters
+%% carry the multipart boundary, which is case-sensitive and is read
+%% from the untouched `ContentType` by `roadrunner_multipart:boundary/1`.
+%% Lowercasing the whole value first would corrupt that boundary, and
+%% would walk and copy it on the way: `----WebKitFormBoundary...` is
+%% the one long mixed-case run a normal request carries.
 -spec content_type_kind(binary()) -> urlencoded | multipart | unsupported.
 content_type_kind(ContentType) ->
     [Type | _] = binary:split(ContentType, persistent_term:get(?SEMI_CP_KEY)),

--- a/src/roadrunner_static.erl
+++ b/src/roadrunner_static.erl
@@ -338,7 +338,7 @@ serve_regular_file(FilePath, Size, Mtime, ETag, LastMod, Siblings, Req) ->
     roadrunner_req:request()
 ) -> {ok, roadrunner_handler:response()} | none.
 maybe_serve_precompressed(FilePath, ETag, LastMod, Siblings, Req) ->
-    case roadrunner_req:header(~"range", Req) of
+    case roadrunner_req:header_normalized(~"range", Req) of
         undefined ->
             case choose_sibling(FilePath, Siblings, Req) of
                 {Encoding, SiblingPath, SiblingSize} ->
@@ -359,7 +359,7 @@ maybe_serve_precompressed(FilePath, ETag, LastMod, Siblings, Req) ->
 -spec choose_sibling(file:filename_all(), lazy | siblings(), roadrunner_req:request()) ->
     {binary(), binary(), non_neg_integer()} | none.
 choose_sibling(FilePath, Siblings, Req) ->
-    AcceptEnc = roadrunner_req:header(~"accept-encoding", Req),
+    AcceptEnc = roadrunner_req:header_normalized(~"accept-encoding", Req),
     case try_encoding(FilePath, br, ~"br", AcceptEnc, Siblings) of
         none -> try_encoding(FilePath, gz, ~"gzip", AcceptEnc, Siblings);
         Chosen -> Chosen
@@ -451,7 +451,7 @@ is_cached(Req, ETag, Mtime) ->
 
 -spec if_modified_since_satisfied(roadrunner_req:request(), integer()) -> boolean().
 if_modified_since_satisfied(Req, Mtime) ->
-    case roadrunner_req:header(~"if-modified-since", Req) of
+    case roadrunner_req:header_normalized(~"if-modified-since", Req) of
         undefined ->
             false;
         Value ->
@@ -472,7 +472,7 @@ if_modified_since_satisfied(Req, Mtime) ->
     roadrunner_req:request()
 ) -> roadrunner_handler:response().
 serve_with_range(FilePath, Size, ETag, LastMod, Req) ->
-    case parse_range(roadrunner_req:header(~"range", Req), Size) of
+    case parse_range(roadrunner_req:header_normalized(~"range", Req), Size) of
         {range, Start, End} ->
             serve_range(FilePath, Size, ETag, LastMod, Start, End);
         unsatisfiable ->
@@ -512,7 +512,7 @@ etag(Size, Mtime) ->
 
 -spec if_none_match(roadrunner_req:request()) -> binary() | undefined.
 if_none_match(Req) ->
-    roadrunner_req:header(~"if-none-match", Req).
+    roadrunner_req:header_normalized(~"if-none-match", Req).
 
 %% Parse a `Range: bytes=N-M`, `bytes=N-`, or `bytes=-S` header against
 %% the file `Size`. `none` means "ignore Range and serve the full body"


### PR DESCRIPTION
# Description

Every framework-internal header lookup passes a compile-time lowercase literal, so `roadrunner_req:header/2` was walking the name to lowercase it before the keyfind. A `header_normalized/2` twin skips that scan, and the HTTP/1 parse loop gets literal clause heads for the canonical `Connection`, `Transfer-Encoding` and `Expect` values, each already its own lowercase. Public `header/2` is untouched.

```erlang
%% roadrunner_compress, and 13 other internal call sites
roadrunner_req:header_normalized(~"accept-encoding", Req)
```

Paired microbench, median of 15 rounds: the `accept-encoding` lookup goes 70 ns to 30 ns, `connection: keep-alive` 43 ns to 26 ns.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
