### PR TITLE
Hibernate the conn process while its WebSocket session runs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -246,25 +246,6 @@ own measurement before shipping.
 
 **Scope:** small.
 
-### Hibernate the conn process while a WebSocket session runs
-
-**What:** During a WebSocket session the parent conn process only
-holds a monitor on the session and forwards drain broadcasts
-(`roadrunner_ws_session:wait_for_session/2`), yet it keeps the heap it
-grew parsing the upgrade request (~5-7 KB measured under load) for the
-session's whole lifetime. Hibernating it would drop that to ~1 KB per
-connection — meaningful at high WebSocket concurrency (100K sessions
-hold ~500 MB of idle conn heaps today). Needs restructuring: hibernate
-discards the stack, so the wait must move into a `roadrunner_conn_loop`
-continuation that can still run the post-session drain + `exit_normal`
-path when the session's `'DOWN'` arrives.
-
-**Why deferred:** the `ws.buffer` opt removed the dominant
-per-session memory cost (the 64 KB inherited socket buffer); the conn
-heap is the next block but wants its own measured commit.
-
-**Scope:** small.
-
 ### h2 receive-window defaults
 
 **What:** Bump the listener's default receive-window peaks above the

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -261,7 +261,7 @@ process. Reserved for future use cases where a non-conn process needs
 direct drain membership (e.g., a long-lived worker spawned outside
 the conn lifecycle). The WS upgrade path no longer calls this: the
 conn (already in pg) forwards `{roadrunner_drain, _}` to its session
-from `roadrunner_ws_session:wait_for_session/2` instead.
+from `roadrunner_conn_loop:ws_session_wake/7` instead.
 
 Silently no-ops when `Name` is `undefined` (manually constructed
 requests in tests) or when the `pg` scope is absent (listener

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -52,7 +52,7 @@
 %% Internal entries — invoked via `proc_lib:start/3` and via
 %% `erlang:hibernate/3`. Must stay exported so the runtime can
 %% re-enter them after wake-from-hibernate.
--export([init_loop/3, recv_request_bytes_hib/2]).
+-export([init_loop/3, recv_request_bytes_hib/2, ws_session_wake/7]).
 
 %% Loop-state record carried through every phase. Allocated once on
 %% the transition out of `awaiting_shoot` and pattern-matched (not
@@ -765,14 +765,23 @@ run_pipeline(#loop_state{socket = Socket} = S, Handler, Req, Pipeline) ->
             %% server-initiated close (count ceiling) lands on the wire as
             %% `Connection: close` — see `ensure_close_signaled/3`.
             Response = ensure_close_signaled(S2, Req2, Response0),
-            _ = dispatch_response(S2, Handler, Req2, Response),
-            ok = roadrunner_telemetry:request_stop(
-                ReqStart,
-                Metadata,
-                roadrunner_conn:response_status(Response),
-                roadrunner_conn:response_kind(Response)
-            ),
-            finishing_phase(S2, Req2, Response)
+            case dispatch_response(S2, Handler, Req2, Response) of
+                {ws_session, MRef, SessPid} ->
+                    %% A WebSocket session now owns the socket; the conn
+                    %% parks in a hibernated wait until it terminates.
+                    %% `request_stop` fires from the wake continuation so
+                    %% its timing (response writer finished) matches the
+                    %% other writer-owned shapes.
+                    ws_session_wait(S2, Req2, Response, MRef, SessPid, ReqStart, Metadata);
+                ok ->
+                    ok = roadrunner_telemetry:request_stop(
+                        ReqStart,
+                        Metadata,
+                        roadrunner_conn:response_status(Response),
+                        roadrunner_conn:response_kind(Response)
+                    ),
+                    finishing_phase(S2, Req2, Response)
+            end
     catch
         Class:Reason:Stack ->
             ok = roadrunner_telemetry:request_exception(
@@ -835,7 +844,7 @@ with_close_if_last(
     module(),
     roadrunner_req:request(),
     roadrunner_handler:response()
-) -> ok.
+) -> ok | {ws_session, reference(), pid()}.
 dispatch_response(
     #loop_state{socket = Socket, buffered = Buffered, proto_opts = ProtoOpts},
     _Handler,
@@ -844,8 +853,14 @@ dispatch_response(
 ) when
     is_atom(Mod)
 ->
-    ok = roadrunner_ws_session:run(Socket, Req, Mod, State, Buffered, ProtoOpts),
-    ok;
+    %% `start/6` returns right after the 101 + socket handoff; the
+    %% session's lifetime is the caller's to wait out (`ws_session_wait`).
+    %% A rejected upgrade (400/500 already sent, `connection: close`)
+    %% falls through to the normal websocket finishing path.
+    case roadrunner_ws_session:start(Socket, Req, Mod, State, Buffered, ProtoOpts) of
+        {session, MRef, SessPid} -> {ws_session, MRef, SessPid};
+        rejected -> ok
+    end;
 dispatch_response(
     #loop_state{socket = Socket, alt_svc = AltSvc},
     _Handler,
@@ -1019,6 +1034,62 @@ buffered_finish(S, Req, Headers) ->
             %% Drain failure — close. Manual-mode handlers can leave the
             %% body_reader in a broken state if they read past EOF.
             exit_normal(S)
+    end.
+
+%% Park the conn in a hibernated wait while the WebSocket session owns
+%% the socket. The conn's only remaining duties are bookkeeping: hold
+%% the session monitor, forward `{roadrunner_drain, _}` broadcasts to
+%% the session (the conn is already in the listener's drain `pg` group
+%% via `roadrunner_conn:join_drain_group/2`; joining the session too
+%% would double the join rate through the single `pg` scope process and
+%% serialize the upgrade path under load), and fire the request-stop /
+%% conn-close telemetry once the session ends. Hibernating sheds the
+%% heap grown parsing the upgrade request (~5-7 KB per connection
+%% measured under load) for the session's entire lifetime — at high
+%% WebSocket concurrency the parked conns are a real share of resident
+%% memory.
+-spec ws_session_wait(
+    #loop_state{},
+    roadrunner_req:request(),
+    roadrunner_handler:response(),
+    reference(),
+    pid(),
+    integer(),
+    roadrunner_telemetry:metadata()
+) -> no_return().
+ws_session_wait(S, Req, Response, MRef, SessPid, ReqStart, Metadata) ->
+    erlang:hibernate(?MODULE, ws_session_wake, [S, Req, Response, MRef, SessPid, ReqStart, Metadata]).
+
+%% Wake-from-hibernate continuation (exported for `erlang:hibernate/3`).
+%% The selective receive mirrors the pre-hibernate wait this replaces:
+%% strays stay queued. A forwarded drain recurses into the receive
+%% without re-hibernating — the post-wake heap is already minimal and a
+%% drain is a one-shot shutdown event. On the session's `'DOWN'` the
+%% conn runs the request-stop telemetry and the websocket finishing
+%% path (drain any unread manual body, then close), exactly what the
+%% non-hibernated return path would have done.
+-spec ws_session_wake(
+    #loop_state{},
+    roadrunner_req:request(),
+    roadrunner_handler:response(),
+    reference(),
+    pid(),
+    integer(),
+    roadrunner_telemetry:metadata()
+) -> no_return().
+ws_session_wake(S, Req, Response, MRef, SessPid, ReqStart, Metadata) ->
+    receive
+        {'DOWN', MRef, process, SessPid, _Reason} ->
+            ok = roadrunner_telemetry:request_stop(
+                ReqStart,
+                Metadata,
+                roadrunner_conn:response_status(Response),
+                roadrunner_conn:response_kind(Response)
+            ),
+            finishing_phase(S, Req, Response);
+        {roadrunner_drain, _Deadline} = Msg ->
+            SessPid ! Msg,
+            ws_session_wake(S, Req, Response, MRef, SessPid, ReqStart, Metadata)
     end.
 
 %% Manual-mode body_reader owns its post-body leftover (returned by

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -4,15 +4,17 @@
 %% Per-connection WebSocket session — runs the frame loop in its own
 %% hand-rolled `proc_lib` process (never a gen_statem, mirroring
 %% `roadrunner_conn_loop_http2` / `roadrunner_quic_connection`) after
-%% `roadrunner_conn:upgrade_to_websocket/4` hands the socket off.
+%% the conn's `{websocket, Mod, State}` dispatch hands the socket off.
 %%
-%% The session owns the socket for its lifetime: the parent `roadrunner_conn`
-%% launcher (`run/4`) starts the session, transfers controlling-process,
+%% The session owns the socket for its lifetime: the parent conn calls
+%% `start/6`, which spawns the session, transfers controlling-process,
 %% sends the `socket_ready` startup signal (mirroring the conn's `shoot`
-%% pattern), and waits via a monitor for the session to terminate.
-%% When the session exits — peer close frame, recv error, frame parse
-%% error, or handler-driven `{close, _}` — the launcher returns and the
-%% parent's `[roadrunner, listener, conn_close]` telemetry fires after.
+%% pattern), and hands the session's monitor back so the conn can park
+%% in a hibernated wait (`roadrunner_conn_loop:ws_session_wake/7`)
+%% until the session terminates. When the session exits — peer close
+%% frame, recv error, frame parse error, or handler-driven `{close, _}`
+%% — the conn wakes and its `[roadrunner, listener, conn_close]`
+%% telemetry fires after.
 %%
 %% Phases (plain functions, not gen_statem states):
 %% - `awaiting_socket/1` — a selective `receive socket_ready` that gates
@@ -58,12 +60,12 @@
 %% each is exported is cached in `#data` at session start so the BIF
 %% check doesn't run on every event.
 %%
-%% Telemetry: `[roadrunner, ws, upgrade]` fires from `run/6` once the
+%% Telemetry: `[roadrunner, ws, upgrade]` fires from `start/6` once the
 %% launcher has decided to enter the session; `[roadrunner, ws, frame_in]`
 %% and `[roadrunner, ws, frame_out]` fire from the session process for
 %% every frame.
 
--export([run/6]).
+-export([start/6]).
 -export([init_session/2]).
 -export([recv_loop/1]).
 -export([unmask_slice/3]).
@@ -160,32 +162,36 @@
 -define(WS_FRAGMENT_OVERHEAD, 64).
 
 -doc """
-Run the WebSocket session synchronously: spawn the session process,
-write the 101 upgrade response, transfer socket ownership, and
-await termination. The process is started **before** the 101
-hits the wire so a start failure can fall back to 500 without
-leaving the upgrade response sent with no process owning the
-socket. Returns `ok` once the session has ended (or the
-handshake check fails — in which case 400 has been sent and
-the session is never started).
+Start the WebSocket session: spawn the session process, write the
+101 upgrade response, and transfer socket ownership. The process is
+started **before** the 101 hits the wire so a start failure can
+fall back to 500 without leaving the upgrade response sent with no
+process owning the socket. Returns `{session, MonitorRef, Pid}`
+once the handoff is complete — the caller owns the wait for the
+session's `'DOWN'` and forwards `{roadrunner_drain, _}` broadcasts
+to `Pid` (see `roadrunner_conn_loop:ws_session_wake/7`). Returns
+`rejected` when the handshake check fails (400 sent, no session
+started) or the session couldn't start (500 sent); both responses
+carry `connection: close`, so the caller just runs its normal
+close path.
 
 `Buffered` is any bytes the conn already read past the upgrade request
 (a client that pipelines its first frame in the handshake segment).
 They seed the session buffer so the first frame isn't lost.
 """.
--spec run(
+-spec start(
     roadrunner_transport:socket(),
     roadrunner_req:request(),
     module(),
     term(),
     binary(),
     roadrunner_conn:proto_opts()
-) -> ok.
-run(Socket, Req, Mod, State, Buffered, ProtoOpts) ->
+) -> {session, reference(), pid()} | rejected.
+start(Socket, Req, Mod, State, Buffered, ProtoOpts) ->
     case roadrunner_ws:handshake_response(roadrunner_req:headers(Req)) of
         {ok, Status, RespHeaders, _, Negotiated} ->
             UpgradeResp = roadrunner_http1:response(Status, RespHeaders, ~""),
-            run_session(Socket, Req, Mod, State, UpgradeResp, Negotiated, Buffered, ProtoOpts);
+            start_session(Socket, Req, Mod, State, UpgradeResp, Negotiated, Buffered, ProtoOpts);
         {error, _} ->
             _ = roadrunner_transport:send(
                 Socket,
@@ -195,10 +201,10 @@ run(Socket, Req, Mod, State, Buffered, ProtoOpts) ->
                     ~""
                 )
             ),
-            ok
+            rejected
     end.
 
--spec run_session(
+-spec start_session(
     roadrunner_transport:socket(),
     roadrunner_req:request(),
     module(),
@@ -207,8 +213,8 @@ run(Socket, Req, Mod, State, Buffered, ProtoOpts) ->
     roadrunner_ws:negotiated(),
     binary(),
     roadrunner_conn:proto_opts()
-) -> ok.
-run_session(
+) -> {session, reference(), pid()} | rejected.
+start_session(
     Socket,
     Req,
     Mod,
@@ -245,7 +251,7 @@ run_session(
             Ref = monitor(process, Pid),
             ok = roadrunner_transport:controlling_process(Socket, Pid),
             Pid ! socket_ready,
-            wait_for_session(Ref, Pid);
+            {session, Ref, Pid};
         {error, _Reason} ->
             %% Couldn't start the session — the 101 was never on the
             %% wire, so we can fall back to 500 without a protocol leak.
@@ -257,7 +263,7 @@ run_session(
                     ~""
                 )
             ),
-            ok
+            rejected
     end.
 
 %% Apply the `ws.buffer` listener opt: resize the socket's inet
@@ -275,25 +281,7 @@ apply_ws_buffer(Socket, #{ws_buffer := Buffer}) ->
     _ = roadrunner_transport:setopts(Socket, [{buffer, Buffer}]),
     ok.
 
-%% The conn process is already a member of the listener's drain `pg`
-%% group via `roadrunner_conn:join_drain_group/2` (joined at conn
-%% start). While the conn waits here for the session to terminate,
-%% forward any `{roadrunner_drain, _}` broadcast to the session pid so
-%% the session's `frame_loop` can dispatch `handle_drain/2`. This
-%% avoids a per-session `pg:join` on the WS upgrade hot path: that
-%% per-session join doubled the rate of joins through the single `pg`
-%% scope process and serialized the upgrade hot path under load.
--spec wait_for_session(reference(), pid()) -> ok.
-wait_for_session(Ref, Pid) ->
-    receive
-        {'DOWN', Ref, process, Pid, _Reason} ->
-            ok;
-        {roadrunner_drain, _Deadline} = Msg ->
-            Pid ! Msg,
-            wait_for_session(Ref, Pid)
-    end.
-
-%% proc_lib entry (started via `proc_lib:start/5` from `run_session/8`).
+%% proc_lib entry (started via `proc_lib:start/5` from `start_session/8`).
 %% Validates the handler and `init_ack`s the outcome to the launcher
 %% BEFORE the 101 is written: `{ok, self()}` lets the launcher send the
 %% 101, `{error, {bad_handler, _}}` makes `proc_lib:start` return an
@@ -438,7 +426,8 @@ recv_loop(#data{socket = Socket} = Data) ->
 %% runtime would reclaim the zlib NIF resources on process exit anyway,
 %% but explicit release reclaims their working buffers immediately rather
 %% than waiting on GC. A crash skips this and relies on that GC. The
-%% launcher's monitor sees `{'DOWN', _, _, _, normal}` and returns.
+%% conn's monitor sees `{'DOWN', _, _, _, normal}` and wakes from its
+%% hibernated wait to run the connection's close path.
 -spec exit_clean(#data{}) -> no_return().
 exit_clean(#data{inflate_z = InflateZ, deflate_z = DeflateZ}) ->
     close_zlib(InflateZ),

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1436,10 +1436,64 @@ sendfile_dispatch_closes_socket_on_error_test() ->
     end,
     Sink ! stop.
 
+websocket_conn_hibernates_forwards_drain_and_closes_test() ->
+    %% Full upgrade through the conn: dispatch spawns the session, the
+    %% conn parks in the hibernated `ws_session_wake/7` wait, forwards a
+    %% `{roadrunner_drain, _}` broadcast to the session, and once the
+    %% session ends (a close frame injected through the fake socket) the
+    %% conn wakes, runs the websocket finishing path, and exits normal.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_ws_sink(Self, Tag, <<
+        "GET /ws HTTP/1.1\r\n"
+        "Host: x\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n"
+    >>),
+    Opts = (fake_opts(ws_hib))#{
+        dispatch :=
+            {handler, roadrunner_ws_upgrade_handler, fun roadrunner_ws_upgrade_handler:handle/1,
+                undefined}
+    },
+    {ok, ConnPid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    ConnRef = monitor(process, ConnPid),
+    ConnPid ! shoot,
+    %% The session's first active-once arm tells us the 101 handshake
+    %% completed and hands us the session pid for frame injection.
+    SessPid =
+        receive
+            {Tag, ws_armed, P} -> P
+        after 2000 -> error(no_session_arm)
+        end,
+    ?assertNotEqual(ConnPid, SessPid),
+    %% The conn has dispatched and parked — hibernated, tiny heap.
+    ?assert(is_hibernating(ConnPid, 1000)),
+    %% Drain broadcast to the conn is forwarded to the session (the echo
+    %% handler exports no handle_drain, so the session just keeps going —
+    %% liveness is the observable).
+    ConnPid ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 30000},
+    ?assert(is_process_alive(SessPid)),
+    %% End the session: inject a masked close frame; the session replies
+    %% with a close frame and exits, waking the conn.
+    SessPid ! {roadrunner_fake_data, undefined, masked_close_frame()},
+    receive
+        {'DOWN', ConnRef, process, ConnPid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertNotEqual(nomatch, binary:match(Sent, ~"101")),
+    %% Close-frame reply: opcode byte 0x88.
+    ?assertNotEqual(nomatch, binary:match(Sent, <<16#88>>)),
+    Sink ! stop.
+
 websocket_dispatch_invokes_session_run_test() ->
-    %% Without proper ws upgrade headers `ws_session:run/5` writes 400
-    %% and returns. We're covering the dispatch_response websocket
-    %% clause — a full handshake test lives in the WS suite.
+    %% Without proper ws upgrade headers `ws_session:start/6` writes 400
+    %% and returns `rejected`. We're covering the dispatch_response
+    %% websocket clause — a full handshake test lives above and in the
+    %% WS suite.
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
@@ -1500,6 +1554,11 @@ fake_opts(ListenerName) ->
             {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         max_content_length => 10485760,
+        %% WS session slice — read on the upgrade path (the listener
+        %% always fills these in production).
+        ws_max_frame_size => 10485760,
+        ws_max_message_size => 10485760,
+        ws_buffer => undefined,
         request_timeout => 5000,
         keep_alive_timeout => 5000,
         max_keep_alive_requests => 100,
@@ -1534,6 +1593,72 @@ sink_loop() ->
 %% calls are accepted but no further data is delivered. Also forwards
 %% `roadrunner_fake_send` to `Logger` tagged with `Tag` so the test
 %% can assert what the conn wrote.
+%% WebSocket-flow sink: delivers the upgrade request bytes on the FIRST
+%% active-once arm (from the conn), then reports every later arm to the
+%% logger as `{Tag, ws_armed, ArmingPid}` — the first of those comes
+%% from the freshly-started session, handing the test its pid so it can
+%% inject frames as `{roadrunner_fake_data, _, Bytes}` messages. Sends
+%% are logged like the other sinks.
+spawn_ws_sink(Logger, Tag, UpgradeBytes) ->
+    spawn(fun() -> ws_sink_loop(Logger, Tag, UpgradeBytes, false) end).
+
+ws_sink_loop(Logger, Tag, UpgradeBytes, Delivered) ->
+    receive
+        stop ->
+            ok;
+        {roadrunner_fake_setopts, ConnPid, _Opts} when not Delivered ->
+            ConnPid ! {roadrunner_fake_data, undefined, UpgradeBytes},
+            ws_sink_loop(Logger, Tag, UpgradeBytes, true);
+        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} when not Delivered ->
+            %% Passive-mode request read (the conn's default path).
+            ConnPid ! {roadrunner_fake_recv_reply, {ok, UpgradeBytes}},
+            ws_sink_loop(Logger, Tag, UpgradeBytes, true);
+        {roadrunner_fake_setopts, ArmingPid, Opts} ->
+            %% Only report active-once arms — the session's `ws.buffer`
+            %% setopts (when configured) would otherwise be mistaken for
+            %% an arm.
+            case lists:member({active, once}, Opts) of
+                true -> Logger ! {Tag, ws_armed, ArmingPid};
+                false -> ok
+            end,
+            ws_sink_loop(Logger, Tag, UpgradeBytes, Delivered);
+        {roadrunner_fake_send, _Pid, Data} ->
+            Logger ! {Tag, sent, Data},
+            ws_sink_loop(Logger, Tag, UpgradeBytes, Delivered);
+        _Other ->
+            ws_sink_loop(Logger, Tag, UpgradeBytes, Delivered)
+    end.
+
+%% A masked client→server close frame (opcode 0x88, code 1000). RFC
+%% 6455 §5.1 requires the mask bit on client frames; key 0 makes the
+%% masked payload equal the payload.
+masked_close_frame() ->
+    <<16#88, (16#80 bor 2), 0, 0, 0, 0, 1000:16>>.
+
+%% A hibernated process is `waiting` with its heap shrunk to the
+%% OTP-configured minimum (+64 words slack) — mirrors the helper in
+%% `roadrunner_ws_session_tests`. Polls until `TimeoutMs` because the
+%% hibernate lands asynchronously after the dispatch.
+is_hibernating(Pid, TimeoutMs) ->
+    {min_heap_size, Min} = erlang:system_info(min_heap_size),
+    is_hibernating_loop(Pid, Min + 64, erlang:monotonic_time(millisecond) + TimeoutMs).
+
+is_hibernating_loop(Pid, Threshold, Deadline) ->
+    case process_info(Pid, [status, total_heap_size, message_queue_len]) of
+        [{status, waiting}, {total_heap_size, H}, {message_queue_len, 0}] when
+            H =< Threshold
+        ->
+            true;
+        _ ->
+            case erlang:monotonic_time(millisecond) >= Deadline of
+                true ->
+                    false;
+                false ->
+                    timer:sleep(10),
+                    is_hibernating_loop(Pid, Threshold, Deadline)
+            end
+    end.
+
 spawn_active_sink_with_send_log(Logger, Tag, Bytes) ->
     spawn(fun() -> active_sink_loop(Logger, Tag, Bytes, false) end).
 

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -2,37 +2,32 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% `roadrunner_ws_session:run/5` must start the gen_statem **before** the
-%% 101 upgrade response is written. If `gen_statem:start/3` fails
-%% (here forced via an unknown handler module — `init/1` rejects it,
-%% turning into `{error, _}` from start), the 101 must never reach
-%% the wire and a 500 fallback must be sent instead.
-run_with_unloadable_handler_sends_500_and_no_101_test() ->
+%% `roadrunner_ws_session:start/6` must spawn the session **before** the
+%% 101 upgrade response is written. If `proc_lib:start/5` fails
+%% (here forced via an unknown handler module — `init_session/2` rejects
+%% it, turning into `{error, _}` from start), the 101 must never reach
+%% the wire and a 500 fallback must be sent instead, with `rejected`
+%% telling the caller no session exists to wait on.
+start_with_unloadable_handler_sends_500_and_no_101_test() ->
     Tag = make_ref(),
     Self = self(),
     Sink = spawn_send_log_sink(Self, Tag),
-    Headers = [
-        {~"upgrade", ~"websocket"},
-        {~"connection", ~"Upgrade"},
-        {~"sec-websocket-key", ~"dGhlIHNhbXBsZSBub25jZQ=="},
-        {~"sec-websocket-version", ~"13"}
-    ],
-    Req = #{
-        headers => Headers,
-        peer => undefined,
-        listener_name => undefined,
-        request_id => undefined
-    },
-    ok = roadrunner_ws_session:run(
-        {fake, Sink}, Req, this_module_does_not_exist_xyz_42, undefined, <<>>, ws_proto_opts()
+    rejected = roadrunner_ws_session:start(
+        {fake, Sink},
+        upgrade_req(),
+        this_module_does_not_exist_xyz_42,
+        undefined,
+        <<>>,
+        ws_proto_opts()
     ),
     Sent = iolist_to_binary(collect_sends(Tag, 100)),
     Sink ! stop,
     ?assertEqual(nomatch, binary:match(Sent, ~"101")),
     ?assertNotEqual(nomatch, binary:match(Sent, ~"500")).
 
-run_with_bad_handshake_still_returns_400_test() ->
-    %% Regression check: bad handshake path is unchanged.
+start_with_bad_handshake_still_returns_400_test() ->
+    %% Regression check: bad handshake path is unchanged — 400 on the
+    %% wire, `rejected` to the caller, no session spawned.
     Tag = make_ref(),
     Self = self(),
     Sink = spawn_send_log_sink(Self, Tag),
@@ -42,7 +37,7 @@ run_with_bad_handshake_still_returns_400_test() ->
         listener_name => undefined,
         request_id => undefined
     },
-    ok = roadrunner_ws_session:run(
+    rejected = roadrunner_ws_session:start(
         {fake, Sink}, Req, roadrunner_ws_echo_handler, undefined, <<>>, ws_proto_opts()
     ),
     Sent = iolist_to_binary(collect_sends(Tag, 100)),
@@ -59,7 +54,7 @@ ws_buffer_opt_applied_before_101_test() ->
     Tag = make_ref(),
     Self = self(),
     Sink = spawn_events_sink(Self, Tag),
-    ok = roadrunner_ws_session:run(
+    {session, Ref, Pid} = roadrunner_ws_session:start(
         {fake, Sink},
         upgrade_req(),
         roadrunner_ws_echo_handler,
@@ -67,6 +62,7 @@ ws_buffer_opt_applied_before_101_test() ->
         frame(close, <<1000:16>>),
         (ws_proto_opts())#{ws_buffer := 4096}
     ),
+    ok = await_down(Ref, Pid),
     Events = collect_events(Tag, 100),
     Sink ! stop,
     BufferIdx = find_event_index(
@@ -93,7 +89,7 @@ ws_buffer_opt_unset_leaves_socket_buffer_alone_test() ->
     Tag = make_ref(),
     Self = self(),
     Sink = spawn_events_sink(Self, Tag),
-    ok = roadrunner_ws_session:run(
+    {session, Ref, Pid} = roadrunner_ws_session:start(
         {fake, Sink},
         upgrade_req(),
         roadrunner_ws_echo_handler,
@@ -101,6 +97,7 @@ ws_buffer_opt_unset_leaves_socket_buffer_alone_test() ->
         frame(close, <<1000:16>>),
         ws_proto_opts()
     ),
+    ok = await_down(Ref, Pid),
     Events = collect_events(Tag, 100),
     Sink ! stop,
     BufferSetopts = [
@@ -766,56 +763,39 @@ handle_drain_drops_when_handler_does_not_export_test() ->
     Sink ! stop,
     ok = stop_ws_session(Pid).
 
-run_session_forwards_drain_to_session_test() ->
-    %% End-to-end: run/4 → run_session/6 → wait_for_session/2 forwards
-    %% `{roadrunner_drain, _}` sent to the conn (the run/4 caller) onward
-    %% to the session pid, where the existing frame_loop drain dispatch
-    %% calls handle_drain/2. The conn is already a `pg` member via
-    %% `roadrunner_conn:join_drain_group/2` so forwarding replaces the
-    %% per-session pg:join the WS upgrade path used to do.
+start_hands_back_a_session_the_caller_drives_test() ->
+    %% `start/6`'s contract: the 101 is on the wire and the caller holds
+    %% `{session, MonitorRef, Pid}` — it owns the drain forwarding (in
+    %% production `roadrunner_conn_loop:ws_session_wake/7`, covered in
+    %% the conn-loop tests) and the wait for the session's 'DOWN'. Here
+    %% the test plays the caller: a drain sent to the session pid
+    %% dispatches handle_drain/2, whose `{close, _, _, _}` return ends
+    %% the session and fires the monitor.
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink(Self, Tag, []),
-    State = #{sink => Self, on_drain => {close, 1000, ~"draining"}},
-    Headers = [
-        {~"upgrade", ~"websocket"},
-        {~"connection", ~"Upgrade"},
-        {~"sec-websocket-key", ~"dGhlIHNhbXBsZSBub25jZQ=="},
-        {~"sec-websocket-version", ~"13"}
-    ],
-    Req = #{
-        headers => Headers,
-        peer => undefined,
-        listener_name => undefined,
-        request_id => undefined
-    },
-    Worker = spawn(fun() ->
-        ok = roadrunner_ws_session:run(
-            {fake, Sink}, Req, roadrunner_ws_lifecycle_handler, State, <<>>, ws_proto_opts()
-        ),
-        Self ! {worker_done, self()}
-    end),
-    Wref = monitor(process, Worker),
-    %% Give the gen_statem time to transition awaiting_socket → frame_loop
-    %% so the forwarded drain hits the steady-state drain dispatch and
-    %% not the awaiting_socket postpone path (that path is covered by
-    %% awaiting_socket_postpones_drain_until_frame_loop_test/0 below).
-    timer:sleep(50),
-    Worker ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 30000},
+    State = #{sink => Self, on_init => ok, on_drain => {close, 1000, ~"draining"}},
+    {session, Ref, Pid} = roadrunner_ws_session:start(
+        {fake, Sink},
+        upgrade_req(),
+        roadrunner_ws_lifecycle_handler,
+        State,
+        <<>>,
+        ws_proto_opts()
+    ),
+    %% The lifecycle handler notifies init — the awaiting_socket →
+    %% frame_loop transition is done, so the drain hits the steady-state
+    %% dispatch and not the postpone path (covered separately below).
+    receive
+        {event, init} -> ok
+    after 500 -> ?assert(false)
+    end,
+    Pid ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 30000},
     receive
         {event, drain} -> ok
     after 500 -> ?assert(false)
     end,
-    %% on_drain => {close, ...} terminates the session; wait_for_session's
-    %% 'DOWN' clause fires, run/4 returns ok, the worker pid exits normal.
-    receive
-        {worker_done, Worker} -> ok
-    after 500 -> ?assert(false)
-    end,
-    receive
-        {'DOWN', Wref, process, Worker, normal} -> ok
-    after 500 -> ?assert(false)
-    end,
+    ok = await_down(Ref, Pid),
     Sent = iolist_to_binary(collect_sends(Tag, 50)),
     ?assertNotEqual(nomatch, binary:match(Sent, ~"101")),
     %% Close frame opcode 0x88.
@@ -2253,7 +2233,7 @@ loop_sys_handles_system_and_gen_messages_test() ->
 
 %% --- helpers ---
 
-%% Start the session the way the production launcher (`run_session/8`)
+%% Start the session the way the production launcher (`start_session/8`)
 %% does — `proc_lib:start` into `init_session/2`, which validates the
 %% handler and `init_ack`s `{ok, Pid}` | `{error, {bad_handler, _}}`.
 %% Same 3-arity shape as the old `gen_statem:start/3` so call sites are a
@@ -2280,8 +2260,15 @@ ws_ctx() ->
         module => roadrunner_ws_echo_handler
     }.
 
+%% Wait for the session's 'DOWN' the way the conn does after `start/6`.
+await_down(Ref, Pid) ->
+    receive
+        {'DOWN', Ref, process, Pid, _Reason} -> ok
+    after 2000 -> error(session_did_not_exit)
+    end.
+
 %% A request map carrying a valid upgrade handshake, for tests driving
-%% the full `run/6` entry.
+%% the full `start/6` entry.
 upgrade_req() ->
     #{
         headers => [


### PR DESCRIPTION
# Description

During a WebSocket session the parent conn process only holds the session's monitor and forwards drain broadcasts, yet it kept the heap it grew parsing the upgrade request for the session's whole lifetime. `roadrunner_ws_session:start/6` now hands the session's monitor back to the conn, which parks in a hibernated wait in `roadrunner_conn_loop`, with drain forwarding and telemetry ordering unchanged. Measured at 2048 connections under load: parked conns shrink from ~6.7 KB to 3.4 KB each, throughput unchanged.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)