### PR TITLE
Cap body reads so a stalled upload still sees a graceful drain

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ Autobahn re-run.
 
 **Source:** Arizona handoff R-h2-1.
 
-## Connection setup under a connect burst — medium effort
+## Connection setup and warm-up cost — medium effort
 
 **What:** Accepting a burst of connections is about twice as slow as it
 needs to be. Measured against another BEAM server on the same machine,
@@ -48,6 +48,20 @@ needs to be. Measured against another BEAM server on the same machine,
 ~31 ms, while a request on an already-warm connection was identical
 between the two (p50 3.21 ms vs 3.22 ms). So the gap is entirely in
 accept-and-start, not in serving.
+
+**Where the tail sits:** per-request service-time histograms inside the
+conn loop, taken on a TLS workload of 512 connections and 10 KB request
+bodies, put roadrunner's own serving well inside budget once a
+connection is warm: p50 54-64 us, p99 152-181 us, max 724 us to 3.4 ms
+across 316,415 requests. Splitting the same run by how many requests a
+connection had already served isolates the cost to the first handful.
+For connections with fewer than 8 requests served, p90 is 13,777 us and
+p99 is 23,170 us. At 512 connections that band is 512 x 7 = 1.1 % of a
+320k-request run, which lands on the p99 boundary, and it is why a
+published p99 can be far worse than the service time behind it.
+Staggering the client's TLS handshakes over 800 ms does not remove it,
+so the cost is warm-up spread across a connection's first requests, not
+accept contention alone.
 
 **Why it matters:** it lands squarely in the tail. At a paced 10k req/s
 over 20 s with 1024 connections, the connection setups are ~0.5 % of all
@@ -73,6 +87,19 @@ these are not worth re-testing):
   a pool of acceptors the blocking is parallel, so it is not the serial
   constraint; starting and scheduling the conn processes themselves
   costs the same either way.
+- the read path. On this workload the conn loop makes zero passive
+  `recv` calls: the whole 10 KB request arrives in one `{active, once}`
+  delivery, and `recv` engages only once a request outgrows the 64 KB
+  listener buffer (measured 0, 1 and 4 calls per request for 10 KB,
+  64 KB and 256 KB bodies). Where it does engage, active-mode reads
+  measured ~2.5 % worse at p50 and unchanged at p99, and `{active, 64}`
+  batching saved ~8 us per request (~3 % of p50) with no p99 movement.
+  The gen_statem cost on TLS is real but sits in `ssl:setopts` and
+  `ssl:send`, about 30 us per request, far too small to explain a
+  p99-to-average ratio of 17.
+- the keep-alive request cap, CPU throttling in the container, VM flag
+  asymmetry, Nagle, and hibernation, each checked and none of them
+  moving the tail.
 
 **Also inconclusive:** spreading accepts over a pool of `SO_REUSEPORT`
 listen sockets (8 vs 1, same total acceptors, isolated from roadrunner

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -49,6 +49,7 @@
 %% machinery directly through these functions.
 -export([
     make_recv/3,
+    drain_check_interval_ms/0,
     rate_ok/3,
     body_framing/1,
     generate_request_id/1,
@@ -524,11 +525,16 @@ set_request_logger_metadata(#{
 
 -define(RECV_BYTES_PDKEY, {?MODULE, recv_bytes}).
 
+%% Drain-detection cap when in passive recv. Each recv call is bounded
+%% to at most this many ms so the conn re-checks its mailbox for
+%% `{roadrunner_drain, _}` between blocks. Trade-off: shorter = lower
+%% drain latency, more recv NIF calls; longer = the opposite. 100 ms
+%% matches typical ops-tooling expectations for graceful-drain
+%% detection.
+-define(DRAIN_CHECK_INTERVAL_MS, 100).
+
 %% Build a recv closure with a single overall deadline plus a rolling
-%% rate check. `gen_tcp:recv` with a negative timeout is undefined, so
-%% we cap at 0 — which makes gen_tcp return `{error, timeout}`
-%% immediately when the deadline has passed. Any timeout here is, by
-%% construction, the request_timeout.
+%% rate check.
 %%
 %% Rate enforcement (anti-Slowloris): track total bytes received and
 %% time since the first recv. After a 1-second grace, require the
@@ -537,29 +543,85 @@ set_request_logger_metadata(#{
 %% allocated lazily on the first recv (see `recv_byte_counter/0`), so a
 %% request with no body to read from the socket skips the allocation
 %% entirely. `Start` is captured eagerly here, so the rate window is
-%% anchored at body-phase entry exactly as before.
+%% anchored at body-phase entry.
 -doc false.
 -spec make_recv(roadrunner_transport:socket(), integer(), non_neg_integer()) ->
-    fun(() -> {ok, binary()} | {error, request_timeout | slow_client | term()}).
+    fun(() -> {ok, binary()} | {error, request_timeout | slow_client | drained | term()}).
 make_recv(Socket, Deadline, MinRate) ->
     Start = erlang:monotonic_time(millisecond),
     _ = erase(?RECV_BYTES_PDKEY),
-    fun() ->
-        Now = erlang:monotonic_time(millisecond),
-        Remaining = max(0, Deadline - Now),
-        case roadrunner_transport:recv(Socket, 0, Remaining) of
-            {ok, Data} ->
-                Total = atomics:add_get(recv_byte_counter(), 1, byte_size(Data)),
-                case rate_ok(Now - Start, Total, MinRate) of
-                    true -> {ok, Data};
-                    false -> {error, slow_client}
-                end;
-            {error, timeout} ->
-                {error, request_timeout};
-            {error, _} = E ->
-                E
-        end
+    fun() -> recv_body_chunk(Socket, Deadline, MinRate, Start) end.
+
+%% One drain-aware body read, kept out of the closure so a
+%% chunk-timeout tick can recurse without rebuilding it.
+%%
+%% Each read is bounded by `?DRAIN_CHECK_INTERVAL_MS` rather than by the
+%% whole remaining deadline, so a peer that stalls mid-body still
+%% notices a graceful drain. Passive recv cannot see the mailbox, so
+%% without the cap a half-sent body would park here for the entire
+%% `request_timeout`, outlive the drain deadline and be hard-killed by
+%% `roadrunner_listener:drain/2` — turning a graceful drain into a
+%% forced one and reporting `{timeout, N}` rather than `{ok, drained}`.
+%% This is the same cap the header path takes in
+%% `roadrunner_conn_loop:recv_passive/2`, for the same reason. Normal
+%% traffic never pays for it: the next chunk of a body already in flight
+%% arrives in microseconds, so the cap only fires for a client that
+%% stopped sending.
+%%
+%% `gen_tcp:recv` with a negative timeout is undefined, hence the cap at
+%% 0 — which makes gen_tcp return `{error, timeout}` immediately once
+%% the deadline has passed. A timeout with time still left on the
+%% deadline is a drain-check tick and loops; one without is the
+%% request_timeout itself.
+-spec recv_body_chunk(roadrunner_transport:socket(), integer(), non_neg_integer(), integer()) ->
+    {ok, binary()} | {error, request_timeout | slow_client | drained | term()}.
+recv_body_chunk(Socket, Deadline, MinRate, Start) ->
+    case drain_pending() of
+        drain ->
+            {error, drained};
+        ok ->
+            Now = erlang:monotonic_time(millisecond),
+            Remaining = max(0, Deadline - Now),
+            ChunkTimeout = min(Remaining, ?DRAIN_CHECK_INTERVAL_MS),
+            case roadrunner_transport:recv(Socket, 0, ChunkTimeout) of
+                {ok, Data} ->
+                    Total = atomics:add_get(recv_byte_counter(), 1, byte_size(Data)),
+                    case rate_ok(Now - Start, Total, MinRate) of
+                        true -> {ok, Data};
+                        false -> {error, slow_client}
+                    end;
+                {error, timeout} when Remaining =< ChunkTimeout ->
+                    {error, request_timeout};
+                {error, timeout} ->
+                    recv_body_chunk(Socket, Deadline, MinRate, Start);
+                {error, _} = E ->
+                    E
+            end
     end.
+
+%% Zero-timeout look for a queued drain. Unlike
+%% `roadrunner_conn_loop:drain_mailbox_check/0`, which also discards
+%% every other message it finds, this matches selectively and leaves the
+%% rest of the mailbox untouched: in `manual` body buffering the handler
+%% itself drives these reads, so the conn's mailbox may already hold
+%% messages meant for the handler (a `{loop, ...}` response's pushes,
+%% say). Dropping those would lose user data. The loop's own version
+%% runs before any handler code, where nothing else can be waiting.
+-spec drain_pending() -> drain | ok.
+drain_pending() ->
+    receive
+        {roadrunner_drain, _Deadline} -> drain
+    after 0 ->
+        ok
+    end.
+
+%% Cap on a single passive recv, shared with
+%% `roadrunner_conn_loop:recv_passive/2`. Exposed as a function because
+%% the two paths live in different modules and the value must not drift.
+-doc false.
+-spec drain_check_interval_ms() -> pos_integer().
+drain_check_interval_ms() ->
+    ?DRAIN_CHECK_INTERVAL_MS.
 
 %% Get-or-create the per-request received-byte counter. Allocated lazily
 %% on the first recv so a bodyless or fully-buffered request (whose recv

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -22,9 +22,11 @@
 %% `gen_tcp_socket`'s gen_statem dispatch (saves ~7 % CPU on the hot
 %% path: `gen:do_call/4`, `recv_data_deliver/4`, `gen_statem:loop/3`,
 %% `nif_getopt/3`). Passive recv cannot see the mailbox, so it wakes
-%% every `?DRAIN_CHECK_INTERVAL_MS` (100 ms) to look for a drain; that
-%% only applies mid-request, where the peer is already sending and a
-%% graceful drain would let the request finish regardless.
+%% every `roadrunner_conn:drain_check_interval_ms/0` (100 ms) to look
+%% for a drain; that only applies mid-request, where the peer is already
+%% sending and a graceful drain would let the request finish regardless.
+%% The body read in `roadrunner_conn:recv_body_chunk/4` is the same
+%% shape for the same reason.
 %%
 %% Keeping the poll off the idle path matters because its cost scales
 %% with *connections* rather than requests: 1024 idle keep-alive conns
@@ -391,26 +393,6 @@ phase_timeout(#loop_state{phase = first, request_timeout = T}) ->
 phase_timeout(#loop_state{phase = keep_alive, keep_alive_timeout = T}) ->
     T.
 
-%% Drain-detection cap when in passive recv. Each `gen_tcp:recv` call
-%% is bounded to at most this many ms so the conn re-checks its
-%% mailbox for `{roadrunner_drain, _}` between blocks. Trade-off:
-%% shorter = lower drain latency, more recv NIF calls; longer =
-%% the opposite. 100 ms matches typical ops-tooling expectations
-%% for graceful-drain detection.
-%%
-%% It looks removable now that the idle wait parks in `receive` and sees
-%% a drain immediately, since a drain should not cut an in-flight
-%% request short anyway. It is not. This bounds how long a conn stalled
-%% MID-request takes to notice: a peer that sent half its headers and
-%% went away would otherwise sit here for the whole `request_timeout`,
-%% outlive the drain deadline, and be hard-killed by
-%% `roadrunner_listener:drain/2` instead of exiting cleanly — turning a
-%% graceful drain into a forced one and reporting `{timeout, N}` rather
-%% than `{ok, drained}`. Normal traffic never pays for it: the next
-%% chunk of a request already in flight arrives in microseconds, so the
-%% cap only fires for a client that stopped sending.
--define(DRAIN_CHECK_INTERVAL_MS, 100).
-
 -spec recv_request_bytes(#loop_state{}, integer()) -> no_return().
 recv_request_bytes(S0, Deadline) ->
     %% About to block on the socket for the next request — everything
@@ -480,12 +462,27 @@ recv_idle(#loop_state{socket = Socket, buffered = Buf} = S, Deadline) ->
 %% prim_socket NIF.
 %%
 %% Drain detection: zero-timeout receive before each blocking recv
-%% drains pending `{roadrunner_drain, _}` and stray messages from
-%% the mailbox. Each recv is capped at `?DRAIN_CHECK_INTERVAL_MS` so
-%% drain delivered while we're blocked surfaces within ~100 ms.
+%% drains pending `{roadrunner_drain, _}` and stray messages from the
+%% mailbox. Each recv is capped at
+%% `roadrunner_conn:drain_check_interval_ms/0` so a drain delivered
+%% while we're blocked surfaces within ~100 ms.
+%%
+%% That cap looks removable now that the idle wait parks in `receive`
+%% and sees a drain immediately, since a drain should not cut an
+%% in-flight request short anyway. It is not. It bounds how long a conn
+%% stalled MID-request takes to notice: a peer that sent half its
+%% headers and went away would otherwise sit here for the whole
+%% `request_timeout`, outlive the drain deadline, and be hard-killed by
+%% `roadrunner_listener:drain/2` instead of exiting cleanly — turning a
+%% graceful drain into a forced one and reporting `{timeout, N}` rather
+%% than `{ok, drained}`. The body read takes the same cap, for the same
+%% reason, in `roadrunner_conn:recv_body_chunk/4`. Normal traffic never
+%% pays for it: the next chunk of a request already in flight arrives in
+%% microseconds, so the cap only fires for a client that stopped
+%% sending.
 %%
 %% Request-timeout: tracked via the absolute `Deadline`. `{error,
-%% timeout}` from recv with `Remaining =< chunk_timeout` means the
+%% timeout}` from recv with `Remaining =< ChunkTimeout` means the
 %% request_timeout actually fired; otherwise it's a drain-check tick
 %% and we loop.
 -spec recv_passive(#loop_state{}, integer()) -> no_return().
@@ -505,7 +502,7 @@ recv_passive(
         ok ->
             Now = erlang:monotonic_time(millisecond),
             Remaining = max(0, Deadline - Now),
-            ChunkTimeout = min(Remaining, ?DRAIN_CHECK_INTERVAL_MS),
+            ChunkTimeout = min(Remaining, roadrunner_conn:drain_check_interval_ms()),
             case roadrunner_transport:recv(Socket, 0, ChunkTimeout) of
                 {ok, Bytes} ->
                     %% Anti-slowloris: track running bytes/sec and drop
@@ -551,7 +548,10 @@ recv_passive(
 %% Zero-timeout drain of the mailbox. Returns `drain` if a drain
 %% message was queued, otherwise drops every other message and
 %% returns `ok`. Stray messages don't queue forever — drained on
-%% every recv iteration.
+%% every recv iteration. Safe to discard them here because this runs
+%% before any handler code; the body read's check
+%% (`roadrunner_conn:recv_body_chunk/4`) matches selectively instead,
+%% since by then the mailbox can hold messages meant for the handler.
 -spec drain_mailbox_check() -> drain | ok.
 drain_mailbox_check() ->
     receive
@@ -765,6 +765,11 @@ read_body_phase(
                     _ = roadrunner_conn:send_request_timeout(Socket),
                     exit_normal(S2);
                 {error, slow_client} ->
+                    exit_normal(S);
+                {error, drained} ->
+                    %% Listener draining while the peer was still
+                    %% uploading. No response: the request never
+                    %% completed, and the conn is going away anyway.
                     exit_normal(S);
                 {error, BodyReason} ->
                     S2 = flush_out(S),

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -18,6 +18,9 @@
 %%     input, sends 408 when the request_timeout fires before any
 %%     bytes arrive, exits cleanly on drain mid-recv, stays alive
 %%     across stray messages, exits silently on TCP close mid-headers.
+%%   - A drain arriving while a message body is being read is picked up
+%%     between drain ticks and closes the conn silently; a tick that
+%%     finds no drain resumes the read instead of ending the request.
 %%   - Slot release on every clean exit path.
 %%   - Telemetry pairing: every `accept` is paired with a `conn_close`.
 %% =============================================================================
@@ -347,6 +350,91 @@ request_timeout_during_body_recv_writes_408_test() ->
     Sent = iolist_to_binary(collect_sends(Tag, 100)),
     ?assertMatch(<<"HTTP/1.1 408", _/binary>>, Sent),
     Sink ! stop.
+
+drain_during_message_body_exits_silently_test() ->
+    %% Drain arriving while the conn is reading a message body — the
+    %% path past the header parse, where the recv closure built by
+    %% `roadrunner_conn:make_recv/3` owns the socket. Each read is
+    %% capped at the drain-check interval, so the tick after the drain
+    %% lands closes the conn cleanly; without the cap the conn would
+    %% hold the full request_timeout, outlive the drain deadline and be
+    %% hard-killed by `roadrunner_listener:drain/2`.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Headers = ~"POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n\r\n",
+    Sink = spawn_headers_then_drain_sink(Self, Tag, Headers),
+    Opts = (fake_opts(drain_body))#{
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
+    },
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    %% Drain bypasses the response — no 408 for the half-sent body.
+    ?assertEqual(<<>>, iolist_to_binary(collect_sends(Tag, 50))),
+    Sink ! stop.
+
+body_read_resumes_after_drain_tick_test() ->
+    %% The counterpart: a drain-check tick that finds no drain must not
+    %% end the request. The peer pauses (one recv timeout) and then sends
+    %% the body, which still completes normally.
+    ensure_pg(),
+    Self = self(),
+    Tag = make_ref(),
+    Headers = ~"POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\n",
+    Sink = spawn_scripted_sink(Self, Tag, [
+        {passive, {ok, Headers}},
+        {passive, {error, timeout}},
+        {passive, {ok, ~"hello"}}
+    ]),
+    Opts = (fake_opts(body_tick))#{
+        dispatch :=
+            {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
+                undefined}
+    },
+    {ok, Pid} = roadrunner_conn_loop:start({fake, Sink}, Opts),
+    Ref = monitor(process, Pid),
+    Pid ! shoot,
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 2000 -> error(no_normal_exit)
+    end,
+    Sent = iolist_to_binary(collect_sends(Tag, 100)),
+    ?assertMatch(<<"HTTP/1.1 200", _/binary>>, Sent),
+    ?assertMatch({_, _}, binary:match(Sent, ~"hello")),
+    Sink ! stop.
+
+%% Delivers a full header block, then answers every body recv with a
+%% drain-check tick, sending `{roadrunner_drain, _}` to the conn BEFORE
+%% the reply. `roadrunner_transport:recv/3` waits on a selective receive
+%% for its reply, so same-sender ordering puts the drain in the mailbox
+%% before the conn loops back to check it. Deterministic — no sleep.
+spawn_headers_then_drain_sink(Logger, Tag, Headers) ->
+    spawn(fun() -> headers_then_drain_loop(Logger, Tag, Headers, false) end).
+
+headers_then_drain_loop(Logger, Tag, Headers, Delivered) ->
+    receive
+        stop ->
+            ok;
+        {roadrunner_fake_setopts, ConnPid, _Opts} when not Delivered ->
+            ConnPid ! {roadrunner_fake_data, undefined, Headers},
+            headers_then_drain_loop(Logger, Tag, Headers, true);
+        {roadrunner_fake_recv, ConnPid, _Len, _Timeout} ->
+            ConnPid ! {roadrunner_drain, infinity},
+            ConnPid ! {roadrunner_fake_recv_reply, {error, timeout}},
+            headers_then_drain_loop(Logger, Tag, Headers, Delivered);
+        {roadrunner_fake_send, _Pid, Data} ->
+            Logger ! {Tag, sent, Data},
+            headers_then_drain_loop(Logger, Tag, Headers, Delivered);
+        _Other ->
+            headers_then_drain_loop(Logger, Tag, Headers, Delivered)
+    end.
 
 tcp_error_during_body_recv_exits_silently_test() ->
     %% A transport error on the remainder of a request → silent exit.
@@ -782,8 +870,12 @@ oversized_body_writes_413_and_fires_request_rejected_test() ->
     Sink ! stop.
 
 body_recv_timeout_writes_408_test() ->
-    %% Headers say Content-Length: 100 but body recv times out. read_body
-    %% returns {error, request_timeout} → 408 + exit.
+    %% Headers say Content-Length: 100 but the body never arrives. Each
+    %% read is capped at the drain-check interval, so the scripted
+    %% timeout is only a tick; the conn keeps ticking until the absolute
+    %% deadline, and that is what read_body reports as
+    %% {error, request_timeout} → 408 + exit. Hence the short
+    %% request_timeout — otherwise the test waits out the default.
     ensure_pg(),
     Self = self(),
     Tag = make_ref(),
@@ -797,6 +889,7 @@ body_recv_timeout_writes_408_test() ->
         {passive, {error, timeout}}
     ]),
     Opts = (fake_opts(body_to))#{
+        request_timeout := 250,
         dispatch :=
             {handler, roadrunner_echo_body_handler, fun roadrunner_echo_body_handler:handle/1,
                 undefined}

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -1329,6 +1329,35 @@ conn_handler_crash_returns_500_test_() ->
             end}
         end}.
 
+%% --- make_recv/3 — pure unit tests ---
+
+%% A queued drain is reported before the socket is touched, and ONLY the
+%% drain is taken. `manual` body buffering runs these reads from inside
+%% the handler, so anything else in the mailbox belongs to the handler
+%% (a `{loop, ...}` response's pushes, say) and has to survive the check.
+%% Runs in its own process: the test drives its own mailbox.
+make_recv_reports_drain_and_spares_other_messages_test_() ->
+    {spawn, fun() ->
+        Deadline = erlang:monotonic_time(millisecond) + 5000,
+        %% The socket is never read — the drain short-circuits ahead of it.
+        Recv = roadrunner_conn:make_recv({fake, self()}, Deadline, 0),
+        self() ! {push, ~"for the handler"},
+        self() ! {roadrunner_drain, infinity},
+        ?assertEqual({error, drained}, Recv()),
+        Survived =
+            receive
+                {push, Bytes} -> Bytes
+            after 0 -> none
+            end,
+        ?assertEqual(~"for the handler", Survived),
+        Leftover =
+            receive
+                {roadrunner_drain, _} -> drain
+            after 0 -> none
+            end,
+        ?assertEqual(none, Leftover)
+    end}.
+
 %% --- consume_body_reader/2 — pure unit tests ---
 
 consume_state_no_framing_returns_empty_test() ->

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -939,6 +939,50 @@ drain_timeout_kills_unresponsive_conns_test_() ->
             end}
         end}.
 
+drain_closes_conn_stalled_mid_body_test_() ->
+    {setup,
+        fun() ->
+            ok = ensure_pg_started(),
+            Name = listener_test_drain_body,
+            {ok, _} = roadrunner_listener:start_link(Name, #{
+                port => 0,
+                routes => roadrunner_echo_body_handler,
+                %% Fifteen times the drain window below. A body read that
+                %% could not see the drain would park here for the whole
+                %% timeout, outlive the deadline, and be hard-killed,
+                %% turning the assertion into {timeout, 1}.
+                request_timeout => 30000
+            }),
+            {Name, roadrunner_listener:port(Name)}
+        end,
+        fun(_) -> ok end, fun({Name, Port}) ->
+            {"drain closes a conn stalled mid-body instead of hard-killing it", fun() ->
+                {ok, Sock} = gen_tcp:connect(
+                    {127, 0, 0, 1}, Port, [binary, {active, false}], 1000
+                ),
+                %% `Expect: 100-continue` with no body bytes yet: the conn
+                %% writes the interim 100 immediately before it starts
+                %% reading the body, so receiving that line proves the conn
+                %% is parked in the body read rather than still waiting on
+                %% headers. Then the client goes quiet and never sends the
+                %% 100 promised bytes.
+                ok = gen_tcp:send(
+                    Sock,
+                    <<
+                        "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n"
+                        "Expect: 100-continue\r\n\r\n"
+                    >>
+                ),
+                ?assertMatch(
+                    {ok, <<"HTTP/1.1 100 Continue", _/binary>>},
+                    gen_tcp:recv(Sock, 0, 2000)
+                ),
+                ?assertEqual({ok, drained}, roadrunner_listener:drain(Name, 2000)),
+                wait_until_unregistered(Name),
+                gen_tcp:close(Sock)
+            end}
+        end}.
+
 drain_closes_keep_alive_conn_after_in_flight_request_test_() ->
     {setup,
         fun() ->


### PR DESCRIPTION
# Description

The recv closure that reads an HTTP/1 message body waited on the socket for the whole remaining `request_timeout` and never looked at its mailbox, so a connection stalled mid-upload never saw `{roadrunner_drain, _}`. It outlived the drain deadline and got hard-killed, turning a graceful drain into a forced one. Each read is now bounded by the same 100 ms drain-check interval the header path already used. The check is a selective receive rather than the conn loop's draining one, because in `manual` body buffering the handler drives these reads and the mailbox can already hold messages meant for it.

A listener draining while a client holds a connection open mid-body now answers `{ok, drained}` instead of `{timeout, 1}`.

Also records in `docs/roadmap.md` where the connection tail actually sits: the first few requests on a fresh connection, not the accept burst.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
