### PR TITLE
Parse bench fixture query ints on the binary

### DIFF
--- a/test/roadrunner_bench_httparena_baseline_handler.erl
+++ b/test/roadrunner_bench_httparena_baseline_handler.erl
@@ -27,11 +27,28 @@ handle(Req) ->
 
 qs_int(Key, Req, Default) ->
     case lists:keyfind(Key, 1, roadrunner_req:parse_qs(Req)) of
-        {Key, V} when is_binary(V) ->
-            case string:to_integer(V) of
-                {N, _} when is_integer(N) -> N;
-                _ -> Default
-            end;
-        _ ->
-            Default
+        {Key, V} when is_binary(V) -> bin_int(V, Default);
+        _ -> Default
     end.
+
+%% Parse the leading (optionally signed) digits — the shape
+%% `string:to_integer/1` accepted — without the unicode list
+%% round-trip the string module pays per call. Mirrors the HttpArena
+%% adapter's parser so bench profiles reflect what the adapter runs.
+bin_int(<<$-, Rest/binary>>, Default) ->
+    case leading_digits(Rest, 0, false) of
+        {ok, N} -> -N;
+        error -> Default
+    end;
+bin_int(Bin, Default) ->
+    case leading_digits(Bin, 0, false) of
+        {ok, N} -> N;
+        error -> Default
+    end.
+
+leading_digits(<<D, Rest/binary>>, Acc, _Any) when D >= $0, D =< $9 ->
+    leading_digits(Rest, Acc * 10 + (D - $0), true);
+leading_digits(_Rest, _Acc, false) ->
+    error;
+leading_digits(_Rest, Acc, true) ->
+    {ok, Acc}.

--- a/test/roadrunner_bench_httparena_json_handler.erl
+++ b/test/roadrunner_bench_httparena_json_handler.erl
@@ -72,13 +72,27 @@ qs_int(Key, Req, Default) ->
         _ -> Default
     end.
 
-bin_int(<<>>, Default) ->
-    Default;
+%% Parse the leading (optionally signed) digits — the shape
+%% `string:to_integer/1` accepted — without the unicode list
+%% round-trip the string module pays per call. Mirrors the HttpArena
+%% adapter's parser so bench profiles reflect what the adapter runs.
+bin_int(<<$-, Rest/binary>>, Default) ->
+    case leading_digits(Rest, 0, false) of
+        {ok, N} -> -N;
+        error -> Default
+    end;
 bin_int(Bin, Default) ->
-    case string:to_integer(Bin) of
-        {N, _} when is_integer(N) -> N;
-        _ -> Default
+    case leading_digits(Bin, 0, false) of
+        {ok, N} -> N;
+        error -> Default
     end.
+
+leading_digits(<<D, Rest/binary>>, Acc, _Any) when D >= $0, D =< $9 ->
+    leading_digits(Rest, Acc * 10 + (D - $0), true);
+leading_digits(_Rest, _Acc, false) ->
+    error;
+leading_digits(_Rest, Acc, true) ->
+    {ok, Acc}.
 
 -spec init_dataset() -> ok.
 init_dataset() ->


### PR DESCRIPTION
# Description

The bench fixture handlers parsed query ints with `string:to_integer`, which round-trips every value through unicode list conversion — that chain showed up as ~2.7% of a profiled keep-alive request and masked real hot-path costs. The fixtures now parse the leading (optionally signed) digits directly on the binary with the same accepted shapes, so bench profiles reflect the cost of the framework rather than the fixture.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)