### PR TITLE
Add a ws hibernate_after opt to park idle WebSocket sessions

### DIFF
--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -105,6 +105,9 @@
     %% inet `buffer` applied to the socket on WebSocket upgrade;
     %% `undefined` inherits the listener socket's 64 KB.
     ws_buffer := pos_integer() | undefined,
+    %% Idle ms after which a WebSocket session hibernates; `infinity`
+    %% (the default) never hibernates on idle.
+    ws_hibernate_after := pos_integer() | infinity,
     request_timeout := non_neg_integer(),
     keep_alive_timeout := non_neg_integer(),
     max_keep_alive_requests := pos_integer(),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -112,7 +112,8 @@ Optional middleware and timing knobs (durations in milliseconds):
   defaulting to 10 MB with over-cap closing the connection with code
   1009, plus `buffer` (per-session inet `buffer` override — bounds
   per-connection memory at high WebSocket concurrency; inherits the
-  listener's 64 KB when unset).
+  listener's 64 KB when unset) and `hibernate_after` (idle-session
+  hibernation timeout in milliseconds; off when unset).
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
 - `keep_alive_timeout` — idle timeout between requests on a
@@ -492,11 +493,22 @@ WebSocket session tunables (under `ws` in the listener opts).
   inbound frames are still delivered correctly with a small buffer,
   just across more deliveries — deployments streaming multi-KB
   frames client→server should keep it larger.
+- `hibernate_after` — idle milliseconds after which a WebSocket
+  session hibernates (heap shrinks to the minimum until the next
+  inbound event wakes it). The session-side counterpart of the
+  top-level `hibernate_after` conn knob, with the same tradeoff:
+  each wake costs a heap rebuild, so it suits mostly-idle sessions
+  (presence, notifications, low-traffic subscriptions) where the
+  per-connection heap held across long silences dominates. A busy
+  session never pays — the next frame arrives before the timer.
+  Unset (the default) never hibernates on idle; handlers can still
+  opt in per event via the `hibernate` return option.
 """.
 -type ws_opts() :: #{
     max_frame_size => 0..16#7FFFFFFF,
     max_message_size => 0..16#7FFFFFFF,
-    buffer => 1..16#7FFFFFFF
+    buffer => 1..16#7FFFFFFF,
+    hibernate_after => 1..16#7FFFFFFF
 }.
 
 -record(state, {
@@ -1088,7 +1100,12 @@ build_proto_opts(Opts, ListenerName) ->
     %% Public `ws` opts are a nested map; flatten to the `ws_*`
     %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
     %% → `http2_*` flattening above.
-    #{max_frame_size := WsFrame, max_message_size := WsMsg, buffer := WsBuffer} =
+    #{
+        max_frame_size := WsFrame,
+        max_message_size := WsMsg,
+        buffer := WsBuffer,
+        hibernate_after := WsHibernateAfter
+    } =
         validate_ws_opts(maps:get(ws, Opts, #{})),
     %% Flatten the nested `handler_spawn` opt to top-level proto_opts keys the
     %% spawn sites read directly, mirroring the `ws` / `http2` flattening above.
@@ -1102,6 +1119,7 @@ build_proto_opts(Opts, ListenerName) ->
             ws_max_frame_size => WsFrame,
             ws_max_message_size => WsMsg,
             ws_buffer => WsBuffer,
+            ws_hibernate_after => WsHibernateAfter,
             request_timeout => maps:get(request_timeout, Opts, ?DEFAULT_REQUEST_TIMEOUT),
             keep_alive_timeout =>
                 maps:get(keep_alive_timeout, Opts, ?DEFAULT_KEEP_ALIVE_TIMEOUT),
@@ -1497,7 +1515,8 @@ flatten_http3_opts(Entries) ->
     #{
         max_frame_size := non_neg_integer(),
         max_message_size := non_neg_integer(),
-        buffer := undefined
+        buffer := undefined,
+        hibernate_after := infinity
     }.
 ws_defaults() ->
     #{
@@ -1505,7 +1524,11 @@ ws_defaults() ->
         max_message_size => ?DEFAULT_WS_MAX_MESSAGE_SIZE,
         %% `undefined` = no setopts on upgrade; the session keeps the
         %% listener socket's inherited 64 KB `buffer`.
-        buffer => undefined
+        buffer => undefined,
+        %% `infinity` = the session's receive never times out into a
+        %% hibernate — the `after infinity` clause is dead by the
+        %% receive's own semantics, so the default costs nothing.
+        hibernate_after => infinity
     }.
 
 %% Resolve the `ws` opts map against defaults, rejecting unknown keys
@@ -1517,7 +1540,8 @@ ws_defaults() ->
     #{
         max_frame_size := non_neg_integer(),
         max_message_size := non_neg_integer(),
-        buffer := pos_integer() | undefined
+        buffer := pos_integer() | undefined,
+        hibernate_after := pos_integer() | infinity
     }.
 validate_ws_opts(Opts) when is_map(Opts) ->
     Defaults = ws_defaults(),
@@ -1539,10 +1563,14 @@ validate_ws_opts(Other) ->
     error({invalid_listener_opt, ws, Other}).
 
 %% Per-key range check for the `ws` sub-opts. The size caps allow 0
-%% (reject every frame / message); `buffer` is an inet buffer size, so
-%% zero is meaningless and rejected.
--spec valid_ws_opt(max_frame_size | max_message_size | buffer, term()) -> boolean().
+%% (reject every frame / message); `buffer` and `hibernate_after` are
+%% a buffer size and an idle interval, so zero is meaningless and
+%% rejected for both.
+-spec valid_ws_opt(max_frame_size | max_message_size | buffer | hibernate_after, term()) ->
+    boolean().
 valid_ws_opt(buffer, V) ->
+    is_integer(V) andalso V >= 1 andalso V =< 16#7FFFFFFF;
+valid_ws_opt(hibernate_after, V) ->
     is_integer(V) andalso V >= 1 andalso V =< 16#7FFFFFFF;
 valid_ws_opt(_SizeCap, V) ->
     is_integer(V) andalso V >= 0 andalso V =< 16#7FFFFFFF.

--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -33,19 +33,27 @@
 %% continuation can take effect. Without active mode we'd be blocked
 %% inside `roadrunner_transport:recv/3` and hibernation would be a no-op.
 %%
-%% ## Handler hibernation opt-in
+%% ## Session hibernation
 %%
-%% The `roadrunner_ws_handler` callback supports an optional 4-tuple
-%% return shape: `{reply, OutFrames, NewState, Opts}` and
-%% `{ok, NewState, Opts}`, where `Opts` is a list that may contain
-%% `hibernate`. When present, the process hibernates after this
-%% event is fully processed — process heap drops to ~1KB until the
-%% next inbound frame wakes it up. For an idle WebSocket session
-%% this is the difference between holding ~5–8KB of process memory
-%% indefinitely vs. ~1KB.
+%% Two complementary ways for an idle session's heap to drop to ~1KB
+%% until the next inbound event wakes it — for an idle WebSocket
+%% session this is the difference between holding ~5–8KB of process
+%% memory indefinitely vs. ~1KB:
 %%
-%% 3-tuple returns (`{reply, OutFrames, NewState}`, `{ok, NewState}`,
-%% `{close, NewState}`) stay valid — the 4-tuple is purely additive.
+%% - **Handler opt-in, per event.** The `roadrunner_ws_handler`
+%%   callback supports an optional 4-tuple return shape:
+%%   `{reply, OutFrames, NewState, Opts}` and `{ok, NewState, Opts}`,
+%%   where `Opts` is a list that may contain `hibernate`. When
+%%   present, the process hibernates after this event is fully
+%%   processed — for handlers that know "this session just went
+%%   quiet" at the moment they return. 3-tuple returns
+%%   (`{reply, OutFrames, NewState}`, `{ok, NewState}`,
+%%   `{close, NewState}`) stay valid — the 4-tuple is purely additive.
+%% - **Idle timeout, per listener.** The `ws.hibernate_after` opt
+%%   hibernates any session after that many milliseconds of
+%%   `recv_loop` silence — no handler code, and a busy session never
+%%   pays because the next frame arrives before the timer. Off
+%%   (`infinity`) by default.
 %%
 %% ## Optional handler callbacks
 %%
@@ -116,6 +124,11 @@
     %% (`finalize_message/3`). Over either cap closes with 1009.
     max_frame_size :: non_neg_integer(),
     max_message_size :: non_neg_integer(),
+    %% Idle hibernation timeout (from the listener's `ws.hibernate_after`
+    %% opt, set once in `init/1`). `infinity` (the default) makes the
+    %% recv_loop's `after` clause dead by the receive's own semantics —
+    %% the timer never arms, so the default costs nothing per message.
+    hibernate_after :: pos_integer() | infinity,
     msg_size = 0 :: non_neg_integer(),
     %% Trailing UTF-8 bytes carried over from a previous fragment that
     %% form the start of a multi-byte sequence whose continuation
@@ -305,7 +318,8 @@ init_session(Parent, {Socket, Mod, State, Ctx, Negotiated, Buffered, ProtoOpts})
             {PmdParams, InflateZ, DeflateZ} = init_pmd(Negotiated),
             #{
                 ws_max_frame_size := MaxFrame,
-                ws_max_message_size := MaxMsg
+                ws_max_message_size := MaxMsg,
+                ws_hibernate_after := HibernateAfter
             } = ProtoOpts,
             Data = #data{
                 socket = Socket,
@@ -321,6 +335,7 @@ init_session(Parent, {Socket, Mod, State, Ctx, Negotiated, Buffered, ProtoOpts})
                 deflate_z = DeflateZ,
                 max_frame_size = MaxFrame,
                 max_message_size = MaxMsg,
+                hibernate_after = HibernateAfter,
                 msg_acc = undefined,
                 msg_opcode = undefined,
                 msg_compressed = false,
@@ -393,7 +408,7 @@ enter_frame_loop(Data, Hibernate) ->
 %% those clauses loop without re-arming. `_Sock` is discarded — one socket
 %% per session, captured in `#data.socket` at init.
 -spec recv_loop(#data{}) -> no_return().
-recv_loop(#data{socket = Socket} = Data) ->
+recv_loop(#data{socket = Socket, hibernate_after = HibernateAfter} = Data) ->
     {DataTag, ClosedTag, ErrorTag} = roadrunner_transport:messages(Socket),
     receive
         {system, From, Req} ->
@@ -419,6 +434,13 @@ recv_loop(#data{socket = Socket} = Data) ->
             %% otherwise drop. Mirrors handle_frame's reply / hibernate /
             %% close return shapes.
             handle_info_msg(Other, Data, false)
+    after HibernateAfter ->
+        %% `ws.hibernate_after` idle window elapsed — park until the next
+        %% message. The socket stays armed active-once, so an inbound
+        %% frame (or a forwarded drain, or a handler info message) wakes
+        %% the continuation straight back into this receive. With the
+        %% default `infinity` this clause never fires.
+        erlang:hibernate(?MODULE, recv_loop, [Data])
     end.
 
 %% Release the permessage-deflate zlib contexts (was `terminate/3`) and

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1559,6 +1559,7 @@ fake_opts(ListenerName) ->
         ws_max_frame_size => 10485760,
         ws_max_message_size => 10485760,
         ws_buffer => undefined,
+        ws_hibernate_after => infinity,
         request_timeout => 5000,
         keep_alive_timeout => 5000,
         max_keep_alive_requests => 100,

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -580,26 +580,31 @@ listener_rejects_invalid_ws_opt_test() ->
             #{max_frame_size => -1},
             #{max_frame_size => bad},
             not_a_map,
-            %% `buffer` is an inet buffer size — zero, negative,
-            %% non-integer, and over-range all reject.
+            %% `buffer` is an inet buffer size and `hibernate_after` an
+            %% idle interval — zero, negative, non-integer, and
+            %% over-range all reject.
             #{buffer => 0},
             #{buffer => -1},
             #{buffer => bad},
-            #{buffer => 16#80000000}
+            #{buffer => 16#80000000},
+            #{hibernate_after => 0},
+            #{hibernate_after => -1},
+            #{hibernate_after => bad},
+            #{hibernate_after => 16#80000000}
         ]
     ).
 
-listener_accepts_ws_buffer_opt_test() ->
-    %% A valid `ws.buffer` passes validation and the listener starts;
-    %% the session-side application is covered in
-    %% `roadrunner_ws_session_tests`.
-    {ok, Pid} = roadrunner_listener:start_link(listener_test_ws_buffer_ok, #{
+listener_accepts_ws_session_opts_test() ->
+    %% Valid `ws.buffer` / `ws.hibernate_after` pass validation and the
+    %% listener starts; the session-side application of each is covered
+    %% in `roadrunner_ws_session_tests`.
+    {ok, Pid} = roadrunner_listener:start_link(listener_test_ws_session_opts_ok, #{
         port => 0,
-        ws => #{buffer => 2048},
+        ws => #{buffer => 2048, hibernate_after => 15000},
         routes => roadrunner_hello_handler
     }),
     ?assert(is_process_alive(Pid)),
-    ok = roadrunner_listener:stop(listener_test_ws_buffer_ok).
+    ok = roadrunner_listener:stop(listener_test_ws_session_opts_ok).
 
 listener_rejects_invalid_handler_spawn_test() ->
     %% `handler_spawn` must be a map; `opts` a list that does not carry the

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -231,6 +231,41 @@ frame_loop_hibernates_when_handler_returns_hibernate_opt_test() ->
     Sink ! stop,
     ok = stop_ws_session(Pid).
 
+ws_hibernate_after_parks_idle_session_and_wakes_on_frame_test() ->
+    %% `ws.hibernate_after` set: a session with no traffic for the idle
+    %% window hibernates on its own — no handler opt-in (the echo
+    %% handler returns plain 3-tuples). A frame delivered after the
+    %% park wakes the continuation straight into recv_loop, gets
+    %% echoed, and the session parks again once idle. The default
+    %% (`infinity`) is pinned by every other test in this file — none
+    %% hibernate without the handler opt.
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_active_sink(Self, Tag, []),
+    {ok, Pid} = start_ws_session(
+        roadrunner_ws_session,
+        {
+            {fake, Sink},
+            roadrunner_ws_echo_handler,
+            undefined,
+            ws_ctx(),
+            none,
+            <<>>,
+            (ws_proto_opts())#{ws_hibernate_after := 30}
+        },
+        []
+    ),
+    Pid ! socket_ready,
+    %% Idle past the window — parked without any handler cooperation.
+    ?assert(is_hibernating(Pid, 1000)),
+    Pid ! {roadrunner_fake_data, undefined, frame(text, ~"hi")},
+    Sent = iolist_to_binary(collect_sends(Tag, 200)),
+    ?assertNotEqual(nomatch, binary:match(Sent, ~"hi")),
+    %% ...and it parks again after the next idle window.
+    ?assert(is_hibernating(Pid, 1000)),
+    Sink ! stop,
+    ok = stop_ws_session(Pid).
+
 frame_loop_hibernates_on_ok_opt_variant_test() ->
     %% Binary frame → {ok, _, [hibernate]} → no reply but hibernate.
     Self = self(),
@@ -2293,6 +2328,7 @@ ws_proto_opts(MaxFrame, MaxMsg) ->
         ws_max_frame_size => MaxFrame,
         ws_max_message_size => MaxMsg,
         ws_buffer => undefined,
+        ws_hibernate_after => infinity,
         handler_spawn_opts => [{fullsweep_after, 0}],
         handler_start_timeout => infinity
     }.


### PR DESCRIPTION
# Description

The handler-side `hibernate` return option already lets a session park after an event, but it asks every handler author to judge idleness per message. `ws => #{hibernate_after => Ms}` adds the time-based counterpart of the conn-level `hibernate_after` knob: any session silent for the window hibernates automatically, and a busy session never pays because the next frame arrives before the timer. Off by default (`infinity` — the receive's `after` clause is dead, so the default costs nothing per message).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)