### PR TITLE
Add opt-in queue mode for the in-flight request ceiling

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,42 +40,29 @@ Autobahn re-run.
 
 **Source:** Arizona handoff R-h2-1.
 
-## HTTP/2 stream admission follow-ups
-
-### Pre-SETTINGS stream leniency — medium effort
+## Pre-SETTINGS stream leniency — small effort
 
 **What:** Do not refuse streams a client opened before it could have
-seen our advertised `max_concurrent_streams`. With prior-knowledge h2c
-a client sends its preface and a burst of HEADERS in the same flight;
-until our SETTINGS completes the round trip, RFC 9113 §5.1.2 binds the
-client only to a limit it has received, so the burst is compliant.
-Refusing the excess sheds real requests at every connection setup when
-the client's default concurrency exceeds our advertised value.
+seen our advertised `max_concurrent_streams`. With prior-knowledge h2c a
+client sends its preface and a burst of HEADERS in the same flight;
+RFC 9113 §6.5.2 makes `SETTINGS_MAX_CONCURRENT_STREAMS` *initially
+unlimited*, so the burst is compliant and refusing it sheds real
+requests at every connection setup.
 
-**Design question:** admit up to some bound until the client's SETTINGS
-ack arrives, or queue the excess and admit as slots free. Note there is
-no protocol default to fall back on: RFC 9113 §6.5.2 says
-`SETTINGS_MAX_CONCURRENT_STREAMS` is *initially unlimited*, which is
-exactly why a prior-knowledge client opens as many as it likes in its
-first flight. So "admit what the default allows" is not an option, and
-admitting the burst outright is how the multi-GiB blowup that took
-`json-h2c` to zero happened. That leaves queueing, which is the entry
-below — worth treating these as one piece of work rather than two.
+**Most of it is already handled.** Admitting the burst outright is how
+the multi-GiB blowup that took `json-h2c` to zero happened, so leniency
+needed somewhere to put the excess. `overload_mode` queueing is that
+somewhere and has shipped: with a listener-wide ceiling in queue mode an
+opening burst waits instead of being refused. What remains is only
+whether to keep admitting past the advertised per-connection limit until
+the client's SETTINGS ack arrives, which is a smaller question than it
+was.
 
-**Scope:** medium — admission bookkeeping in the h2 conn loop plus
-tests for the ack-timing windows.
-
-### Queue mode for `max_concurrent_requests` — medium effort
-
-**What:** An opt-in mode where a stream over the listener-wide
-in-flight ceiling waits for a free slot instead of being refused with
-`REFUSED_STREAM` / `H3_REQUEST_REJECTED`. Bounds live handler
-processes (and their memory) with no shed requests: latency rises
-under overload instead of the error rate. A client that does not
-retry refusals sees today's refusal mode as hard failures.
-
-**Scope:** medium — a wait queue in the conn loops for both
-multiplexed protocols, flow-control interaction, drain/timeout rules.
+**HTTP/3 does not need this.** h3 has no
+`SETTINGS_MAX_CONCURRENT_STREAMS`; stream concurrency is QUIC's, via the
+`initial_max_streams_bidi` transport parameter and `MAX_STREAMS` frames.
+The client learns the limit during the handshake, before it can open a
+stream, so there is no burst to be lenient about.
 
 ## HTTP/3 follow-ups
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -35,8 +35,10 @@
     try_acquire_slot/1,
     release_slot/1,
     try_acquire_request_slot/2,
-    release_request_slot/2,
-    release_request_slots/3,
+    acquire_request_slot/4,
+    cancel_slot_wait/2,
+    release_request_slot/3,
+    release_request_slots/4,
     consume_body_reader/2,
     join_drain_group/2,
     join_drain_group_for/2
@@ -82,11 +84,23 @@
     head_response/2
 ]).
 
--export_type([proto_opts/0, dispatch/0, rate_limit/0, rate_limit_state/0]).
+-export_type([proto_opts/0, dispatch/0, rate_limit/0, rate_limit_state/0, overload/0]).
 
 -on_load(init_patterns/0).
 
 -define(CONN_COMMA_CP_KEY, {?MODULE, conn_comma_cp}).
+
+-doc """
+How a request over the listener-wide `max_concurrent_requests` ceiling
+is handled. `refuse` is the default and today's behavior: reject it
+immediately. The queue form parks it until a slot frees, so handler
+memory stays bounded without shedding the request; it carries the
+listener's queue process, the atomic that says whether anyone is parked
+(read on the release path to avoid a message per request), and the wait
+deadline in milliseconds.
+""".
+-type overload() ::
+    refuse | {queue, pid(), atomics:atomics_ref(), pos_integer()}.
 
 -type dispatch() ::
     {handler, module(), roadrunner_middleware:next(), State :: term()}
@@ -129,6 +143,10 @@
     %% `throttled_counter` is the cumulative count of streams refused at
     %% the ceiling. h1 is bounded by `max_clients` and does not use these.
     max_concurrent_requests := infinity | pos_integer(),
+    %% What happens to a request over that ceiling. Optional so a
+    %% hand-built proto_opts map (tests, embedded callers) defaults to
+    %% today's refuse behavior.
+    overload => overload(),
     inflight_counter := counters:counters_ref(),
     throttled_counter := atomics:atomics_ref(),
     %% Per-peer request-rate guard (off by default). `rate_limit` carries the
@@ -340,7 +358,7 @@ unconfigured listener pays nothing on the hot path.
 Same eventually-consistent overshoot contract as `try_acquire_slot/1`: the
 `counters` ref uses `write_concurrency`, so a brief read slightly above the
 cap is possible before rollbacks reconcile, bounded by in-flight admissions.
-Paired with `release_request_slot/2`, which must run exactly once per
+Paired with `release_request_slot/3`, which must run exactly once per
 successfully-acquired worker (tie it to the worker monitor-ref removal so a
 worker is released by its `DOWN` or by the conn's clean exit, never both).
 
@@ -450,13 +468,75 @@ rate_limit_evict_idle(Table, NowMs, IdleTtl) ->
     Spec = [{{'_', '_', '$1'}, [{'<', '$1', Cutoff}], [true]}],
     ets:select_delete(Table, Spec).
 
--doc "Decrement the in-flight-request counter, paired with `try_acquire_request_slot/2`.".
--spec release_request_slot(infinity | pos_integer(), counters:counters_ref() | undefined) -> ok.
-release_request_slot(infinity, _Counter) ->
+-doc """
+Take an in-flight slot, or park the request when the listener is in
+queue mode. The fast path is `try_acquire_request_slot/2` and nothing
+else, so a listener that never reaches its ceiling pays a single
+`counters` operation.
+
+Returns `true` when the slot is held and the caller may spawn its
+worker, `false` when the caller should refuse the request exactly as it
+does today, and `queued` when the request is parked. A parked caller
+MUST NOT block: it returns to its loop and later receives
+`{roadrunner_slot, Token, granted | timeout | full}`. `granted` means the
+slot is already held on its behalf, so a caller that has since dropped
+the request has to release it rather than ignore it.
+
+`Token` only has to be unique within the calling process; the stream id
+is the natural choice.
+""".
+-spec acquire_request_slot(
+    infinity | pos_integer(), counters:counters_ref() | undefined, overload(), term()
+) -> true | false | queued.
+acquire_request_slot(Max, Counter, Overload, Token) ->
+    case try_acquire_request_slot(Max, Counter) of
+        true -> true;
+        false -> park(Overload, Token)
+    end.
+
+-spec park(overload(), term()) -> false | queued.
+park(refuse, _Token) ->
+    false;
+park({queue, Pid, _Waiters, Timeout}, Token) ->
+    ok = roadrunner_overload_queue:enqueue(Pid, Token, Timeout),
+    queued.
+
+-doc """
+Withdraw a parked request, because its stream was reset or its
+connection is going away. Racing an in-flight grant is expected: the
+caller may still receive `granted` afterwards and must release that slot.
+""".
+-spec cancel_slot_wait(overload(), term()) -> ok.
+cancel_slot_wait(refuse, _Token) ->
     ok;
-release_request_slot(_Max, Counter) ->
+cancel_slot_wait({queue, Pid, _Waiters, _Timeout}, Token) ->
+    roadrunner_overload_queue:cancel(Pid, Token).
+
+-doc """
+Decrement the in-flight-request counter, paired with
+`acquire_request_slot/4`, and wake a parked request if one is waiting.
+
+The wake is guarded by an atomic read rather than sent unconditionally,
+so a listener in queue mode that is not at its ceiling pays one extra
+`atomics:get/2` per request and no message.
+""".
+-spec release_request_slot(
+    infinity | pos_integer(), counters:counters_ref() | undefined, overload()
+) -> ok.
+release_request_slot(infinity, _Counter, _Overload) ->
+    ok;
+release_request_slot(_Max, Counter, Overload) ->
     ok = counters:sub(Counter, 1, 1),
-    ok.
+    notify_release(Overload).
+
+-spec notify_release(overload()) -> ok.
+notify_release(refuse) ->
+    ok;
+notify_release({queue, Pid, Waiters, _Timeout}) ->
+    case roadrunner_overload_queue:waiting(Waiters) of
+        true -> roadrunner_overload_queue:note_release(Pid);
+        false -> ok
+    end.
 
 -doc """
 Release `N` in-flight slots at once. Used by the conn clean-exit path to
@@ -465,15 +545,15 @@ their slots are not leaked until the listener restarts. `N = 0` and
 `infinity` are no-ops.
 """.
 -spec release_request_slots(
-    infinity | pos_integer(), counters:counters_ref() | undefined, non_neg_integer()
+    infinity | pos_integer(), counters:counters_ref() | undefined, non_neg_integer(), overload()
 ) -> ok.
-release_request_slots(_Max, _Counter, 0) ->
+release_request_slots(_Max, _Counter, 0, _Overload) ->
     ok;
-release_request_slots(infinity, _Counter, _N) ->
+release_request_slots(infinity, _Counter, _N, _Overload) ->
     ok;
-release_request_slots(_Max, Counter, N) ->
+release_request_slots(_Max, Counter, N, Overload) ->
     ok = counters:sub(Counter, 1, N),
-    ok.
+    notify_release(Overload).
 
 -doc false.
 -spec refine_conn_label(

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -258,6 +258,15 @@
     %% passes them to `roadrunner_conn` directly. See `dispatch_stream/2`.
     max_concurrent_requests = infinity :: infinity | pos_integer(),
     inflight_counter :: counters:counters_ref() | undefined,
+    %% What happens to a stream that arrives over the ceiling: refuse it
+    %% (the default) or park it until a slot frees. Read from proto_opts
+    %% at `enter/6` so the per-stream path never re-reads the map.
+    overload = refuse :: roadrunner_conn:overload(),
+    %% Streams parked waiting for an in-flight slot, holding the request
+    %% already assembled for them. The loop must NOT block waiting: it
+    %% releases slots by processing its own workers' `DOWN` messages, so
+    %% a blocked loop would wait on something only it can deliver.
+    awaiting_slot = #{} :: #{stream_id() => roadrunner_req:request()},
     %% Per-peer rate-limit guard resolved from proto_opts + peer at `enter/6`
     %% (`undefined` when off). Checked in `dispatch_stream/2`.
     rate_limit = undefined :: roadrunner_conn:rate_limit_state(),
@@ -350,6 +359,7 @@ enter(Socket, ProtoOpts, ListenerName, Peer, StartMono, Buffered) ->
         alt_svc = AltSvc,
         max_concurrent_requests = MaxConcReq,
         inflight_counter = InflightCounter,
+        overload = maps:get(overload, ProtoOpts, refuse),
         rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer),
         handshake_timeout = HandshakeTimeout,
         idle_timeout = IdleTimeout
@@ -517,6 +527,8 @@ recv_more(
             recv_more(handle_send_response(State, From, Ref, StreamId, Status, Headers, Body));
         {'DOWN', MonRef, process, _Pid, Reason} ->
             recv_more(maybe_exit_when_drained(handle_worker_down(State, MonRef, Reason)));
+        {roadrunner_slot, StreamId, Outcome} ->
+            recv_more(handle_slot(State, StreamId, Outcome));
         {roadrunner_drain, _Deadline} ->
             recv_more(maybe_exit_when_drained(start_drain(State)))
     after recv_timeout(State) ->
@@ -1127,7 +1139,8 @@ dispatch_stream(
         scheme = Scheme,
         listener_name = ListenerName,
         max_concurrent_requests = MaxConcReq,
-        inflight_counter = InflightCounter
+        inflight_counter = InflightCounter,
+        overload = Overload
     } = State
 ) ->
     #{
@@ -1163,8 +1176,8 @@ dispatch_stream(
                             frame_loop(remove_stream(State1, StreamId));
                         ok ->
                             case
-                                roadrunner_conn:try_acquire_request_slot(
-                                    MaxConcReq, InflightCounter
+                                roadrunner_conn:acquire_request_slot(
+                                    MaxConcReq, InflightCounter, Overload, StreamId
                                 )
                             of
                                 true ->
@@ -1181,6 +1194,20 @@ dispatch_stream(
                                         streams = Streams#{StreamId := Stream1},
                                         worker_refs =
                                             (StateBuf#loop.worker_refs)#{MonRef => StreamId}
+                                    });
+                                queued ->
+                                    %% Over the ceiling, but this listener
+                                    %% parks rather than sheds. Keep the
+                                    %% assembled request and go back to the
+                                    %% frame loop; the grant arrives as a
+                                    %% message.
+                                    Parked = Stream#{
+                                        state := half_closed_remote, body := []
+                                    },
+                                    Awaiting = StateBuf#loop.awaiting_slot,
+                                    frame_loop(StateBuf#loop{
+                                        streams = Streams#{StreamId := Parked},
+                                        awaiting_slot = Awaiting#{StreamId => Req}
                                     });
                                 false ->
                                     %% Listener-wide in-flight ceiling reached —
@@ -1322,7 +1349,9 @@ handle_worker_down(#loop{worker_refs = Refs} = State, MonRef, Reason) ->
             %% worker ref so a worker is accounted for by its `DOWN` here or
             %% by the conn's clean exit, never both.
             ok = roadrunner_conn:release_request_slot(
-                State#loop.max_concurrent_requests, State#loop.inflight_counter
+                State#loop.max_concurrent_requests,
+                State#loop.inflight_counter,
+                State#loop.overload
             ),
             State1 = State#loop{worker_refs = maps:remove(MonRef, Refs)},
             case Reason of
@@ -1658,14 +1687,19 @@ reset_stream(State0, StreamId) ->
                 %% place that can release the slot — `handle_worker_down`
                 %% never runs and `exit_clean` no longer sees the ref.
                 ok = roadrunner_conn:release_request_slot(
-                    State#loop.max_concurrent_requests, State#loop.inflight_counter
+                    State#loop.max_concurrent_requests,
+                    State#loop.inflight_counter,
+                    State#loop.overload
                 ),
                 maps:remove(MonRef, Refs)
         end,
-    State#loop{
-        streams = maps:remove(StreamId, Streams),
-        worker_refs = Refs1
-    }.
+    withdraw_parked(
+        State#loop{
+            streams = maps:remove(StreamId, Streams),
+            worker_refs = Refs1
+        },
+        StreamId
+    ).
 
 %% Called by `handle_worker_down/3` when a worker dies abnormally.
 %% Send RST_STREAM(error_code) to the peer and drop our state.
@@ -1674,13 +1708,71 @@ abort_stream(State0, StreamId, ErrorCode) ->
     #{StreamId := #{pending_sends := Pending}} = Streams,
     notify_pending_reset(StreamId, Pending),
     _ = send_rst_stream(State, StreamId, ErrorCode),
-    State#loop{streams = maps:remove(StreamId, Streams)}.
+    withdraw_parked(State#loop{streams = maps:remove(StreamId, Streams)}, StreamId).
 
 %% Worker exited normally (handler done, all frames already on the
 %% wire). Just drop state.
 remove_stream(State0, StreamId) ->
-    #loop{streams = Streams} = State = uncount_stream(State0, StreamId),
+    #loop{streams = Streams} = State = withdraw_parked(uncount_stream(State0, StreamId), StreamId),
     State#loop{streams = maps:remove(StreamId, Streams)}.
+
+%% Withdraw a request parked for a slot. Every path that drops a stream
+%% goes through here, so `awaiting_slot` never outlives its stream entry
+%% and a grant can always find the stream it was granted for. A grant
+%% already in flight still arrives; `handle_slot/3` gives that slot back.
+-spec withdraw_parked(#loop{}, stream_id()) -> #loop{}.
+withdraw_parked(#loop{awaiting_slot = Awaiting, overload = Overload} = State, StreamId) ->
+    case Awaiting of
+        #{StreamId := _} ->
+            ok = roadrunner_conn:cancel_slot_wait(Overload, StreamId),
+            State#loop{awaiting_slot = maps:remove(StreamId, Awaiting)};
+        _ ->
+            State
+    end.
+
+%% A parked stream's admission resolved. `granted` means the queue has
+%% already taken the slot on our behalf, so a stream that has gone away
+%% in the meantime must hand it back rather than drop it.
+-spec handle_slot(#loop{}, stream_id(), granted | timeout | full) -> #loop{}.
+handle_slot(#loop{awaiting_slot = Awaiting} = State, StreamId, granted) ->
+    case Awaiting of
+        #{StreamId := Req} ->
+            spawn_parked(
+                State#loop{awaiting_slot = maps:remove(StreamId, Awaiting)}, StreamId, Req
+            );
+        _ ->
+            give_back_slot(State)
+    end;
+handle_slot(#loop{awaiting_slot = Awaiting, listener_name = ListenerName} = State, StreamId, _) ->
+    case Awaiting of
+        #{StreamId := _} ->
+            State1 = State#loop{awaiting_slot = maps:remove(StreamId, Awaiting)},
+            ok = throttle_stream(State1, ListenerName),
+            _ = send_rst_stream(State1, StreamId, refused_stream),
+            remove_stream(State1, StreamId);
+        _ ->
+            State
+    end.
+
+%% `withdraw_parked/2` keeps `awaiting_slot` and `streams` in step, so a
+%% grant that still has its parked request always has its stream too.
+-spec spawn_parked(#loop{}, stream_id(), roadrunner_req:request()) -> #loop{}.
+spawn_parked(#loop{streams = Streams, proto_opts = ProtoOpts} = State, StreamId, Req) ->
+    #{StreamId := Stream} = Streams,
+    {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(self(), StreamId, Req, ProtoOpts),
+    State#loop{
+        streams = Streams#{StreamId := Stream#{worker_pid := WorkerPid, worker_ref := MonRef}},
+        worker_refs = (State#loop.worker_refs)#{MonRef => StreamId}
+    }.
+
+-spec give_back_slot(#loop{}) -> #loop{}.
+give_back_slot(State) ->
+    ok = roadrunner_conn:release_request_slot(
+        State#loop.max_concurrent_requests,
+        State#loop.inflight_counter,
+        State#loop.overload
+    ),
+    State.
 
 notify_pending_reset(StreamId, Pending) ->
     case queue:out(Pending) of
@@ -1863,7 +1955,8 @@ exit_clean(#loop{
     start_mono = StartMono,
     worker_refs = Refs,
     max_concurrent_requests = MaxConcReq,
-    inflight_counter = InflightCounter
+    inflight_counter = InflightCounter,
+    overload = Overload
 }) ->
     roadrunner_telemetry:listener_conn_close(StartMono, #{
         listener_name => ListenerName,
@@ -1873,7 +1966,9 @@ exit_clean(#loop{
     %% Account for any stream workers still live at teardown (each holds one
     %% in-flight slot). Workers whose `DOWN` already fired were removed from
     %% `worker_refs`, so this releases each remaining worker exactly once.
-    ok = roadrunner_conn:release_request_slots(MaxConcReq, InflightCounter, map_size(Refs)),
+    ok = roadrunner_conn:release_request_slots(
+        MaxConcReq, InflightCounter, map_size(Refs), Overload
+    ),
     ok = roadrunner_conn:release_slot(ProtoOpts),
     ok = roadrunner_transport:close(Socket),
     exit(normal).

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -145,6 +145,15 @@
     %% them to `roadrunner_conn` directly. See `dispatch_decoded/3`.
     max_concurrent_requests = infinity :: infinity | pos_integer(),
     inflight_counter :: counters:counters_ref() | undefined,
+    %% What happens to a request that arrives over the ceiling: refuse it
+    %% (the default) or park it until a slot frees. Read from proto_opts
+    %% alongside the two fields above.
+    overload = refuse :: roadrunner_conn:overload(),
+    %% Requests parked waiting for an in-flight slot, already assembled.
+    %% The loop must NOT block waiting: it releases slots by processing
+    %% its own workers' `DOWN` messages, so a blocked loop would wait on
+    %% something only it can deliver.
+    awaiting_slot = #{} :: #{non_neg_integer() => roadrunner_req:request()},
     %% Per-peer rate-limit guard resolved from proto_opts + peer at conn start
     %% (`undefined` when off). Checked in `dispatch_decoded/4`.
     rate_limit = undefined :: roadrunner_conn:rate_limit_state()
@@ -210,6 +219,7 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
         ),
         max_concurrent_requests = maps:get(max_concurrent_requests, ProtoOpts, infinity),
         inflight_counter = maps:get(inflight_counter, ProtoOpts, undefined),
+        overload = maps:get(overload, ProtoOpts, refuse),
         rate_limit = roadrunner_conn:resolve_rate_limit(ProtoOpts, Peer)
     }).
 
@@ -245,6 +255,8 @@ recv_loop(#h3{conn = Conn} = State) ->
             terminate(State);
         {'DOWN', MonRef, process, _Pid, Reason} ->
             loop(handle_worker_down(State, MonRef, Reason));
+        {roadrunner_slot, StreamId, Outcome} ->
+            loop(handle_slot(State, StreamId, Outcome));
         {roadrunner_drain, _Deadline} ->
             %% Begin a graceful drain: send GOAWAY, refuse new requests,
             %% let in-flight ones finish (the `loop/1` head closes the
@@ -313,8 +325,16 @@ start_drain(#h3{conn = Conn, control_stream_id = CtrlId, last_request_id = LastI
 -spec is_drained(#h3{}) -> boolean().
 is_drained(#h3{goaway_id = undefined}) ->
     false;
-is_drained(#h3{streams = Streams, worker_refs = WorkerRefs}) ->
-    map_size(Streams) =:= 0 andalso map_size(WorkerRefs) =:= 0.
+is_drained(#h3{streams = Streams, worker_refs = WorkerRefs, awaiting_slot = Awaiting}) ->
+    %% A request parked for an in-flight slot is in neither `streams` (it
+    %% is fully received) nor `worker_refs` (no worker yet), but it has
+    %% been accepted and still owes the client a response. Leaving it out
+    %% here would close the connection under it, silently dropping a
+    %% request the peer sent before the GOAWAY. Its wait is bounded by
+    %% the queue deadline, and the listener force-closes at the drain
+    %% deadline regardless.
+    map_size(Streams) =:= 0 andalso map_size(WorkerRefs) =:= 0 andalso
+        map_size(Awaiting) =:= 0.
 
 %% Track the highest request stream id accepted, for the drain GOAWAY id.
 -spec note_request_id(#h3{}, non_neg_integer()) -> #h3{}.
@@ -459,9 +479,16 @@ handle_stream_reset(#h3{uni = Uni, streams = Streams, worker_pids = WorkerPids} 
                     _ = (WorkerPid ! {roadrunner_stream_reset, StreamId}),
                     State;
                 _ ->
-                    %% Still mid-receive (or already gone) — drop the
-                    %% in-progress frame-accumulation entry.
-                    State#h3{streams = maps:remove(StreamId, Streams)}
+                    %% Still mid-receive, parked for a slot, or already
+                    %% gone. Drop the frame-accumulation entry and
+                    %% withdraw any parked request; a grant already in
+                    %% flight still arrives and `handle_slot/3` gives
+                    %% that slot back.
+                    ok = roadrunner_conn:cancel_slot_wait(State#h3.overload, StreamId),
+                    State#h3{
+                        streams = maps:remove(StreamId, Streams),
+                        awaiting_slot = maps:remove(StreamId, State#h3.awaiting_slot)
+                    }
             end
     end.
 
@@ -801,8 +828,11 @@ dispatch_decoded(State, StreamId, Headers, Body) ->
     handle_result().
 dispatch_with_slot(#h3{streams = Streams} = State1, StreamId, Req) ->
     case
-        roadrunner_conn:try_acquire_request_slot(
-            State1#h3.max_concurrent_requests, State1#h3.inflight_counter
+        roadrunner_conn:acquire_request_slot(
+            State1#h3.max_concurrent_requests,
+            State1#h3.inflight_counter,
+            State1#h3.overload,
+            StreamId
         )
     of
         true ->
@@ -818,6 +848,14 @@ dispatch_with_slot(#h3{streams = Streams} = State1, StreamId, Req) ->
                 worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId},
                 worker_pids = (State1#h3.worker_pids)#{StreamId => WorkerPid}
             };
+        queued ->
+            %% Over the ceiling, but this listener parks rather than
+            %% sheds. Keep the assembled request and return to the loop;
+            %% the grant arrives as a message.
+            State1#h3{
+                streams = maps:remove(StreamId, Streams),
+                awaiting_slot = (State1#h3.awaiting_slot)#{StreamId => Req}
+            };
         false ->
             %% Listener-wide in-flight ceiling reached — refuse the
             %% stream (retry-safe H3_REQUEST_REJECTED) without spawning
@@ -825,6 +863,41 @@ dispatch_with_slot(#h3{streams = Streams} = State1, StreamId, Req) ->
             ok = throttle_stream(State1),
             reset_and_drop(State1, StreamId, ?H3_REQUEST_REJECTED)
     end.
+
+%% A parked request's admission resolved. `granted` means the queue has
+%% already taken the slot on our behalf, so a request that has gone away
+%% in the meantime must hand it back rather than drop it.
+-spec handle_slot(#h3{}, non_neg_integer(), granted | timeout | full) -> #h3{}.
+handle_slot(#h3{awaiting_slot = Awaiting} = State, StreamId, granted) ->
+    case Awaiting of
+        #{StreamId := Req} ->
+            State1 = State#h3{awaiting_slot = maps:remove(StreamId, Awaiting)},
+            {WorkerPid, MonRef} = roadrunner_http3_stream_worker:start(
+                State1#h3.conn, StreamId, Req, State1#h3.proto_opts
+            ),
+            State1#h3{
+                worker_refs = (State1#h3.worker_refs)#{MonRef => StreamId},
+                worker_pids = (State1#h3.worker_pids)#{StreamId => WorkerPid}
+            };
+        _ ->
+            give_back_slot(State)
+    end;
+handle_slot(#h3{awaiting_slot = Awaiting} = State, StreamId, _Refused) ->
+    case Awaiting of
+        #{StreamId := _} ->
+            State1 = State#h3{awaiting_slot = maps:remove(StreamId, Awaiting)},
+            ok = throttle_stream(State1),
+            reset_and_drop(State1, StreamId, ?H3_REQUEST_REJECTED);
+        _ ->
+            State
+    end.
+
+-spec give_back_slot(#h3{}) -> #h3{}.
+give_back_slot(State) ->
+    ok = roadrunner_conn:release_request_slot(
+        State#h3.max_concurrent_requests, State#h3.inflight_counter, State#h3.overload
+    ),
+    State.
 
 %% A worker exit: normal means it sent its response with the stream FIN
 %% (drop the stream); abnormal (QPACK decompression, malformed
@@ -839,7 +912,7 @@ handle_worker_down(#h3{worker_refs = WorkerRefs, worker_pids = WorkerPids} = Sta
     %% ref so it is accounted for by this `DOWN` or by the conn's clean
     %% exit, never both.
     ok = roadrunner_conn:release_request_slot(
-        State#h3.max_concurrent_requests, State#h3.inflight_counter
+        State#h3.max_concurrent_requests, State#h3.inflight_counter, State#h3.overload
     ),
     State1 = State#h3{
         worker_refs = WorkerRefs1, worker_pids = maps:remove(StreamId, WorkerPids)
@@ -919,7 +992,8 @@ terminate(#h3{
     start_mono = StartMono,
     worker_refs = Refs,
     max_concurrent_requests = MaxConcReq,
-    inflight_counter = InflightCounter
+    inflight_counter = InflightCounter,
+    overload = Overload
 }) ->
     ok = roadrunner_telemetry:listener_conn_close(StartMono, #{
         listener_name => ListenerName,
@@ -929,5 +1003,7 @@ terminate(#h3{
     %% Account for any stream workers still live at teardown (each holds one
     %% in-flight slot); workers whose `DOWN` already fired were removed from
     %% `worker_refs`, so this releases each remaining worker exactly once.
-    ok = roadrunner_conn:release_request_slots(MaxConcReq, InflightCounter, map_size(Refs)),
+    ok = roadrunner_conn:release_request_slots(
+        MaxConcReq, InflightCounter, map_size(Refs), Overload
+    ),
     ok = roadrunner_conn:release_slot(ProtoOpts).

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -166,6 +166,34 @@ Optional middleware and timing knobs (durations in milliseconds):
   `[roadrunner, request, throttled]` and increments the `throttled`
   count from `info/1`. HTTP/1 is unaffected (one request per connection,
   already bounded by `max_clients`).
+- `overload_mode` — what happens to a request that arrives over
+  `max_concurrent_requests`. Default `refuse`, which is the behavior
+  described above. `{queue, Opts}` instead
+  parks it until a slot frees, so handler memory stays bounded without
+  shedding the request: latency rises under overload rather than the
+  error rate. A request still waiting after `Ms` is refused exactly as
+  `refuse` would, and one arriving when `N` are already parked is
+  refused immediately, so overload still sheds rather than queueing
+  without bound. Requires a finite `max_concurrent_requests` — there is
+  nothing to queue behind otherwise, and asking for it without one is a
+  configuration error.
+
+  `Opts` takes `max_queued` and `timeout`, and both are derived when
+  absent, so `{queue, #{}}` needs no tuning. `timeout` follows
+  `request_timeout`, since a request already carries that deadline and
+  waiting past it only produces a response nobody is left to read.
+  `max_queued` follows the ceiling, so at most as many requests wait as
+  run.
+
+  Worth setting when a per-connection `max_concurrent_streams` is the
+  only thing keeping handler memory down, because that ties concurrency
+  to connection count: 64 connections with a window of 4 can never have
+  more than 256 handlers running, however much budget is left. A
+  listener-wide ceiling spends the budget you configured instead.
+  Measured on 64 h2c connections against a cheap route, moving from a
+  window of 4 to a window of 64 with a queued ceiling of 4096 took
+  252,259 to 397,747 resp/s with no refusals and concurrency still
+  bounded.
 - `socket_backlog` — TCP listen backlog (kernel SYN/accept queue
   depth). Default 1024. Raise it for connection bursts (load tests,
   health-check storms); Linux clamps the effective value at
@@ -261,6 +289,8 @@ ops-tuning rationale.
     max_keep_alive_requests => pos_integer(),
     max_clients => pos_integer(),
     max_concurrent_requests => infinity | pos_integer(),
+    overload_mode =>
+        refuse | {queue, #{max_queued => pos_integer(), timeout => pos_integer()}},
     socket_backlog => pos_integer(),
     %% Local interface to bind. Unset means all interfaces
     %% (`0.0.0.0` / `::`). Set to `{127,0,0,1}` to restrict the
@@ -1112,6 +1142,51 @@ spawn_acceptors_loop(LSocket, ProtoOpts, I, N) ->
 %% feature (an L4 balancer prepends the header before the first byte), so it
 %% conflicts with an HTTP/3-only (UDP) listener; on a mixed `[http1, http3]`
 %% listener the TCP side honors it and h3 ignores it.
+%% Queue mode only means something when there is a ceiling to queue
+%% behind, so asking for it without `max_concurrent_requests` is a
+%% configuration error rather than a silent no-op.
+%%
+%% Both knobs are derived when absent, so `{queue, #{}}` is usable
+%% without inventing numbers. `timeout` follows `request_timeout`,
+%% because a request already carries that deadline and waiting past it
+%% only produces a response nobody is left to read. `max_queued` follows
+%% the ceiling, so at most as many requests wait as run: total requests
+%% in the system stay under twice the ceiling, and the worst-case wait
+%% stays around one service time per queued request.
+-spec validate_overload_mode(term(), infinity | pos_integer(), pos_integer()) ->
+    refuse | {queue, #{max_queued := pos_integer(), timeout := pos_integer()}}.
+validate_overload_mode(refuse, _Max, _RequestTimeout) ->
+    refuse;
+validate_overload_mode({queue, _Queue} = Mode, infinity, _RequestTimeout) ->
+    error({invalid_listener_opt, overload_mode, {Mode, requires_max_concurrent_requests}});
+validate_overload_mode({queue, Queue}, Max, RequestTimeout) when is_map(Queue) ->
+    MaxQueued = maps:get(max_queued, Queue, Max),
+    Timeout = maps:get(timeout, Queue, RequestTimeout),
+    case
+        is_integer(MaxQueued) andalso MaxQueued > 0 andalso is_integer(Timeout) andalso Timeout > 0
+    of
+        true ->
+            {queue, #{max_queued => MaxQueued, timeout => Timeout}};
+        false ->
+            error({invalid_listener_opt, overload_mode, {queue, Queue}})
+    end;
+validate_overload_mode(Other, _Max, _RequestTimeout) ->
+    error({invalid_listener_opt, overload_mode, Other}).
+
+%% `refuse` costs nothing at all on the release path; the queue form
+%% carries the process, the atomic that says whether anyone is parked,
+%% and the wait deadline, so the hot path never reads proto_opts again.
+-spec setup_overload(
+    refuse | {queue, #{max_queued := pos_integer(), timeout := pos_integer()}},
+    infinity | pos_integer(),
+    counters:counters_ref()
+) -> roadrunner_conn:overload().
+setup_overload(refuse, _Max, _Counter) ->
+    refuse;
+setup_overload({queue, #{max_queued := MaxQueued, timeout := Timeout}}, Max, Counter) ->
+    {ok, Pid} = roadrunner_overload_queue:start_link(Max, Counter, MaxQueued),
+    {queue, Pid, roadrunner_overload_queue:waiters_ref(Pid), Timeout}.
+
 -spec validate_proxy_protocol(term(), [http1 | http2 | http3, ...]) -> boolean().
 validate_proxy_protocol(false, _Protocols) ->
     false;
@@ -1156,6 +1231,20 @@ build_proto_opts(Opts, ListenerName) ->
     %% store is created only when `rate_limit` is configured.
     RateLimitedCounter = atomics:new(1, [{signed, false}]),
     RateLimit = build_rate_limit(maps:get(rate_limit, Opts, undefined)),
+    MaxConcurrentRequests =
+        maps:get(max_concurrent_requests, Opts, ?DEFAULT_MAX_CONCURRENT_REQUESTS),
+    %% `overload_mode` decides what happens to a request that arrives over
+    %% the ceiling. Queue mode needs a process to park waiters in; it is
+    %% started here so it is linked to the listener and dies with it.
+    Overload = setup_overload(
+        validate_overload_mode(
+            maps:get(overload_mode, Opts, refuse),
+            MaxConcurrentRequests,
+            maps:get(request_timeout, Opts, ?DEFAULT_REQUEST_TIMEOUT)
+        ),
+        MaxConcurrentRequests,
+        InflightCounter
+    ),
     %% Public `ws` opts are a nested map; flatten to the `ws_*`
     %% proto_opts keys the hot path reads, mirroring the `{http2, #{}}`
     %% → `http2_*` flattening above.
@@ -1187,8 +1276,8 @@ build_proto_opts(Opts, ListenerName) ->
             max_keep_alive_requests =>
                 maps:get(max_keep_alive_requests, Opts, ?DEFAULT_MAX_KEEP_ALIVE),
             max_clients => maps:get(max_clients, Opts, ?DEFAULT_MAX_CLIENTS),
-            max_concurrent_requests =>
-                maps:get(max_concurrent_requests, Opts, ?DEFAULT_MAX_CONCURRENT_REQUESTS),
+            max_concurrent_requests => MaxConcurrentRequests,
+            overload => Overload,
             client_counter => ClientCounter,
             requests_counter => RequestsCounter,
             rejected_counter => RejectedCounter,

--- a/src/roadrunner_overload_queue.erl
+++ b/src/roadrunner_overload_queue.erl
@@ -1,0 +1,225 @@
+-module(roadrunner_overload_queue).
+-moduledoc false.
+
+-behaviour(gen_server).
+
+%% One per listener, started and linked by `roadrunner_listener` when
+%% `overload_mode` is a queue. Parks requests that arrive over the
+%% listener-wide `max_concurrent_requests` ceiling until a slot frees,
+%% instead of refusing them.
+%%
+%% Everything here is asynchronous, and that is the whole point. A
+%% multiplexed connection releases in-flight slots by processing its own
+%% workers' `DOWN` messages, so a loop that blocked waiting for a slot
+%% would stop reading the very messages that free one and park forever.
+%% Callers therefore `enqueue/3` and go back to their frame loop; the
+%% grant arrives later as a message.
+%%
+%% The queue sits on the slow path only. Taking a slot is a plain
+%% `counters` operation in the caller, and this process is consulted
+%% solely when that fails; releases read one atomic (`waiting/1`) and
+%% message us only when someone is actually parked.
+
+-export([
+    start_link/3,
+    enqueue/3,
+    cancel/2,
+    note_release/1,
+    waiting/1,
+    waiters_ref/1
+]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+%% A parked request. `token` is chosen by the caller (the stream id) and
+%% only has to be unique within that caller, since entries are keyed by
+%% `{pid, token}`.
+-record(entry, {
+    pid :: pid(),
+    token :: term(),
+    monitor :: reference(),
+    timer :: reference()
+}).
+
+-record(state, {
+    max :: pos_integer(),
+    counter :: counters:counters_ref(),
+    max_queued :: pos_integer(),
+    waiters :: atomics:atomics_ref(),
+    %% Keys in arrival order, so grants are FIFO and the worst-case wait
+    %% is bounded. An entry that was served, expired or cancelled is
+    %% removed from `live` but left here, so the order queue is drained
+    %% lazily on the next pop rather than searched on every removal.
+    order = queue:new() :: queue:queue(key()),
+    live = #{} :: #{key() => #entry{}}
+}).
+
+-type key() :: {pid(), term()}.
+
+-spec start_link(pos_integer(), counters:counters_ref(), pos_integer()) ->
+    {ok, pid()} | {error, term()}.
+start_link(Max, Counter, MaxQueued) ->
+    gen_server:start_link(?MODULE, {Max, Counter, MaxQueued}, []).
+
+-doc false.
+%% Park the caller's request. Returns immediately; the outcome arrives as
+%% `{roadrunner_slot, Token, granted | timeout | full}`. A `granted`
+%% message means the slot has ALREADY been taken on the caller's behalf,
+%% so a caller that no longer wants it must release it rather than drop
+%% it.
+-spec enqueue(pid(), term(), pos_integer()) -> ok.
+enqueue(Pid, Token, Timeout) ->
+    gen_server:cast(Pid, {enqueue, self(), Token, Timeout}).
+
+%% Withdraw a parked request (the stream was reset, or its connection is
+%% going away). Racing a grant is expected and safe: the caller may still
+%% receive `granted` after cancelling, and must release that slot.
+-spec cancel(pid(), term()) -> ok.
+cancel(Pid, Token) ->
+    gen_server:cast(Pid, {cancel, self(), Token}).
+
+-spec note_release(pid()) -> ok.
+note_release(Pid) ->
+    _ = erlang:send(Pid, slot_freed),
+    ok.
+
+-spec waiting(atomics:atomics_ref()) -> boolean().
+waiting(Ref) ->
+    atomics:get(Ref, 1) > 0.
+
+-spec waiters_ref(pid()) -> atomics:atomics_ref().
+waiters_ref(Pid) ->
+    gen_server:call(Pid, waiters_ref, infinity).
+
+-spec init({pos_integer(), counters:counters_ref(), pos_integer()}) -> {ok, #state{}}.
+init({Max, Counter, MaxQueued}) ->
+    {ok, #state{
+        max = Max,
+        counter = Counter,
+        max_queued = MaxQueued,
+        waiters = atomics:new(1, [{signed, false}])
+    }}.
+
+-spec handle_call(term(), gen_server:from(), #state{}) -> {reply, term(), #state{}}.
+handle_call(waiters_ref, _From, #state{waiters = Ref} = State) ->
+    {reply, Ref, State};
+handle_call(_Other, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
+handle_cast(
+    {enqueue, Pid, Token, _Timeout}, #state{live = Live, max_queued = MaxQueued} = State
+) when
+    map_size(Live) >= MaxQueued
+->
+    %% The shed valve: overload still sheds rather than growing the queue
+    %% without bound. The caller refuses the request as it does today.
+    _ = erlang:send(Pid, {roadrunner_slot, Token, full}),
+    {noreply, State};
+handle_cast({enqueue, Pid, Token, Timeout}, State) ->
+    #state{order = Order, live = Live, waiters = Waiters} = State,
+    Key = {Pid, Token},
+    Entry = #entry{
+        pid = Pid,
+        token = Token,
+        monitor = erlang:monitor(process, Pid),
+        timer = erlang:send_after(Timeout, self(), {expire, Key})
+    },
+    ok = atomics:add(Waiters, 1, 1),
+    %% Try to serve immediately. Enqueuing is a cast, so a slot can free
+    %% between the caller's failed acquire and this park: the releaser
+    %% would have read the waiters atomic as 0, sent no wake-up, and left
+    %% this request stranded until its deadline. Serving here closes that
+    %% window from the other side. Once the atomic is set above, any
+    %% later release sees it and wakes us the normal way.
+    Parked = State#state{order = queue:in(Key, Order), live = Live#{Key => Entry}},
+    {noreply, serve(Parked)};
+handle_cast({cancel, Pid, Token}, State) ->
+    {noreply, forget({Pid, Token}, State)};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), #state{}) -> {noreply, #state{}}.
+handle_info(slot_freed, State) ->
+    {noreply, serve(State)};
+handle_info({expire, Key}, State) ->
+    {noreply, resolve(Key, timeout, State)};
+handle_info({'DOWN', Mon, process, _Pid, _Reason}, #state{live = Live} = State) ->
+    %% A parked connection died. Drop everything it was waiting on; no
+    %% slot was taken for those entries, so nothing leaks.
+    Keys = [K || {K, #entry{monitor = M}} <- maps:to_list(Live), M =:= Mon],
+    {noreply, lists:foldl(fun forget/2, State, Keys)};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+%% Hand the freed slot to the oldest parked request. The slot is taken
+%% here, on that caller's behalf, so it cannot be stolen by a request
+%% that arrives while the grant is in flight.
+-spec serve(#state{}) -> #state{}.
+serve(#state{max = Max, counter = Counter} = State) ->
+    case next(State) of
+        empty ->
+            State;
+        {Key, #entry{pid = Pid, token = Token} = Entry, State1} ->
+            case roadrunner_conn:try_acquire_request_slot(Max, Counter) of
+                true ->
+                    ok = cancel_entry(Entry),
+                    _ = erlang:send(Pid, {roadrunner_slot, Token, granted}),
+                    decrement(State1);
+                false ->
+                    %% Lost the slot to a fresh request between the
+                    %% release and here. Keep our place at the head.
+                    requeue(Key, Entry, State1)
+            end
+    end.
+
+-spec next(#state{}) -> empty | {key(), #entry{}, #state{}}.
+next(#state{order = Order, live = Live} = State) ->
+    case queue:out(Order) of
+        {empty, _} ->
+            empty;
+        {{value, Key}, Rest} ->
+            case Live of
+                #{Key := Entry} ->
+                    {Key, Entry, State#state{order = Rest, live = maps:remove(Key, Live)}};
+                _ ->
+                    next(State#state{order = Rest})
+            end
+    end.
+
+-spec requeue(key(), #entry{}, #state{}) -> #state{}.
+requeue(Key, Entry, #state{order = Order, live = Live} = State) ->
+    State#state{order = queue:in_r(Key, Order), live = Live#{Key => Entry}}.
+
+-spec resolve(key(), timeout, #state{}) -> #state{}.
+resolve(Key, Reply, #state{live = Live} = State) ->
+    case Live of
+        #{Key := #entry{pid = Pid, token = Token} = Entry} ->
+            ok = cancel_entry(Entry),
+            _ = erlang:send(Pid, {roadrunner_slot, Token, Reply}),
+            decrement(State#state{live = maps:remove(Key, Live)});
+        _ ->
+            State
+    end.
+
+%% Remove without telling the caller — it either asked to cancel or is
+%% gone.
+-spec forget(key(), #state{}) -> #state{}.
+forget(Key, #state{live = Live} = State) ->
+    case Live of
+        #{Key := Entry} ->
+            ok = cancel_entry(Entry),
+            decrement(State#state{live = maps:remove(Key, Live)});
+        _ ->
+            State
+    end.
+
+-spec cancel_entry(#entry{}) -> ok.
+cancel_entry(#entry{monitor = Mon, timer = Timer}) ->
+    _ = erlang:demonitor(Mon, [flush]),
+    _ = erlang:cancel_timer(Timer),
+    ok.
+
+-spec decrement(#state{}) -> #state{}.
+decrement(#state{waiters = Waiters} = State) ->
+    ok = atomics:sub(Waiters, 1, 1),
+    State.

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -1329,6 +1329,108 @@ conn_handler_crash_returns_500_test_() ->
             end}
         end}.
 
+%% --- in-flight slot accounting ---
+
+%% `refuse` is the default shape and must stay a pure counters path: no
+%% queue process, no messages, and the same false the conn loops already
+%% turn into REFUSED_STREAM / H3_REQUEST_REJECTED.
+slot_refuse_mode_is_pure_counters_test() ->
+    Counter = counters:new(1, [write_concurrency]),
+    ?assert(roadrunner_conn:acquire_request_slot(1, Counter, refuse, s1)),
+    ?assertNot(roadrunner_conn:acquire_request_slot(1, Counter, refuse, s2)),
+    ok = roadrunner_conn:cancel_slot_wait(refuse, s2),
+    ok = roadrunner_conn:release_request_slot(1, Counter, refuse),
+    ?assertEqual(0, counters:get(Counter, 1)),
+    %% `infinity` short-circuits both directions.
+    ?assert(roadrunner_conn:acquire_request_slot(infinity, Counter, refuse, s3)),
+    ok = roadrunner_conn:release_request_slot(infinity, Counter, refuse),
+    ?assertEqual(0, counters:get(Counter, 1)).
+
+slot_release_many_test() ->
+    Counter = counters:new(1, [write_concurrency]),
+    true = roadrunner_conn:acquire_request_slot(3, Counter, refuse, a),
+    true = roadrunner_conn:acquire_request_slot(3, Counter, refuse, b),
+    ok = roadrunner_conn:release_request_slots(3, Counter, 0, refuse),
+    ?assertEqual(2, counters:get(Counter, 1)),
+    ok = roadrunner_conn:release_request_slots(infinity, Counter, 2, refuse),
+    ?assertEqual(2, counters:get(Counter, 1)),
+    ok = roadrunner_conn:release_request_slots(3, Counter, 2, refuse),
+    ?assertEqual(0, counters:get(Counter, 1)).
+
+%% In queue mode an over-ceiling acquire parks instead of refusing, and
+%% the release wakes it. `{spawn, _}` because the grant lands in this
+%% process's mailbox.
+slot_queue_mode_parks_and_wakes_test_() ->
+    {spawn, fun() ->
+        Counter = counters:new(1, [write_concurrency]),
+        {ok, Pid} = roadrunner_overload_queue:start_link(1, Counter, 8),
+        Waiters = roadrunner_overload_queue:waiters_ref(Pid),
+        Overload = {queue, Pid, Waiters, 5000},
+        ?assert(roadrunner_conn:acquire_request_slot(1, Counter, Overload, s1)),
+        ?assertEqual(queued, roadrunner_conn:acquire_request_slot(1, Counter, Overload, s2)),
+        ok = roadrunner_conn:release_request_slot(1, Counter, Overload),
+        Outcome =
+            receive
+                {roadrunner_slot, s2, O} -> O
+            after 2000 -> never_granted
+            end,
+        ?assertEqual(granted, Outcome)
+    end}.
+
+%% A release with nobody parked must not send a message; the atomic guard
+%% is what keeps queue mode off the hot path.
+slot_queue_mode_release_without_waiters_test_() ->
+    {spawn, fun() ->
+        Counter = counters:new(1, [write_concurrency]),
+        {ok, Pid} = roadrunner_overload_queue:start_link(1, Counter, 8),
+        Overload = {queue, Pid, roadrunner_overload_queue:waiters_ref(Pid), 5000},
+        true = roadrunner_conn:acquire_request_slot(1, Counter, Overload, s1),
+        ok = roadrunner_conn:release_request_slot(1, Counter, Overload),
+        ok = roadrunner_conn:release_request_slots(1, Counter, 0, Overload),
+        ?assertEqual(0, counters:get(Counter, 1)),
+        ?assert(is_process_alive(Pid))
+    end}.
+
+slot_queue_mode_cancel_test_() ->
+    {spawn, fun() ->
+        Counter = counters:new(1, [write_concurrency]),
+        {ok, Pid} = roadrunner_overload_queue:start_link(1, Counter, 8),
+        Overload = {queue, Pid, roadrunner_overload_queue:waiters_ref(Pid), 5000},
+        Waiters = roadrunner_overload_queue:waiters_ref(Pid),
+        true = roadrunner_conn:acquire_request_slot(1, Counter, Overload, s1),
+        queued = roadrunner_conn:acquire_request_slot(1, Counter, Overload, s2),
+        %% Wait for the park to land before cancelling. A cancel that
+        %% races an in-flight grant is legal and the caller has to give
+        %% that slot back, but this test is about the ordered case.
+        ?assert(until(fun() -> roadrunner_overload_queue:waiting(Waiters) end)),
+        ok = roadrunner_conn:cancel_slot_wait(Overload, s2),
+        ?assert(until(fun() -> not roadrunner_overload_queue:waiting(Waiters) end)),
+        ok = roadrunner_conn:release_request_slot(1, Counter, Overload),
+        %% Withdrawn before the slot freed, so no grant arrives.
+        Got =
+            receive
+                {roadrunner_slot, s2, O} -> O
+            after 200 -> nothing
+            end,
+        ?assertEqual(nothing, Got)
+    end}.
+
+until(Fun) ->
+    until(Fun, 200).
+
+until(_Fun, 0) ->
+    false;
+until(Fun, N) ->
+    case Fun() of
+        true ->
+            true;
+        false ->
+            receive
+            after 5 -> ok
+            end,
+            until(Fun, N - 1)
+    end.
+
 %% --- make_recv/3 — pure unit tests ---
 
 %% A queued drain is reported before the socket is touched, and ONLY the
@@ -2245,6 +2347,7 @@ parse_error_status_other_is_400_test() ->
 
 %% =============================================================================
 %% try_acquire_request_slot/2 + release_request_slot[s] — pure unit tests
+%% (`refuse` is the default overload mode: pure counters, no queue.)
 %% =============================================================================
 
 request_slot_infinity_is_noop_test() ->
@@ -2253,8 +2356,8 @@ request_slot_infinity_is_noop_test() ->
     %% no-op.
     ?assert(roadrunner_conn:try_acquire_request_slot(infinity, undefined)),
     ?assert(roadrunner_conn:try_acquire_request_slot(infinity, undefined)),
-    ?assertEqual(ok, roadrunner_conn:release_request_slot(infinity, undefined)),
-    ?assertEqual(ok, roadrunner_conn:release_request_slots(infinity, undefined, 5)).
+    ?assertEqual(ok, roadrunner_conn:release_request_slot(infinity, undefined, refuse)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(infinity, undefined, 5, refuse)).
 
 request_slot_admits_up_to_cap_then_refuses_test() ->
     Ref = counters:new(1, [write_concurrency]),
@@ -2265,7 +2368,7 @@ request_slot_admits_up_to_cap_then_refuses_test() ->
     ?assertNot(roadrunner_conn:try_acquire_request_slot(2, Ref)),
     ?assertEqual(2, counters:get(Ref, 1)),
     %% Releasing one frees a slot; the next acquire succeeds again.
-    ?assertEqual(ok, roadrunner_conn:release_request_slot(2, Ref)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slot(2, Ref, refuse)),
     ?assertEqual(1, counters:get(Ref, 1)),
     ?assert(roadrunner_conn:try_acquire_request_slot(2, Ref)),
     ?assertEqual(2, counters:get(Ref, 1)).
@@ -2276,7 +2379,7 @@ request_slot_release_many_test() ->
     ?assertEqual(4, counters:get(Ref, 1)),
     %% Bulk release (conn teardown with N live workers) drops the gauge by N;
     %% N = 0 is a no-op.
-    ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 0)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 0, refuse)),
     ?assertEqual(4, counters:get(Ref, 1)),
-    ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 4)),
+    ?assertEqual(ok, roadrunner_conn:release_request_slots(10, Ref, 4, refuse)),
     ?assertEqual(0, counters:get(Ref, 1)).

--- a/test/roadrunner_h2_overload_tests.erl
+++ b/test/roadrunner_h2_overload_tests.erl
@@ -1,0 +1,255 @@
+-module(roadrunner_h2_overload_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% =============================================================================
+%% HTTP/2 admission under `overload_mode`.
+%%
+%% Drives a real h2c listener with the in-tree codec. The ceiling is 1, so
+%% the second stream always has to wait: with `refuse` it is rejected the
+%% way it is today, and with a queue it is served once the first handler
+%% lets go of its slot.
+%%
+%% The loop must NOT block while waiting. It releases slots by processing
+%% its own workers' `DOWN` messages, so a blocked loop would wait on
+%% something only it can deliver — the whole reason admission is
+%% asynchronous.
+%% =============================================================================
+
+queue_mode_serves_a_parked_stream_test_() ->
+    {timeout, 30,
+        {spawn, fun() ->
+            {Name, Port} = start_listener(
+                queue_serves, {queue, #{max_queued => 4, timeout => 5000}}
+            ),
+            try
+                Sock = h2_connect(Port),
+                ok = send_request(Sock, 1),
+                First = expect_handler(),
+                %% Stream 1 holds the only slot, so stream 3 parks rather
+                %% than being refused.
+                ok = send_request(Sock, 3),
+                ?assertEqual(no_handler, expect_no_handler()),
+                First ! release,
+                Second = expect_handler(),
+                Second ! release,
+                {Ok, Refused} = collect(Sock, 2, 0, 0),
+                ?assertEqual(2, Ok),
+                ?assertEqual(0, Refused),
+                ok = gen_tcp:close(Sock)
+            after
+                ok = roadrunner_listener:stop(Name)
+            end
+        end}}.
+
+queue_mode_refuses_after_the_deadline_test_() ->
+    {timeout, 30,
+        {spawn, fun() ->
+            {Name, Port} = start_listener(
+                queue_expires, {queue, #{max_queued => 4, timeout => 50}}
+            ),
+            try
+                Sock = h2_connect(Port),
+                ok = send_request(Sock, 1),
+                First = expect_handler(),
+                ok = send_request(Sock, 3),
+                %% Nothing frees a slot in time, so the parked stream falls
+                %% back to exactly today's refusal.
+                {Ok, Refused} = collect(Sock, 1, 0, 0),
+                ?assertEqual(0, Ok),
+                ?assertEqual(1, Refused),
+                First ! release,
+                ok = gen_tcp:close(Sock)
+            after
+                ok = roadrunner_listener:stop(Name)
+            end
+        end}}.
+
+refuse_mode_is_unchanged_test_() ->
+    {timeout, 30,
+        {spawn, fun() ->
+            {Name, Port} = start_listener(refuse_default, refuse),
+            try
+                Sock = h2_connect(Port),
+                ok = send_request(Sock, 1),
+                First = expect_handler(),
+                ok = send_request(Sock, 3),
+                {Ok, Refused} = collect(Sock, 1, 0, 0),
+                ?assertEqual(0, Ok),
+                ?assertEqual(1, Refused),
+                First ! release,
+                ok = gen_tcp:close(Sock)
+            after
+                ok = roadrunner_listener:stop(Name)
+            end
+        end}}.
+
+%% A client RST while a stream is parked has to withdraw it from the
+%% queue, or the entry outlives its stream.
+queue_mode_reset_withdraws_a_parked_stream_test_() ->
+    {timeout, 30,
+        {spawn, fun() ->
+            {Name, Port} = start_listener(
+                queue_reset, {queue, #{max_queued => 4, timeout => 5000}}
+            ),
+            try
+                Sock = h2_connect(Port),
+                ok = send_request(Sock, 1),
+                First = expect_handler(),
+                ok = send_request(Sock, 3),
+                ?assertEqual(no_handler, expect_no_handler()),
+                %% Withdraw the parked stream, then free the slot it was
+                %% waiting for. It must not be dispatched afterwards.
+                ok = gen_tcp:send(
+                    Sock, roadrunner_http2_frame:encode({rst_stream, 3, cancel})
+                ),
+                %% Frames are processed in order, so a PING ack proves the
+                %% RST has been handled. Without the barrier the connection
+                %% can see the first worker's DOWN, free the slot and
+                %% dispatch the parked stream before it ever reads the RST.
+                ok = await_ping_ack(Sock),
+                First ! release,
+                ?assertEqual(no_handler, expect_no_handler()),
+                ?assertMatch({1, _}, collect(Sock, 1, 0, 0)),
+                ok = gen_tcp:close(Sock)
+            after
+                ok = roadrunner_listener:stop(Name)
+            end
+        end}}.
+
+%% A grant that arrives for a stream the loop no longer has is the one
+%% leak the design must handle: the queue took that slot on our behalf,
+%% so it has to be given back rather than dropped. Injected directly
+%% because the window it happens in is a race by nature.
+queue_mode_hands_back_a_stale_grant_test_() ->
+    {timeout, 30,
+        {spawn, fun() ->
+            {Name, Port} = start_listener(
+                queue_stale, {queue, #{max_queued => 4, timeout => 5000}}
+            ),
+            try
+                Sock = h2_connect(Port),
+                ok = send_request(Sock, 1),
+                First = expect_handler(),
+                Conn = conn_pid(Name),
+                Conn ! {roadrunner_slot, 99, granted},
+                Conn ! {roadrunner_slot, 99, timeout},
+                First ! release,
+                %% The connection carries on serving as if nothing happened.
+                ?assertMatch({1, _}, collect(Sock, 1, 0, 0)),
+                ?assert(is_process_alive(Conn)),
+                ok = gen_tcp:close(Sock)
+            after
+                ok = roadrunner_listener:stop(Name)
+            end
+        end}}.
+
+await_ping_ack(Sock) ->
+    ok = gen_tcp:send(
+        Sock, roadrunner_http2_frame:encode({ping, 0, <<1, 2, 3, 4, 5, 6, 7, 8>>})
+    ),
+    await_ping_ack(Sock, <<>>).
+
+await_ping_ack(Sock, Buf) ->
+    case roadrunner_http2_frame:parse(Buf, 16384) of
+        {ok, {ping, 1, _}, _Rest} ->
+            ok;
+        {ok, _, Rest} ->
+            await_ping_ack(Sock, Rest);
+        {more, _} ->
+            {ok, More} = gen_tcp:recv(Sock, 0, 5000),
+            await_ping_ack(Sock, <<Buf/binary, More/binary>>)
+    end.
+
+conn_pid(Name) ->
+    [Pid] = pg:get_members({roadrunner_drain, Name}),
+    Pid.
+
+%% --- harness ---
+
+start_listener(Name, OverloadMode) ->
+    _ = ensure_pg(),
+    %% Each test runs in its own process, so the previous one's
+    %% registration may still be settling. Take the name rather than
+    %% racing for it.
+    _ =
+        case whereis(roadrunner_h2_slot_collector) of
+            undefined -> ok;
+            _ -> unregister(roadrunner_h2_slot_collector)
+        end,
+    true = register(roadrunner_h2_slot_collector, self()),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        routes => roadrunner_h2_slot_handler,
+        protocols => [http2],
+        max_concurrent_requests => 1,
+        overload_mode => OverloadMode
+    }),
+    {Name, roadrunner_listener:port(Name)}.
+
+ensure_pg() ->
+    case whereis(pg) of
+        undefined -> pg:start_link();
+        Pid -> {ok, Pid}
+    end.
+
+expect_handler() ->
+    receive
+        {handler_started, Pid} -> Pid
+    after 5000 -> error(handler_never_started)
+    end.
+
+expect_no_handler() ->
+    receive
+        {handler_started, _} -> handler_started_unexpectedly
+    after 300 -> no_handler
+    end.
+
+h2_connect(Port) ->
+    {ok, Sock} = gen_tcp:connect(
+        {127, 0, 0, 1}, Port, [binary, {active, false}, {nodelay, true}], 5000
+    ),
+    ok = gen_tcp:send(Sock, [~"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", <<0:24, 4, 0, 0:32>>]),
+    Sock.
+
+send_request(Sock, StreamId) ->
+    Enc = roadrunner_http2_hpack:new_encoder(4096),
+    {Block, _} = roadrunner_http2_hpack:encode(
+        [
+            {~":method", ~"GET"},
+            {~":scheme", ~"http"},
+            {~":authority", ~"localhost"},
+            {~":path", ~"/"}
+        ],
+        Enc
+    ),
+    gen_tcp:send(
+        Sock,
+        roadrunner_http2_frame:encode(
+            {headers, StreamId, 16#04 bor 16#01, undefined, iolist_to_binary(Block)}
+        )
+    ).
+
+%% Read until `Want` streams have ended, counting completions against
+%% RST_STREAM refusals.
+collect(Sock, Want, Ok, Refused) ->
+    collect(Sock, Want, Ok, Refused, <<>>).
+
+collect(_Sock, Want, Ok, Refused, _Buf) when Ok + Refused >= Want ->
+    {Ok, Refused};
+collect(Sock, Want, Ok, Refused, Buf) ->
+    case roadrunner_http2_frame:parse(Buf, 16384) of
+        {ok, {rst_stream, _, _}, Rest} ->
+            collect(Sock, Want, Ok, Refused + 1, Rest);
+        {ok, {data, _, Flags, _, _}, Rest} when (Flags band 16#01) =/= 0 ->
+            collect(Sock, Want, Ok + 1, Refused, Rest);
+        {ok, {headers, _, Flags, _, _}, Rest} when (Flags band 16#01) =/= 0 ->
+            collect(Sock, Want, Ok + 1, Refused, Rest);
+        {ok, _, Rest} ->
+            collect(Sock, Want, Ok, Refused, Rest);
+        {more, _} ->
+            case gen_tcp:recv(Sock, 0, 10000) of
+                {ok, More} -> collect(Sock, Want, Ok, Refused, <<Buf/binary, More/binary>>);
+                _ -> {Ok, Refused}
+            end
+    end.

--- a/test/roadrunner_h2_slot_handler.erl
+++ b/test/roadrunner_h2_slot_handler.erl
@@ -1,0 +1,32 @@
+-module(roadrunner_h2_slot_handler).
+-moduledoc """
+Test fixture — announces itself and then holds its in-flight slot until
+released, so a second stream has to park behind
+`max_concurrent_requests`. Announcing to a registered collector rather
+than registering itself lets several run at once.
+""".
+
+-behaviour(roadrunner_handler).
+
+-export([handle/1]).
+
+-spec handle(roadrunner_req:request()) -> roadrunner_handler:result().
+handle(Req) ->
+    _ =
+        case whereis(roadrunner_h2_slot_collector) of
+            undefined -> ok;
+            Pid -> Pid ! {handler_started, self()}
+        end,
+    receive
+        release -> ok
+    after 5000 -> ok
+    end,
+    Body = ~"ok",
+    Resp =
+        {200,
+            [
+                {~"content-type", ~"text/plain"},
+                {~"content-length", integer_to_binary(byte_size(Body))}
+            ],
+            Body},
+    {Resp, Req}.

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -61,6 +61,10 @@ process with its own listener, mirroring `roadrunner_http2_*_SUITE`.
     rejects_http3_without_tls/1,
     max_clients_refuse/1,
     max_concurrent_requests_refuse/1,
+    max_concurrent_requests_queue/1,
+    max_concurrent_requests_queue_expires/1,
+    max_concurrent_requests_queue_stale_grant/1,
+    max_concurrent_requests_queue_survives_drain/1,
     stream_cancel/1,
     response_to_cancelled_stream/1,
     badheaders_reset/1,
@@ -135,6 +139,10 @@ all() ->
         rejects_http3_without_tls,
         max_clients_refuse,
         max_concurrent_requests_refuse,
+        max_concurrent_requests_queue,
+        max_concurrent_requests_queue_expires,
+        max_concurrent_requests_queue_stale_grant,
+        max_concurrent_requests_queue_survives_drain,
         stream_cancel,
         response_to_cancelled_stream,
         badheaders_reset,
@@ -204,6 +212,10 @@ init_per_testcase(Case, Config) when
     Case =:= rejects_http3_without_tls;
     Case =:= max_clients_refuse;
     Case =:= max_concurrent_requests_refuse;
+    Case =:= max_concurrent_requests_queue;
+    Case =:= max_concurrent_requests_queue_expires;
+    Case =:= max_concurrent_requests_queue_stale_grant;
+    Case =:= max_concurrent_requests_queue_survives_drain;
     Case =:= extra_data_after_413;
     Case =:= oversized_headers_431;
     Case =:= advertises_max_field_section_size;
@@ -952,6 +964,134 @@ max_concurrent_requests_refuse(_Config) ->
         roadrunner_listener:stop(Name)
     end.
 
+max_concurrent_requests_queue(_Config) ->
+    %% Same ceiling of 1, but the listener queues instead of refusing. The
+    %% second request parks until the loop worker lets go of the slot, and
+    %% is then served rather than rejected. `open_request/2` and
+    %% `collect/2` are separate calls, so the request can be in flight
+    %% while the slot is freed.
+    Name = listener_name(max_concurrent_requests_queue),
+    {ok, _} = start_h3(Name, #{
+        max_concurrent_requests => 1,
+        overload_mode => {queue, #{max_queued => 4, timeout => 5000}}
+    }),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        %% An earlier case uses the same registered name, so wait for it to
+        %% be free before claiming it.
+        ok = wait_for_unregister(roadrunner_h3_loop_test, 5000),
+        {ok, _} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
+        First = wait_for_register(roadrunner_h3_loop_test, 1000),
+        %% Both requests go to `/loop`, whose handler re-registers the
+        %% name. That makes dispatch observable: while the second is
+        %% parked the name still points at the first worker, and it only
+        %% moves once the parked request is granted a slot. Asserting that
+        %% is what stops this passing without ever exercising the queue.
+        {ok, _} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
+        timer:sleep(200),
+        ?assertEqual(First, whereis(roadrunner_h3_loop_test)),
+        FirstRef = monitor(process, First),
+        First ! stop,
+        receive
+            {'DOWN', FirstRef, process, First, _} -> ok
+        after 5000 -> ct:fail(loop_worker_did_not_exit)
+        end,
+        Second = wait_for_new_register(roadrunner_h3_loop_test, First, 5000),
+        ?assertNotEqual(First, Second),
+        Second ! stop
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+max_concurrent_requests_queue_expires(_Config) ->
+    %% Nothing frees a slot before the deadline, so a parked request falls
+    %% back to exactly the refusal `refuse` mode would have produced.
+    Name = listener_name(max_concurrent_requests_queue_expires),
+    {ok, _} = start_h3(Name, #{
+        max_concurrent_requests => 1,
+        overload_mode => {queue, #{max_queued => 4, timeout => 50}}
+    }),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        %% An earlier case uses the same route and registered name, so wait
+        %% for it to be free: a stale pid here would mean the slot was
+        %% never actually held and nothing ever parked.
+        ok = wait_for_unregister(roadrunner_h3_loop_test, 5000),
+        {ok, _} = roadrunner_quic_test_h3:open_request(Conn, headers(~"GET", ~"/loop")),
+        Worker = wait_for_register(roadrunner_h3_loop_test, 1000),
+        ?assertEqual(error, try_get(Conn, ~"/")),
+        ?assert(maps:get(throttled, roadrunner_listener:info(Name)) >= 1),
+        Worker ! stop
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+max_concurrent_requests_queue_stale_grant(_Config) ->
+    %% A grant for a request the loop no longer has is the one leak the
+    %% design must handle: the queue took that slot on our behalf, so it
+    %% has to be given back. Injected directly, because the window it
+    %% happens in is a race by nature.
+    Name = listener_name(max_concurrent_requests_queue_stale_grant),
+    {ok, _} = start_h3(Name, #{
+        max_concurrent_requests => 4,
+        overload_mode => {queue, #{max_queued => 4, timeout => 5000}}
+    }),
+    Conn = connect(roadrunner_listener:port(Name)),
+    try
+        ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/"))),
+        [ConnPid] = pg:get_members({roadrunner_drain, Name}),
+        ConnPid ! {roadrunner_slot, 999, granted},
+        ConnPid ! {roadrunner_slot, 999, timeout},
+        %% The connection carries on serving as if nothing happened.
+        ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/"))),
+        ?assert(is_process_alive(ConnPid))
+    after
+        close(Conn),
+        roadrunner_listener:stop(Name)
+    end.
+
+max_concurrent_requests_queue_survives_drain(_Config) ->
+    %% A parked request is in neither `streams` nor `worker_refs`, so a
+    %% drain-complete check that looks only at those closes the connection
+    %% under it and drops a request the peer already sent. The slot is
+    %% deliberately held by a DIFFERENT connection, so the parked one has
+    %% nothing else keeping it alive.
+    Name = listener_name(max_concurrent_requests_queue_survives_drain),
+    {ok, _} = start_h3(Name, #{
+        max_concurrent_requests => 1,
+        overload_mode => {queue, #{max_queued => 4, timeout => 5000}}
+    }),
+    Port = roadrunner_listener:port(Name),
+    Holder = connect(Port),
+    Parked = connect(Port),
+    try
+        ok = wait_for_unregister(roadrunner_h3_loop_test, 5000),
+        {ok, _} = roadrunner_quic_test_h3:open_request(Holder, headers(~"GET", ~"/loop")),
+        First = wait_for_register(roadrunner_h3_loop_test, 1000),
+        %% Parks: the only slot is held by the other connection.
+        {ok, _} = roadrunner_quic_test_h3:open_request(Parked, headers(~"GET", ~"/loop")),
+        timer:sleep(200),
+        ?assertEqual(First, whereis(roadrunner_h3_loop_test)),
+        %% Drain, then free the slot. The parked request must still be
+        %% dispatched rather than dropped with the connection.
+        Self = self(),
+        _ = spawn(fun() -> Self ! {drained, roadrunner_listener:drain(Name, 5000)} end),
+        timer:sleep(200),
+        First ! stop,
+        Second = wait_for_new_register(roadrunner_h3_loop_test, First, 5000),
+        ?assertNotEqual(First, Second),
+        Second ! stop,
+        receive
+            {drained, _} -> ok
+        after 10000 -> ct:fail(drain_never_returned)
+        end
+    after
+        close(Holder),
+        close(Parked)
+    end.
+
 %% Retry a GET until it succeeds: the in-flight slot is released on the
 %% worker's `DOWN`, which is processed by the conn loop slightly after the
 %% monitor fires here, so the first follow-up request can still race it.
@@ -1352,6 +1492,31 @@ ll_collect_until_end(Conn, StreamId, Acc) ->
 
 %% Spin until a `{loop, _}` handler registers `Name` (it does so from
 %% `handle/1`), so the test can address the worker from outside.
+wait_for_new_register(_Name, _Old, RemainingMs) when RemainingMs =< 0 ->
+    ct:fail(parked_request_never_dispatched);
+wait_for_new_register(Name, Old, RemainingMs) ->
+    case whereis(Name) of
+        undefined ->
+            timer:sleep(10),
+            wait_for_new_register(Name, Old, RemainingMs - 10);
+        Old ->
+            timer:sleep(10),
+            wait_for_new_register(Name, Old, RemainingMs - 10);
+        New ->
+            New
+    end.
+
+wait_for_unregister(_Name, RemainingMs) when RemainingMs =< 0 ->
+    ct:fail(worker_still_registered);
+wait_for_unregister(Name, RemainingMs) ->
+    case whereis(Name) of
+        undefined ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_for_unregister(Name, RemainingMs - 10)
+    end.
+
 wait_for_register(_Name, RemainingMs) when RemainingMs =< 0 ->
     ct:fail(worker_not_registered);
 wait_for_register(Name, RemainingMs) ->

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -863,6 +863,83 @@ drain(Sock) ->
     end.
 
 %% =============================================================================
+%% overload_mode
+%% =============================================================================
+
+overload_mode_rejects_bad_config_test() ->
+    ok = ensure_pg_started(),
+    Base = #{port => 0, routes => roadrunner_hello_handler, max_concurrent_requests => 4},
+    %% Validation runs in `init/1`, so a bad opt comes back as a start
+    %% error rather than an exception in the caller.
+    Queue = {queue, #{max_queued => 1, timeout => 1}},
+    %% Queue mode with nothing to queue behind is a configuration error,
+    %% not a silent no-op.
+    ?assertMatch(
+        {error, {
+            {invalid_listener_opt, overload_mode, {Queue, requires_max_concurrent_requests}}, _
+        }},
+        roadrunner_listener:start_link(
+            overload_bad_1,
+            maps:remove(max_concurrent_requests, Base#{overload_mode => Queue})
+        )
+    ),
+    ?assertMatch(
+        {error, {{invalid_listener_opt, overload_mode, nonsense}, _}},
+        roadrunner_listener:start_link(overload_bad_2, Base#{overload_mode => nonsense})
+    ),
+    ?assertMatch(
+        {error, {{invalid_listener_opt, overload_mode, {queue, _}}, _}},
+        roadrunner_listener:start_link(overload_bad_3, Base#{
+            overload_mode => {queue, #{max_queued => 0, timeout => 1}}
+        })
+    ),
+    %% A supplied value is still validated even though it has a default.
+    ?assertMatch(
+        {error, {{invalid_listener_opt, overload_mode, {queue, _}}, _}},
+        roadrunner_listener:start_link(overload_bad_4, Base#{
+            overload_mode => {queue, #{timeout => nonsense}}
+        })
+    ).
+
+%% Both knobs are optional: `{queue, #{}}` derives `timeout` from
+%% `request_timeout` and `max_queued` from the ceiling, so the feature is
+%% usable without inventing numbers.
+overload_mode_queue_derives_its_knobs_test() ->
+    ok = ensure_pg_started(),
+    Name = overload_queue_derived,
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        routes => roadrunner_hello_handler,
+        max_concurrent_requests => 4,
+        overload_mode => {queue, #{}}
+    }),
+    Port = roadrunner_listener:port(Name),
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
+    {ok, Reply} = gen_tcp:recv(Sock, 0, 2000),
+    ?assertMatch(<<"HTTP/1.1 200", _/binary>>, Reply),
+    ok = gen_tcp:close(Sock),
+    ok = roadrunner_listener:stop(Name).
+
+overload_mode_queue_starts_a_listener_test() ->
+    ok = ensure_pg_started(),
+    Name = overload_queue_ok,
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0,
+        routes => roadrunner_hello_handler,
+        max_concurrent_requests => 4,
+        overload_mode => {queue, #{max_queued => 16, timeout => 1000}}
+    }),
+    %% A plain request is unaffected: the ceiling is nowhere near reached.
+    Port = roadrunner_listener:port(Name),
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
+    {ok, Reply} = gen_tcp:recv(Sock, 0, 2000),
+    ?assertMatch(<<"HTTP/1.1 200", _/binary>>, Reply),
+    ok = gen_tcp:close(Sock),
+    ok = roadrunner_listener:stop(Name).
+
+%% =============================================================================
 %% Graceful shutdown via drain/2.
 %% =============================================================================
 

--- a/test/roadrunner_overload_queue_tests.erl
+++ b/test/roadrunner_overload_queue_tests.erl
@@ -1,0 +1,212 @@
+-module(roadrunner_overload_queue_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% =============================================================================
+%% Overload queue — parks requests over the in-flight ceiling.
+%%
+%% Every test drives the real gen_server against a real `counters` ref, so
+%% the slot arithmetic under test is the same arithmetic the conn loops
+%% use. `{spawn, _}` throughout because the tests receive the queue's
+%% `{roadrunner_slot, _, _}` replies in their own mailbox.
+%% =============================================================================
+
+%% Max 1 slot, already taken, so the next acquire is guaranteed to park.
+saturated(MaxQueued) ->
+    Counter = counters:new(1, [write_concurrency]),
+    true = roadrunner_conn:try_acquire_request_slot(1, Counter),
+    {ok, Pid} = roadrunner_overload_queue:start_link(1, Counter, MaxQueued),
+    {Pid, Counter}.
+
+%% Enqueue and cancel are casts, so a test that depends on ordering has
+%% to wait for them to land. `waiters_ref/1` is a call from the same
+%% process, so returning from it means every earlier cast was processed.
+sync(Pid) ->
+    _ = roadrunner_overload_queue:waiters_ref(Pid),
+    ok.
+
+recv_slot(Token) ->
+    receive
+        {roadrunner_slot, Token, Outcome} -> Outcome
+    after 2000 -> timeout_waiting_for_reply
+    end.
+
+release(Counter, Pid) ->
+    ok = roadrunner_conn:release_request_slot(1, Counter, refuse),
+    roadrunner_overload_queue:note_release(Pid).
+
+granted_when_a_slot_frees_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 5000),
+        ok = sync(Pid),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(s1)),
+        %% The queue took the slot on our behalf: the counter is full again.
+        ?assertEqual(1, counters:get(Counter, 1))
+    end}.
+
+fifo_order_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        ok = roadrunner_overload_queue:enqueue(Pid, first, 5000),
+        ok = sync(Pid),
+        ok = roadrunner_overload_queue:enqueue(Pid, second, 5000),
+        ok = sync(Pid),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(first)),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(second))
+    end}.
+
+expires_after_the_deadline_test_() ->
+    {spawn, fun() ->
+        {Pid, _Counter} = saturated(8),
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 50),
+        %% No slot ever frees — the queue owns the deadline and answers.
+        ?assertEqual(timeout, recv_slot(s1))
+    end}.
+
+full_queue_sheds_immediately_test_() ->
+    {spawn, fun() ->
+        {Pid, _Counter} = saturated(1),
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 5000),
+        ok = sync(Pid),
+        ok = roadrunner_overload_queue:enqueue(Pid, s2, 5000),
+        %% The shed valve: overload sheds rather than queueing without bound.
+        ?assertEqual(full, recv_slot(s2))
+    end}.
+
+cancelled_entry_is_skipped_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        ok = roadrunner_overload_queue:enqueue(Pid, gone, 5000),
+        ok = sync(Pid),
+        ok = roadrunner_overload_queue:enqueue(Pid, kept, 5000),
+        ok = sync(Pid),
+        ok = roadrunner_overload_queue:cancel(Pid, gone),
+        ok = sync(Pid),
+        release(Counter, Pid),
+        %% The stale head is dropped and the slot goes to the live entry.
+        ?assertEqual(granted, recv_slot(kept))
+    end}.
+
+cancelling_an_unknown_token_is_a_noop_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        ok = roadrunner_overload_queue:cancel(Pid, never_queued),
+        ok = sync(Pid),
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 5000),
+        ok = sync(Pid),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(s1))
+    end}.
+
+dead_waiter_is_dropped_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        Self = self(),
+        Dying = spawn(fun() ->
+            ok = roadrunner_overload_queue:enqueue(Pid, doomed, 5000),
+            Self ! queued,
+            receive
+                die -> ok
+            end
+        end),
+        receive
+            queued -> ok
+        after 2000 -> error(never_queued)
+        end,
+        Ref = monitor(process, Dying),
+        Dying ! die,
+        receive
+            {'DOWN', Ref, process, Dying, _} -> ok
+        after 2000 -> error(never_died)
+        end,
+        %% Our own entry still gets the slot; nothing was taken for the
+        %% dead one, so nothing leaked.
+        ok = roadrunner_overload_queue:enqueue(Pid, mine, 5000),
+        ok = sync(Pid),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(mine))
+    end}.
+
+keeps_its_place_when_the_slot_is_lost_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 5000),
+        ok = sync(Pid),
+        %% Notify without actually freeing anything: the queue tries to
+        %% take a slot, fails, and must keep the entry at the head rather
+        %% than dropping it.
+        roadrunner_overload_queue:note_release(Pid),
+        ?assertEqual(timeout_waiting_for_reply, recv_slot_short(s1)),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(s1))
+    end}.
+
+recv_slot_short(Token) ->
+    receive
+        {roadrunner_slot, Token, Outcome} -> Outcome
+    after 200 -> timeout_waiting_for_reply
+    end.
+
+release_on_an_empty_queue_is_harmless_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        release(Counter, Pid),
+        ?assert(is_process_alive(Pid))
+    end}.
+
+waiting_flag_tracks_the_queue_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        Ref = roadrunner_overload_queue:waiters_ref(Pid),
+        ?assertNot(roadrunner_overload_queue:waiting(Ref)),
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 5000),
+        ?assert(wait_until(fun() -> roadrunner_overload_queue:waiting(Ref) end)),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(s1)),
+        ?assert(wait_until(fun() -> not roadrunner_overload_queue:waiting(Ref) end))
+    end}.
+
+unknown_messages_do_not_disturb_it_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        ?assertEqual({error, unknown_call}, gen_server:call(Pid, nonsense)),
+        ok = gen_server:cast(Pid, nonsense),
+        Pid ! nonsense,
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 5000),
+        ok = sync(Pid),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(s1))
+    end}.
+
+%% A timer that fired just before its entry was served still delivers.
+%% Resolving a key that is already gone must be a no-op.
+late_expire_for_a_served_entry_is_ignored_test_() ->
+    {spawn, fun() ->
+        {Pid, Counter} = saturated(8),
+        Pid ! {expire, {self(), never_queued}},
+        ok = sync(Pid),
+        ok = roadrunner_overload_queue:enqueue(Pid, s1, 5000),
+        ok = sync(Pid),
+        release(Counter, Pid),
+        ?assertEqual(granted, recv_slot(s1))
+    end}.
+
+wait_until(Fun) ->
+    wait_until(Fun, 100).
+
+wait_until(_Fun, 0) ->
+    false;
+wait_until(Fun, N) ->
+    case Fun() of
+        true ->
+            true;
+        false ->
+            receive
+            after 10 -> ok
+            end,
+            wait_until(Fun, N - 1)
+    end.


### PR DESCRIPTION
# Description

`max_concurrent_requests` bounds live handler processes, but it bounds them by *refusing*: a stream over the ceiling gets `REFUSED_STREAM` / `H3_REQUEST_REJECTED`. That leaves no way to bound handler memory without either shedding load or throttling every connection with a small `max_concurrent_streams`, and a per-connection window ties total concurrency to connection count, so 64 connections with a window of 4 can never run more than 256 handlers however much budget is left. `overload_mode` adds the missing third option: park the request until a slot frees, so latency rises under overload instead of the error rate.

```erlang
roadrunner:start_listener(api, #{
    max_concurrent_requests => 4096,
    overload_mode => {queue, #{}}
}).
```

Opt-in and off by default, so `refuse` stays byte-identical to today and a listener that never reaches its ceiling pays one atomic read per request. Both knobs derive when absent: `timeout` from `request_timeout`, `max_queued` from the ceiling. Admission is asynchronous by necessity rather than preference, because a multiplexed loop that blocked waiting for a slot would stop reading the `DOWN` messages that free slots and park forever.

Measured locally, not on a bench rig: 64 h2c connections against a cheap route, a per-connection window of 4 gives 252,259 resp/s and a window of 64 with a queued ceiling of 4096 gives 397,747, with no refusals and concurrency still bounded.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
