### PR TITLE
Free the h2 stream slot when the response ends, not on worker DOWN

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,37 @@ Autobahn re-run.
 
 **Source:** Arizona handoff R-h2-1.
 
+## HTTP/2 stream admission follow-ups
+
+### Pre-SETTINGS stream leniency — medium effort
+
+**What:** Do not refuse streams a client opened before it could have
+seen our advertised `max_concurrent_streams`. With prior-knowledge h2c
+a client sends its preface and a burst of HEADERS in the same flight;
+until our SETTINGS completes the round trip, RFC 9113 §5.1.2 binds the
+client only to a limit it has received, so the burst is compliant.
+Refusing the excess sheds real requests at every connection setup when
+the client's default concurrency exceeds our advertised value.
+
+**Design question:** admit up to the protocol default (100) until the
+client's SETTINGS ack arrives, or queue the excess and admit as slots
+free. Queueing composes with the entry below.
+
+**Scope:** medium — admission bookkeeping in the h2 conn loop plus
+tests for the ack-timing windows.
+
+### Queue mode for `max_concurrent_requests` — medium effort
+
+**What:** An opt-in mode where a stream over the listener-wide
+in-flight ceiling waits for a free slot instead of being refused with
+`REFUSED_STREAM` / `H3_REQUEST_REJECTED`. Bounds live handler
+processes (and their memory) with no shed requests: latency rises
+under overload instead of the error rate. A client that does not
+retry refusals sees today's refusal mode as hard failures.
+
+**Scope:** medium — a wait queue in the conn loops for both
+multiplexed protocols, flow-control interaction, drain/timeout rules.
+
 ## HTTP/3 follow-ups
 
 h3 shipped experimentally (`protocols => [http3]`, QPACK static-table

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -149,6 +149,12 @@
 
 -type stream_entry() :: #{
     state := stream_state(),
+    %% Whether this stream still counts toward the advertised
+    %% `max_concurrent_streams` (RFC 9113 §5.1.2: open and half-closed
+    %% streams count; a fully closed one does not). Cleared exactly once —
+    %% either when both sides have ended or on teardown — while the map
+    %% entry itself lives until the worker's DOWN for state cleanup.
+    counted := boolean(),
     %% Field block fragments (the HEADERS frame plus any CONTINUATIONs):
     %% a bare binary for a single frame, an iolist once CONTINUATIONs
     %% append, flattened once at finalize (like `body` accumulates DATA).
@@ -213,6 +219,14 @@
     %% Max concurrent client-initiated streams: advertised in our SETTINGS
     %% and enforced in `on_headers/5`. Read from proto_opts at `enter/6`.
     max_concurrent_streams = ?MAX_CONCURRENT_STREAMS :: pos_integer(),
+    %% Streams currently counting toward `max_concurrent_streams` — the
+    %% entries whose `counted` flag is still set. Tracked separately from
+    %% `map_size(streams)` because an entry outlives its RFC stream: it is
+    %% kept until the worker's DOWN for cleanup, and admission must not
+    %% charge a stream whose response already ended on the wire (a compliant
+    %% client that refills the moment it sees our END_STREAM would otherwise
+    %% race that DOWN and eat a spurious REFUSED_STREAM).
+    live_streams = 0 :: non_neg_integer(),
     %% Cumulative HEADERS+CONTINUATION block cap (CONTINUATION-flood guard).
     %% Read from proto_opts at `enter/6`.
     max_header_block = ?MAX_HEADER_BLOCK :: pos_integer(),
@@ -766,9 +780,9 @@ on_headers(
     _Flags,
     _Priority,
     _Fragment,
-    #loop{streams = Streams, max_concurrent_streams = MaxStreams} = State
+    #loop{live_streams = Live, max_concurrent_streams = MaxStreams} = State
 ) when
-    map_size(Streams) >= MaxStreams
+    Live >= MaxStreams
 ->
     %% Over the advertised concurrency limit — refuse the stream.
     _ = send_rst_stream(State, StreamId, refused_stream),
@@ -785,6 +799,7 @@ on_headers(StreamId, Flags, _Priority, Fragment, State) ->
     ),
     State1 = State#loop{
         streams = (State#loop.streams)#{StreamId => Stream},
+        live_streams = State#loop.live_streams + 1,
         last_stream_id = StreamId,
         awaiting_continuation =
             if
@@ -800,6 +815,7 @@ on_headers(StreamId, Flags, _Priority, Fragment, State) ->
 new_stream(Fragment, EndHeaders, EndStream, SendWindow, RecvWindow) ->
     #{
         state => open,
+        counted => true,
         header_fragment => Fragment,
         header_len => byte_size(Fragment),
         end_headers => EndHeaders,
@@ -1410,10 +1426,26 @@ encode_and_send_trailers(#loop{hpack_enc = Enc} = State, StreamId, Trailers) ->
     close_stream_send_side(State1, StreamId).
 
 %% Mark the send side closed. Future worker writes on this stream
-%% get `{h2_stream_reset, _}` so they unwind cleanly.
+%% get `{h2_stream_reset, _}` so they unwind cleanly. Every path that
+%% puts the response's final END_STREAM on the wire funnels through
+%% here, so this is also where the stream stops counting toward the
+%% advertised concurrency limit: with the peer's END_STREAM already
+%% seen, the stream is closed on both sides (RFC 9113 §5.1.2), and a
+%% compliant client may open a replacement the instant it reads our
+%% END_STREAM — before the worker's DOWN retires the map entry. If the
+%% peer is still sending (no END_STREAM yet), the stream is
+%% half-closed(local), keeps counting, and is uncounted on teardown.
 close_stream_send_side(#loop{streams = Streams} = State, StreamId) ->
     #{StreamId := Stream} = Streams,
-    State#loop{streams = Streams#{StreamId := Stream#{state := closed}}}.
+    case Stream of
+        #{end_stream_seen := true, counted := true} ->
+            State#loop{
+                streams = Streams#{StreamId := Stream#{state := closed, counted := false}},
+                live_streams = State#loop.live_streams - 1
+            };
+        _ ->
+            State#loop{streams = Streams#{StreamId := Stream#{state := closed}}}
+    end.
 
 %% =============================================================================
 %% DATA send + flow control
@@ -1584,10 +1616,27 @@ drain_pending(State, StreamId, #{pending_sends := Pending} = Stream) ->
 update_stream(#loop{streams = Streams} = State, StreamId, Stream) ->
     State#loop{streams = Streams#{StreamId := Stream}}.
 
+%% Release the stream's concurrency-limit slot if it still holds one.
+%% Idempotent via the `counted` flag; called by every teardown path so
+%% a stream that never reached `close_stream_send_side/2` with both
+%% sides ended (peer RST, worker crash, early response) cannot leak a
+%% slot when its map entry is dropped.
+uncount_stream(#loop{streams = Streams, live_streams = Live} = State, StreamId) ->
+    case Streams of
+        #{StreamId := #{counted := true} = Stream} ->
+            State#loop{
+                streams = Streams#{StreamId := Stream#{counted := false}},
+                live_streams = Live - 1
+            };
+        #{} ->
+            State
+    end.
+
 %% Peer sent RST_STREAM for a stream we have alive. Tell the worker
 %% (if any) to bail, then drop our stream entry. Pending sends get
 %% reset notifications so workers waiting on `h2_send_ack` unwind.
-reset_stream(#loop{streams = Streams, worker_refs = Refs} = State, StreamId) ->
+reset_stream(State0, StreamId) ->
+    #loop{streams = Streams, worker_refs = Refs} = State = uncount_stream(State0, StreamId),
     #{
         StreamId := #{
             pending_sends := Pending,
@@ -1620,7 +1669,8 @@ reset_stream(#loop{streams = Streams, worker_refs = Refs} = State, StreamId) ->
 
 %% Called by `handle_worker_down/3` when a worker dies abnormally.
 %% Send RST_STREAM(error_code) to the peer and drop our state.
-abort_stream(#loop{streams = Streams} = State, StreamId, ErrorCode) ->
+abort_stream(State0, StreamId, ErrorCode) ->
+    #loop{streams = Streams} = State = uncount_stream(State0, StreamId),
     #{StreamId := #{pending_sends := Pending}} = Streams,
     notify_pending_reset(StreamId, Pending),
     _ = send_rst_stream(State, StreamId, ErrorCode),
@@ -1628,7 +1678,8 @@ abort_stream(#loop{streams = Streams} = State, StreamId, ErrorCode) ->
 
 %% Worker exited normally (handler done, all frames already on the
 %% wire). Just drop state.
-remove_stream(#loop{streams = Streams} = State, StreamId) ->
+remove_stream(State0, StreamId) ->
+    #loop{streams = Streams} = State = uncount_stream(State0, StreamId),
     State#loop{streams = maps:remove(StreamId, Streams)}.
 
 notify_pending_reset(StreamId, Pending) ->

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -93,6 +93,8 @@ all_test_() ->
         fun over_max_concurrent_streams_refused/0,
         fun over_inflight_ceiling_refused_and_throttled/0,
         fun reset_stream_releases_inflight_slot/0,
+        fun stream_slot_freed_when_response_ends_before_worker_down/0,
+        fun peer_rst_frees_stream_slot/0,
         fun rst_during_stream_response_unwinds_worker/0,
         fun drain_with_no_streams_exits_immediately/0,
         fun drain_refuses_new_streams/0,
@@ -2136,6 +2138,102 @@ reset_stream_releases_inflight_slot() ->
         serve_recv(ConnPid, complete_get_headers(3, ~"/empty")),
         _ = drain_send(100),
         ?assertEqual(0, atomics:get(Throttled, 1))
+    after
+        cleanup(Pid, Ref)
+    end.
+
+stream_slot_freed_when_response_ends_before_worker_down() ->
+    %% With an advertised limit of 1, a compliant client may open a new
+    %% stream the instant it reads our response's END_STREAM — before the
+    %% worker's DOWN retires the stream entry (RFC 9113 §5.1.2: a stream
+    %% closed on both sides no longer counts). The slot must free on the
+    %% END_STREAM write itself, so park the worker after its final chunk
+    %% (no DOWN can exist yet) and require the next stream to be admitted.
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(#{
+        http2_max_concurrent_streams => 1,
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined}
+    }),
+    try
+        _ = expect_send(),
+        serve_recv(ConnPid, ?PREFACE),
+        serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+        _ = expect_send(),
+        serve_recv(ConnPid, complete_get_headers(1, ~"/stream/fin-then-park")),
+        %% The worker registers only after `Send(_, fin)` returned, i.e.
+        %% after the conn loop put stream 1's END_STREAM on the wire.
+        _ = wait_for_register(roadrunner_h2_fin_park_test, 1000),
+        %% Stream 1's response is exactly two sends: HEADERS, DATA(fin).
+        _ = expect_send(),
+        {ok, {data, 1, 16#01, ~"done", _}, <<>>} =
+            roadrunner_http2_frame:parse(expect_send(), 16384),
+        %% Worker 1 is still alive holding its stream's map entry; the
+        %% follow-up stream must be served, not refused.
+        serve_recv(ConnPid, complete_get_headers(3, ~"/empty")),
+        Resp = expect_send(),
+        ?assertMatch(
+            {ok, {headers, 3, _, _, _}, _},
+            roadrunner_http2_frame:parse(Resp, 16384)
+        )
+    after
+        case whereis(roadrunner_h2_fin_park_test) of
+            undefined -> ok;
+            Parked -> Parked ! stop
+        end,
+        cleanup(Pid, Ref)
+    end.
+
+peer_rst_frees_stream_slot() ->
+    %% A peer RST of a stream that still counts toward the advertised
+    %% limit must release its slot, or the live-stream count leaks and
+    %% later streams are wrongly refused.
+    drain_mailbox(),
+    {Pid, Ref, ConnPid} = start_http2_conn(#{
+        http2_max_concurrent_streams => 1,
+        dispatch =>
+            {handler, roadrunner_h2_test_handler, fun roadrunner_h2_test_handler:handle/1,
+                undefined}
+    }),
+    try
+        _ = expect_send(),
+        serve_recv(ConnPid, ?PREFACE),
+        serve_recv(ConnPid, ?EMPTY_SETTINGS_FRAME),
+        _ = expect_send(),
+        %% Stream 1: HEADERS without END_STREAM — open and counted, no
+        %% worker dispatched yet.
+        HpackBin = encode_post_root_headers(),
+        serve_recv(
+            ConnPid,
+            iolist_to_binary(
+                roadrunner_http2_frame:encode({headers, 1, 16#04, undefined, HpackBin})
+            )
+        ),
+        %% Limit reached: stream 3 is refused.
+        serve_recv(
+            ConnPid,
+            iolist_to_binary(
+                roadrunner_http2_frame:encode({headers, 3, 16#04, undefined, HpackBin})
+            )
+        ),
+        Rst = expect_send(),
+        ?assertMatch(
+            {ok, {rst_stream, 3, refused_stream}, _},
+            roadrunner_http2_frame:parse(Rst, 16384)
+        ),
+        %% Peer cancels stream 1 — its slot must free.
+        serve_recv(
+            ConnPid,
+            iolist_to_binary(roadrunner_http2_frame:encode({rst_stream, 1, cancel}))
+        ),
+        %% Stream 5 is admitted and served.
+        serve_recv(ConnPid, complete_get_headers(5, ~"/empty")),
+        Resp = expect_send(),
+        ?assertMatch(
+            {ok, {headers, 5, _, _, _}, _},
+            roadrunner_http2_frame:parse(Resp, 16384)
+        )
     after
         cleanup(Pid, Ref)
     end.

--- a/test/roadrunner_h2_test_handler.erl
+++ b/test/roadrunner_h2_test_handler.erl
@@ -51,6 +51,27 @@ handle(#{target := ~"/stream/multiframe"} = Req) ->
         end},
         Req
     };
+handle(#{target := ~"/stream/fin-then-park"} = Req) ->
+    %% Finish the response on the wire, then keep the worker alive: by the
+    %% time `Send(_, fin)` returns, the conn loop has written END_STREAM,
+    %% but no `DOWN` exists yet. Lets a test prove the concurrency slot
+    %% frees on END_STREAM, not on the worker's exit. Unregister first in
+    %% case a prior failed test leaked the name (see the `/loop` clause).
+    try
+        unregister(roadrunner_h2_fin_park_test)
+    catch
+        _:_ -> ok
+    end,
+    {
+        {stream, 200, [], fun(Send) ->
+            Send(~"done", fin),
+            true = register(roadrunner_h2_fin_park_test, self()),
+            receive
+                stop -> ok
+            end
+        end},
+        Req
+    };
 handle(#{target := ~"/stream/empty"} = Req) ->
     {{stream, 200, [], fun(_Send) -> ok end}, Req};
 handle(#{target := ~"/stream/empty-fin"} = Req) ->


### PR DESCRIPTION
# Description

The h2 conn loop released a stream's `max_concurrent_streams` slot only when the handler worker's `DOWN` arrived, which is strictly after the response's END_STREAM went out on the wire. A compliant client that opens a replacement stream the moment it reads END_STREAM races that `DOWN` and eats a spurious `REFUSED_STREAM`; measured with a client pinned at the advertised limit, 0.2-3.8% of stream opens were refused. The stream map now carries a `counted` flag with a `live_streams` counter: the slot frees exactly when the stream reaches the RFC 9113 closed state (our END_STREAM written and the peer's already seen), teardown paths (peer RST, worker crash, early response) release it idempotently, and the map entry still lives until `DOWN` for state cleanup. Re-measured with the same client: zero refusals at identical throughput, while over-offered streams beyond the advertised limit are still refused. Two new deterministic regression tests pin the race (a worker parked alive after its final chunk) and the RST release path.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)