### PR TITLE
Parse Accept-Encoding qvalues on the binary, no list round-trip

### DIFF
--- a/src/roadrunner_compress.erl
+++ b/src/roadrunner_compress.erl
@@ -312,20 +312,45 @@ find_q([Param | Rest], Default) ->
         _ -> find_q(Rest, Default)
     end.
 
-%% Parse the qvalue itself. RFC 9110 §12.4.2 allows 0, 0.NNN, 1, or
-%% 1.000 (max 3 decimals). Anything malformed falls back to the
-%% default.
+%% Parse the qvalue itself. RFC 9110 §12.4.2 grammar:
+%% `("0" ["." 0*3DIGIT]) / ("1" ["." 0*3("0")])`. Matched directly on
+%% the binary — the string-module parsers this replaces round-trip
+%% every qvalue through unicode list conversion, which profiled at a
+%% low-percent share of a keep-alive request's total time whenever the
+%% client sends q-values. Anything outside the grammar falls back to
+%% the default (the previous parser also accepted garbage-suffixed
+%% values like `0.8x`; those are malformed per RFC and now default).
 -spec parse_q(binary(), float()) -> float().
-parse_q(QBin, Default) ->
-    case string:to_float(QBin) of
-        {Float, _} when Float >= 0.0, Float =< 1.0 -> Float;
-        _ ->
-            case string:to_integer(QBin) of
-                {0, _} -> 0.0;
-                {1, _} -> 1.0;
-                _ -> Default
-            end
-    end.
+parse_q(~"1", _Default) -> 1.0;
+parse_q(~"0", _Default) -> 0.0;
+parse_q(<<"1.", Zeros/binary>>, Default) -> one_fraction(Zeros, Default);
+parse_q(<<"0.", Digits/binary>>, Default) -> zero_fraction(Digits, Default);
+parse_q(_QBin, Default) -> Default.
+
+%% `1.`, `1.0`, `1.00`, `1.000` — all exactly 1.0; any other fraction
+%% after `1.` would exceed the qvalue range.
+-spec one_fraction(binary(), float()) -> float().
+one_fraction(~"", _Default) -> 1.0;
+one_fraction(~"0", _Default) -> 1.0;
+one_fraction(~"00", _Default) -> 1.0;
+one_fraction(~"000", _Default) -> 1.0;
+one_fraction(_Zeros, Default) -> Default.
+
+-spec zero_fraction(binary(), float()) -> float().
+zero_fraction(~"", _Default) ->
+    0.0;
+zero_fraction(<<D>>, _Default) when D >= $0, D =< $9 ->
+    (D - $0) / 10;
+zero_fraction(<<D1, D2>>, _Default) when
+    D1 >= $0, D1 =< $9, D2 >= $0, D2 =< $9
+->
+    ((D1 - $0) * 10 + (D2 - $0)) / 100;
+zero_fraction(<<D1, D2, D3>>, _Default) when
+    D1 >= $0, D1 =< $9, D2 >= $0, D2 =< $9, D3 >= $0, D3 =< $9
+->
+    ((D1 - $0) * 100 + (D2 - $0) * 10 + (D3 - $0)) / 1000;
+zero_fraction(_Digits, Default) ->
+    Default.
 
 -spec has_header(binary(), roadrunner_http:headers()) -> boolean().
 has_header(Name, Headers) ->

--- a/test/roadrunner_compress_tests.erl
+++ b/test/roadrunner_compress_tests.erl
@@ -84,6 +84,37 @@ higher_qvalue_wins_when_gzip_lower_test() ->
     ?assertEqual(~"deflate", header(~"content-encoding", Headers)),
     ?assertEqual(iolist_to_binary(Body), zlib:uncompress(iolist_to_binary(OutBody))).
 
+qvalue_grammar_edges_test() ->
+    %% RFC 9110 §12.4.2 grammar edges through the negotiation: every
+    %% arm of the binary qvalue parser, including the malformed
+    %% fallbacks (which default to 1.0, the no-q default).
+    Body = big_body(),
+    Next = fun(R) -> {{200, [], Body}, R} end,
+    Winner = fun(AE) ->
+        {{200, Headers, _}, _} =
+            roadrunner_compress:call(req([{~"accept-encoding", AE}]), Next, undefined),
+        header(~"content-encoding", Headers)
+    end,
+    %% `1.` / `1.00` / `1.000` are exactly 1.0 — beat a 0.9.
+    ?assertEqual(~"gzip", Winner(~"gzip;q=1., deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=1.0, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=1.00, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=1.000, deflate;q=0.9")),
+    %% Two- and three-digit fractions order correctly.
+    ?assertEqual(~"deflate", Winner(~"gzip;q=0.85, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=0.125, deflate;q=0.1")),
+    %% `0.` is an explicit refusal, same as `0`.
+    ?assertEqual(undefined, Winner(~"gzip;q=0.")),
+    %% Malformed values fall back to the default 1.0: a garbage
+    %% suffix, a fraction after `1.` that isn't zeros, out-of-grammar
+    %% integers, and non-digit fractions.
+    ?assertEqual(~"gzip", Winner(~"gzip;q=0.8x, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=1.5, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=2, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=0.x9, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=0.9!!, deflate;q=0.9")),
+    ?assertEqual(~"gzip", Winner(~"gzip;q=0.12!, deflate;q=0.9")).
+
 equal_qvalues_tie_break_to_gzip_test() ->
     Req = req([{~"accept-encoding", ~"gzip;q=0.5, deflate;q=0.5"}]),
     Body = big_body(),


### PR DESCRIPTION
# Description

The compress middleware parsed each qvalue with `string:to_float`/`string:to_integer`, which round-trip the binary through unicode list conversion and the grapheme walker on every request that carries q-values. The RFC 9110 §12.4.2 grammar is tiny (`0[.###]` / `1[.000]`), so it's now matched directly on the binary: 19-39x faster per qvalue in an interleaved microbench (~940ns -> ~24ns per pair), and garbage-suffixed values like `0.8x` — malformed per RFC — now fall back to the default instead of being half-parsed. New tests pin every grammar edge and fallback.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)