### PR TITLE
Add a ws buffer listener opt to bound per-session socket memory

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -246,6 +246,25 @@ own measurement before shipping.
 
 **Scope:** small.
 
+### Hibernate the conn process while a WebSocket session runs
+
+**What:** During a WebSocket session the parent conn process only
+holds a monitor on the session and forwards drain broadcasts
+(`roadrunner_ws_session:wait_for_session/2`), yet it keeps the heap it
+grew parsing the upgrade request (~5-7 KB measured under load) for the
+session's whole lifetime. Hibernating it would drop that to ~1 KB per
+connection — meaningful at high WebSocket concurrency (100K sessions
+hold ~500 MB of idle conn heaps today). Needs restructuring: hibernate
+discards the stack, so the wait must move into a `roadrunner_conn_loop`
+continuation that can still run the post-session drain + `exit_normal`
+path when the session's `'DOWN'` arrives.
+
+**Why deferred:** the `ws.buffer` opt removed the dominant
+per-session memory cost (the 64 KB inherited socket buffer); the conn
+heap is the next block but wants its own measured commit.
+
+**Scope:** small.
+
 ### h2 receive-window defaults
 
 **What:** Bump the listener's default receive-window peaks above the

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -102,6 +102,9 @@
     %% `roadrunner_listener:build_proto_opts/2` fills defaults.
     ws_max_frame_size := non_neg_integer(),
     ws_max_message_size := non_neg_integer(),
+    %% inet `buffer` applied to the socket on WebSocket upgrade;
+    %% `undefined` inherits the listener socket's 64 KB.
+    ws_buffer := pos_integer() | undefined,
     request_timeout := non_neg_integer(),
     keep_alive_timeout := non_neg_integer(),
     max_keep_alive_requests := pos_integer(),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -106,10 +106,13 @@ Optional middleware and timing knobs (durations in milliseconds):
 - `max_content_length` — request-body cap across HTTP/1.1, HTTP/2, and
   HTTP/3; an over-cap body answers `413 Payload Too Large` (and resets
   the stream on h2/h3). Default 10 MB.
-- `ws` — WebSocket inbound size caps as a nested map (see
+- `ws` — WebSocket session tunables as a nested map (see
   `t:ws_opts/0`): `max_frame_size` (per-frame payload cap) and
-  `max_message_size` (reassembled + decompressed message cap). Both
-  default to 10 MB; over-cap closes the connection with code 1009.
+  `max_message_size` (reassembled + decompressed message cap), both
+  defaulting to 10 MB with over-cap closing the connection with code
+  1009, plus `buffer` (per-session inet `buffer` override — bounds
+  per-connection memory at high WebSocket concurrency; inherits the
+  listener's 64 KB when unset).
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
 - `keep_alive_timeout` — idle timeout between requests on a
@@ -466,7 +469,7 @@ HTTP/3 listener tunables (under `{http3, ThisMap}` in `protocols`).
 }.
 
 -doc """
-WebSocket inbound size caps (under `ws` in the listener opts).
+WebSocket session tunables (under `ws` in the listener opts).
 
 - `max_frame_size` — per-frame payload cap in bytes. An inbound
   frame declaring more than this closes the connection with code
@@ -475,10 +478,25 @@ WebSocket inbound size caps (under `ws` in the listener opts).
   running fragment total, and the decompressed size when
   permessage-deflate is negotiated. Over-cap closes with 1009. Must
   be `>= max_frame_size`. Default 10 MB.
+- `buffer` — inet `buffer` (user-space receive buffer, bytes)
+  applied to the socket when a connection upgrades to a WebSocket
+  session. The emulator keeps a buffer of this size alive per
+  socket, so it bounds how many bytes one `{tcp, _, Data}` delivery
+  carries AND what every connection pays in resident memory. Unset
+  (the default) inherits the listener socket's 64 KB — sized for
+  HTTP request flow, where bodies arrive in bulk. Long-lived
+  WebSocket sessions that exchange small messages should set this
+  lower in production: at high connection counts the inherited
+  64 KB dominates per-connection memory (64 KB × connections),
+  while a few KB is plenty for message-sized deliveries. Large
+  inbound frames are still delivered correctly with a small buffer,
+  just across more deliveries — deployments streaming multi-KB
+  frames client→server should keep it larger.
 """.
 -type ws_opts() :: #{
     max_frame_size => 0..16#7FFFFFFF,
-    max_message_size => 0..16#7FFFFFFF
+    max_message_size => 0..16#7FFFFFFF,
+    buffer => 1..16#7FFFFFFF
 }.
 
 -record(state, {
@@ -1070,7 +1088,7 @@ build_proto_opts(Opts, ListenerName) ->
     %% Public `ws` opts are a nested map; flatten to the `ws_*`
     %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
     %% → `http2_*` flattening above.
-    #{max_frame_size := WsFrame, max_message_size := WsMsg} =
+    #{max_frame_size := WsFrame, max_message_size := WsMsg, buffer := WsBuffer} =
         validate_ws_opts(maps:get(ws, Opts, #{})),
     %% Flatten the nested `handler_spawn` opt to top-level proto_opts keys the
     %% spawn sites read directly, mirroring the `ws` / `http2` flattening above.
@@ -1083,6 +1101,7 @@ build_proto_opts(Opts, ListenerName) ->
                 maps:get(max_content_length, Opts, ?DEFAULT_MAX_CONTENT_LENGTH),
             ws_max_frame_size => WsFrame,
             ws_max_message_size => WsMsg,
+            ws_buffer => WsBuffer,
             request_timeout => maps:get(request_timeout, Opts, ?DEFAULT_REQUEST_TIMEOUT),
             keep_alive_timeout =>
                 maps:get(keep_alive_timeout, Opts, ?DEFAULT_KEEP_ALIVE_TIMEOUT),
@@ -1475,11 +1494,18 @@ flatten_http3_opts(Entries) ->
     end.
 
 -spec ws_defaults() ->
-    #{max_frame_size := non_neg_integer(), max_message_size := non_neg_integer()}.
+    #{
+        max_frame_size := non_neg_integer(),
+        max_message_size := non_neg_integer(),
+        buffer := undefined
+    }.
 ws_defaults() ->
     #{
         max_frame_size => ?DEFAULT_WS_MAX_FRAME_SIZE,
-        max_message_size => ?DEFAULT_WS_MAX_MESSAGE_SIZE
+        max_message_size => ?DEFAULT_WS_MAX_MESSAGE_SIZE,
+        %% `undefined` = no setopts on upgrade; the session keeps the
+        %% listener socket's inherited 64 KB `buffer`.
+        buffer => undefined
     }.
 
 %% Resolve the `ws` opts map against defaults, rejecting unknown keys
@@ -1488,15 +1514,18 @@ ws_defaults() ->
 %% frame is also a whole message: `max_message_size` below
 %% `max_frame_size` is contradictory and rejected at startup.
 -spec validate_ws_opts(term()) ->
-    #{max_frame_size := non_neg_integer(), max_message_size := non_neg_integer()}.
+    #{
+        max_frame_size := non_neg_integer(),
+        max_message_size := non_neg_integer(),
+        buffer := pos_integer() | undefined
+    }.
 validate_ws_opts(Opts) when is_map(Opts) ->
     Defaults = ws_defaults(),
     Resolved = maps:fold(
         fun(K, V, Acc) ->
-            case is_map_key(K, Defaults) of
-                false -> error({invalid_listener_opt, ws, Opts});
-                true when is_integer(V), V >= 0, V =< 16#7FFFFFFF -> Acc#{K => V};
-                true -> error({invalid_listener_opt, ws, Opts})
+            case is_map_key(K, Defaults) andalso valid_ws_opt(K, V) of
+                true -> Acc#{K => V};
+                false -> error({invalid_listener_opt, ws, Opts})
             end
         end,
         Defaults,
@@ -1508,6 +1537,15 @@ validate_ws_opts(Opts) when is_map(Opts) ->
     Resolved;
 validate_ws_opts(Other) ->
     error({invalid_listener_opt, ws, Other}).
+
+%% Per-key range check for the `ws` sub-opts. The size caps allow 0
+%% (reject every frame / message); `buffer` is an inet buffer size, so
+%% zero is meaningless and rejected.
+-spec valid_ws_opt(max_frame_size | max_message_size | buffer, term()) -> boolean().
+valid_ws_opt(buffer, V) ->
+    is_integer(V) andalso V >= 1 andalso V =< 16#7FFFFFFF;
+valid_ws_opt(_SizeCap, V) ->
+    is_integer(V) andalso V >= 0 andalso V =< 16#7FFFFFFF.
 
 %% Validate the `rate_limit` opt and, when set, create its per-listener ETS
 %% bucket store. `undefined` (the default) skips the guard entirely.

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -218,6 +218,7 @@ run_session(
     Buffered,
     #{handler_spawn_opts := SpawnOpts, handler_start_timeout := StartTimeout} = ProtoOpts
 ) ->
+    ok = apply_ws_buffer(Socket, ProtoOpts),
     Ctx = ws_context(Req, Mod),
     %% Start the session **before** writing the 101 to the wire so a
     %% start failure never leaves the upgrade response sent with no
@@ -258,6 +259,21 @@ run_session(
             ),
             ok
     end.
+
+%% Apply the `ws.buffer` listener opt: resize the socket's inet
+%% `buffer` for the session's lifetime, before the 101 goes out. The
+%% conn still owns the socket here. `undefined` (the default) keeps the
+%% listener socket's inherited 64 KB — sized for HTTP request flow;
+%% high-concurrency small-message deployments set it lower because the
+%% emulator holds a live buffer of this size per socket. A setopts
+%% failure means the socket already died; the session discovers that on
+%% its first receive, so the result is ignored rather than special-cased.
+-spec apply_ws_buffer(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) -> ok.
+apply_ws_buffer(_Socket, #{ws_buffer := undefined}) ->
+    ok;
+apply_ws_buffer(Socket, #{ws_buffer := Buffer}) ->
+    _ = roadrunner_transport:setopts(Socket, [{buffer, Buffer}]),
+    ok.
 
 %% The conn process is already a member of the listener's drain `pg`
 %% group via `roadrunner_conn:join_drain_group/2` (joined at conn

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -575,8 +575,31 @@ listener_rejects_invalid_ws_opt_test() ->
             }),
             ?assertMatch({error, {{invalid_listener_opt, ws, _}, _Stack}}, R)
         end,
-        [#{frame_size => 1}, #{max_frame_size => -1}, #{max_frame_size => bad}, not_a_map]
+        [
+            #{frame_size => 1},
+            #{max_frame_size => -1},
+            #{max_frame_size => bad},
+            not_a_map,
+            %% `buffer` is an inet buffer size — zero, negative,
+            %% non-integer, and over-range all reject.
+            #{buffer => 0},
+            #{buffer => -1},
+            #{buffer => bad},
+            #{buffer => 16#80000000}
+        ]
     ).
+
+listener_accepts_ws_buffer_opt_test() ->
+    %% A valid `ws.buffer` passes validation and the listener starts;
+    %% the session-side application is covered in
+    %% `roadrunner_ws_session_tests`.
+    {ok, Pid} = roadrunner_listener:start_link(listener_test_ws_buffer_ok, #{
+        port => 0,
+        ws => #{buffer => 2048},
+        routes => roadrunner_hello_handler
+    }),
+    ?assert(is_process_alive(Pid)),
+    ok = roadrunner_listener:stop(listener_test_ws_buffer_ok).
 
 listener_rejects_invalid_handler_spawn_test() ->
     %% `handler_spawn` must be a map; `opts` a list that does not carry the

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -50,6 +50,65 @@ run_with_bad_handshake_still_returns_400_test() ->
     ?assertNotEqual(nomatch, binary:match(Sent, ~"400")),
     ?assertEqual(nomatch, binary:match(Sent, ~"101")).
 
+ws_buffer_opt_applied_before_101_test() ->
+    %% `ws.buffer` set: the session must resize the socket's inet
+    %% `buffer` while the conn still owns the socket — i.e. the setopts
+    %% must land BEFORE the 101 goes out. The events sink logs setopts
+    %% and sends into one ordered stream; a seeded close frame ends the
+    %% session so `run/6` returns.
+    Tag = make_ref(),
+    Self = self(),
+    Sink = spawn_events_sink(Self, Tag),
+    ok = roadrunner_ws_session:run(
+        {fake, Sink},
+        upgrade_req(),
+        roadrunner_ws_echo_handler,
+        undefined,
+        frame(close, <<1000:16>>),
+        (ws_proto_opts())#{ws_buffer := 4096}
+    ),
+    Events = collect_events(Tag, 100),
+    Sink ! stop,
+    BufferIdx = find_event_index(
+        fun
+            ({setopts, Opts}) -> Opts =:= [{buffer, 4096}];
+            (_) -> false
+        end,
+        Events
+    ),
+    SendIdx = find_event_index(
+        fun
+            ({send, Data}) -> binary:match(iolist_to_binary(Data), ~"101") =/= nomatch;
+            (_) -> false
+        end,
+        Events
+    ),
+    ?assertNotEqual(not_found, BufferIdx),
+    ?assertNotEqual(not_found, SendIdx),
+    ?assert(BufferIdx < SendIdx).
+
+ws_buffer_opt_unset_leaves_socket_buffer_alone_test() ->
+    %% Default (`ws_buffer => undefined`): no `{buffer, _}` setopts may
+    %% reach the socket — the session inherits the listener's buffer.
+    Tag = make_ref(),
+    Self = self(),
+    Sink = spawn_events_sink(Self, Tag),
+    ok = roadrunner_ws_session:run(
+        {fake, Sink},
+        upgrade_req(),
+        roadrunner_ws_echo_handler,
+        undefined,
+        frame(close, <<1000:16>>),
+        ws_proto_opts()
+    ),
+    Events = collect_events(Tag, 100),
+    Sink ! stop,
+    BufferSetopts = [
+        Opts
+     || {setopts, Opts} <- Events, lists:keyfind(buffer, 1, Opts) =/= false
+    ],
+    ?assertEqual([], BufferSetopts).
+
 coalesced_first_frame_seeded_in_buffer_is_processed_test() ->
     %% A client that pipelines its first frame in the same segment as
     %% the upgrade handshake: the conn read it past the request and
@@ -2221,6 +2280,21 @@ ws_ctx() ->
         module => roadrunner_ws_echo_handler
     }.
 
+%% A request map carrying a valid upgrade handshake, for tests driving
+%% the full `run/6` entry.
+upgrade_req() ->
+    #{
+        headers => [
+            {~"upgrade", ~"websocket"},
+            {~"connection", ~"Upgrade"},
+            {~"sec-websocket-key", ~"dGhlIHNhbXBsZSBub25jZQ=="},
+            {~"sec-websocket-version", ~"13"}
+        ],
+        peer => undefined,
+        listener_name => undefined,
+        request_id => undefined
+    }.
+
 %% Minimal `proto_opts` slice the session reads in `init/1`. Defaults to
 %% the production 16 MB caps so existing small-frame tests are
 %% unaffected; cap tests call `ws_proto_opts/2` with tight values.
@@ -2231,6 +2305,7 @@ ws_proto_opts(MaxFrame, MaxMsg) ->
     #{
         ws_max_frame_size => MaxFrame,
         ws_max_message_size => MaxMsg,
+        ws_buffer => undefined,
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity
     }.
@@ -2244,7 +2319,8 @@ frame(Opcode, Payload) ->
     OpcodeByte =
         case Opcode of
             text -> 16#81;
-            binary -> 16#82
+            binary -> 16#82;
+            close -> 16#88
         end,
     <<OpcodeByte, (16#80 bor Len), 1, 2, 3, 4, Masked/binary>>.
 
@@ -2434,6 +2510,60 @@ is_hibernating_loop(Pid, Threshold, Deadline) ->
 
 spawn_send_log_sink(Logger, Tag) ->
     spawn(fun() -> sink_loop(Logger, Tag) end).
+
+%% Events sink: like the send-log sink, but logs `setopts` calls too,
+%% into the same ordered stream — for tests that assert on the ORDER
+%% of socket operations (e.g. `ws.buffer` applied before the 101).
+spawn_events_sink(Logger, Tag) ->
+    spawn(fun() -> events_sink_loop(Logger, Tag) end).
+
+events_sink_loop(Logger, Tag) ->
+    receive
+        stop ->
+            ok;
+        {roadrunner_fake_send, _Pid, Data} ->
+            Logger ! {evt, Tag, {send, Data}},
+            events_sink_loop(Logger, Tag);
+        {roadrunner_fake_setopts, _Pid, Opts} ->
+            Logger ! {evt, Tag, {setopts, Opts}},
+            events_sink_loop(Logger, Tag);
+        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
+            ConnPid ! {roadrunner_fake_recv_reply, {error, closed}},
+            events_sink_loop(Logger, Tag);
+        _ ->
+            events_sink_loop(Logger, Tag)
+    end.
+
+%% Same settle discipline as `collect_sends/2`, over `{evt, _, _}`
+%% messages from the events sink.
+collect_events(Tag, Timeout) ->
+    collect_events_loop(Tag, [], Timeout, Timeout).
+
+collect_events_loop(Tag, Acc, _InitialTimeout, SettleMs) when Acc =/= [] ->
+    receive
+        {evt, Tag, Event} -> collect_events_loop(Tag, [Event | Acc], SettleMs, SettleMs)
+    after SettleMs ->
+        lists:reverse(Acc)
+    end;
+collect_events_loop(Tag, [], InitialTimeout, SettleMs) ->
+    receive
+        {evt, Tag, Event} -> collect_events_loop(Tag, [Event], InitialTimeout, SettleMs)
+    after InitialTimeout ->
+        []
+    end.
+
+%% 1-based index of the first event the (total) predicate accepts, or
+%% `not_found`.
+find_event_index(Pred, Events) ->
+    find_event_index(Pred, Events, 1).
+
+find_event_index(_Pred, [], _N) ->
+    not_found;
+find_event_index(Pred, [Event | Rest], N) ->
+    case Pred(Event) of
+        true -> N;
+        false -> find_event_index(Pred, Rest, N + 1)
+    end.
 
 sink_loop(Logger, Tag) ->
     receive


### PR DESCRIPTION
# Description

WebSocket sessions inherit the listener socket's 64 KB inet buffer, which the emulator keeps live per socket, so it dominates per-connection memory at high WebSocket concurrency. This adds a `buffer` key to the `ws` listener opts that resizes the socket buffer at upgrade time, e.g. `ws => #{buffer => 4096}`; unset keeps the inherited value unchanged. Measured at 2048 echo connections: total memory 285 MB -> 101 MB with throughput unchanged.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)