### PR TITLE
Run the TLS handshake in the connection process, not the acceptor

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,23 +242,21 @@ lot of them.
 
 ## Other
 
-### Move the TLS handshake out of the acceptor
+### PROXY protocol on TLS listeners reads the header after the handshake
 
-**What:** the transport's TLS accept runs the handshake inside the
-acceptor (now bounded by the `tls_handshake_timeout` listener opt), so
-handshake time serializes across the pool, capping
-TLS connection-establishment throughput at
-`num_acceptors / handshake_time`. The fix is `ssl:transport_accept`
-in the acceptor with the handshake after the handoff, so a slow
-handshake costs only its own connection — it changes the
-`roadrunner_conn` startup contract, which expects a
-handshake-complete socket at `shoot`.
+**What:** `proxy_protocol => true` is accepted on TLS listeners, but the
+conn reads the PROXY header only after the TLS handshake, from the
+decrypted stream. An L4 balancer prepends that header in plaintext before
+the ClientHello, so on TLS the handshake sees the header instead of a
+hello and fails. The header has to be read from the raw TCP socket
+first. With the handshake now running in the conn process at `shoot`,
+the two stages sit next to each other and can simply be swapped.
 
-**Why deferred:** surfaced while auditing the acceptor
-transient-error fix; the timeout bound shipped, the throughput
-restructure wants its own design pass.
+**Why deferred:** surfaced while auditing the handshake move; no
+listener in the test suite combines the two options, and the swap wants
+a fixture that speaks PROXY-then-TLS.
 
-**Scope:** medium.
+**Scope:** small.
 
 ### Connection-process memory tuning follow-ups
 

--- a/rebar.config
+++ b/rebar.config
@@ -91,6 +91,7 @@
         %% rule still flags them.
         {"test/roadrunner_http2_flow_control_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_http3_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_tls_handshake_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_test_conn_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_test_h3_SUITE.erl", unnecessary_function_arguments},

--- a/src/roadrunner_acceptor.erl
+++ b/src/roadrunner_acceptor.erl
@@ -11,15 +11,24 @@
 %% listener doesn't supervise acceptors — a quiet exit would leave it
 %% permanently down one acceptor). How the retry paces depends on the
 %% error class (`accept_error_class/1`): per-connection failures — an
-%% aborted connection, a failed TLS handshake — retry immediately, since
-%% they arrive at connection rate and sleeping per event would throttle
-%% the whole pool; resource errors (`emfile`/`enfile`/`system_limit`
-%% descriptor exhaustion when `max_clients` sits above the OS
-%% `ulimit -n`, and anything unrecognized) back off briefly first.
-%% Unrelated acceptor crashes propagate back via the link, taking the
-%% listener down for supervisor restart. Connection workers are spawned
-%% **without** a link so that a crash in one connection does not bring
-%% down the acceptor.
+%% aborted connection — retry immediately, since they arrive at
+%% connection rate and sleeping per event would throttle the whole
+%% pool; resource errors (`emfile`/`enfile`/`system_limit` descriptor
+%% exhaustion when `max_clients` sits above the OS `ulimit -n`, and
+%% anything unrecognized) back off briefly first. Unrelated acceptor
+%% crashes propagate back via the link, taking the listener down for
+%% supervisor restart. Connection workers are spawned **without** a
+%% link so that a crash in one connection does not bring down the
+%% acceptor.
+%%
+%% The TLS handshake is NOT run here. `roadrunner_transport:accept/1`
+%% returns the socket pre-handshake and the connection process
+%% completes it at `shoot` (`roadrunner_conn_loop`), so handshake time
+%% — bounded by `tls_handshake_timeout` — is paid by the connection it
+%% belongs to and never parks an acceptor. A failed handshake is
+%% reported by that connection as `[roadrunner, listener,
+%% accept_error]` with a `{handshake, _}` reason, the same event this
+%% pool emits for its own accept failures.
 
 %% Back-off between retries after a resource-class accept error. Bounds
 %% the retry/telemetry rate and gives the box a moment to reclaim
@@ -27,7 +36,7 @@
 -define(ACCEPT_ERROR_BACKOFF_MS, 100).
 
 -export([start_link/3]).
--export([accept_error_class/1]).
+-export([accept_error_class/1, pace_after_error/1]).
 
 -doc """
 Spawn-link an acceptor process bound to `LSocket` with the given
@@ -41,19 +50,18 @@ the same opts. The index is used in the `proc_lib` label so
     {ok, pid()}.
 start_link(LSocket, ProtoOpts, Index) ->
     ListenerName = maps:get(listener_name, ProtoOpts, undefined),
-    #{tls_handshake_timeout := HsTimeout} = ProtoOpts,
     Pid = proc_lib:spawn_link(fun() ->
         proc_lib:set_label({roadrunner_acceptor, ListenerName, Index}),
-        loop(LSocket, ProtoOpts, HsTimeout)
+        loop(LSocket, ProtoOpts)
     end),
     {ok, Pid}.
 
--spec loop(roadrunner_transport:socket(), roadrunner_conn:proto_opts(), timeout()) -> ok.
-loop(LSocket, ProtoOpts, HsTimeout) ->
-    case roadrunner_transport:accept(LSocket, HsTimeout) of
+-spec loop(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) -> ok.
+loop(LSocket, ProtoOpts) ->
+    case roadrunner_transport:accept(LSocket) of
         {ok, Socket} ->
             handle_accepted(Socket, ProtoOpts),
-            loop(LSocket, ProtoOpts, HsTimeout);
+            loop(LSocket, ProtoOpts);
         {error, closed} ->
             %% Listen socket was closed — the listener is stopping. Exit
             %% cleanly; the linked listener tears the rest of the pool down.
@@ -67,16 +75,8 @@ loop(LSocket, ProtoOpts, HsTimeout) ->
                 listener_name => maps:get(listener_name, ProtoOpts, undefined),
                 reason => Reason
             }),
-            ok =
-                case accept_error_class(Reason) of
-                    retry ->
-                        ok;
-                    backoff ->
-                        receive
-                        after ?ACCEPT_ERROR_BACKOFF_MS -> ok
-                        end
-                end,
-            loop(LSocket, ProtoOpts, HsTimeout)
+            ok = pace_after_error(accept_error_class(Reason)),
+            loop(LSocket, ProtoOpts)
     end.
 
 %% Classify a non-`closed` accept error for retry pacing. Exported for
@@ -84,10 +84,9 @@ loop(LSocket, ProtoOpts, HsTimeout) ->
 %%
 %% `retry` — per-connection events that arrive at connection rate:
 %% `econnaborted` (peer reset between the kernel queue and our accept;
-%% bursts under SYN-flood conditions) and `{handshake, _}` (a garbage or
-%% aborted TLS handshake — routine internet background noise on a TLS
-%% port). Sleeping on these would let plain noise cap the whole accept
-%% pool at `acceptors / backoff` accepts per second.
+%% bursts under SYN-flood conditions). Sleeping on these would let plain
+%% noise cap the whole accept pool at `acceptors / backoff` accepts per
+%% second.
 %%
 %% `backoff` — resource exhaustion (`emfile`/`enfile`/`system_limit`),
 %% where hammering `accept/1` cannot help until the box reclaims
@@ -97,8 +96,19 @@ loop(LSocket, ProtoOpts, HsTimeout) ->
 -doc false.
 -spec accept_error_class(term()) -> retry | backoff.
 accept_error_class(econnaborted) -> retry;
-accept_error_class({handshake, _}) -> retry;
 accept_error_class(_Resource) -> backoff.
+
+%% Wait out the retry pacing for an accept error of the given class
+%% before the next `accept/1`. Exported alongside `accept_error_class/1`
+%% for exhaustive unit coverage; not part of any public API.
+-doc false.
+-spec pace_after_error(retry | backoff) -> ok.
+pace_after_error(retry) ->
+    ok;
+pace_after_error(backoff) ->
+    receive
+    after ?ACCEPT_ERROR_BACKOFF_MS -> ok
+    end.
 
 -spec handle_accepted(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) -> ok.
 handle_accepted(Socket, ProtoOpts) ->

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -42,17 +42,21 @@
 %% ## Phase introspection vs hot-path cost
 %%
 %% The label set on the conn process via `proc_lib:set_label/1` is
-%% written **at most twice per conn**: once at `init_loop` time
-%% (`{roadrunner_conn, awaiting_shoot, ListenerName}`) and once at the
-%% `shoot` handoff (`refine_conn_label/2` rewrites it to include the
-%% peer). The phases AFTER `awaiting_shoot` (read_request, read_body,
-%% dispatching, finishing) run in microseconds on the happy path — too
-%% fast for an operator's `observer` snapshot to catch a specific phase
-%% anyway. Per-phase label updates measured ~1.2 % CPU on hello (4
-%% writes/req, each touching the process dictionary) and contributed
-%% to run-to-run variance. Stuck conns still surface via the conn-entry
-%% label and the `reading_request` idle window (where hibernation
-%% parks the process).
+%% written **at most twice per conn** on plain TCP, three times on TLS:
+%% once at `init_loop` time (`{roadrunner_conn, awaiting_shoot,
+%% ListenerName}`), once more on a TLS listener when `shoot` starts the
+%% handshake (`{roadrunner_conn, tls_handshake, ListenerName}` — the one
+%% pre-serve phase that can park for up to `tls_handshake_timeout` on a
+%% silent peer, so an `observer` snapshot must tell it apart from a conn
+%% that was never shot), and once in `refine_conn_label/2`, which
+%% rewrites it to include the peer. The phases AFTER that (read_request,
+%% read_body, dispatching, finishing) run in microseconds on the happy
+%% path — too fast for an operator's `observer` snapshot to catch a
+%% specific phase anyway. Per-phase label updates measured ~1.2 % CPU on
+%% hello (4 writes/req, each touching the process dictionary) and
+%% contributed to run-to-run variance. Stuck conns still surface via the
+%% conn-entry label and the `reading_request` idle window (where
+%% hibernation parks the process).
 %%
 %% ## Stability features preserved
 %%
@@ -181,35 +185,76 @@ init_loop(Parent, Socket, ProtoOpts) ->
 
 -spec awaiting_shoot(roadrunner_transport:socket(), roadrunner_conn:proto_opts(), atom()) ->
     no_return().
-awaiting_shoot(Socket, ProtoOpts, ListenerName) ->
+awaiting_shoot(Socket0, ProtoOpts, ListenerName) ->
     receive
         shoot ->
-            %% Socket ownership has just transferred from the acceptor. If the
-            %% listener enabled the PROXY protocol, read and strip the header an
-            %% L4 balancer prepended so we serve the real client peer; otherwise
-            %% the OS peer passes through unchanged.
-            OsPeer = roadrunner_conn:peer(Socket),
-            case proxy_protocol_stage(Socket, ProtoOpts, OsPeer) of
-                {ok, Peer, Buffered} ->
-                    serve(Socket, ProtoOpts, ListenerName, Peer, Buffered);
-                close ->
-                    %% Malformed/absent PROXY header on a proxy_protocol
-                    %% listener (a misconfigured upstream). No accept telemetry
-                    %% has fired yet (it pairs with the real peer in serve/5),
-                    %% so release the slot and close silently, like the
-                    %% pre-`shoot` drain path below.
-                    exit_clean(Socket, ProtoOpts, undefined, undefined, ListenerName, 0, normal)
+            %% Socket ownership has just transferred from the acceptor. On a
+            %% TLS listener the socket arrives pre-handshake: the handshake
+            %% runs here, in the connection it belongs to, so a slow or
+            %% silent peer costs only this process and never parks an
+            %% acceptor (see `roadrunner_transport:handshake/2`). Plain TCP
+            %% passes straight through.
+            #{tls_handshake_timeout := HsTimeout} = ProtoOpts,
+            ok = label_handshake(Socket0, ListenerName),
+            case roadrunner_transport:handshake(Socket0, HsTimeout) of
+                {ok, Socket} ->
+                    %% If the listener enabled the PROXY protocol, read and
+                    %% strip the header an L4 balancer prepended so we serve
+                    %% the real client peer; otherwise the OS peer passes
+                    %% through unchanged.
+                    OsPeer = roadrunner_conn:peer(Socket),
+                    case proxy_protocol_stage(Socket, ProtoOpts, OsPeer) of
+                        {ok, Peer, Buffered} ->
+                            serve(Socket, ProtoOpts, ListenerName, Peer, Buffered);
+                        close ->
+                            %% Malformed/absent PROXY header on a proxy_protocol
+                            %% listener (a misconfigured upstream). No accept
+                            %% telemetry has fired yet (it pairs with the real
+                            %% peer in serve/5), so release the slot and close
+                            %% silently, like the pre-`shoot` drain path below.
+                            exit_clean(
+                                Socket, ProtoOpts, undefined, undefined, ListenerName, 0, normal
+                            )
+                    end;
+                {error, {handshake, _} = Reason} ->
+                    %% A garbage ClientHello, a TLS alert, a peer gone
+                    %% mid-handshake, or the `tls_handshake_timeout` bound —
+                    %% routine noise on an internet-facing TLS port. Surface
+                    %% it as the same accept_error event the acceptor pool
+                    %% emits for its own failures, then release the slot. No
+                    %% accept telemetry has fired (it pairs with the peer in
+                    %% serve/5), so no conn_close either. The socket is not
+                    %% closed here: `handshake/2` already closed a timed-out
+                    %% one, and on any other failure `ssl` tore the
+                    %% connection down itself.
+                    ok = roadrunner_telemetry:listener_accept_error(#{
+                        listener_name => ListenerName, reason => Reason
+                    }),
+                    ok = roadrunner_conn:release_slot(ProtoOpts),
+                    exit(normal)
             end;
         {roadrunner_drain, _Deadline} ->
             %% Drain before `shoot` — no telemetry was fired yet (accept
             %% pairs with `shoot`), so no listener_conn_close either. Just
             %% release the slot and close the socket.
-            exit_clean(Socket, ProtoOpts, undefined, undefined, ListenerName, 0, normal);
+            exit_clean(Socket0, ProtoOpts, undefined, undefined, ListenerName, 0, normal);
         _Stray ->
             %% Stray-msg tolerance — gen_statem drops unmatched info events
             %% silently; we do the same so a buggy library can't crash the
             %% conn with a typo'd message.
-            awaiting_shoot(Socket, ProtoOpts, ListenerName)
+            awaiting_shoot(Socket0, ProtoOpts, ListenerName)
+    end.
+
+%% The handshake is the one pre-serve phase that can block for a while (up
+%% to `tls_handshake_timeout` on a silent peer), so a TLS conn is relabelled
+%% for its duration; `refine_conn_label/2` takes over once the peer is being
+%% served. Plain TCP has no handshake and keeps the `awaiting_shoot` label
+%% until then.
+-spec label_handshake(roadrunner_transport:socket(), atom()) -> ok.
+label_handshake(Socket, ListenerName) ->
+    case roadrunner_conn:scheme(Socket) of
+        https -> proc_lib:set_label({roadrunner_conn, tls_handshake, ListenerName});
+        http -> ok
     end.
 
 %% Begin serving a connection once the peer is settled (the real client when

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -40,10 +40,11 @@ All duration and interval values in `opts()` are in milliseconds —
 
 -define(DEFAULT_MAX_CONTENT_LENGTH, 10485760).
 -define(DEFAULT_REQUEST_TIMEOUT, 30000).
-%% Bound on `ssl:handshake/2` in the accept path. Without one, a client
-%% that connects to a TLS listener and never sends a ClientHello parks
-%% an acceptor indefinitely — `num_acceptors` such sockets and the
-%% listener stops accepting. 5 s comfortably covers slow real clients.
+%% Bound on `ssl:handshake/2`, run by the connection process after the
+%% acceptor hands the socket over. Without one, a client that connects
+%% to a TLS listener and never sends a ClientHello holds its
+%% `max_clients` slot and descriptor indefinitely. 5 s comfortably
+%% covers slow real clients.
 -define(DEFAULT_TLS_HANDSHAKE_TIMEOUT, 5000).
 -define(DEFAULT_KEEP_ALIVE_TIMEOUT, 60000).
 -define(DEFAULT_NUM_ACCEPTORS, 10).
@@ -124,19 +125,22 @@ Optional middleware and timing knobs (durations in milliseconds):
   hibernation timeout in milliseconds; off when unset).
 - `request_timeout` — header-read timeout on a fresh conn.
   Default 30 s.
-- `tls_handshake_timeout` — bound on the TLS handshake during accept
-  (TLS listeners only). A handshake that exceeds it fails as a
-  per-connection `{handshake, timeout}` accept error and the acceptor
-  keeps accepting; without a bound, a client that never sends its
-  ClientHello would park an acceptor indefinitely. Default 5 s.
+- `tls_handshake_timeout` — bound on the TLS handshake (TLS listeners
+  only). The handshake runs in the connection process, not the
+  acceptor, so a slow or silent peer never blocks other connections
+  from being accepted; one that exceeds the bound is closed and
+  reported as a per-connection `{handshake, timeout}` accept error,
+  releasing its `max_clients` slot. Default 5 s.
 - `keep_alive_timeout` — idle timeout between requests on a
   keep-alive conn. Default 60 s.
 - `num_acceptors` — size of the acceptor pool. Default 10.
 - `max_keep_alive_requests` — requests served per conn before
   forced close. Default 1000.
 - `max_clients` — concurrent connection cap. Default 16384 (the modern
-  Erlang/Elixir HTTP-server norm). Connections accepted while already at
-  the cap are closed immediately without a response. The effective cap is
+  Erlang/Elixir HTTP-server norm). A connection counts from the moment
+  it is accepted, so on a TLS listener one still in its handshake holds
+  a slot too. Connections accepted while already at the cap are closed
+  immediately without a response. The effective cap is
   `min(max_clients, the OS file-descriptor limit)` — raise `ulimit -n`
   (and the systemd `LimitNOFILE`) for high concurrency, otherwise the
   acceptors hit `emfile` at the descriptor ceiling and emit

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -77,15 +77,17 @@
 %%   - **Metadata:** `listener_name`, `reason` (`max_clients`).
 %%
 %% - `[roadrunner, listener, accept_error]` — fired when an acceptor's
-%%   `accept/1` returns any error other than the listen socket closing,
-%%   and the acceptor keeps accepting instead of exiting. Two classes
-%%   share the event, told apart by `reason`: per-connection failures
-%%   (`econnaborted`, or `{handshake, HsReason}` for a failed TLS
-%%   handshake — routine noise on an internet-facing TLS port) retry
-%%   immediately; resource errors (`emfile`/`enfile`/`system_limit`
-%%   descriptor exhaustion, usually `max_clients` above the OS
-%%   `ulimit -n`) retry after a short back-off. A sustained stream of
-%%   descriptor-exhaustion reasons is the signal to raise `ulimit -n`.
+%%   `accept/1` returns any error other than the listen socket closing
+%%   (the acceptor keeps accepting instead of exiting), and when a
+%%   connection process fails its TLS handshake. Told apart by
+%%   `reason`: per-connection failures (`econnaborted`, or
+%%   `{handshake, HsReason}` for a failed TLS handshake — routine noise
+%%   on an internet-facing TLS port, reported by the connection that ran
+%%   it) cost nothing beyond that connection; resource errors
+%%   (`emfile`/`enfile`/`system_limit` descriptor exhaustion, usually
+%%   `max_clients` above the OS `ulimit -n`) make the acceptor retry
+%%   after a short back-off. A sustained stream of descriptor-exhaustion
+%%   reasons is the signal to raise `ulimit -n`.
 %%
 %%   - **Measurements:** `system_time`.
 %%   - **Metadata:** `listener_name`, `reason` (the accept error).
@@ -328,15 +330,16 @@ listener_conn_rejected(Metadata) ->
 -doc """
 Emit `[roadrunner, listener, accept_error]` when an acceptor's `accept/1`
 fails with anything other than the listen socket closing — a
-per-connection failure (`econnaborted`, a failed TLS handshake as
-`{handshake, _}`) or descriptor exhaustion
+per-connection failure (`econnaborted`) or descriptor exhaustion
 (`emfile`/`enfile`/`system_limit`, typically `max_clients` sitting above
-the OS `ulimit -n`). The acceptor reports it here and keeps accepting
-rather than exiting (immediately for per-connection failures, after a
-short back-off for resource errors), so a sustained stream of
-descriptor-exhaustion reasons is the signal to raise `ulimit -n`.
-`Metadata` should include `listener_name` and `reason` (the accept
-error). Carries no `peer`: there is no connection to name.
+the OS `ulimit -n`) — and when a connection process fails its TLS
+handshake (`{handshake, _}`). The acceptor reports its own failures
+here and keeps accepting rather than exiting (immediately for
+per-connection failures, after a short back-off for resource errors),
+so a sustained stream of descriptor-exhaustion reasons is the signal
+to raise `ulimit -n`. `Metadata` should include `listener_name` and
+`reason` (the accept or handshake error). Carries no `peer`: there is
+no served connection to name.
 """.
 -spec listener_accept_error(map()) -> ok.
 listener_accept_error(Metadata) ->

--- a/src/roadrunner_transport.erl
+++ b/src/roadrunner_transport.erl
@@ -42,7 +42,8 @@
 -export([
     listen/2,
     listen_tls/2,
-    accept/2,
+    accept/1,
+    handshake/2,
     controlling_process/2,
     recv/3,
     send/2,
@@ -92,49 +93,60 @@ listen_tls(Port, Opts) ->
     end.
 
 -doc """
-Accept the next pending connection. For TLS, runs the handshake before
-returning, bounded by `HandshakeTimeout` ms (plain TCP has no
-handshake; the timeout is unused there).
+Accept the next pending connection. For TLS the socket comes back
+**before** its handshake: the acceptor hands it to the connection
+process, which completes it with `handshake/2`. That keeps the
+acceptor pool free of handshake time — a slow or silent peer costs
+only its own connection process instead of parking an acceptor, and
+the number of handshakes in flight is bounded by `max_clients`
+rather than by `num_acceptors`.
 
-TLS failures are two different events and come back distinguishably:
-a `ssl:transport_accept/1` error is about the LISTEN socket (`closed`
-means the listener is going away), while a failed `ssl:handshake/2` is
-about that one connection — a garbage ClientHello, a TLS alert, the
-peer disconnecting mid-handshake (which `ssl` also reports as
-`closed`), or the handshake outrunning the bound (`timeout` — a client
-that connects and never speaks would otherwise park the caller
-forever). Handshake failures are wrapped as
-`{error, {handshake, Reason}}` so an acceptor can keep accepting
-through per-connection noise and reserve the bare `{error, closed}`
-for the listener actually stopping.
+Errors here are about the LISTEN socket: `closed` means the listener
+is going away, anything else is a transient accept failure the
+acceptor reports and retries.
 """.
--spec accept(socket(), timeout()) -> {ok, socket()} | {error, term()}.
-accept({gen_tcp, LSock}, _HandshakeTimeout) ->
+-spec accept(socket()) -> {ok, socket()} | {error, term()}.
+accept({gen_tcp, LSock}) ->
     case gen_tcp:accept(LSock) of
         {ok, S} -> {ok, {gen_tcp, S}};
         {error, _} = Err -> Err
     end;
-accept({ssl, LSock}, HandshakeTimeout) ->
-    maybe
-        {ok, Pre} ?= ssl:transport_accept(LSock),
-        case ssl:handshake(Pre, HandshakeTimeout) of
-            {ok, S} ->
-                {ok, {ssl, S}};
-            {error, timeout} ->
-                %% The connection process is still parked mid-handshake
-                %% waiting on the client — close it (measured instant on
-                %% this path) so a silent client can't hold the
-                %% descriptor until it deigns to disconnect.
-                _ = ssl:close(Pre),
-                {error, {handshake, timeout}};
-            {error, HsReason} ->
-                %% `ssl` already tore the connection down on a failed
-                %% handshake; closing again would block for ssl's
-                %% internal close timeout (measured 5 s) on the dead
-                %% connection process.
-                {error, {handshake, HsReason}}
-        end
+accept({ssl, LSock}) ->
+    case ssl:transport_accept(LSock) of
+        {ok, S} -> {ok, {ssl, S}};
+        {error, _} = Err -> Err
     end.
+
+-doc """
+Complete the TLS handshake on a socket from `accept/1`, bounded by
+`HandshakeTimeout` ms. Plain TCP (and the `{fake, _}` test transport)
+has no handshake and passes straight through.
+
+A failed handshake is about this one connection — a garbage
+ClientHello, a TLS alert, the peer disconnecting mid-handshake (which
+`ssl` also reports as `closed`), or the handshake outrunning the bound
+(`timeout` — a client that connects and never speaks). It comes back
+as `{error, {handshake, Reason}}`. On `timeout` the connection process
+is still parked waiting on the client, so it is closed here (measured
+instant on this path) rather than left holding the descriptor until
+the client deigns to disconnect. On any other failure `ssl` already
+tore the connection down, and closing again would block for ssl's
+internal close timeout (measured 5 s) on the dead connection process,
+so the socket is left alone.
+""".
+-spec handshake(socket(), timeout()) -> {ok, socket()} | {error, {handshake, term()}}.
+handshake({ssl, Pre}, HandshakeTimeout) ->
+    case ssl:handshake(Pre, HandshakeTimeout) of
+        {ok, S} ->
+            {ok, {ssl, S}};
+        {error, timeout} ->
+            _ = ssl:close(Pre),
+            {error, {handshake, timeout}};
+        {error, HsReason} ->
+            {error, {handshake, HsReason}}
+    end;
+handshake(Socket, _HandshakeTimeout) ->
+    {ok, Socket}.
 
 -doc "Hand the controlling process for the underlying socket.".
 -spec controlling_process(socket(), pid()) -> ok | {error, term()}.

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -189,6 +189,7 @@ proto_opts(ListenerName, Counter) ->
         proxy_protocol => false,
         listener_name => ListenerName,
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity
     }.
 

--- a/test/roadrunner_acceptor_tests.erl
+++ b/test/roadrunner_acceptor_tests.erl
@@ -152,26 +152,27 @@ accept_error_class_test() ->
     %% Per-connection failures retry immediately; resource exhaustion
     %% and unknowns back off. Exhaustive over the classifier's clauses.
     ?assertEqual(retry, roadrunner_acceptor:accept_error_class(econnaborted)),
-    ?assertEqual(retry, roadrunner_acceptor:accept_error_class({handshake, closed})),
-    ?assertEqual(
-        retry,
-        roadrunner_acceptor:accept_error_class(
-            {handshake, {tls_alert, {handshake_failure, "reason"}}}
-        )
-    ),
     ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(emfile)),
     ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(enfile)),
     ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(system_limit)),
     ?assertEqual(backoff, roadrunner_acceptor:accept_error_class(einval)).
 
-acceptor_survives_failed_tls_handshake_test() ->
-    %% A garbage ClientHello on a TLS listener fails `ssl:handshake/1`
-    %% inside `roadrunner_transport:accept/1`. The acceptor must treat
-    %% that as per-connection noise — telemetry with a `{handshake, _}`
-    %% reason, keep accepting — and reserve plain `closed` (the listen
-    %% socket going away) for its clean exit. Before the transport
-    %% tagged handshake errors, a peer disconnecting mid-handshake also
-    %% surfaced as `closed` and silently killed the acceptor.
+pace_after_error_test() ->
+    %% `retry` goes straight back to accept; `backoff` sits out the
+    %% pause first.
+    T0 = erlang:monotonic_time(millisecond),
+    ?assertEqual(ok, roadrunner_acceptor:pace_after_error(retry)),
+    ?assert(erlang:monotonic_time(millisecond) - T0 < 50),
+    ?assertEqual(ok, roadrunner_acceptor:pace_after_error(backoff)),
+    ?assert(erlang:monotonic_time(millisecond) - T0 >= 100).
+
+acceptor_hands_tls_sockets_off_before_the_handshake_test() ->
+    %% The acceptor takes a TLS socket pre-handshake and hands it to a
+    %% conn, which runs the handshake itself. A garbage ClientHello
+    %% therefore never touches the acceptor: the conn reports it as a
+    %% `{handshake, _}` accept_error and gives the slot back, while the
+    %% acceptor keeps accepting and reserves plain `closed` (the listen
+    %% socket going away) for its clean exit.
     {ok, _} = application:ensure_all_started(ssl),
     {ok, _} = application:ensure_all_started(telemetry),
     ServerOpts =
@@ -187,19 +188,33 @@ acceptor_survives_failed_tls_handshake_test() ->
         fun(_Event, _Measure, Meta, _Cfg) -> Self ! {accept_error, Meta} end,
         undefined
     ),
+    Counter = counters:new(1, [write_concurrency]),
     {ok, Pid} = roadrunner_acceptor:start_link(
-        LSock, #{listener_name => acceptor_test_tls_noise, tls_handshake_timeout => 5000}, 1
+        LSock,
+        #{
+            listener_name => acceptor_test_tls_noise,
+            tls_handshake_timeout => 5000,
+            client_counter => Counter,
+            max_clients => 10,
+            graceful_drain => false,
+            handler_spawn_opts => [{fullsweep_after, 0}],
+            handler_start_timeout => infinity
+        },
+        1
     ),
-    %% Plain-HTTP bytes can't form a TLS hello — the handshake fails.
+    %% Plain-HTTP bytes can't form a TLS hello — the conn's handshake fails.
     {ok, Noise} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
     ok = gen_tcp:send(Noise, ~"GET / HTTP/1.1\r\n\r\n"),
     receive
         {accept_error, Meta} ->
+            ?assertEqual(acceptor_test_tls_noise, maps:get(listener_name, Meta)),
             ?assertMatch({handshake, _}, maps:get(reason, Meta))
     after 5000 ->
         error(no_handshake_error_telemetry)
     end,
     ok = gen_tcp:close(Noise),
+    %% The slot taken at accept is released by the failing conn.
+    ok = wait_for_counter(Counter, 0, 200),
     %% Survived the noise connection.
     ?assert(is_process_alive(Pid)),
     %% Closing the listen socket ends the loop cleanly.
@@ -213,6 +228,19 @@ acceptor_survives_failed_tls_handshake_test() ->
     ok = telemetry:detach(HandlerId).
 
 %% --- helpers ---
+
+%% Poll the live-connection counter until it reads `Expected`; the slot
+%% release runs after the accept_error event, so the first read can race it.
+wait_for_counter(_Counter, Expected, 0) ->
+    error({counter_never_reached, Expected});
+wait_for_counter(Counter, Expected, Attempts) ->
+    case counters:get(Counter, 1) of
+        Expected ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_for_counter(Counter, Expected, Attempts - 1)
+    end.
 
 %% Poll until we see a refined `{roadrunner_conn, Name, Peer}` label or run
 %% out of attempts. Avoids a fixed `timer:sleep` race on slow CI.

--- a/test/roadrunner_conn_loop_http2_tests.erl
+++ b/test/roadrunner_conn_loop_http2_tests.erl
@@ -443,6 +443,7 @@ concurrent_streams_both_dispatch() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -509,6 +510,7 @@ h2c_dispatch_routes_plaintext_to_http2_loop() ->
     RequestsCounter = atomics:new(1, [{signed, false}]),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -565,6 +567,7 @@ plaintext_listener_without_h2c_stays_h1() ->
     RequestsCounter = atomics:new(1, [{signed, false}]),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -1203,6 +1206,7 @@ middleware_chain_runs() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -1268,6 +1272,7 @@ router_404_returns_not_found() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -1331,6 +1336,7 @@ router_405_returns_method_not_allowed() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -2285,6 +2291,7 @@ rst_during_stream_response_unwinds_worker() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -2366,6 +2373,7 @@ drain_refuses_new_streams() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -2422,6 +2430,7 @@ drain_with_in_flight_stream_waits() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -2485,6 +2494,7 @@ drain_message_is_idempotent() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -2538,6 +2548,7 @@ drain_then_peer_rst_exits_via_frame_loop() ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -2634,6 +2645,7 @@ telemetry_request_stop_fires_for_router_404() ->
         ok = counters:add(Counter, 1, 1),
         ProtoOpts = #{
             handler_spawn_opts => [{fullsweep_after, 0}],
+            tls_handshake_timeout => 5000,
             handler_start_timeout => infinity,
             max_concurrent_requests => infinity,
             client_counter => Counter,
@@ -2718,6 +2730,7 @@ run_h2_with_compress_middleware(Path, ExtraHeaders) ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -3696,6 +3709,7 @@ post_handshake_handler(Handler) ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -3827,6 +3841,7 @@ start_http2_conn(Extra) ->
             client_counter => Counter,
             listener_name => http2_test,
             handler_spawn_opts => [{fullsweep_after, 0}],
+            tls_handshake_timeout => 5000,
             handler_start_timeout => infinity,
             dispatch =>
                 {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1,
@@ -3954,6 +3969,7 @@ run_h2_request_with_handler(Handler, Path) ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,
@@ -4018,6 +4034,7 @@ run_stream_request(Path, PrefaceSettings) ->
     ok = counters:add(Counter, 1, 1),
     ProtoOpts = #{
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         max_concurrent_requests => infinity,
         client_counter => Counter,

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -1903,6 +1903,7 @@ fake_opts(ListenerName) ->
         proxy_protocol => false,
         listener_name => ListenerName,
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity
     }.
 

--- a/test/roadrunner_h2_window_tuning_tests.erl
+++ b/test/roadrunner_h2_window_tuning_tests.erl
@@ -248,6 +248,7 @@ start_conn(H2Opts) ->
             {handler, roadrunner_hello_handler, fun roadrunner_hello_handler:handle/1, undefined},
         middlewares => [],
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity,
         protocols => [http2],
         http2_conn_window => maps:get(conn_window, H2Opts, 65535),

--- a/test/roadrunner_http2_flow_control_SUITE.erl
+++ b/test/roadrunner_http2_flow_control_SUITE.erl
@@ -406,6 +406,7 @@ start_conn(Handler, Extra) ->
             dispatch => {handler, Handler, fun Handler:handle/1, undefined},
             middlewares => [],
             handler_spawn_opts => [{fullsweep_after, 0}],
+            tls_handshake_timeout => 5000,
             handler_start_timeout => infinity
         },
         Extra

--- a/test/roadrunner_http2_stream_worker_tests.erl
+++ b/test/roadrunner_http2_stream_worker_tests.erl
@@ -32,6 +32,7 @@ logger_metadata_set_in_h2_worker_test_() ->
                     fun roadrunner_logger_probe_handler:handle/1, undefined},
             middlewares => [],
             handler_spawn_opts => [{fullsweep_after, 0}],
+            tls_handshake_timeout => 5000,
             handler_start_timeout => infinity
         },
         {WorkerPid, MonRef} = roadrunner_http2_stream_worker:start(

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -137,6 +137,7 @@ request_rejected_event_fires_on_bad_request_line_test() ->
             proxy_protocol => false,
             listener_name => probe_listener_rej,
             handler_spawn_opts => [{fullsweep_after, 0}],
+            tls_handshake_timeout => 5000,
             handler_start_timeout => infinity
         },
         true = roadrunner_conn:try_acquire_slot(Opts),

--- a/test/roadrunner_tls_handshake_SUITE.erl
+++ b/test/roadrunner_tls_handshake_SUITE.erl
@@ -1,0 +1,173 @@
+-module(roadrunner_tls_handshake_SUITE).
+-moduledoc """
+The TLS handshake runs in the connection process, not the acceptor.
+
+Drives a real `roadrunner_listener` over TLS with clients that never
+complete a handshake, and checks the three things that follow from
+where the handshake runs: a failed handshake is reported as an
+`accept_error` and frees its `max_clients` slot, a silent peer is cut
+off by `tls_handshake_timeout` without ever firing `accept`, and
+parked peers do not stop other connections from being accepted.
+
+Lives as a CT suite so every case gets its own process and its own
+listener, and a parked connection left by one case cannot leak into
+the next.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0, init_per_testcase/2, end_per_testcase/2]).
+-export([
+    garbage_hello_reports_accept_error_and_releases_slot/1,
+    silent_peer_times_out_without_accept_telemetry/1,
+    parked_handshakes_do_not_block_accepting/1
+]).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [
+        garbage_hello_reports_accept_error_and_releases_slot,
+        silent_peer_times_out_without_accept_telemetry,
+        parked_handshakes_do_not_block_accepting
+    ].
+
+init_per_testcase(Case, Config) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    HandlerId = {?MODULE, Case},
+    ok = telemetry:attach_many(
+        HandlerId,
+        [[roadrunner, listener, accept], [roadrunner, listener, accept_error]],
+        fun(Event, _Measure, Meta, _Cfg) -> Self ! {lists:last(Event), Meta} end,
+        undefined
+    ),
+    [{handler_id, HandlerId} | Config].
+
+end_per_testcase(_Case, Config) ->
+    ok = telemetry:detach(?config(handler_id, Config)),
+    ok = roadrunner_listener:stop(?MODULE).
+
+garbage_hello_reports_accept_error_and_releases_slot(_Config) ->
+    Port = start_listener(#{}),
+    {ok, Noise} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    %% Plain HTTP bytes can't form a TLS hello: the conn's handshake fails.
+    ok = gen_tcp:send(Noise, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
+    receive
+        {accept_error, Meta} ->
+            ?assertEqual(?MODULE, maps:get(listener_name, Meta)),
+            ?assertMatch({handshake, _}, maps:get(reason, Meta))
+    after 5000 ->
+        error(no_handshake_accept_error)
+    end,
+    ok = gen_tcp:close(Noise),
+    %% The slot the acceptor took for the noise connection is given back.
+    ok = wait_for_active_clients(0),
+    %% And the listener is none the worse for it.
+    ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, tls_get(Port, 5000)),
+    ok.
+
+silent_peer_times_out_without_accept_telemetry(_Config) ->
+    Port = start_listener(#{tls_handshake_timeout => 200}),
+    {ok, Silent} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    receive
+        {accept_error, Meta} ->
+            ?assertEqual({handshake, timeout}, maps:get(reason, Meta))
+    after 5000 ->
+        error(no_handshake_timeout)
+    end,
+    %% The parked connection was closed, so the peer sees it go away ...
+    ?assertEqual({error, closed}, gen_tcp:recv(Silent, 0, 5000)),
+    ok = gen_tcp:close(Silent),
+    ok = wait_for_active_clients(0),
+    %% ... and nothing was ever accepted: `accept` pairs with a served peer.
+    receive
+        {accept, _} -> error(accept_fired_for_unhandshaken_peer)
+    after 0 -> ok
+    end.
+
+parked_handshakes_do_not_block_accepting(_Config) ->
+    %% One acceptor, three peers that never send a ClientHello. With the
+    %% handshake in the acceptor each would park it for the whole
+    %% `tls_handshake_timeout` and a real client would wait behind them;
+    %% with the handshake in the connection process the acceptor is free
+    %% the moment it has handed the socket over.
+    Port = start_listener(#{num_acceptors => 1, tls_handshake_timeout => 10000}),
+    Parked = [
+        begin
+            {ok, S} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+            S
+        end
+     || _ <- lists:seq(1, 3)
+    ],
+    %% While parked, each conn is labelled as handshaking, so an operator
+    %% can tell a silent-peer pile-up from conns that were never shot.
+    ok = wait_for_labels({roadrunner_conn, tls_handshake, ?MODULE}, 3),
+    ?assertMatch(<<"HTTP/1.1 200 OK", _/binary>>, tls_get(Port, 2000)),
+    lists:foreach(fun gen_tcp:close/1, Parked).
+
+%% --- helpers ---
+
+start_listener(Extra) ->
+    {ok, _} = roadrunner_listener:start_link(
+        ?MODULE,
+        Extra#{
+            port => 0,
+            tls => roadrunner_test_certs:server_opts(),
+            routes => roadrunner_hello_handler
+        }
+    ),
+    roadrunner_listener:port(?MODULE).
+
+%% A full TLS request; `Timeout` bounds connect + handshake, which is the
+%% part these cases are about.
+tls_get(Port, Timeout) ->
+    ClientOpts = [{verify, verify_none} | roadrunner_test_certs:client_opts()],
+    {ok, Sock} = ssl:connect(
+        {127, 0, 0, 1}, Port, ClientOpts ++ [binary, {active, false}], Timeout
+    ),
+    ok = ssl:send(Sock, ~"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+    {ok, Reply} = ssl:recv(Sock, 0, 5000),
+    ok = ssl:close(Sock),
+    Reply.
+
+%% Labels are set by the conn after the acceptor's handoff, so poll for
+%% the expected count rather than assert on the first read.
+wait_for_labels(Label, N) ->
+    wait_for_labels(Label, N, erlang:monotonic_time(millisecond) + 5000).
+
+wait_for_labels(Label, N, Deadline) ->
+    case length([P || P <- processes(), proc_lib:get_label(P) =:= Label]) of
+        N ->
+            ok;
+        Other ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                true ->
+                    timer:sleep(10),
+                    wait_for_labels(Label, N, Deadline);
+                false ->
+                    error({labelled_conns, Other, expected, N})
+            end
+    end.
+
+%% Slot release happens after the telemetry event, so poll the counter
+%% until it settles rather than assert on the first read.
+wait_for_active_clients(N) ->
+    wait_for_active_clients(N, erlang:monotonic_time(millisecond) + 5000).
+
+wait_for_active_clients(N, Deadline) ->
+    case roadrunner_listener:info(?MODULE) of
+        #{active_clients := N} ->
+            ok;
+        #{active_clients := Other} ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                true ->
+                    timer:sleep(10),
+                    wait_for_active_clients(N, Deadline);
+                false ->
+                    error({active_clients, Other, expected, N})
+            end
+    end.

--- a/test/roadrunner_transport_tests.erl
+++ b/test/roadrunner_transport_tests.erl
@@ -138,9 +138,31 @@ listen_tls_with_no_cert_returns_error_test() ->
     %% No cert/key in opts — ssl:listen rejects before binding.
     ?assertMatch({error, _}, roadrunner_transport:listen_tls(0, [])).
 
-accept_handshake_failure_returns_error_test() ->
+accept_returns_tls_socket_before_handshake_test() ->
+    %% `accept/1` hands a TLS socket back pre-handshake: the peer is
+    %% already known, and the handshake is the new owner's job.
+    {ok, _} = application:ensure_all_started(ssl),
+    ServerOpts = roadrunner_test_certs:server_opts(),
+    {ok, LSocket} = roadrunner_transport:listen_tls(
+        0, ServerOpts ++ [binary, {active, false}, {reuseaddr, true}]
+    ),
+    {ok, Port} = roadrunner_transport:port(LSocket),
+    {ok, Client} = gen_tcp:connect(
+        {127, 0, 0, 1}, Port, [binary, {active, false}], 1000
+    ),
+    {ok, {ssl, _} = Pre} = roadrunner_transport:accept(LSocket),
+    ?assertMatch({ok, {{127, 0, 0, 1}, _}}, roadrunner_transport:peername(Pre)),
+    roadrunner_transport:close(Pre),
+    roadrunner_transport:close(LSocket),
+    %% A closed listen socket is the listener going away: bare `closed`.
+    ?assertEqual({error, closed}, roadrunner_transport:accept(LSocket)),
+    gen_tcp:close(Client).
+
+handshake_failure_returns_tagged_error_test() ->
     %% Set up a TLS listener, connect to it via plain TCP, send non-TLS
-    %% bytes — the server's ssl:handshake fails, propagating an error.
+    %% bytes — `handshake/2` on the accepted socket fails, and the error
+    %% comes back tagged as this connection's, distinct from the listen
+    %% socket's own `closed`.
     {ok, _} = application:ensure_all_started(ssl),
     ServerOpts = roadrunner_test_certs:server_opts(),
     {ok, LSocket} = roadrunner_transport:listen_tls(
@@ -149,10 +171,9 @@ accept_handshake_failure_returns_error_test() ->
     {ok, Port} = roadrunner_transport:port(LSocket),
     Self = self(),
     spawn(fun() ->
-        Self ! {accept_result, roadrunner_transport:accept(LSocket, 5000)}
+        {ok, Pre} = roadrunner_transport:accept(LSocket),
+        Self ! {handshake_result, roadrunner_transport:handshake(Pre, 5000)}
     end),
-    %% Give the server time to enter accept.
-    timer:sleep(50),
     {ok, Client} = gen_tcp:connect(
         {127, 0, 0, 1}, Port, [binary, {active, false}], 1000
     ),
@@ -160,19 +181,18 @@ accept_handshake_failure_returns_error_test() ->
     ok = gen_tcp:send(Client, ~"GET / HTTP/1.1\r\n\r\n"),
     Result =
         receive
-            {accept_result, R} -> R
-        after 5000 -> error(accept_timeout)
+            {handshake_result, R} -> R
+        after 5000 -> error(handshake_timeout)
         end,
-    %% Handshake failures come back tagged, distinguishing this
-    %% per-connection event from the listen socket's own `closed`.
     ?assertMatch({error, {handshake, _}}, Result),
     roadrunner_transport:close(LSocket),
     gen_tcp:close(Client).
 
-accept_handshake_times_out_on_silent_client_test() ->
+handshake_times_out_on_silent_client_test() ->
     %% A client that connects and never sends a ClientHello must not
-    %% park the accept: the handshake bound turns it into a tagged
-    %% per-connection `{handshake, timeout}` error.
+    %% park its owner forever: the bound turns it into a tagged
+    %% `{handshake, timeout}` error, and the parked connection is closed
+    %% so the peer sees the socket go away.
     {ok, _} = application:ensure_all_started(ssl),
     ServerOpts = roadrunner_test_certs:server_opts(),
     {ok, LSocket} = roadrunner_transport:listen_tls(
@@ -181,19 +201,34 @@ accept_handshake_times_out_on_silent_client_test() ->
     {ok, Port} = roadrunner_transport:port(LSocket),
     Self = self(),
     spawn(fun() ->
-        Self ! {accept_result, roadrunner_transport:accept(LSocket, 200)}
+        {ok, Pre} = roadrunner_transport:accept(LSocket),
+        Self ! {handshake_result, roadrunner_transport:handshake(Pre, 200)}
     end),
     {ok, Silent} = gen_tcp:connect(
         {127, 0, 0, 1}, Port, [binary, {active, false}], 1000
     ),
     Result =
         receive
-            {accept_result, R} -> R
-        after 5000 -> error(accept_timeout)
+            {handshake_result, R} -> R
+        after 5000 -> error(handshake_timeout)
         end,
     ?assertEqual({error, {handshake, timeout}}, Result),
+    ?assertEqual({error, closed}, gen_tcp:recv(Silent, 0, 5000)),
     roadrunner_transport:close(LSocket),
     gen_tcp:close(Silent).
+
+handshake_passes_plain_and_fake_sockets_through_test() ->
+    %% No handshake to run on plain TCP or the test transport: the socket
+    %% comes back unchanged.
+    {ok, LSock} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(LSock),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    {ok, {gen_tcp, _} = Sock} = roadrunner_transport:accept({gen_tcp, LSock}),
+    ?assertEqual({ok, Sock}, roadrunner_transport:handshake(Sock, 5000)),
+    ?assertEqual({ok, {fake, self()}}, roadrunner_transport:handshake({fake, self()}, 5000)),
+    roadrunner_transport:close(Sock),
+    gen_tcp:close(Client),
+    gen_tcp:close(LSock).
 
 port_on_closed_ssl_socket_returns_error_test() ->
     {ok, _} = application:ensure_all_started(ssl),
@@ -603,5 +638,6 @@ fake_proto_opts(Handler) ->
         body_buffering => auto,
         proxy_protocol => false,
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity
     }.

--- a/test/roadrunner_ws_session_tests.erl
+++ b/test/roadrunner_ws_session_tests.erl
@@ -2330,6 +2330,7 @@ ws_proto_opts(MaxFrame, MaxMsg) ->
         ws_buffer => undefined,
         ws_hibernate_after => infinity,
         handler_spawn_opts => [{fullsweep_after, 0}],
+        tls_handshake_timeout => 5000,
         handler_start_timeout => infinity
     }.
 


### PR DESCRIPTION
# Description

The TLS handshake moves out of the acceptor into the connection process: `roadrunner_transport:accept/1` hands the socket over pre-handshake and the conn completes it at shoot, bounded by `tls_handshake_timeout`, labelled `{roadrunner_conn, tls_handshake, Name}` while it runs, and reported through the existing `[roadrunner, listener, accept_error]` event with a `{handshake, _}` reason when it fails. Until now a peer that connected and never sent a ClientHello parked an acceptor for the whole timeout, so a few silent peers stopped a TLS listener from accepting at all; handshaking connections now hold a `max_clients` slot from accept instead. The steady-state request path is unchanged.

The new `roadrunner_tls_handshake_SUITE` reproduces the parked-acceptor case (on `main` a real client times out behind one silent peer) and covers the garbage-hello and silent-peer paths.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
