### PR TITLE
Reword a roadmap reference to a hidden function ex_doc flags

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -220,9 +220,9 @@ lot of them.
 
 ### Move the TLS handshake out of the acceptor
 
-**What:** `roadrunner_transport:accept/2` for TLS runs the handshake
-inside the acceptor (now bounded by the `tls_handshake_timeout`
-listener opt), so handshake time serializes across the pool, capping
+**What:** the transport's TLS accept runs the handshake inside the
+acceptor (now bounded by the `tls_handshake_timeout` listener opt), so
+handshake time serializes across the pool, capping
 TLS connection-establishment throughput at
 `num_acceptors / handshake_time`. The fix is `ssl:transport_accept`
 in the acceptor with the handshake after the handoff, so a slow


### PR DESCRIPTION
# Description

`rebar3 ex_doc` warns on the roadmap's backticked `mod:fun/arity` reference to the hidden transport module (it auto-links the pattern and finds the target undocumented); the sentence now names the path in prose, and the docs build is warning-free again.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)