### PR TITLE
Bound the TLS handshake in the accept path

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -218,28 +218,23 @@ lot of them.
 
 ## Other
 
-### Bound and parallelize the TLS handshake in the accept path
+### Move the TLS handshake out of the acceptor
 
-**What:** `roadrunner_transport:accept/1` for TLS runs
-`ssl:handshake/1` inside the acceptor with no timeout. Two
-consequences: a client that connects and never sends a ClientHello
-parks that acceptor indefinitely (a trivial slow-loris against the
-accept pool — `num_acceptors` such clients and the listener stops
-accepting), and handshake time serializes across the pool, capping
+**What:** `roadrunner_transport:accept/2` for TLS runs the handshake
+inside the acceptor (now bounded by the `tls_handshake_timeout`
+listener opt), so handshake time serializes across the pool, capping
 TLS connection-establishment throughput at
-`num_acceptors / handshake_time`. The fixes are separable: pass a
-`handshake_timeout` to `ssl:handshake/2` (small), and move the
-handshake out of the acceptor into the connection process —
-`ssl:transport_accept` in the acceptor, handshake after the handoff —
-so slow handshakes cost only their own connection (medium; changes
-the `roadrunner_conn` startup contract, which expects a
-handshake-complete socket at `shoot`).
+`num_acceptors / handshake_time`. The fix is `ssl:transport_accept`
+in the acceptor with the handshake after the handoff, so a slow
+handshake costs only its own connection — it changes the
+`roadrunner_conn` startup contract, which expects a
+handshake-complete socket at `shoot`.
 
 **Why deferred:** surfaced while auditing the acceptor
-transient-error fix; that fix makes handshake FAILURES harmless but
-doesn't bound handshake TIME.
+transient-error fix; the timeout bound shipped, the throughput
+restructure wants its own design pass.
 
-**Scope:** small (timeout) / medium (handshake in the conn process).
+**Scope:** medium.
 
 ### Connection-process memory tuning follow-ups
 

--- a/src/roadrunner_acceptor.erl
+++ b/src/roadrunner_acceptor.erl
@@ -41,18 +41,19 @@ the same opts. The index is used in the `proc_lib` label so
     {ok, pid()}.
 start_link(LSocket, ProtoOpts, Index) ->
     ListenerName = maps:get(listener_name, ProtoOpts, undefined),
+    #{tls_handshake_timeout := HsTimeout} = ProtoOpts,
     Pid = proc_lib:spawn_link(fun() ->
         proc_lib:set_label({roadrunner_acceptor, ListenerName, Index}),
-        loop(LSocket, ProtoOpts)
+        loop(LSocket, ProtoOpts, HsTimeout)
     end),
     {ok, Pid}.
 
--spec loop(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) -> ok.
-loop(LSocket, ProtoOpts) ->
-    case roadrunner_transport:accept(LSocket) of
+-spec loop(roadrunner_transport:socket(), roadrunner_conn:proto_opts(), timeout()) -> ok.
+loop(LSocket, ProtoOpts, HsTimeout) ->
+    case roadrunner_transport:accept(LSocket, HsTimeout) of
         {ok, Socket} ->
             handle_accepted(Socket, ProtoOpts),
-            loop(LSocket, ProtoOpts);
+            loop(LSocket, ProtoOpts, HsTimeout);
         {error, closed} ->
             %% Listen socket was closed — the listener is stopping. Exit
             %% cleanly; the linked listener tears the rest of the pool down.
@@ -75,7 +76,7 @@ loop(LSocket, ProtoOpts) ->
                         after ?ACCEPT_ERROR_BACKOFF_MS -> ok
                         end
                 end,
-            loop(LSocket, ProtoOpts)
+            loop(LSocket, ProtoOpts, HsTimeout)
     end.
 
 %% Classify a non-`closed` accept error for retry pacing. Exported for

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -110,6 +110,9 @@
     %% (the default) never hibernates on idle.
     ws_hibernate_after := pos_integer() | infinity,
     request_timeout := non_neg_integer(),
+    %% Bound on the TLS handshake in the accept path; see the
+    %% `tls_handshake_timeout` listener opt.
+    tls_handshake_timeout := pos_integer(),
     keep_alive_timeout := non_neg_integer(),
     max_keep_alive_requests := pos_integer(),
     max_clients := pos_integer(),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -40,6 +40,11 @@ All duration and interval values in `opts()` are in milliseconds —
 
 -define(DEFAULT_MAX_CONTENT_LENGTH, 10485760).
 -define(DEFAULT_REQUEST_TIMEOUT, 30000).
+%% Bound on `ssl:handshake/2` in the accept path. Without one, a client
+%% that connects to a TLS listener and never sends a ClientHello parks
+%% an acceptor indefinitely — `num_acceptors` such sockets and the
+%% listener stops accepting. 5 s comfortably covers slow real clients.
+-define(DEFAULT_TLS_HANDSHAKE_TIMEOUT, 5000).
 -define(DEFAULT_KEEP_ALIVE_TIMEOUT, 60000).
 -define(DEFAULT_NUM_ACCEPTORS, 10).
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
@@ -116,6 +121,11 @@ Optional middleware and timing knobs (durations in milliseconds):
   hibernation timeout in milliseconds; off when unset).
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
+- `tls_handshake_timeout` — bound on the TLS handshake during accept
+  (TLS listeners only). A handshake that exceeds it fails as a
+  per-connection `{handshake, timeout}` accept error and the acceptor
+  keeps accepting; without a bound, a client that never sends its
+  ClientHello would park an acceptor indefinitely. Default 5 s.
 - `keep_alive_timeout` — idle timeout between requests on a
   keep-alive conn. Default 60 s.
 - `num_acceptors` — size of the acceptor pool. Default 10.
@@ -201,6 +211,7 @@ ops-tuning rationale.
     max_content_length => non_neg_integer(),
     ws => ws_opts(),
     request_timeout => non_neg_integer(),
+    tls_handshake_timeout => pos_integer(),
     keep_alive_timeout => non_neg_integer(),
     num_acceptors => pos_integer(),
     max_keep_alive_requests => pos_integer(),
@@ -1121,6 +1132,8 @@ build_proto_opts(Opts, ListenerName) ->
             ws_buffer => WsBuffer,
             ws_hibernate_after => WsHibernateAfter,
             request_timeout => maps:get(request_timeout, Opts, ?DEFAULT_REQUEST_TIMEOUT),
+            tls_handshake_timeout =>
+                maps:get(tls_handshake_timeout, Opts, ?DEFAULT_TLS_HANDSHAKE_TIMEOUT),
             keep_alive_timeout =>
                 maps:get(keep_alive_timeout, Opts, ?DEFAULT_KEEP_ALIVE_TIMEOUT),
             max_keep_alive_requests =>

--- a/src/roadrunner_transport.erl
+++ b/src/roadrunner_transport.erl
@@ -42,7 +42,7 @@
 -export([
     listen/2,
     listen_tls/2,
-    accept/1,
+    accept/2,
     controlling_process/2,
     recv/3,
     send/2,
@@ -81,7 +81,7 @@ the `ssl` application is started (typically `application:ensure_all_started(ssl)
 
 `Opts` is the list passed to `ssl:listen/2` — `cert`, `key`/`keyfile`,
 `cacerts`, etc. Performs the TCP listen + TLS context bind in one call;
-each `accept/1` then runs the per-connection handshake.
+each `accept/2` then runs the per-connection handshake.
 """.
 -spec listen_tls(inet:port_number(), [ssl:tls_server_option() | gen_tcp:listen_option()]) ->
     {ok, socket()} | {error, term()}.
@@ -93,29 +93,46 @@ listen_tls(Port, Opts) ->
 
 -doc """
 Accept the next pending connection. For TLS, runs the handshake before
-returning.
+returning, bounded by `HandshakeTimeout` ms (plain TCP has no
+handshake; the timeout is unused there).
 
 TLS failures are two different events and come back distinguishably:
 a `ssl:transport_accept/1` error is about the LISTEN socket (`closed`
-means the listener is going away), while a failed `ssl:handshake/1` is
-about that one connection — a garbage ClientHello, a TLS alert, or the
-peer disconnecting mid-handshake (which `ssl` also reports as `closed`).
-Handshake failures are wrapped as `{error, {handshake, Reason}}` so an
-acceptor can keep accepting through per-connection noise and reserve
-the bare `{error, closed}` for the listener actually stopping.
+means the listener is going away), while a failed `ssl:handshake/2` is
+about that one connection — a garbage ClientHello, a TLS alert, the
+peer disconnecting mid-handshake (which `ssl` also reports as
+`closed`), or the handshake outrunning the bound (`timeout` — a client
+that connects and never speaks would otherwise park the caller
+forever). Handshake failures are wrapped as
+`{error, {handshake, Reason}}` so an acceptor can keep accepting
+through per-connection noise and reserve the bare `{error, closed}`
+for the listener actually stopping.
 """.
--spec accept(socket()) -> {ok, socket()} | {error, term()}.
-accept({gen_tcp, LSock}) ->
+-spec accept(socket(), timeout()) -> {ok, socket()} | {error, term()}.
+accept({gen_tcp, LSock}, _HandshakeTimeout) ->
     case gen_tcp:accept(LSock) of
         {ok, S} -> {ok, {gen_tcp, S}};
         {error, _} = Err -> Err
     end;
-accept({ssl, LSock}) ->
+accept({ssl, LSock}, HandshakeTimeout) ->
     maybe
         {ok, Pre} ?= ssl:transport_accept(LSock),
-        case ssl:handshake(Pre) of
-            {ok, S} -> {ok, {ssl, S}};
-            {error, HsReason} -> {error, {handshake, HsReason}}
+        case ssl:handshake(Pre, HandshakeTimeout) of
+            {ok, S} ->
+                {ok, {ssl, S}};
+            {error, timeout} ->
+                %% The connection process is still parked mid-handshake
+                %% waiting on the client — close it (measured instant on
+                %% this path) so a silent client can't hold the
+                %% descriptor until it deigns to disconnect.
+                _ = ssl:close(Pre),
+                {error, {handshake, timeout}};
+            {error, HsReason} ->
+                %% `ssl` already tore the connection down on a failed
+                %% handshake; closing again would block for ssl's
+                %% internal close timeout (measured 5 s) on the dead
+                %% connection process.
+                {error, {handshake, HsReason}}
         end
     end.
 

--- a/test/roadrunner_acceptor_tests.erl
+++ b/test/roadrunner_acceptor_tests.erl
@@ -124,7 +124,9 @@ acceptor_retries_on_transient_accept_error_test() ->
         undefined
     ),
     {ok, Pid} = roadrunner_acceptor:start_link(
-        {gen_tcp, CSock}, #{listener_name => acceptor_test_accept_error}, 1
+        {gen_tcp, CSock},
+        #{listener_name => acceptor_test_accept_error, tls_handshake_timeout => 5000},
+        1
     ),
     receive
         {accept_error, Meta} ->
@@ -186,7 +188,7 @@ acceptor_survives_failed_tls_handshake_test() ->
         undefined
     ),
     {ok, Pid} = roadrunner_acceptor:start_link(
-        LSock, #{listener_name => acceptor_test_tls_noise}, 1
+        LSock, #{listener_name => acceptor_test_tls_noise, tls_handshake_timeout => 5000}, 1
     ),
     %% Plain-HTTP bytes can't form a TLS hello — the handshake fails.
     {ok, Noise} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -149,7 +149,7 @@ accept_handshake_failure_returns_error_test() ->
     {ok, Port} = roadrunner_transport:port(LSocket),
     Self = self(),
     spawn(fun() ->
-        Self ! {accept_result, roadrunner_transport:accept(LSocket)}
+        Self ! {accept_result, roadrunner_transport:accept(LSocket, 5000)}
     end),
     %% Give the server time to enter accept.
     timer:sleep(50),
@@ -168,6 +168,32 @@ accept_handshake_failure_returns_error_test() ->
     ?assertMatch({error, {handshake, _}}, Result),
     roadrunner_transport:close(LSocket),
     gen_tcp:close(Client).
+
+accept_handshake_times_out_on_silent_client_test() ->
+    %% A client that connects and never sends a ClientHello must not
+    %% park the accept: the handshake bound turns it into a tagged
+    %% per-connection `{handshake, timeout}` error.
+    {ok, _} = application:ensure_all_started(ssl),
+    ServerOpts = roadrunner_test_certs:server_opts(),
+    {ok, LSocket} = roadrunner_transport:listen_tls(
+        0, ServerOpts ++ [binary, {active, false}, {reuseaddr, true}]
+    ),
+    {ok, Port} = roadrunner_transport:port(LSocket),
+    Self = self(),
+    spawn(fun() ->
+        Self ! {accept_result, roadrunner_transport:accept(LSocket, 200)}
+    end),
+    {ok, Silent} = gen_tcp:connect(
+        {127, 0, 0, 1}, Port, [binary, {active, false}], 1000
+    ),
+    Result =
+        receive
+            {accept_result, R} -> R
+        after 5000 -> error(accept_timeout)
+        end,
+    ?assertEqual({error, {handshake, timeout}}, Result),
+    roadrunner_transport:close(LSocket),
+    gen_tcp:close(Silent).
 
 port_on_closed_ssl_socket_returns_error_test() ->
     {ok, _} = application:ensure_all_started(ssl),


### PR DESCRIPTION
# Description

`ssl:handshake` ran inside the acceptor with no timeout, so a client that connects to a TLS listener and never sends a ClientHello parks that acceptor indefinitely — `num_acceptors` such sockets and the listener stops accepting. A new `tls_handshake_timeout` listener opt (default 5 s) bounds it: a stalled handshake now fails as a per-connection `{handshake, timeout}` accept error, the acceptor keeps accepting, and the parked connection is closed so the descriptor is reclaimed. The close is deliberately scoped to the timeout path — after a normal handshake failure `ssl` has already torn the connection down and a redundant close measurably blocks for ssl's internal 5 s close timeout on the dead connection process.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)