### PR TITLE
Park idle keep-alive connections instead of polling for drain

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -188,3 +188,32 @@ roadrunner:start_listener(my_api, #{
 
 See `t:roadrunner_listener:opts/0` for the full list and the canonical
 defaults.
+
+## CPU in containers: scheduler busy-wait
+
+The listener options above bound memory. The one emulator flag worth
+setting for CPU is the scheduler busy-wait threshold. By default a
+scheduler that runs out of work spins for a while before sleeping, on
+the bet that more work is about to arrive. That bet pays off on a
+dedicated machine; in a container with a CPU quota it burns quota doing
+nothing, and the spin is charged to your workload.
+
+Add to `vm.args` when running in a container, or anywhere CPU is metered
+or shared:
+
+```
++sbwt none
++sbwtdcpu none
++sbwtdio none
+```
+
+Measured on a mostly-idle server (1024 connections, a paced 10k req/s,
+so schedulers repeatedly run dry — the shape most production services
+actually have): **CPU 265% → 110%** for the same request rate, with p99
+and p99.9 both *improving* and peak throughput unchanged. Run-to-run
+variance also drops sharply, because the spin is what was varying.
+
+The trade is real but small and worth measuring for your workload: a
+scheduler that slept must be woken, which adds latency to the first
+request that arrives after an idle gap. At saturation, where schedulers
+never run dry, these flags do nothing either way.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,26 @@ Autobahn re-run.
 
 **Source:** Arizona handoff R-h2-1.
 
+## Tail latency at low load — small effort
+
+**What:** Track down the multi-millisecond stalls that show up in the
+99.9th percentile on an otherwise idle server. `erlang:system_monitor`
+attributes them to the `tcp_inet` port driver being scheduled for up to
+20 ms at a stretch, and to conn processes blocked that long inside
+`erlang:port_control/3` (the `{active, once}` re-arm). No `long_gc`
+events fire, so garbage collection is not the cause.
+
+**Why it matters:** p50 and p99 are already good; it is p99.9 that
+carries these. A stall that rare is invisible in throughput numbers and
+very visible to anyone measuring tail latency.
+
+**Where to start:** whether the stalls track accept bursts (the listen
+socket's port doing a large batch) or steady-state traffic, and whether
+`{active, N}` or spreading accepts over more listen sockets moves them.
+
+**Scope:** small to medium — the instrumentation exists, the fix is
+unknown.
+
 ## HTTP/2 stream admission follow-ups
 
 ### Pre-SETTINGS stream leniency — medium effort

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,25 +40,57 @@ Autobahn re-run.
 
 **Source:** Arizona handoff R-h2-1.
 
-## Tail latency at low load — small effort
+## Connection setup under a connect burst — medium effort
 
-**What:** Track down the multi-millisecond stalls that show up in the
-99.9th percentile on an otherwise idle server. `erlang:system_monitor`
-attributes them to the `tcp_inet` port driver being scheduled for up to
-20 ms at a stretch, and to conn processes blocked that long inside
-`erlang:port_control/3` (the `{active, once}` re-arm). No `long_gc`
-events fire, so garbage collection is not the cause.
+**What:** Accepting a burst of connections is about twice as slow as it
+needs to be. Measured against another BEAM server on the same machine,
+1024 simultaneous connects took ~61 ms to reach a first response versus
+~31 ms, while a request on an already-warm connection was identical
+between the two (p50 3.21 ms vs 3.22 ms). So the gap is entirely in
+accept-and-start, not in serving.
 
-**Why it matters:** p50 and p99 are already good; it is p99.9 that
-carries these. A stall that rare is invisible in throughput numbers and
-very visible to anyone measuring tail latency.
+**Why it matters:** it lands squarely in the tail. At a paced 10k req/s
+over 20 s with 1024 connections, the connection setups are ~0.5 % of all
+requests — which is exactly the p99.9 band, and it matches the shape of
+the published numbers, where p99 is excellent and p99.9 is 60x worse.
+Connection churn is also a workload in its own right.
 
-**Where to start:** whether the stalls track accept bursts (the listen
-socket's port doing a large batch) or steady-state traffic, and whether
-`{active, N}` or spreading accepts over more listen sockets moves them.
+**Already ruled out by measurement** (3-round interleaved A/B each, so
+these are not worth re-testing):
 
-**Scope:** small to medium — the instrumentation exists, the fix is
-unknown.
+- the `pg:join` into the drain group, both by moving it after
+  `proc_lib:init_ack` (off the acceptor's critical path) and by
+  disabling `graceful_drain` entirely — both tied
+- acceptor pool size — 16 and 100 acceptors behave the same
+- garbage collection — `erlang:system_monitor` fires no `long_gc`
+
+**Where to start:** `erlang:system_monitor` attributes the stalls to the
+`tcp_inet` port being scheduled for up to 20 ms at a stretch during the
+burst, and to conn processes blocked that long inside
+`erlang:port_control/3` (the `{active, once}` re-arm). In steady state
+those stalls nearly vanish (max ~5 ms, a handful per 14 s), which is
+what points at accept rather than at serving. Worth testing whether the
+synchronous `proc_lib:start` handshake per accepted connection, or the
+single listen socket's port, is the serializer.
+
+**Scope:** medium — the instrumentation exists, the cause does not.
+
+## Drop the mid-request drain poll — small effort
+
+**What:** `recv_passive/2` still wakes every `?DRAIN_CHECK_INTERVAL_MS`
+(100 ms) to look for a drain message while reading the rest of a request
+whose first byte already arrived. Every other read path has moved past
+needing that: the first-byte wait parks in `receive` (so it sees a drain
+instantly), and the body read blocks for the full remaining deadline
+without checking at all.
+
+**Why:** a graceful drain should not cut an in-flight request short, so
+the poll has no one left to serve — it only costs wakeups on requests
+whose headers span more than one packet. Removing it would make the
+header path consistent with the body path and simplify the function.
+
+**Scope:** small — delete the tick, use the full deadline, keep the
+`{error, timeout}` handling.
 
 ## HTTP/2 stream admission follow-ups
 

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -8,20 +8,34 @@
 %% function calls between phase functions. No `gen_statem` dispatch,
 %% no per-request timer arms in the steady state.
 %%
-%% ## Two recv paths
+%% ## Recv paths
 %%
-%% Default is **passive recv** — `gen_tcp:recv(Socket, 0, ChunkTimeout)`
-%% in a loop with mailbox drain checks at `?DRAIN_CHECK_INTERVAL_MS`
-%% (100 ms) granularity. Bypasses `gen_tcp_socket`'s gen_statem dispatch
-%% on every recv (saves ~7 % CPU on the hot path: `gen:do_call/4`,
-%% `recv_data_deliver/4`, `gen_statem:loop/3`, `nif_getopt/3`).
+%% Waiting for the **first byte** of a request (`recv_idle/2`) is
+%% active-mode: `{active, once}` + `receive`, parked until bytes, a close
+%% or a drain arrive. A conn can sit here for the whole keep-alive
+%% window, so it must cost nothing while it does — and a drain is seen
+%% the moment it is sent. The deadline rides the receive's own `after`,
+%% so there is still no `start_timer` / `cancel_timer` per request.
 %%
-%% When the listener sets `hibernate_after => Ms > 0`, the recv path
-%% flips to **active-mode** (`{active, once}` + receive). The receive's
-%% `after Ms` clause has a window to call `erlang:hibernate/3` between
-%% keep-alive iterations so the conn's heap GCs and shrinks — only
-%% `receive` supports hibernation; passive recv blocks the process
-%% inside a NIF.
+%% Reading the **rest of a request already in flight** is **passive
+%% recv** — `gen_tcp:recv(Socket, 0, ChunkTimeout)`, which bypasses
+%% `gen_tcp_socket`'s gen_statem dispatch (saves ~7 % CPU on the hot
+%% path: `gen:do_call/4`, `recv_data_deliver/4`, `gen_statem:loop/3`,
+%% `nif_getopt/3`). Passive recv cannot see the mailbox, so it wakes
+%% every `?DRAIN_CHECK_INTERVAL_MS` (100 ms) to look for a drain; that
+%% only applies mid-request, where the peer is already sending and a
+%% graceful drain would let the request finish regardless.
+%%
+%% Keeping the poll off the idle path matters because its cost scales
+%% with *connections* rather than requests: 1024 idle keep-alive conns
+%% polling at 100 ms burned ~1.2 cores doing nothing, which is invisible
+%% at saturation but dominates a mostly-idle server.
+%%
+%% When the listener sets `hibernate_after => Ms > 0`, the first-byte
+%% wait instead uses `recv_with_hibernate/3`, whose `after Ms` clause has
+%% a window to call `erlang:hibernate/3` between keep-alive iterations so
+%% the conn's heap GCs and shrinks — only `receive` supports hibernation;
+%% passive recv blocks the process inside a NIF.
 %%
 %% ## Phase introspection vs hot-path cost
 %%
@@ -393,13 +407,65 @@ recv_request_bytes(S0, Deadline) ->
         #loop_state{hibernate_after = Ms} = S when Ms > 0 ->
             arm_active_once(S),
             recv_with_hibernate(S, Deadline, Ms);
+        #loop_state{recv_phase_bytes = 0} = S ->
+            %% Waiting for the first byte of a request: the conn may sit
+            %% here for the whole keep-alive window, so block in `receive`
+            %% rather than poll. Passive recv cannot see the mailbox, so
+            %% that path has to wake every `?DRAIN_CHECK_INTERVAL_MS` just
+            %% to look for a drain — a cost per *connection* rather than
+            %% per request, which idle keep-alive connections pay forever.
+            recv_idle(S, Deadline);
         S ->
+            %% Mid-request: the peer is already sending and the remaining
+            %% bytes are in flight, so passive recv blocks briefly. A drain
+            %% must not cut an in-flight request short anyway.
             recv_passive(S, Deadline)
     end.
 
-%% Passive-mode recv path (default — `hibernate_after` unset or 0).
-%% Bypasses `gen_tcp_socket`'s gen_statem dispatch entirely — direct
-%% `gen_tcp:recv` call into the kernel via the prim_socket NIF.
+%% Idle wait for the next request on a keep-alive connection. Armed
+%% active-once and parked in `receive`, so the process costs nothing until
+%% bytes, a close or a drain arrive — and a drain is picked up the instant
+%% it is sent instead of on the next poll tick. The deadline rides the
+%% receive's own `after` clause: no `send_after` / `cancel_timer` pair per
+%% request, which is what kept the passive path cheap.
+-spec recv_idle(#loop_state{}, integer()) -> no_return().
+recv_idle(#loop_state{socket = Socket, buffered = Buf} = S, Deadline) ->
+    arm_active_once(S),
+    {DataTag, ClosedTag, ErrorTag} = roadrunner_transport:messages(Socket),
+    Remaining = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    receive
+        {DataTag, _Sock, Bytes} ->
+            %% Anchor the anti-slowloris window at this first byte rather
+            %% than at phase entry, so the idle keep-alive gap that just
+            %% ended is not counted as slow transmission. No rate check
+            %% here: the window is zero-length at its own anchor, so the
+            %% first chunk always passes. `recv_passive/2` measures every
+            %% chunk after it.
+            handle_request_bytes(
+                S#loop_state{
+                    buffered = <<Buf/binary, Bytes/binary>>,
+                    recv_phase_bytes = byte_size(Bytes),
+                    recv_phase_start = erlang:monotonic_time(millisecond)
+                },
+                Deadline
+            );
+        {ClosedTag, _Sock} ->
+            exit_normal(S);
+        {ErrorTag, _Sock, _Reason} ->
+            exit_normal(S);
+        {roadrunner_drain, _DrainDeadline} ->
+            exit_normal(S);
+        _Stray ->
+            recv_idle(S, Deadline)
+    after Remaining ->
+        timeout_response(S),
+        exit_normal(S)
+    end.
+
+%% Passive-mode recv path — reads the remainder of a request whose first
+%% byte `recv_idle/2` already took. Bypasses `gen_tcp_socket`'s gen_statem
+%% dispatch entirely — direct `gen_tcp:recv` call into the kernel via the
+%% prim_socket NIF.
 %%
 %% Drain detection: zero-timeout receive before each blocking recv
 %% drains pending `{roadrunner_drain, _}` and stray messages from
@@ -434,24 +500,19 @@ recv_passive(
                     %% the conn if `min_rate` isn't met after the 1 s
                     %% grace. Cheap when `min_rate = 0` because
                     %% `roadrunner_conn:rate_ok/3` short-circuits at
-                    %% `MinRate * Elapsed = 0`. Anchor the window at the
-                    %% first byte of the request (`PhaseBytes =:= 0`), not
-                    %% at phase entry — `recv` never returns `{ok, <<>>}`
-                    %% on a stream socket, so the first chunk always sets
-                    %% the anchor and subsequent chunks measure from there.
-                    PhaseStart1 =
-                        case PhaseBytes of
-                            0 -> Now;
-                            _ -> PhaseStart
-                        end,
+                    %% `MinRate * Elapsed = 0`. The window is already
+                    %% anchored at the request's first byte by
+                    %% `recv_idle/2`, which is the only way into this
+                    %% path, so every chunk measured here is a genuine
+                    %% continuation of a request already in flight.
                     NewBytes = PhaseBytes + byte_size(Bytes),
-                    case roadrunner_conn:rate_ok(Now - PhaseStart1, NewBytes, MinRate) of
+                    case roadrunner_conn:rate_ok(Now - PhaseStart, NewBytes, MinRate) of
                         true ->
                             handle_request_bytes(
                                 S#loop_state{
                                     buffered = <<Buf/binary, Bytes/binary>>,
                                     recv_phase_bytes = NewBytes,
-                                    recv_phase_start = PhaseStart1
+                                    recv_phase_start = PhaseStart
                                 },
                                 Deadline
                             );

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -202,7 +202,19 @@ Optional middleware and timing knobs (durations in milliseconds):
   `[{fullsweep_after, 0}]` so the per-conn response heap is reclaimed
   instead of hoarding it as old-gen garbage across keep-alive
   requests) and `start_timeout` (init-ack deadline, default
-  `infinity`). For the lowest *resident* memory you can also add
+  `infinity`).
+
+  `fullsweep_after, 0` makes every collection a full sweep, which is
+  what keeps the heap flat — and it is not free on handlers that
+  allocate heavily. Measured on a JSON route building a large transient
+  iolist per request, against the emulator's generational default at
+  the same CPU: throughput 51k vs 58k req/s and mean latency 3.25 ms vs
+  2.63 ms, for 189 MB vs 361 MB of RSS. Bounded memory is the safer
+  default for a server, so that is the trade taken here; a service that
+  would rather spend the memory can pass `opts => []` and get the
+  emulator's generational behaviour back.
+
+  For the lowest *resident* memory you can also add
   `+MHacul 0 +MBacul 0` to `vm.args` to return freed allocator carriers
   to the OS, but that is a tradeoff, not a free win: it raises
   allocator↔OS traffic and can hurt throughput at high core counts, so

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -552,10 +552,11 @@ plaintext_listener_without_h2c_stays_h1() ->
     %%
     %% - The h2 path proactively sends a SETTINGS frame on the wire
     %%   right after `shoot` (`{roadrunner_fake_send, _, _}`).
-    %% - The h1 path enters passive recv and asks the fake transport
-    %%   for bytes (`{roadrunner_fake_recv, _, _, _}`).
+    %% - The h1 path writes nothing and waits for the request's first
+    %%   byte, which on a fake socket surfaces as an arm
+    %%   (`{roadrunner_fake_setopts, _, _}`) or a recv.
     %%
-    %% Receiving the recv message (and no send) proves we routed to h1.
+    %% Waiting for bytes without writing first proves we routed to h1.
     {ok, _} = application:ensure_all_started(telemetry),
     drain_mailbox(),
     Self = self(),
@@ -588,15 +589,15 @@ plaintext_listener_without_h2c_stays_h1() ->
     {ok, Pid} = roadrunner_conn_loop:start(Sock, ProtoOpts),
     Ref = monitor(process, Pid),
     Pid ! shoot,
-    %% h1 issues a passive recv on the socket; on a fake socket that
-    %% surfaces as a `{roadrunner_fake_recv, ConnPid, Len, Timeout}`
-    %% message to our process. h2 would never do this — it goes
-    %% active-once via setopts and proactively writes SETTINGS first.
+    %% h1 waits for the request before writing anything; on a fake socket
+    %% that surfaces as an arm or a recv. h2 would have written its
+    %% SETTINGS frame first.
     receive
+        {roadrunner_fake_setopts, _, _} -> ok;
         {roadrunner_fake_recv, _, _, _} -> ok;
         {roadrunner_fake_send, _, _} -> error(unexpected_h2_send)
     after 500 ->
-        error(no_recv_call)
+        error(no_read_attempt)
     end,
     ?assert(is_process_alive(Pid)),
     cleanup(Pid, Ref).

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -232,10 +232,10 @@ drain_during_read_request_exits_silently_test() ->
     ?assertEqual(<<>>, iolist_to_binary(collect_sends(Tag, 50))),
     Sink ! stop.
 
-tcp_closed_during_passive_recv_exits_silently_test() ->
-    %% Phase A' default path uses passive recv. TCP close is signaled
-    %% by `gen_tcp:recv` returning `{error, closed}` — script the sink
-    %% to reply with that.
+tcp_closed_while_awaiting_request_exits_silently_test() ->
+    %% Peer closes while the conn waits for a request's first byte.
+    %% The scripted close is delivered as the active-mode close event
+    %% the conn is parked on.
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
@@ -251,9 +251,9 @@ tcp_closed_during_passive_recv_exits_silently_test() ->
     ?assertEqual(<<>>, iolist_to_binary(collect_sends(Tag, 50))),
     Sink ! stop.
 
-tcp_error_during_passive_recv_exits_silently_test() ->
-    %% Phase A' passive path: any non-timeout, non-closed recv error
-    %% (e.g. econnreset) → silent exit.
+tcp_error_while_awaiting_request_exits_silently_test() ->
+    %% Any non-timeout, non-closed transport error (e.g. econnreset)
+    %% while awaiting a request → silent exit.
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
@@ -264,6 +264,104 @@ tcp_error_during_passive_recv_exits_silently_test() ->
     receive
         {'DOWN', Ref, process, Pid, normal} -> ok
     after 2000 -> error(no_normal_exit)
+    end,
+    ?assertEqual(<<>>, iolist_to_binary(collect_sends(Tag, 50))),
+    Sink ! stop.
+
+%% --- mid-request passive recv -------------------------------------
+%%
+%% The conn reads a request's first byte in active mode and the rest
+%% passively, so these drive a PARTIAL request in first and then fail
+%% the remainder. Sink: deliver `Partial` when the conn arms, then
+%% behave per `Then` on the passive recv that follows.
+
+spawn_partial_then_sink(Logger, Tag, Partial, Then) ->
+    spawn(fun() -> partial_then_loop(Logger, Tag, Partial, Then, false) end).
+
+partial_then_loop(Logger, Tag, Partial, Then, Delivered) ->
+    receive
+        stop ->
+            ok;
+        {roadrunner_fake_setopts, ConnPid, _Opts} when not Delivered ->
+            ConnPid ! {roadrunner_fake_data, undefined, Partial},
+            partial_then_loop(Logger, Tag, Partial, Then, true);
+        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
+            case Then of
+                silent ->
+                    %% No reply: the transport honours the caller's
+                    %% timeout, so recv returns `{error, timeout}`.
+                    ok;
+                {reply, Result} ->
+                    ConnPid ! {roadrunner_fake_recv_reply, Result}
+            end,
+            partial_then_loop(Logger, Tag, Partial, Then, Delivered);
+        {roadrunner_fake_send, _Pid, Data} ->
+            Logger ! {Tag, sent, Data},
+            partial_then_loop(Logger, Tag, Partial, Then, Delivered);
+        _Other ->
+            partial_then_loop(Logger, Tag, Partial, Then, Delivered)
+    end.
+
+%% Request line + one header, no terminating CRLF — parses as `{more, _}`
+%% so the conn goes back for the remainder.
+partial_request() -> ~"GET / HTTP/1.1\r\nHost: x\r\n".
+
+drain_during_body_recv_exits_silently_test() ->
+    %% Drain arriving while the conn is reading the rest of a request:
+    %% picked up by the mailbox check between drain ticks, after a
+    %% stray message ahead of it in the queue is skipped.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_partial_then_sink(Self, Tag, partial_request(), silent),
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, fake_opts(drain_passive)),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    %% Let the conn take the partial request and block on the remainder.
+    timer:sleep(50),
+    Pid ! {junk_from_a_buggy_lib, make_ref()},
+    Pid ! {roadrunner_drain, infinity},
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 3000 -> error(no_normal_exit)
+    end,
+    %% Drain bypasses the response — no 408 for the half-sent request.
+    ?assertEqual(<<>>, iolist_to_binary(collect_sends(Tag, 50))),
+    Sink ! stop.
+
+request_timeout_during_body_recv_writes_408_test() ->
+    %% The absolute deadline is enforced across drain ticks: a client
+    %% that sends half a request and stalls gets a 408.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_partial_then_sink(Self, Tag, partial_request(), silent),
+    Opts = (fake_opts(timeout_passive))#{request_timeout := 250},
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 5000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertMatch(<<"HTTP/1.1 408", _/binary>>, Sent),
+    Sink ! stop.
+
+tcp_error_during_body_recv_exits_silently_test() ->
+    %% A transport error on the remainder of a request → silent exit.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Sink = spawn_partial_then_sink(
+        Self, Tag, partial_request(), {reply, {error, econnreset}}
+    ),
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, fake_opts(err_passive)),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 3000 -> error(no_normal_exit)
     end,
     ?assertEqual(<<>>, iolist_to_binary(collect_sends(Tag, 50))),
     Sink ! stop.
@@ -340,9 +438,11 @@ slowloris_during_passive_recv_drops_client_test() ->
     %% the sleep queue up; the held reply lands on whichever recv is
     %% pending when the sink wakes.
     Sink = spawn(fun() ->
+        %% First byte lands on the active-mode wait for the request's
+        %% first byte; the dribble that follows is read passively.
         receive
-            {roadrunner_fake_recv, C1, _, _} ->
-                C1 ! {roadrunner_fake_recv_reply, {ok, ~"G"}}
+            {roadrunner_fake_setopts, C1, _} ->
+                C1 ! {roadrunner_fake_data, undefined, ~"G"}
         after 5000 -> ok
         end,
         timer:sleep(1200),
@@ -597,7 +697,7 @@ interim_buffered_response_writes_500_test() ->
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
-    Sink = spawn_active_sink_with_send_log(
+    Sink = spawn_active_sink_once(
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     Opts = (fake_opts(interim))#{
@@ -928,7 +1028,7 @@ pipelined_responses_coalesce_into_one_send_test() ->
     Self = self(),
     Tag = make_ref(),
     Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
-    Sink = spawn_active_sink_with_send_log(
+    Sink = spawn_active_sink_once(
         Self, Tag, <<Req/binary, Req/binary, Req/binary>>
     ),
     Opts = (fake_opts(coalesced))#{
@@ -958,7 +1058,7 @@ manual_mode_bodyless_pipelined_requests_coalesce_test() ->
     Self = self(),
     Tag = make_ref(),
     Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
-    Sink = spawn_active_sink_with_send_log(Self, Tag, <<Req/binary, Req/binary>>),
+    Sink = spawn_active_sink_once(Self, Tag, <<Req/binary, Req/binary>>),
     Opts = (fake_opts(manual_coalesced))#{
         body_buffering := manual,
         dispatch :=
@@ -1499,7 +1599,7 @@ sendfile_dispatch_closes_socket_on_error_test() ->
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
-    Sink = spawn_active_sink_with_send_log(
+    Sink = spawn_active_sink_once(
         Self, Tag, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
     ),
     HandlerFun = fun(Req) ->
@@ -1800,6 +1900,35 @@ is_hibernating_loop(Pid, Threshold, Deadline) ->
 spawn_active_sink_with_send_log(Logger, Tag, Bytes) ->
     spawn(fun() -> active_sink_loop(Logger, Tag, Bytes, false) end).
 
+%% Same, but the peer goes away once `Bytes` have been served: the conn
+%% closes instead of waiting out its keep-alive window. For tests that
+%% assert on what one request wrote and then expect a clean exit.
+spawn_active_sink_once(Logger, Tag, Bytes) ->
+    spawn(fun() -> active_sink_once_loop(Logger, Tag, Bytes, false) end).
+
+active_sink_once_loop(Logger, Tag, Bytes, Delivered) ->
+    receive
+        stop ->
+            ok;
+        {roadrunner_fake_setopts, ConnPid, _Opts} when not Delivered ->
+            ConnPid ! {roadrunner_fake_data, undefined, Bytes},
+            active_sink_once_loop(Logger, Tag, Bytes, true);
+        {roadrunner_fake_setopts, ConnPid, _Opts} ->
+            ConnPid ! {roadrunner_fake_closed, undefined},
+            active_sink_once_loop(Logger, Tag, Bytes, Delivered);
+        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} when not Delivered ->
+            ConnPid ! {roadrunner_fake_recv_reply, {ok, Bytes}},
+            active_sink_once_loop(Logger, Tag, Bytes, true);
+        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
+            ConnPid ! {roadrunner_fake_recv_reply, {error, closed}},
+            active_sink_once_loop(Logger, Tag, Bytes, Delivered);
+        {roadrunner_fake_send, _Pid, Data} ->
+            Logger ! {Tag, sent, Data},
+            active_sink_once_loop(Logger, Tag, Bytes, Delivered);
+        _Other ->
+            active_sink_once_loop(Logger, Tag, Bytes, Delivered)
+    end.
+
 active_sink_loop(Logger, Tag, Bytes, Delivered) ->
     receive
         stop ->
@@ -1896,7 +2025,19 @@ scripted_sink_loop(Logger, Tag, Script) ->
                     ConnPid ! {roadrunner_fake_data, undefined, Bytes},
                     scripted_sink_loop(Logger, Tag, Rest);
                 empty ->
-                    scripted_sink_loop(Logger, Tag, Script)
+                    %% The conn waits for the first byte of a request in
+                    %% active mode and reads the rest passively, so a
+                    %% script describes socket events without knowing
+                    %% which mode the conn is in when each one lands.
+                    %% Deliver a `passive` entry as its active-mode
+                    %% equivalent when the conn armed instead of recv'ing.
+                    case take_passive(Script) of
+                        {ok, Result, Rest} ->
+                            ConnPid ! as_active_message(Result),
+                            scripted_sink_loop(Logger, Tag, Rest);
+                        empty ->
+                            scripted_sink_loop(Logger, Tag, Script)
+                    end
             end;
         {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
             case take_passive(Script) of
@@ -1922,6 +2063,12 @@ take_active([]) -> empty.
 take_passive([{passive, Result} | Rest]) -> {ok, Result, Rest};
 take_passive([_ | Rest]) -> take_passive(Rest);
 take_passive([]) -> empty.
+
+%% The active-mode message a `gen_tcp:recv` result corresponds to, so one
+%% script drives either recv path.
+as_active_message({ok, Bytes}) -> {roadrunner_fake_data, undefined, Bytes};
+as_active_message({error, closed}) -> {roadrunner_fake_closed, undefined};
+as_active_message({error, Reason}) -> {roadrunner_fake_error, undefined, Reason}.
 
 %% Two-chunk active sink — exercises the `{more, _}` parse branch.
 %% First setopts arms → deliver Chunk1. Second setopts arms → deliver

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -566,10 +566,13 @@ fake_conn_drives_handler_without_sockets_test() ->
         {fake, Self}, fake_proto_opts(roadrunner_test_handler)
     ),
     ConnPid ! shoot,
+    %% The conn waits for a request's first byte in active mode, so it
+    %% arms the socket and the request arrives as a data message.
     receive
-        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
-            ConnPid ! {roadrunner_fake_recv_reply, {ok, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"}}
-    after 1000 -> error(no_recv_request)
+        {roadrunner_fake_setopts, ConnPid, _Opts} ->
+            ConnPid !
+                {roadrunner_fake_data, undefined, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"}
+    after 1000 -> error(no_arm_for_request)
     end,
     Reply =
         receive


### PR DESCRIPTION
# Description

A connection waiting for its next keep-alive request woke every 100 ms to check its mailbox for a graceful-drain message, because passive `recv` cannot see the mailbox. That is a cost per *connection* rather than per request, so it is invisible at saturation and dominant on a mostly-idle server: 1024 idle connections burned over a core doing nothing. The first-byte wait now arms the socket active-once and parks in `receive`, so an idle connection costs nothing until bytes, a close or a drain arrive, and a drain is picked up the moment it is sent rather than on the next tick. The deadline rides the receive's own `after`, so there is still no timer pair per request, and reading the rest of a request already in flight still uses passive recv. Also documents the emulator's scheduler busy-wait flags for containers, and the memory-for-throughput trade the `fullsweep_after` default makes.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)