### PR TITLE
Note why the interned name table has no first-byte gate

### DIFF
--- a/src/roadrunner_http1.erl
+++ b/src/roadrunner_http1.erl
@@ -351,6 +351,12 @@ validate_and_lowercase_name(<<>>) ->
 %% copy below, and yields a shared literal rather than a fresh binary.
 %% A miss falls through to the general path unchanged.
 %%
+%% Deliberately no first-byte uppercase gate in front of the table.
+%% Every entry does start uppercase, so gating looks like it would let
+%% lowercase names skip the lot, but the decision tree already
+%% discriminates from byte 0: adding the gate saved 0.09 ns on a
+%% lowercase miss and cost every hit a redundant test.
+%%
 %% Every entry carries an uppercase byte: an already-lowercase name
 %% reaches `{ok, Bin}` via `scan_name_lower/1` without allocating, so
 %% interning one would buy nothing. `roadrunner_http1_tests` drives


### PR DESCRIPTION
# Description

Records why the interned header-name table in `roadrunner_http1:validate_and_lowercase_name/1` has no first-byte uppercase gate. Every entry starts uppercase, so gating the table looks like an easy win, but the compiler's decision tree already discriminates from byte 0: adding the gate saved 0.09 ns on a lowercase miss and cost every hit a redundant test. Comment only, no behaviour change.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
