### PR TITLE
Merge handler spawn options over the defaults instead of replacing

### DIFF
--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -214,6 +214,13 @@ Optional middleware and timing knobs (durations in milliseconds):
   would rather spend the memory can pass `opts => []` and get the
   emulator's generational behaviour back.
 
+  The choice is effectively binary — an intermediate sweep interval buys
+  no middle ground. Values of 5, 10 and 20 all measured within noise of
+  the generational default on *both* axes (≈60k req/s, ≈340 MB) on that
+  same route, because the refc-binary garbage driving the heap piles up
+  between full sweeps whatever the interval between them is. Sweep every
+  time or effectively never.
+
   For the lowest *resident* memory you can also add
   `+MHacul 0 +MBacul 0` to `vm.args` to return freed allocator carriers
   to the OS, but that is a tradeoff, not a free win: it raises

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -202,7 +202,9 @@ Optional middleware and timing knobs (durations in milliseconds):
   `[{fullsweep_after, 0}]` so the per-conn response heap is reclaimed
   instead of hoarding it as old-gen garbage across keep-alive
   requests) and `start_timeout` (init-ack deadline, default
-  `infinity`).
+  `infinity`). `opts` merges over the defaults per option key, so
+  setting one option keeps the rest — asking for a heap hint does not
+  silently change the GC policy.
 
   `fullsweep_after, 0` makes every collection a full sweep, which is
   what keeps the heap flat — and it is not free on handlers that
@@ -211,8 +213,12 @@ Optional middleware and timing knobs (durations in milliseconds):
   the same CPU: throughput 51k vs 58k req/s and mean latency 3.25 ms vs
   2.63 ms, for 189 MB vs 361 MB of RSS. Bounded memory is the safer
   default for a server, so that is the trade taken here; a service that
-  would rather spend the memory can pass `opts => []` and get the
-  emulator's generational behaviour back.
+  would rather spend the memory names `fullsweep_after` itself to
+  override it — an empty list will not do, since `opts` merges. Use
+  `[{fullsweep_after, 65535}]` for the emulator's usual value, or
+  `[{fullsweep_after, element(2, erlang:system_info(fullsweep_after))}]`
+  to follow whatever this node is set to, which `ERL_FULLSWEEP_AFTER`
+  can move.
 
   The choice is effectively binary — an intermediate sweep interval buys
   no middle ground. Values of 5, 10 and 20 all measured within noise of
@@ -1236,11 +1242,14 @@ build_proto_opts(Opts, ListenerName) ->
 resolve_handler_spawn(Opts) ->
     case maps:get(handler_spawn, Opts, #{}) of
         HandlerSpawn when is_map(HandlerSpawn) ->
-            SpawnOpts = maps:get(opts, HandlerSpawn, ?DEFAULT_HANDLER_SPAWN_OPTS),
+            UserOpts = maps:get(opts, HandlerSpawn, []),
             Timeout = maps:get(start_timeout, HandlerSpawn, ?DEFAULT_HANDLER_START_TIMEOUT),
-            ok = validate_handler_spawn_opts(SpawnOpts, HandlerSpawn),
+            ok = validate_handler_spawn_opts(UserOpts, HandlerSpawn),
             ok = validate_handler_start_timeout(Timeout, HandlerSpawn),
-            #{opts => SpawnOpts, start_timeout => Timeout};
+            #{
+                opts => merge_spawn_opts(?DEFAULT_HANDLER_SPAWN_OPTS, UserOpts),
+                start_timeout => Timeout
+            };
         Other ->
             error({invalid_listener_opt, handler_spawn, Other})
     end.
@@ -1252,6 +1261,30 @@ validate_handler_spawn_opts(SpawnOpts, Raw) when is_list(SpawnOpts) ->
     end;
 validate_handler_spawn_opts(_SpawnOpts, Raw) ->
     error({invalid_listener_opt, handler_spawn, Raw}).
+
+%% A caller's option wins per key and the rest of the defaults stay.
+%% Replacing the list wholesale would mean setting any one option
+%% silently drops the others — and dropping `fullsweep_after` alone
+%% roughly doubles a listener's memory, with nothing in the config to
+%% suggest why. To get the emulator's generational behaviour, name
+%% `fullsweep_after` explicitly rather than passing an empty list.
+merge_spawn_opts(Defaults, UserOpts) ->
+    lists:foldr(
+        fun(Default, Acc) ->
+            Key = spawn_opt_key(Default),
+            case lists:any(fun(Opt) -> spawn_opt_key(Opt) =:= Key end, UserOpts) of
+                true -> Acc;
+                false -> [Default | Acc]
+            end
+        end,
+        UserOpts,
+        Defaults
+    ).
+
+%% Everything reaching the merge is a `{Key, Value}` pair: `link` is the
+%% only bare-atom spawn option and it is reserved below, rejected before
+%% this runs.
+spawn_opt_key(Opt) -> element(1, Opt).
 
 is_reserved_spawn_opt(link) -> true;
 is_reserved_spawn_opt(monitor) -> true;

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -360,18 +360,57 @@ listener_threads_handler_spawn_defaults_into_proto_opts_test() ->
 listener_threads_custom_handler_spawn_into_proto_opts_test() ->
     %% A custom `handler_spawn` map is flattened to the two top-level
     %% proto_opts keys the spawn sites read directly (no nested lookup
-    %% on the hot path), mirroring the `ws` / `http2` flattening.
+    %% on the hot path), mirroring the `ws` / `http2` flattening. Options
+    %% the caller sets win over the defaults for the same key.
     Name = listener_test_handler_spawn_custom,
-    SpawnOpts = [{fullsweep_after, 20}, {min_bin_vheap_size, 1024}],
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
         port => 0,
-        handler_spawn => #{opts => SpawnOpts, start_timeout => 5000},
+        handler_spawn => #{
+            opts => [{fullsweep_after, 20}, {min_bin_vheap_size, 1024}],
+            start_timeout => 5000
+        },
         routes => roadrunner_hello_handler
     }),
     State = sys:get_state(ListenerPid),
     ProtoOpts = element(4, State),
-    ?assertEqual(SpawnOpts, maps:get(handler_spawn_opts, ProtoOpts)),
+    ?assertEqual(
+        [{fullsweep_after, 20}, {min_bin_vheap_size, 1024}],
+        lists:sort(maps:get(handler_spawn_opts, ProtoOpts))
+    ),
     ?assertEqual(5000, maps:get(handler_start_timeout, ProtoOpts)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_handler_spawn_opts_keep_unset_defaults_test() ->
+    %% Setting one spawn option must not drop the others. Dropping
+    %% `fullsweep_after` alone roughly doubles a listener's memory, and
+    %% nothing in a config asking for a heap hint would explain it.
+    Name = listener_test_handler_spawn_merge,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        handler_spawn => #{opts => [{min_bin_vheap_size, 1024}]},
+        routes => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    Merged = maps:get(handler_spawn_opts, ProtoOpts),
+    ?assert(lists:member({min_bin_vheap_size, 1024}, Merged)),
+    ?assert(lists:member({fullsweep_after, 0}, Merged)),
+    ok = roadrunner_listener:stop(Name).
+
+listener_handler_spawn_opts_allow_overriding_gc_default_test() ->
+    %% The escape hatch: naming `fullsweep_after` explicitly replaces the
+    %% default rather than merging alongside it, so a service that would
+    %% rather spend memory than sweep can have the emulator's own
+    %% generational behaviour.
+    Name = listener_test_handler_spawn_override,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        handler_spawn => #{opts => [{fullsweep_after, 65535}]},
+        routes => roadrunner_hello_handler
+    }),
+    State = sys:get_state(ListenerPid),
+    ProtoOpts = element(4, State),
+    ?assertEqual([{fullsweep_after, 65535}], maps:get(handler_spawn_opts, ProtoOpts)),
     ok = roadrunner_listener:stop(Name).
 
 listener_accepts_http1_tuple_form_test() ->


### PR DESCRIPTION
# Description

`handler_spawn`'s `opts` replaced the defaults wholesale, so setting one spawn option silently dropped the others — `opts => [{min_bin_vheap_size, 1024}]` also dropped `{fullsweep_after, 0}` and roughly doubled a listener's memory, with nothing in the config to suggest why. A caller's option now wins per key and the rest of the defaults stay, which is how every sibling option group here (`ws`, `http1`, `http2`, `http3`, `rate_limit`) already resolves. `opts` keeps taking `proc_lib:start_spawn_option()` so the accepted options track OTP rather than a list copied into this module.

Because `opts` merges, an empty list no longer means "no options": overriding the GC default means naming `fullsweep_after` explicitly, which the option's docs now show both ways, along with the throughput-for-memory trade that default is making (measured on an allocation-heavy route: 51k vs 58k req/s and 3.25 ms vs 2.63 ms mean latency at the same CPU, for 189 MB vs 361 MB of RSS — and no intermediate sweep interval buys a middle ground).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)