### PR TITLE
Intern common request-header names in the h1 name parser

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -434,39 +434,24 @@ Revisit only if a real workload reports false `slow_client` drops.
 
 **Scope:** small.
 
-### Intern common header names in the h1 name parser
+### SWAR scan for has_uppercase
 
-**What:** Give `roadrunner_http1:validate_and_lowercase_name/1` a table of
-literal clause heads for the canonical casing of the common request header
-names (`Host`, `Connection`, `Accept-Encoding`, ...), each returning the
-lowercase literal directly, ahead of the existing `scan_name_lower/1` walk.
-A hit replaces the validate walk plus the lowercase walk plus the
-`iolist_to_binary` copy with a single comparison, and hands back a shared
-literal instead of a freshly allocated sub-binary of the request buffer.
+**What:** `roadrunner_bin:has_uppercase/1` walks one byte per call, gating
+every `ascii_lowercase/1`. A 32-bit SWAR word-at-a-time scan (false
+positives are fine, the caller falls through to the correct walk either
+way) measured 23-37% faster on lowercase inputs and 1.2 ns slower on an
+early uppercase exit.
 
-**Why deferred:** it needs a generated table plus a property test asserting
-every entry equals roadrunner_bin:ascii_lowercase/1 of its key, which is
-more machinery than the surrounding hot-path work shipped so far. The
-measurement supports it: paired microbench, median of 15 rounds, shows a
-hit at 9-13 ns against 71 ns (`Host`), 195 ns (`Accept-Encoding`) and 431 ns
-(`Access-Control-Request-Headers`), while a miss costs 9-14 ns and, tested
-at 36 hand-written entries, does not grow with table size. Re-check that
-last point once the table is generated: a larger generated set is a
-different input to the compiler's trie construction than the one measured.
-HTTP/1 clients send Title-Case names, so a typical request is mostly hits.
+**Why deferred:** interning the h1 header names removed the callers that
+dominated this, so what is left is the public `roadrunner_req:header/2`
+plus the short Connection / Transfer-Encoding / Expect / Upgrade values,
+all of them a handful of bytes where the win is a few ns. 64-bit SWAR is
+not available: an Erlang small integer is 60 bits on a 64-bit VM, so a
+full word forces a bignum and the allocation costs more than the scan
+saves. Wants a real workload showing the remaining calls matter before
+adding bit-twiddling to a function whose current form is obvious.
 
-**Careful:** this is not the validate-plus-lowercase *fusion* that was
-measured and reverted (that one lost 667 ns/call on Title-Case names). The
-two-pass scan stays exactly as it is; the table only sits in front of it.
-
-**Related, smaller:** `roadrunner_bin:has_uppercase/1` walks one byte per
-call. A 32-bit SWAR word-at-a-time scan measured 23-37% faster on
-lowercase inputs and 1.2 ns slower on an early uppercase exit, which would
-speed up every remaining ascii_lowercase/1 caller including the public
-`roadrunner_req:header/2`. Worth it only if the interning work does not
-already remove the calls that matter.
-
-**Scope:** medium.
+**Scope:** small.
 
 ## Per-route framework knobs the map shape unlocks
 

--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -344,6 +344,123 @@ classify_header(NameRaw, ValueRaw, Rest) ->
 -spec validate_and_lowercase_name(binary()) -> {ok, binary()} | error.
 validate_and_lowercase_name(<<>>) ->
     error;
+%% Interned canonical request-header names. Each clause head compiles
+%% to a `bs_match_string`, and the compiler folds the whole set into a
+%% shared-prefix decision tree, so a hit costs one comparison instead
+%% of the validate walk, the lowercase walk and the `iolist_to_binary`
+%% copy below, and yields a shared literal rather than a fresh binary.
+%% A miss falls through to the general path unchanged.
+%%
+%% Every entry carries an uppercase byte: an already-lowercase name
+%% reaches `{ok, Bin}` via `scan_name_lower/1` without allocating, so
+%% interning one would buy nothing. `roadrunner_http1_tests` drives
+%% each entry, which is also what keeps this list and that one in
+%% step: adding a clause here without adding it there drops coverage
+%% below the 100 % the precommit gate requires.
+validate_and_lowercase_name(~"Accept") ->
+    {ok, ~"accept"};
+validate_and_lowercase_name(~"Accept-Charset") ->
+    {ok, ~"accept-charset"};
+validate_and_lowercase_name(~"Accept-Encoding") ->
+    {ok, ~"accept-encoding"};
+validate_and_lowercase_name(~"Accept-Language") ->
+    {ok, ~"accept-language"};
+validate_and_lowercase_name(~"Access-Control-Request-Headers") ->
+    {ok, ~"access-control-request-headers"};
+validate_and_lowercase_name(~"Access-Control-Request-Method") ->
+    {ok, ~"access-control-request-method"};
+validate_and_lowercase_name(~"Authorization") ->
+    {ok, ~"authorization"};
+validate_and_lowercase_name(~"Cache-Control") ->
+    {ok, ~"cache-control"};
+validate_and_lowercase_name(~"Connection") ->
+    {ok, ~"connection"};
+validate_and_lowercase_name(~"Content-Disposition") ->
+    {ok, ~"content-disposition"};
+validate_and_lowercase_name(~"Content-Encoding") ->
+    {ok, ~"content-encoding"};
+validate_and_lowercase_name(~"Content-Language") ->
+    {ok, ~"content-language"};
+validate_and_lowercase_name(~"Content-Length") ->
+    {ok, ~"content-length"};
+validate_and_lowercase_name(~"Content-Type") ->
+    {ok, ~"content-type"};
+validate_and_lowercase_name(~"Cookie") ->
+    {ok, ~"cookie"};
+validate_and_lowercase_name(~"Date") ->
+    {ok, ~"date"};
+validate_and_lowercase_name(~"DNT") ->
+    {ok, ~"dnt"};
+validate_and_lowercase_name(~"Expect") ->
+    {ok, ~"expect"};
+validate_and_lowercase_name(~"Forwarded") ->
+    {ok, ~"forwarded"};
+validate_and_lowercase_name(~"From") ->
+    {ok, ~"from"};
+validate_and_lowercase_name(~"Host") ->
+    {ok, ~"host"};
+validate_and_lowercase_name(~"If-Match") ->
+    {ok, ~"if-match"};
+validate_and_lowercase_name(~"If-Modified-Since") ->
+    {ok, ~"if-modified-since"};
+validate_and_lowercase_name(~"If-None-Match") ->
+    {ok, ~"if-none-match"};
+validate_and_lowercase_name(~"If-Range") ->
+    {ok, ~"if-range"};
+validate_and_lowercase_name(~"If-Unmodified-Since") ->
+    {ok, ~"if-unmodified-since"};
+validate_and_lowercase_name(~"Max-Forwards") ->
+    {ok, ~"max-forwards"};
+validate_and_lowercase_name(~"Origin") ->
+    {ok, ~"origin"};
+validate_and_lowercase_name(~"Pragma") ->
+    {ok, ~"pragma"};
+validate_and_lowercase_name(~"Proxy-Authorization") ->
+    {ok, ~"proxy-authorization"};
+validate_and_lowercase_name(~"Range") ->
+    {ok, ~"range"};
+validate_and_lowercase_name(~"Referer") ->
+    {ok, ~"referer"};
+validate_and_lowercase_name(~"Sec-Fetch-Dest") ->
+    {ok, ~"sec-fetch-dest"};
+validate_and_lowercase_name(~"Sec-Fetch-Mode") ->
+    {ok, ~"sec-fetch-mode"};
+validate_and_lowercase_name(~"Sec-Fetch-Site") ->
+    {ok, ~"sec-fetch-site"};
+validate_and_lowercase_name(~"Sec-Fetch-User") ->
+    {ok, ~"sec-fetch-user"};
+validate_and_lowercase_name(~"Sec-WebSocket-Extensions") ->
+    {ok, ~"sec-websocket-extensions"};
+validate_and_lowercase_name(~"Sec-WebSocket-Key") ->
+    {ok, ~"sec-websocket-key"};
+validate_and_lowercase_name(~"Sec-WebSocket-Protocol") ->
+    {ok, ~"sec-websocket-protocol"};
+validate_and_lowercase_name(~"Sec-WebSocket-Version") ->
+    {ok, ~"sec-websocket-version"};
+validate_and_lowercase_name(~"TE") ->
+    {ok, ~"te"};
+validate_and_lowercase_name(~"Trailer") ->
+    {ok, ~"trailer"};
+validate_and_lowercase_name(~"Transfer-Encoding") ->
+    {ok, ~"transfer-encoding"};
+validate_and_lowercase_name(~"Upgrade") ->
+    {ok, ~"upgrade"};
+validate_and_lowercase_name(~"Upgrade-Insecure-Requests") ->
+    {ok, ~"upgrade-insecure-requests"};
+validate_and_lowercase_name(~"User-Agent") ->
+    {ok, ~"user-agent"};
+validate_and_lowercase_name(~"Via") ->
+    {ok, ~"via"};
+validate_and_lowercase_name(~"X-Forwarded-For") ->
+    {ok, ~"x-forwarded-for"};
+validate_and_lowercase_name(~"X-Forwarded-Host") ->
+    {ok, ~"x-forwarded-host"};
+validate_and_lowercase_name(~"X-Forwarded-Proto") ->
+    {ok, ~"x-forwarded-proto"};
+validate_and_lowercase_name(~"X-Real-IP") ->
+    {ok, ~"x-real-ip"};
+validate_and_lowercase_name(~"X-Requested-With") ->
+    {ok, ~"x-requested-with"};
 validate_and_lowercase_name(Bin) ->
     case scan_name_lower(Bin) of
         lower -> {ok, Bin};

--- a/test/property_test/roadrunner_http1_props.erl
+++ b/test/property_test/roadrunner_http1_props.erl
@@ -89,6 +89,90 @@ feed(Fn, <<C, Rest/binary>>, Buf) ->
     end.
 
 %% =============================================================================
+%% Header-name normalization: the interned literal clauses in
+%% `validate_and_lowercase_name/1` must be indistinguishable from the
+%% general validate-and-lowercase path they short-circuit.
+%% =============================================================================
+
+prop_parse_header_name_matches_reference() ->
+    ?FORALL(
+        Name,
+        header_name_bytes(),
+        roadrunner_http1:parse_header(<<Name/binary, ": v\r\n">>) =:=
+            reference_header_name(Name)
+    ).
+
+%% What the parser must produce, derived independently of how it does
+%% it: a name of one or more tchars lowercases, anything else is
+%% rejected.
+reference_header_name(Name) ->
+    case is_tchar_name(Name) of
+        true -> {ok, roadrunner_bin:ascii_lowercase(Name), ~"v", ~""};
+        false -> {error, bad_header}
+    end.
+
+is_tchar_name(<<>>) -> false;
+is_tchar_name(Bin) -> lists:all(fun is_tchar/1, binary_to_list(Bin)).
+
+is_tchar(C) when C >= $a, C =< $z -> true;
+is_tchar(C) when C >= $A, C =< $Z -> true;
+is_tchar(C) when C >= $0, C =< $9 -> true;
+is_tchar(C) -> lists:member(C, "!#$%&'*+-.^_`|~").
+
+%% Half arbitrary names, half re-casings of names the parser interns, so
+%% the generator lands on the literal clauses and on the near-misses one
+%% flipped byte away from them. `:`, CR and LF are excluded because they
+%% frame the line rather than the name; arbitrary binaries are already
+%% covered by `prop_parse_header_never_crashes/0`.
+header_name_bytes() ->
+    oneof([arbitrary_name(), recased_common_name()]).
+
+arbitrary_name() ->
+    ?LET(Cs, non_empty(list(name_byte())), list_to_binary(Cs)).
+
+name_byte() ->
+    frequency([
+        {60, oneof(lists:seq($a, $z) ++ lists:seq($A, $Z))},
+        {15, $-},
+        {10, oneof(lists:seq($0, $9))},
+        {10, oneof("!#$%&'*+.^_`|~")},
+        {5, oneof("()@,;=\" <>?{}[]\\")}
+    ]).
+
+recased_common_name() ->
+    ?LET(
+        {Name, Flips},
+        {common_name(), list(boolean())},
+        recase(Name, Flips)
+    ).
+
+common_name() ->
+    oneof([
+        ~"Host",
+        ~"TE",
+        ~"Accept-Encoding",
+        ~"Content-Type",
+        ~"User-Agent",
+        ~"Sec-WebSocket-Key",
+        ~"Access-Control-Request-Headers",
+        ~"X-Forwarded-For"
+    ]).
+
+recase(Bin, []) -> Bin;
+recase(<<>>, _) -> <<>>;
+recase(<<C, R/binary>>, [Flip | Fs]) ->
+    Head =
+        case Flip of
+            true -> flip_case(C);
+            false -> C
+        end,
+    <<Head, (recase(R, Fs))/binary>>.
+
+flip_case(C) when C >= $a, C =< $z -> C - 32;
+flip_case(C) when C >= $A, C =< $Z -> C + 32;
+flip_case(C) -> C.
+
+%% =============================================================================
 %% Generators
 %% =============================================================================
 

--- a/test/roadrunner_http1_tests.erl
+++ b/test/roadrunner_http1_tests.erl
@@ -191,6 +191,109 @@ header_lowercases_name_test() ->
         roadrunner_http1:parse_header(~"Content-Type: text/html\r\n")
     ).
 
+%% Every name interned as a literal clause in
+%% `roadrunner_http1:validate_and_lowercase_name/1`. Driving each one is
+%% what keeps this list and that one in step: a clause added there and
+%% not here leaves that clause uncovered, and the precommit gate
+%% requires full coverage.
+interned_header_names() ->
+    [
+        ~"Accept",
+        ~"Accept-Charset",
+        ~"Accept-Encoding",
+        ~"Accept-Language",
+        ~"Access-Control-Request-Headers",
+        ~"Access-Control-Request-Method",
+        ~"Authorization",
+        ~"Cache-Control",
+        ~"Connection",
+        ~"Content-Disposition",
+        ~"Content-Encoding",
+        ~"Content-Language",
+        ~"Content-Length",
+        ~"Content-Type",
+        ~"Cookie",
+        ~"Date",
+        ~"DNT",
+        ~"Expect",
+        ~"Forwarded",
+        ~"From",
+        ~"Host",
+        ~"If-Match",
+        ~"If-Modified-Since",
+        ~"If-None-Match",
+        ~"If-Range",
+        ~"If-Unmodified-Since",
+        ~"Max-Forwards",
+        ~"Origin",
+        ~"Pragma",
+        ~"Proxy-Authorization",
+        ~"Range",
+        ~"Referer",
+        ~"Sec-Fetch-Dest",
+        ~"Sec-Fetch-Mode",
+        ~"Sec-Fetch-Site",
+        ~"Sec-Fetch-User",
+        ~"Sec-WebSocket-Extensions",
+        ~"Sec-WebSocket-Key",
+        ~"Sec-WebSocket-Protocol",
+        ~"Sec-WebSocket-Version",
+        ~"TE",
+        ~"Trailer",
+        ~"Transfer-Encoding",
+        ~"Upgrade",
+        ~"Upgrade-Insecure-Requests",
+        ~"User-Agent",
+        ~"Via",
+        ~"X-Forwarded-For",
+        ~"X-Forwarded-Host",
+        ~"X-Forwarded-Proto",
+        ~"X-Real-IP",
+        ~"X-Requested-With"
+    ].
+
+%% The interned clause must return exactly what the general
+%% validate-and-lowercase path would have returned for the same name.
+header_interned_names_test_() ->
+    [
+        {
+            binary_to_list(Name),
+            ?_assertEqual(
+                {ok, roadrunner_bin:ascii_lowercase(Name), ~"v", ~""},
+                roadrunner_http1:parse_header(<<Name/binary, ": v\r\n">>)
+            )
+        }
+     || Name <- interned_header_names()
+    ].
+
+%% A near-miss sharing a long prefix with an interned name must still
+%% take the general path rather than the clause it almost matched.
+header_interned_near_miss_test_() ->
+    [
+        ?_assertEqual(
+            {ok, ~"accept-encodinx", ~"v", ~""},
+            roadrunner_http1:parse_header(~"Accept-Encodinx: v\r\n")
+        ),
+        ?_assertEqual(
+            {ok, ~"hos", ~"v", ~""},
+            roadrunner_http1:parse_header(~"Hos: v\r\n")
+        ),
+        ?_assertEqual(
+            {ok, ~"hostx", ~"v", ~""},
+            roadrunner_http1:parse_header(~"Hostx: v\r\n")
+        ),
+        %% Same name, a casing no interned clause covers.
+        ?_assertEqual(
+            {ok, ~"host", ~"v", ~""},
+            roadrunner_http1:parse_header(~"hOST: v\r\n")
+        ),
+        %% An interned name with a non-tchar byte appended is still rejected.
+        ?_assertEqual(
+            {error, bad_header},
+            roadrunner_http1:parse_header(~"Host(: v\r\n")
+        )
+    ].
+
 header_allows_digit_in_name_test() ->
     ?assertEqual(
         {ok, ~"x1-y2", ~"foo", ~""},

--- a/test/roadrunner_property_SUITE.erl
+++ b/test/roadrunner_property_SUITE.erl
@@ -24,6 +24,7 @@ Add a new property:
     cookie_parse_returns_well_formed_pairs/1,
     http1_parse_request_line_never_crashes/1,
     http1_parse_header_never_crashes/1,
+    http1_parse_header_name_matches_reference/1,
     http1_parse_headers_never_crashes/1,
     http1_parse_request_never_crashes/1,
     http1_parse_chunk_never_crashes/1,
@@ -60,6 +61,7 @@ all() ->
         cookie_parse_returns_well_formed_pairs,
         http1_parse_request_line_never_crashes,
         http1_parse_header_never_crashes,
+        http1_parse_header_name_matches_reference,
         http1_parse_headers_never_crashes,
         http1_parse_request_never_crashes,
         http1_parse_chunk_never_crashes,
@@ -129,6 +131,12 @@ http1_parse_request_line_never_crashes(Config) ->
 http1_parse_header_never_crashes(Config) ->
     ct_property_test:quickcheck(
         roadrunner_http1_props:prop_parse_header_never_crashes(),
+        Config
+    ).
+
+http1_parse_header_name_matches_reference(Config) ->
+    ct_property_test:quickcheck(
+        roadrunner_http1_props:prop_parse_header_name_matches_reference(),
         Config
     ).
 


### PR DESCRIPTION
# Description

Fifty-two canonical request-header names get a literal clause head in `roadrunner_http1:validate_and_lowercase_name/1`, so the common case skips the tchar walk, the lowercase walk and the `iolist_to_binary` copy, and returns a shared literal instead of a fresh binary. A miss falls through to the existing scan unchanged, and the compiler folds the clause heads into a shared-prefix decision tree, so miss cost stays flat as the table grows.

```erlang
validate_and_lowercase_name(~"Accept-Encoding") -> {ok, ~"accept-encoding"};
```

Paired microbench, min of 21 rounds: `Host` 70 ns to 9 ns, `Accept-Encoding` 184 ns to 11 ns, `Access-Control-Request-Headers` 408 ns to 12 ns.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
