### PR TITLE
Keep the mid-request drain poll and say why

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,23 +98,6 @@ single listen socket's port, is the serializer.
 
 **Scope:** medium — the instrumentation exists, the cause does not.
 
-## Drop the mid-request drain poll — small effort
-
-**What:** `recv_passive/2` still wakes every `?DRAIN_CHECK_INTERVAL_MS`
-(100 ms) to look for a drain message while reading the rest of a request
-whose first byte already arrived. Every other read path has moved past
-needing that: the first-byte wait parks in `receive` (so it sees a drain
-instantly), and the body read blocks for the full remaining deadline
-without checking at all.
-
-**Why:** a graceful drain should not cut an in-flight request short, so
-the poll has no one left to serve — it only costs wakeups on requests
-whose headers span more than one packet. Removing it would make the
-header path consistent with the body path and simplify the function.
-
-**Scope:** small — delete the tick, use the full deadline, keep the
-`{error, timeout}` handling.
-
 ## HTTP/2 stream admission follow-ups
 
 ### Pre-SETTINGS stream leniency — medium effort
@@ -127,9 +110,15 @@ client only to a limit it has received, so the burst is compliant.
 Refusing the excess sheds real requests at every connection setup when
 the client's default concurrency exceeds our advertised value.
 
-**Design question:** admit up to the protocol default (100) until the
-client's SETTINGS ack arrives, or queue the excess and admit as slots
-free. Queueing composes with the entry below.
+**Design question:** admit up to some bound until the client's SETTINGS
+ack arrives, or queue the excess and admit as slots free. Note there is
+no protocol default to fall back on: RFC 9113 §6.5.2 says
+`SETTINGS_MAX_CONCURRENT_STREAMS` is *initially unlimited*, which is
+exactly why a prior-knowledge client opens as many as it likes in its
+first flight. So "admit what the default allows" is not an option, and
+admitting the burst outright is how the multi-GiB blowup that took
+`json-h2c` to zero happened. That leaves queueing, which is the entry
+below — worth treating these as one piece of work rather than two.
 
 **Scope:** medium — admission bookkeeping in the h2 conn loop plus
 tests for the ack-timing windows.

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -397,6 +397,18 @@ phase_timeout(#loop_state{phase = keep_alive, keep_alive_timeout = T}) ->
 %% shorter = lower drain latency, more recv NIF calls; longer =
 %% the opposite. 100 ms matches typical ops-tooling expectations
 %% for graceful-drain detection.
+%%
+%% It looks removable now that the idle wait parks in `receive` and sees
+%% a drain immediately, since a drain should not cut an in-flight
+%% request short anyway. It is not. This bounds how long a conn stalled
+%% MID-request takes to notice: a peer that sent half its headers and
+%% went away would otherwise sit here for the whole `request_timeout`,
+%% outlive the drain deadline, and be hard-killed by
+%% `roadrunner_listener:drain/2` instead of exiting cleanly — turning a
+%% graceful drain into a forced one and reporting `{timeout, N}` rather
+%% than `{ok, drained}`. Normal traffic never pays for it: the next
+%% chunk of a request already in flight arrives in microseconds, so the
+%% cap only fires for a client that stopped sending.
 -define(DRAIN_CHECK_INTERVAL_MS, 100).
 
 -spec recv_request_bytes(#loop_state{}, integer()) -> no_return().


### PR DESCRIPTION
# Description

The roadmap suggested dropping the 100 ms drain tick in `recv_passive/2`, on the grounds that the idle wait now parks in `receive` and sees a drain immediately, and a drain should not cut an in-flight request short anyway. That reasoning is wrong: the tick bounds how long a conn stalled MID-request takes to notice. A peer that sends half its headers and goes away would otherwise sit for the whole `request_timeout`, outlive the drain deadline and be hard-killed by `drain/2` instead of exiting cleanly — a graceful drain turned into a forced one, returning `{timeout, N}` rather than `{ok, drained}`. Removing it also buys nothing measurable (interleaved A/B: 617k vs 608k req/s, tied), because normal traffic never reaches the timeout — the next chunk of a request already in flight arrives in microseconds. So the idea moves out of the roadmap and into a comment where the next reader of that constant will find it.

Also corrects the pre-SETTINGS leniency entry: it offered "admit up to the protocol default (100)" as an option, but RFC 9113 §6.5.2 makes `SETTINGS_MAX_CONCURRENT_STREAMS` initially unlimited, which is why a prior-knowledge client bursts in the first place. There is no default to fall back on and admitting the burst outright is what took `json-h2c` to zero, so queueing is the only safe answer and the two entries are one piece of work.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)