### PR TITLE
Skip the frame-header peek when the WS buffer is empty

### DIFF
--- a/src/roadrunner_ws_session.erl
+++ b/src/roadrunner_ws_session.erl
@@ -484,7 +484,18 @@ close_zlib(Z) -> zlib:close(Z).
 %% accumulating any handler-requested `hibernate` opt. When the buffer
 %% doesn't hold a full frame, re-arm the socket (hibernating first if a
 %% handler asked) and wait for more bytes.
+%%
+%% The empty-buffer head skips the peek machinery outright: after the
+%% common one-frame-per-delivery dispatch the loop re-enters here with
+%% nothing buffered, and the general clause would build the parse opts
+%% and run the full header peek on zero bytes just to conclude
+%% `{more, _}` — a second whole peek chain per frame. A partially
+%% validated frame always has its bytes in the buffer, so an empty
+%% buffer implies clean per-frame state and re-arming directly is
+%% behavior-identical.
 -spec process_buffer(#data{}, boolean()) -> no_return().
+process_buffer(#data{buffer = <<>>} = Data, HibernateAcc) ->
+    arm_and_recv(Data, HibernateAcc);
 process_buffer(#data{buffer = Buf, pmd_params = Pmd} = Data, HibernateAcc) ->
     Opts =
         case Pmd of


### PR DESCRIPTION
# Description

After the common one-frame-per-delivery dispatch, `process_buffer/2` re-enters with an empty buffer and ran the full parse-opts build plus header peek on zero bytes just to conclude it needs more data — a second whole peek chain per frame. An empty-buffer head clause re-arms directly instead; a partially validated frame always has its bytes in the buffer, so the skip is behavior-identical. Profiled on the echo workload: the peek chain drops from two runs per frame to exactly one.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)