### PR TITLE
Register conns for drain in a per-listener ETS table instead of pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,12 +410,12 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
 
 - **Drain**: `roadrunner_listener:drain/2` does graceful shutdown with a
   timeout: closes the listen socket, broadcasts `{roadrunner_drain, Deadline}`
-  to in-flight conns via `pg`, polls until idle or deadline, then
+  to in-flight conns, polls until idle or deadline, then
   `exit(Pid, shutdown)` for stragglers.
 - **Status**: `roadrunner_listener:status/1` returns `accepting | draining`.
 - **Slot reconciliation**: Optional `slot_reconciliation => #{interval => N}`
   listener opt: a periodic reaper that compares `client_counter` against the
-  conn `pg` group and releases slots orphaned by `kill`-style exits. Off by
+  live registered conns and releases slots orphaned by `kill`-style exits. Off by
   default; enable in production where you can't trust every exit path to run
   `terminate/3` (`kill` signals, OOM kills, supervisor brutal-kill).
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -166,7 +166,7 @@ Requires Docker and a compiled test profile. See
 |--------------------------------|----------------------------------|----------------------------|-------------------------------|
 | Per-conn process model         | tail-recursive `proc_lib` loop   | tail-recursive loop        | gen_server + stream handlers  |
 | Request lifecycle observable   | yes (`proc_lib:get_label/1`)     | no                         | partial                       |
-| Drain / graceful shutdown      | built-in (`pg`-broadcast)        | DIY                        | partial                       |
+| Drain / graceful shutdown      | built-in (registry broadcast)    | DIY                        | partial                       |
 | Telemetry                      | `telemetry` library, 10+ events  | none (handler callbacks)   | `cowboy_metrics_h` opt-in     |
 | Middleware shape               | continuation-passing             | `pre_request`/`post_request` callback | deprecated `(Req, Env)`/stream handlers |
 | Hibernation between requests   | `hibernate_after` works          | no                         | depends on stream handler     |

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -40,8 +40,8 @@
     release_request_slot/3,
     release_request_slots/4,
     consume_body_reader/2,
-    join_drain_group/2,
-    join_drain_group_for/2
+    register_for_drain/1,
+    unregister_for_drain/1
 ]).
 %% Internal helpers shared with `roadrunner_conn_loop`. Marked `-doc false`
 %% individually so they stay invisible to the public API surface but
@@ -133,6 +133,9 @@ deadline in milliseconds.
     max_keep_alive_requests := pos_integer(),
     max_clients := pos_integer(),
     client_counter := counters:counters_ref(),
+    %% Per-listener drain registry (`{Pid}` rows). Optional so hand-built
+    %% proto_opts in tests can leave it out; the listener always sets it.
+    drain_table => ets:table(),
     requests_counter := atomics:atomics_ref(),
     rejected_counter := atomics:atomics_ref(),
     %% Aggregate in-flight ceiling for the multiplexed protocols (h2/h3):
@@ -160,12 +163,12 @@ deadline in milliseconds.
     min_bytes_per_second := non_neg_integer(),
     body_buffering := auto | manual,
     listener_name => atom(),
-    %% When `false`, conns skip the per-process `pg:join` into
-    %% `{roadrunner_drain, ListenerName}`. The drain group is the
-    %% mechanism `roadrunner_listener:drain/2` uses to broadcast
+    %% When `false`, conns skip registering in the listener's drain
+    %% registry (`drain_table`). The registry is the mechanism
+    %% `roadrunner_listener:drain/2` uses to broadcast
     %% `{roadrunner_drain, Deadline}` to in-flight conns; loop /
     %% SSE / WebSocket handlers depend on it. Short-lived h1
-    %% workloads can opt out for ~10% lower per-conn overhead.
+    %% workloads can opt out to skip the insert and delete per conn.
     graceful_drain => boolean(),
     %% When `true`, `roadrunner_conn_loop:awaiting_shoot/3` reads and strips a
     %% PROXY-protocol header (an L4 balancer prepends it) before serving, and
@@ -260,48 +263,42 @@ start(Socket, ProtoOpts) when is_map(ProtoOpts) ->
     {ok, _Pid} = roadrunner_conn_loop:start(Socket, ProtoOpts).
 
 -doc """
-Join the per-listener `pg` group so `roadrunner_listener:drain/2` can
-broadcast a `{roadrunner_drain, Deadline}` notification to the calling
-process. `pg` removes the caller automatically when the process
-exits. The `pg` scope is started by `roadrunner_sup`; in tests that
-drive `roadrunner_listener:start_link/2` directly without starting the
-application, the scope is absent and the join is silently skipped
-— drain will simply not see those conns.
+Register the calling connection process in its listener's drain
+registry so `roadrunner_listener:drain/2` and `notify_drain/2` can send
+it `{roadrunner_drain, Deadline}`. A lock-free ETS insert, so
+connection starts never queue behind a registry process. Skipped when
+the listener opted out with `graceful_drain => false`, or when the
+proto_opts carry no registry (requests built by hand in tests).
 
-Called by `roadrunner_conn_loop:init_loop/3` after the conn process
-starts but before it accepts any work.
+Called by the connection loops as they start, before they accept any
+work, and paired with `unregister_for_drain/1` on every exit path. A
+process outside the conn lifecycle registers through
+`roadrunner_listener:register_for_drain/2` instead.
 """.
--spec join_drain_group(atom(), boolean()) -> ok.
-join_drain_group(_Name, false) ->
+-spec register_for_drain(proto_opts()) -> ok.
+register_for_drain(#{graceful_drain := false}) ->
     ok;
-join_drain_group(undefined, _) ->
+register_for_drain(#{drain_table := Table}) ->
+    true = ets:insert(Table, {self()}),
     ok;
-join_drain_group(Name, true) ->
-    case whereis(pg) of
-        undefined -> ok;
-        _ -> pg:join({roadrunner_drain, Name}, self())
-    end.
+register_for_drain(#{}) ->
+    ok.
 
 -doc """
-Join `Pid` into the per-listener `pg` drain group on behalf of another
-process. Reserved for future use cases where a non-conn process needs
-direct drain membership (e.g., a long-lived worker spawned outside
-the conn lifecycle). The WS upgrade path no longer calls this: the
-conn (already in pg) forwards `{roadrunner_drain, _}` to its session
-from `roadrunner_conn_loop:ws_session_wake/7` instead.
-
-Silently no-ops when `Name` is `undefined` (manually constructed
-requests in tests) or when the `pg` scope is absent (listener
-started without the supervision tree).
+Remove the calling process from its listener's drain registry, paired
+with `register_for_drain/1`. The listener owns the table, and `stop/1`
+does not wait for in-flight conns, so a conn that outlives its listener
+finds no registry to leave and that is fine.
 """.
--spec join_drain_group_for(pid(), atom()) -> ok.
-join_drain_group_for(_Pid, undefined) ->
-    ok;
-join_drain_group_for(Pid, Name) when is_pid(Pid), is_atom(Name) ->
-    case whereis(pg) of
-        undefined -> ok;
-        _ -> pg:join({roadrunner_drain, Name}, Pid)
-    end.
+-spec unregister_for_drain(proto_opts()) -> ok.
+unregister_for_drain(#{drain_table := Table}) ->
+    try ets:delete(Table, self()) of
+        true -> ok
+    catch
+        error:badarg -> ok
+    end;
+unregister_for_drain(#{}) ->
+    ok.
 
 -doc """
 Try to bump the live-connection counter under `max_clients`. Returns
@@ -327,8 +324,8 @@ skips the cleanup funnel, so the slot is **leaked** for the lifetime
 of the listener process. This is bounded:
 `max_clients` accepted connections each leak at most one slot
 under killing, and the listener restart resets the counter. If
-leaks become a real concern under chaos-test conditions, add a
-periodic reaper that compares `pg:get_members({roadrunner_drain, _})`
+leaks become a real concern under chaos-test conditions, the optional
+`slot_reconciliation` reaper compares the registered conns still alive
 against the live counter and reconciles the difference.
 """.
 -spec try_acquire_slot(proto_opts()) -> boolean().

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -60,7 +60,7 @@
 %%
 %% ## Stability features preserved
 %%
-%% Drain via `pg`-broadcast, slot tracking via atomics, full telemetry
+%% Drain via registry broadcast, slot tracking via atomics, full telemetry
 %% pairing (`[roadrunner, request, start | stop | exception]` with
 %% shared `StartMono`), HEAD body suppression, `Expect: 100-continue`,
 %% anti-Slowloris rate-check on the request-read phase, all five
@@ -177,9 +177,8 @@ start(
     no_return().
 init_loop(Parent, Socket, ProtoOpts) ->
     ListenerName = maps:get(listener_name, ProtoOpts, undefined),
-    DrainGroup = maps:get(graceful_drain, ProtoOpts, true),
     proc_lib:set_label({roadrunner_conn, awaiting_shoot, ListenerName}),
-    ok = roadrunner_conn:join_drain_group(ListenerName, DrainGroup),
+    ok = roadrunner_conn:register_for_drain(ProtoOpts),
     proc_lib:init_ack(Parent, {ok, self()}),
     awaiting_shoot(Socket, ProtoOpts, ListenerName).
 
@@ -230,6 +229,7 @@ awaiting_shoot(Socket0, ProtoOpts, ListenerName) ->
                     ok = roadrunner_telemetry:listener_accept_error(#{
                         listener_name => ListenerName, reason => Reason
                     }),
+                    ok = roadrunner_conn:unregister_for_drain(ProtoOpts),
                     ok = roadrunner_conn:release_slot(ProtoOpts),
                     exit(normal)
             end;
@@ -1259,11 +1259,11 @@ buffered_finish(S0, Req, Headers) ->
 %% Park the conn in a hibernated wait while the WebSocket session owns
 %% the socket. The conn's only remaining duties are bookkeeping: hold
 %% the session monitor, forward `{roadrunner_drain, _}` broadcasts to
-%% the session (the conn is already in the listener's drain `pg` group
-%% via `roadrunner_conn:join_drain_group/2`; joining the session too
-%% would double the join rate through the single `pg` scope process and
-%% serialize the upgrade path under load), and fire the request-stop /
-%% conn-close telemetry once the session ends. Hibernating sheds the
+%% the session (the conn is already in the listener's drain registry via
+%% `roadrunner_conn:register_for_drain/1`; registering the session too
+%% would be a second row to keep in step for nothing), and fire the
+%% request-stop / conn-close telemetry once the session ends. Hibernating
+%% sheds the
 %% heap grown parsing the upgrade request (~5-7 KB per connection
 %% measured under load) for the session's entire lifetime — at high
 %% WebSocket concurrency the parked conns are a real share of resident
@@ -1417,6 +1417,7 @@ exit_clean(Socket, ProtoOpts, StartMono, Peer, ListenerName, Served, Reason) ->
                 requests_served => Served
             })
     end,
+    ok = roadrunner_conn:unregister_for_drain(ProtoOpts),
     ok = roadrunner_conn:release_slot(ProtoOpts),
     ok = roadrunner_transport:close(Socket),
     exit(Reason).

--- a/src/roadrunner_conn_loop_http2.erl
+++ b/src/roadrunner_conn_loop_http2.erl
@@ -1969,6 +1969,7 @@ exit_clean(#loop{
     ok = roadrunner_conn:release_request_slots(
         MaxConcReq, InflightCounter, map_size(Refs), Overload
     ),
+    ok = roadrunner_conn:unregister_for_drain(ProtoOpts),
     ok = roadrunner_conn:release_slot(ProtoOpts),
     ok = roadrunner_transport:close(Socket),
     exit(normal).

--- a/src/roadrunner_conn_loop_http3.erl
+++ b/src/roadrunner_conn_loop_http3.erl
@@ -189,8 +189,7 @@ init(Conn, #{listener_name := ListenerName, max_content_length := MaxContentLeng
     proc_lib:set_label({roadrunner_conn_loop_http3, ListenerName, Conn}),
     %% The `max_clients` slot was acquired by `start/2` (in the listener
     %% process); it is released in `terminate/1`.
-    DrainGroup = maps:get(graceful_drain, ProtoOpts, true),
-    ok = roadrunner_conn:join_drain_group(ListenerName, DrainGroup),
+    ok = roadrunner_conn:register_for_drain(ProtoOpts),
     %% Share fate with the QUIC connection process: if it dies abnormally
     %% (without a `closed` event) the loop dies too, rather than hanging.
     %% The slot then leaks until slot reconciliation reaps it, the same
@@ -1006,4 +1005,5 @@ terminate(#h3{
     ok = roadrunner_conn:release_request_slots(
         MaxConcReq, InflightCounter, map_size(Refs), Overload
     ),
+    ok = roadrunner_conn:unregister_for_drain(ProtoOpts),
     ok = roadrunner_conn:release_slot(ProtoOpts).

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -29,6 +29,7 @@ All duration and interval values in `opts()` are in milliseconds —
     stop/1,
     drain/2,
     notify_drain/2,
+    register_for_drain/2,
     port/1,
     info/1,
     status/1,
@@ -222,10 +223,11 @@ Optional middleware and timing knobs (durations in milliseconds):
   `roadrunner_req:read_body/1,2`).
 - `slot_reconciliation` — `disabled` (default) or
   `#{interval := Ms}` to periodically reap slots orphaned by
-  brutal-kill exits.
-- `graceful_drain` — opt out of the per-conn pg drain group
-  (`true` default; `false` trades drain notification for ~10 %
-  lower per-conn overhead on short-lived workloads).
+  brutal-kill exits, and with them the killed conns' rows in the
+  drain registry.
+- `graceful_drain` — opt out of the per-conn drain registry
+  (`true` default; `false` trades drain notification for a little
+  less per-conn work on short-lived workloads).
 - `hibernate_after` — when set, idle conns hibernate after this
   many milliseconds of main-loop idle time.
 - `handler_spawn` — spawn config for every handler-running process (the
@@ -311,7 +313,7 @@ ops-tuning rationale.
     rate_check_interval => pos_integer(),
     body_buffering => auto | manual,
     slot_reconciliation => disabled | #{interval := pos_integer()},
-    %% Opt out of the per-conn `pg` drain group. Default `true`
+    %% Opt out of the per-conn drain registry. Default `true`
     %% (current behavior). Set to `false` for short-lived h1-only
     %% workloads (REST APIs, health-check probes, CLI clients) where
     %% conns finish on their own faster than any drain notification
@@ -611,11 +613,11 @@ WebSocket session tunables (under `ws` in the listener opts).
     proto_opts :: roadrunner_conn:proto_opts(),
     phase = accepting :: accepting | draining | stopped,
     %% Slot reconciliation (off by default). When enabled, a periodic
-    %% timer compares `client_counter` against pg group membership and
-    %% releases slots that have been orphaned by `kill`-style exits
+    %% timer compares `client_counter` against the live registered conns
+    %% and releases slots that have been orphaned by `kill`-style exits
     %% (which bypass `terminate/3`). `prev_diff` tracks the previous
     %% tick's diff to filter out spawn-time races (a freshly-started
-    %% conn has bumped the counter but not yet pg:join'd) — only
+    %% conn has bumped the counter but not yet registered) — only
     %% sustained diffs are reaped.
     reconciliation = disabled ::
         disabled
@@ -671,7 +673,7 @@ drain(Name, Timeout) ->
 
 -doc """
 Broadcast a `{roadrunner_drain, Deadline}` notification to every conn /
-WS session in the listener's `pg` drain group **without** stopping the
+WS session in the listener's drain registry **without** stopping the
 listener or waiting on the counter.
 
 Use for soft-drain workflows — telling long-lived sessions to wind down
@@ -679,14 +681,24 @@ ahead of a deploy, or in test suites that want to observe drain
 behavior without losing the listener for subsequent cases. Unlike
 `drain/2`, the listener keeps accepting new connections.
 
-Requires the `pg` scope to be running (started by `roadrunner_sup`).
+Like every other call into a listener, exits with `noproc` when no
+listener by that name is running.
 """.
 -spec notify_drain(Name :: atom(), Deadline :: integer()) -> ok.
 notify_drain(Name, Deadline) when is_atom(Name), is_integer(Deadline) ->
-    lists:foreach(
-        fun(Pid) -> Pid ! {roadrunner_drain, Deadline} end,
-        pg:get_members({roadrunner_drain, Name})
-    ).
+    gen_server:call(Name, {notify_drain, Deadline}).
+
+-doc """
+Register `Pid` in the listener's drain registry so `drain/2` and
+`notify_drain/2` reach it with `{roadrunner_drain, Deadline}`. The
+connection processes register themselves; this is for a process that
+lives outside the conn lifecycle (a long-lived worker, say) and wants
+the same notification. Exits with `noproc` when no listener by that
+name is running.
+""".
+-spec register_for_drain(Name :: atom(), pid()) -> ok.
+register_for_drain(Name, Pid) when is_atom(Name), is_pid(Pid) ->
+    gen_server:call(Name, {register_for_drain, Pid}).
 
 -doc "Return the actual TCP port the listener is bound to.".
 -spec port(Name :: atom()) -> inet:port_number().
@@ -1222,6 +1234,18 @@ build_proto_opts(Opts, ListenerName) ->
     ClientCounter = counters:new(1, [write_concurrency]),
     RequestsCounter = atomics:new(1, [{signed, false}]),
     RejectedCounter = atomics:new(1, [{signed, false}]),
+    %% Per-listener drain registry: every conn inserts its own pid as it
+    %% starts and deletes it on exit, which is how `drain/2` and
+    %% `notify_drain/2` find the processes to notify. A `write_concurrency`
+    %% set owned by this process (it dies with the listener), so a join is
+    %% a lock-free insert rather than a call into a registry process: 512
+    %% simultaneous connection starts queued 3-4 ms behind the single `pg`
+    %% scope this replaces. The by-name entry points (`notify_drain/2`,
+    %% `register_for_drain/2`) go through this process
+    %% instead of a shared pointer: they are rare, and a call to a stopped
+    %% listener fails as `noproc` rather than reaching a table that died
+    %% with it.
+    DrainTable = ets:new(roadrunner_drain, [set, public, {write_concurrency, true}]),
     %% `inflight_counter` is the live in-flight-request gauge (h2/h3 stream
     %% workers acquire before spawn, release on `DOWN`), same lock-free
     %% `write_concurrency` shape as `client_counter`. `throttled_counter`
@@ -1283,6 +1307,7 @@ build_proto_opts(Opts, ListenerName) ->
             max_concurrent_requests => MaxConcurrentRequests,
             overload => Overload,
             client_counter => ClientCounter,
+            drain_table => DrainTable,
             requests_counter => RequestsCounter,
             rejected_counter => RejectedCounter,
             inflight_counter => InflightCounter,
@@ -1892,6 +1917,13 @@ handle_call({drain, Timeout}, _From, State) ->
 handle_call({reload_routes, Routes}, _From, State) ->
     Reply = do_reload_routes(State, Routes),
     {reply, Reply, State};
+handle_call({notify_drain, Deadline}, _From, #state{proto_opts = #{drain_table := Table}} = State) ->
+    {reply, notify_conns(Table, Deadline), State};
+handle_call(
+    {register_for_drain, Pid}, _From, #state{proto_opts = #{drain_table := Table}} = State
+) ->
+    true = ets:insert(Table, {Pid}),
+    {reply, ok, State};
 handle_call(info, _From, #state{proto_opts = ProtoOpts} = State) ->
     #{
         client_counter := ClientCounter,
@@ -1946,10 +1978,9 @@ do_drain(
     %% existing TCP conns keep their own sockets and drain below.
     ok = close_tcp(LSocket),
     Deadline = erlang:monotonic_time(millisecond) + Timeout,
-    Group = drain_group(ProtoOpts),
-    notify_conns(Group, Deadline),
-    #{client_counter := Counter} = ProtoOpts,
-    Reply = wait_for_drain(Counter, Deadline, Group),
+    #{client_counter := Counter, drain_table := Table} = ProtoOpts,
+    notify_conns(Table, Deadline),
+    Reply = wait_for_drain(Counter, Deadline, Table),
     %% Stop the QUIC listener LAST: `roadrunner_quic_listener:stop/1` kills the
     %% connections it `start_link`ed (and the h3 conn loops linked to
     %% them), so doing it before the notify/wait above would abruptly
@@ -1968,16 +1999,16 @@ do_drain(
 %% handlers can pattern-match on `{roadrunner_drain, Deadline}` in
 %% `handle_info/3`; non-loop conns ignore the message and fall through
 %% to the mailbox check at the next keep-alive boundary.
--spec notify_conns(term(), integer()) -> ok.
-notify_conns(Group, Deadline) ->
-    _ = [Pid ! {roadrunner_drain, Deadline} || Pid <- pg:get_members(Group)],
+-spec notify_conns(ets:table(), integer()) -> ok.
+notify_conns(Table, Deadline) ->
+    _ = [Pid ! {roadrunner_drain, Deadline} || {Pid} <- ets:tab2list(Table)],
     ok.
 
 %% Poll the active-clients counter every 50ms (or whatever remains,
 %% if smaller) until it hits zero or the deadline expires.
--spec wait_for_drain(counters:counters_ref(), integer(), term()) ->
+-spec wait_for_drain(counters:counters_ref(), integer(), ets:table()) ->
     {ok, drained} | {timeout, non_neg_integer()}.
-wait_for_drain(Counter, Deadline, Group) ->
+wait_for_drain(Counter, Deadline, Table) ->
     case counters:get(Counter, 1) of
         0 ->
             {ok, drained};
@@ -1985,17 +2016,13 @@ wait_for_drain(Counter, Deadline, Group) ->
             Remaining = Deadline - erlang:monotonic_time(millisecond),
             case Remaining =< 0 of
                 true ->
-                    _ = [exit(Pid, shutdown) || Pid <- pg:get_members(Group)],
+                    _ = [exit(Pid, shutdown) || {Pid} <- ets:tab2list(Table)],
                     {timeout, N};
                 false ->
                     timer:sleep(min(50, Remaining)),
-                    wait_for_drain(Counter, Deadline, Group)
+                    wait_for_drain(Counter, Deadline, Table)
             end
     end.
-
--spec drain_group(roadrunner_conn:proto_opts()) -> {roadrunner_drain, atom()}.
-drain_group(#{listener_name := Name}) ->
-    {roadrunner_drain, Name}.
 
 -doc false.
 -spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
@@ -2012,26 +2039,20 @@ handle_info(reconcile_slots, #state{reconciliation = disabled} = State) ->
 handle_info(
     reconcile_slots,
     #state{
-        proto_opts = #{client_counter := Counter, listener_name := Name},
+        proto_opts = #{client_counter := Counter, listener_name := Name, drain_table := Table},
         reconciliation = #{interval := Interval, prev_diff := PrevDiff}
     } = State
 ) ->
-    %% pg is supervised by roadrunner_sup so it's always up when the
-    %% reconciler runs (which only fires when explicitly opted into).
-    %%
-    %% We avoid `length/1` on the member list because `max_clients`
-    %% can be configured into the tens of thousands and a full O(N)
-    %% length walk would dominate the tick. We only need to know
-    %% whether `length(members) >= counter` (no orphans) or
-    %% `length(members) < counter` (orphans = counter - length); a
-    %% bounded count short-circuits at the counter so the worst case
-    %% is `min(length(members), counter)` element visits.
+    %% We only need to know whether `live members >= counter` (no
+    %% orphans) or `live members < counter` (orphans = counter - live);
+    %% a bounded count short-circuits at the counter so the alive checks
+    %% per tick are capped at `min(members, counter)`.
     Counter0 = counters:get(Counter, 1),
-    PgCountBounded = count_up_to(pg:get_members({roadrunner_drain, Name}), Counter0),
-    NewDiff = Counter0 - PgCountBounded,
+    LiveBounded = count_live_up_to(Table, Counter0),
+    NewDiff = Counter0 - LiveBounded,
     %% Only release slots that have been orphaned for two consecutive
     %% ticks — filters out the spawn-time race where a fresh conn has
-    %% incremented the counter but hasn't yet pg:join'd.
+    %% incremented the counter but hasn't yet registered.
     Release = min(PrevDiff, NewDiff),
     case Release of
         0 ->
@@ -2043,7 +2064,7 @@ handle_info(
                 listener_name => Name,
                 released => N,
                 counter_was => Counter0,
-                pg_count_bounded => PgCountBounded
+                live_conns_bounded => LiveBounded
             }),
             ok = roadrunner_telemetry:slots_reconciled(#{
                 listener_name => Name,
@@ -2074,18 +2095,30 @@ handle_info(
 handle_info(_Msg, State) ->
     {noreply, State}.
 
-%% Count list elements, short-circuiting at `Cap`. Used by the slot
-%% reconciler so the worst-case walk per tick is bounded by the
-%% `client_counter` (i.e. `max_clients`) rather than the absolute
-%% size of the pg member list.
--spec count_up_to([term()], non_neg_integer()) -> non_neg_integer().
-count_up_to(List, Cap) ->
-    count_up_to(List, Cap, 0).
+%% Count registered conns that are still alive, short-circuiting at
+%% `Cap` (the `client_counter`, i.e. `max_clients`) so the per-tick
+%% alive checks are bounded by the counter rather than by the registry
+%% size. A conn that was `kill`ed never ran its exit path, so its pid is
+%% still registered: it is dropped here, the same reaping this tick does
+%% for its slot.
+-spec count_live_up_to(ets:table(), non_neg_integer()) -> non_neg_integer().
+count_live_up_to(Table, Cap) ->
+    count_live_up_to(ets:tab2list(Table), Table, Cap, 0).
 
--spec count_up_to([term()], non_neg_integer(), non_neg_integer()) -> non_neg_integer().
-count_up_to(_, Cap, N) when N >= Cap -> Cap;
-count_up_to([], _Cap, N) -> N;
-count_up_to([_ | T], Cap, N) -> count_up_to(T, Cap, N + 1).
+-spec count_live_up_to([{pid()}], ets:table(), non_neg_integer(), non_neg_integer()) ->
+    non_neg_integer().
+count_live_up_to(_, _Table, Cap, N) when N >= Cap ->
+    Cap;
+count_live_up_to([], _Table, _Cap, N) ->
+    N;
+count_live_up_to([{Pid} | T], Table, Cap, N) ->
+    case is_process_alive(Pid) of
+        true ->
+            count_live_up_to(T, Table, Cap, N + 1);
+        false ->
+            true = ets:delete(Table, Pid),
+            count_live_up_to(T, Table, Cap, N)
+    end.
 
 -doc false.
 -spec terminate(term(), #state{}) -> ok.

--- a/src/roadrunner_sup.erl
+++ b/src/roadrunner_sup.erl
@@ -18,22 +18,13 @@ start_link() ->
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     %% Listeners are added dynamically via roadrunner:start_listener/2. The
-    %% static children are `pg`'s default scope (which `roadrunner_conn` joins
-    %% so `roadrunner_listener:drain/2` can find conns to notify) and the
-    %% static-file metadata cache table owner. one_for_one isolates per-listener
-    %% crashes; the static children only restart on their own crash.
+    %% one static child is the static-file metadata cache table owner.
+    %% one_for_one isolates per-listener crashes; the static child only
+    %% restarts on its own crash.
     SupFlags = #{
         strategy => one_for_one,
         intensity => 5,
         period => 10
-    },
-    PgScope = #{
-        id => pg,
-        start => {pg, start_link, []},
-        type => worker,
-        restart => permanent,
-        shutdown => 5000,
-        modules => [pg]
     },
     StaticCache = #{
         id => roadrunner_static_cache,
@@ -43,6 +34,6 @@ init([]) ->
         shutdown => 5000,
         modules => [roadrunner_static_cache]
     },
-    {ok, {SupFlags, [PgScope, StaticCache]}}.
+    {ok, {SupFlags, [StaticCache]}}.
 
 %% internal functions

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -391,8 +391,9 @@ request_throttled(Metadata) ->
 Emit `[roadrunner, listener, slots_reconciled]` when the optional
 `slot_reconciliation` reaper releases orphan slots that the
 `kill`-bypasses-`terminate` path left behind. `Metadata` should
-include `listener_name`, `released` (count), and `counter_was`
-(value before reconciliation).
+include `listener_name`, `released` (count), `counter_was` (value
+before reconciliation) and `live_conns_bounded` (registered conns
+found alive, counted up to `counter_was`).
 """.
 -spec slots_reconciled(map()) -> ok.
 slots_reconciled(Metadata) ->

--- a/test/property_test/roadrunner_conn_loop_props.erl
+++ b/test/property_test/roadrunner_conn_loop_props.erl
@@ -35,7 +35,6 @@ prop_loop_terminates_normal_on_random_inputs() ->
         },
         begin
             {ok, _} = application:ensure_all_started(telemetry),
-            ensure_pg(),
             Counter = counters:new(1, [write_concurrency]),
             Opts = proto_opts(prop_listener, Counter),
             %% Mirror the acceptor's slot acquisition so the conn's
@@ -91,7 +90,6 @@ prop_request_start_and_stop_share_request_id() ->
         method(),
         begin
             {ok, _} = application:ensure_all_started(telemetry),
-            ensure_pg(),
             Self = self(),
             HandlerId = make_ref(),
             ok = telemetry:attach_many(
@@ -161,15 +159,6 @@ method() ->
 %% =============================================================================
 %% Helpers
 %% =============================================================================
-
-ensure_pg() ->
-    case whereis(pg) of
-        undefined ->
-            {ok, _} = pg:start_link(),
-            ok;
-        _ ->
-            ok
-    end.
 
 proto_opts(ListenerName, Counter) ->
     #{

--- a/test/roadrunner_bench_client_tests.erl
+++ b/test/roadrunner_bench_client_tests.erl
@@ -159,23 +159,9 @@ drive_n_alive(N, Conn0) ->
 
 %% --- listener helpers ---
 %%
-%% Other test modules in this project (`roadrunner_listener_tests`,
-%% `roadrunner_telemetry_tests`, …) bypass `application:start(roadrunner)`
-%% because `roadrunner_tests` calls `application:stop(roadrunner)` in
-%% its `{setup, ...}` teardown and pg is left running by other
-%% tests' direct `pg:start_link/0` calls — so a fresh
-%% `application:ensure_all_started(roadrunner)` after that fails
-%% with `{failed_to_start_child, pg, {already_started, _}}`.
-%% Match the project pattern: ensure pg, start the listener directly.
-
-ensure_pg() ->
-    case whereis(pg) of
-        undefined ->
-            {ok, _} = pg:start_link(),
-            ok;
-        _ ->
-            ok
-    end.
+%% Like the other test modules in this project (`roadrunner_listener_tests`,
+%% `roadrunner_telemetry_tests`, …), start the listener directly rather
+%% than through `application:start(roadrunner)`.
 
 stop_listener(Name) ->
     case whereis(Name) of
@@ -192,13 +178,11 @@ stop_listener(Name) ->
     end.
 
 start_h1_listener(Name, Handler) ->
-    ensure_pg(),
     {ok, _} = roadrunner_listener:start_link(Name, #{port => 0, routes => Handler}),
     roadrunner_listener:port(Name).
 
 start_h2_listener(Name, Handler) ->
     {ok, _} = application:ensure_all_started(ssl),
-    ensure_pg(),
     {ok, _} = roadrunner_listener:start_link(Name, #{
         port => 0,
         protocols => [http1, http2],
@@ -209,7 +193,6 @@ start_h2_listener(Name, Handler) ->
 
 start_h3_listener(Name, Handler) ->
     {ok, _} = application:ensure_all_started(ssl),
-    ensure_pg(),
     {ok, _} = roadrunner_listener:start_link(Name, #{
         port => 0,
         protocols => [http3],

--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -8,7 +8,7 @@
 %% Asserts:
 %%   - `start/2` returns `{ok, Pid}` shape.
 %%   - `proc_lib:get_label/1` reflects awaiting_shoot before `shoot`.
-%%   - The conn joins the drain pg group.
+%%   - The conn registers in the listener's drain registry.
 %%   - `Pid ! shoot` fires `listener_accept` telemetry.
 %%   - `Pid ! {roadrunner_drain, _}` exits cleanly in awaiting_shoot
 %%     (no telemetry — accept hadn't fired yet).
@@ -26,7 +26,6 @@
 %% =============================================================================
 
 start_returns_ok_pid_test() ->
-    ensure_pg(),
     {ok, Pid} = roadrunner_conn_loop:start({fake, spawn_sink()}, fake_opts(start_ok)),
     ?assert(is_pid(Pid)),
     ?assert(is_process_alive(Pid)),
@@ -37,7 +36,6 @@ start_applies_handler_spawn_opts_to_process_test() ->
     %% just sit in proto_opts: start a conn with a non-default
     %% `fullsweep_after` and read it back from the live process's own
     %% garbage-collection info.
-    ensure_pg(),
     Opts = (fake_opts(gc_flag))#{handler_spawn_opts := [{fullsweep_after, 42}]},
     {ok, Pid} = roadrunner_conn_loop:start({fake, spawn_sink()}, Opts),
     {garbage_collection, GcInfo} = process_info(Pid, garbage_collection),
@@ -45,26 +43,25 @@ start_applies_handler_spawn_opts_to_process_test() ->
     drain_then_wait(Pid).
 
 conn_start_routes_through_loop_test() ->
-    ensure_pg(),
     {ok, Pid} = roadrunner_conn:start({fake, spawn_sink()}, fake_opts(dispatch)),
     ?assertMatch({roadrunner_conn, awaiting_shoot, dispatch}, proc_lib:get_label(Pid)),
     drain_then_wait(Pid).
 
 awaiting_shoot_label_set_test() ->
-    ensure_pg(),
     {ok, Pid} = roadrunner_conn_loop:start({fake, spawn_sink()}, fake_opts(label)),
     ?assertMatch({roadrunner_conn, awaiting_shoot, label}, proc_lib:get_label(Pid)),
     drain_then_wait(Pid).
 
-awaiting_shoot_joins_drain_group_test() ->
-    ensure_pg(),
-    Name = drain_join,
-    {ok, Pid} = roadrunner_conn_loop:start({fake, spawn_sink()}, fake_opts(Name)),
-    ?assertEqual([Pid], pg:get_members({roadrunner_drain, Name})),
-    drain_then_wait(Pid).
+awaiting_shoot_registers_for_drain_test() ->
+    Table = ets:new(drain_join, [set, public]),
+    Opts = (fake_opts(drain_join))#{drain_table => Table},
+    {ok, Pid} = roadrunner_conn_loop:start({fake, spawn_sink()}, Opts),
+    ?assertEqual([{Pid}], ets:tab2list(Table)),
+    drain_then_wait(Pid),
+    %% The exit path takes the row back out.
+    ?assertEqual([], ets:tab2list(Table)).
 
 drain_in_awaiting_shoot_exits_without_telemetry_test() ->
-    ensure_pg(),
     Tag = make_ref(),
     attach_telemetry(Tag, [
         [roadrunner, listener, accept],
@@ -83,7 +80,6 @@ drain_in_awaiting_shoot_exits_without_telemetry_test() ->
     detach_telemetry(Tag).
 
 stray_msg_in_awaiting_shoot_is_ignored_test() ->
-    ensure_pg(),
     {ok, Pid} = roadrunner_conn_loop:start({fake, spawn_sink()}, fake_opts(stray)),
     Pid ! {stray_msg_from_buggy_lib, make_ref()},
     Pid ! 12345,
@@ -94,7 +90,6 @@ stray_msg_in_awaiting_shoot_is_ignored_test() ->
     drain_then_wait(Pid).
 
 slot_released_on_drain_in_awaiting_shoot_test() ->
-    ensure_pg(),
     Counter = counters:new(1, [write_concurrency]),
     ok = counters:add(Counter, 1, 1),
     Opts = (fake_opts(slot))#{client_counter := Counter},
@@ -113,7 +108,6 @@ shoot_then_valid_request_dispatches_hello_handler_test() ->
     %% The conn parses the request, dispatches the configured handler
     %% (default `roadrunner_hello_handler`), writes the 200 response,
     %% and exits cleanly.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -131,7 +125,6 @@ shoot_then_valid_request_dispatches_hello_handler_test() ->
     Sink ! stop.
 
 bad_request_writes_400_then_exits_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -152,7 +145,6 @@ oversized_request_line_writes_414_then_exits_test() ->
     %% A request line past the 8192-byte cap is `request_line_too_long`,
     %% which answers 414 URI Too Long (RFC 9110 §15.5.15), not a generic
     %% 400.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     LongTarget = binary:copy(~"a", 9000),
@@ -173,7 +165,6 @@ oversized_request_line_writes_414_then_exits_test() ->
 too_many_headers_writes_431_then_exits_test() ->
     %% More than 100 header lines is `too_many_headers`, which answers
     %% 431 Request Header Fields Too Large (RFC 6585 §5), not a 400.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = iolist_to_binary([
@@ -197,7 +188,6 @@ too_many_headers_writes_431_then_exits_test() ->
 request_timeout_writes_408_then_exits_test() ->
     %% No bytes — the request_timeout `after` clause should fire and
     %% the conn should write 408 before exiting.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_silent_sink_with_send_log(Self, Tag),
@@ -214,7 +204,6 @@ request_timeout_writes_408_then_exits_test() ->
     Sink ! stop.
 
 drain_during_read_request_exits_silently_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_silent_sink_with_send_log(Self, Tag),
@@ -239,7 +228,6 @@ tcp_closed_while_awaiting_request_exits_silently_test() ->
     %% Peer closes while the conn waits for a request's first byte.
     %% The scripted close is delivered as the active-mode close event
     %% the conn is parked on.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_scripted_sink(Self, Tag, [{passive, {error, closed}}]),
@@ -257,7 +245,6 @@ tcp_closed_while_awaiting_request_exits_silently_test() ->
 tcp_error_while_awaiting_request_exits_silently_test() ->
     %% Any non-timeout, non-closed transport error (e.g. econnreset)
     %% while awaiting a request → silent exit.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_scripted_sink(Self, Tag, [{passive, {error, econnreset}}]),
@@ -313,7 +300,6 @@ drain_during_body_recv_exits_silently_test() ->
     %% Drain arriving while the conn is reading the rest of a request:
     %% picked up by the mailbox check between drain ticks, after a
     %% stray message ahead of it in the queue is skipped.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_partial_then_sink(Self, Tag, partial_request(), silent),
@@ -335,7 +321,6 @@ drain_during_body_recv_exits_silently_test() ->
 request_timeout_during_body_recv_writes_408_test() ->
     %% The absolute deadline is enforced across drain ticks: a client
     %% that sends half a request and stalls gets a 408.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_partial_then_sink(Self, Tag, partial_request(), silent),
@@ -359,7 +344,6 @@ drain_during_message_body_exits_silently_test() ->
     %% lands closes the conn cleanly; without the cap the conn would
     %% hold the full request_timeout, outlive the drain deadline and be
     %% hard-killed by `roadrunner_listener:drain/2`.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n\r\n",
@@ -384,7 +368,6 @@ body_read_resumes_after_drain_tick_test() ->
     %% The counterpart: a drain-check tick that finds no drain must not
     %% end the request. The peer pauses (one recv timeout) and then sends
     %% the body, which still completes normally.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\n",
@@ -438,7 +421,6 @@ headers_then_drain_loop(Logger, Tag, Headers, Delivered) ->
 
 tcp_error_during_body_recv_exits_silently_test() ->
     %% A transport error on the remainder of a request → silent exit.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_partial_then_sink(
@@ -458,7 +440,6 @@ partial_request_then_remainder_parses_test() ->
     %% Drives the `{more, _}` branch — first packet has only the request
     %% line, second packet completes the headers. Both must parse + the
     %% handler dispatches a 200.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_two_chunks_with_log(
@@ -483,7 +464,6 @@ setopts_on_dead_socket_exits_silently_test() ->
     %% Phase A' default path uses passive recv (no setopts call) —
     %% so to exercise this code path the test opts into the
     %% active-mode `recv_with_hibernate` branch via `hibernate_after`.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     DeadSink = spawn(fun() -> ok end),
@@ -518,7 +498,6 @@ slowloris_during_passive_recv_drops_client_test() ->
     %% rate window is anchored at the FIRST byte (not at phase entry), so
     %% the drop is driven by genuine slow transmission. The conn must
     %% close silently.
-    ensure_pg(),
     Self = self(),
     %% Deliver 1 byte immediately (anchors the window), then sleep past
     %% the grace and deliver 1 more byte. Total 2 bytes over ~1.2 s
@@ -564,7 +543,6 @@ slowloris_during_active_mode_recv_drops_client_test() ->
     %% average falls under it. The window is anchored at the first byte.
     %% The conn must close silently (no 408, same as the passive path's
     %% slowloris branch).
-    ensure_pg(),
     Self = self(),
     %% Deliver 1 byte immediately (anchors the window), then sleep past
     %% the grace and deliver 1 more byte. Total 2 bytes over ~1.2 s
@@ -606,7 +584,6 @@ keep_alive_reuse_after_idle_serves_second_request_passive_test() ->
     %% is anchored at the first byte of each request, so the idle gap is
     %% not counted as slow transmission. Under the old phase-entry anchor
     %% the second request was silently dropped (one response on the wire).
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
@@ -636,7 +613,6 @@ keep_alive_reuse_after_idle_serves_second_request_hibernate_test() ->
     %% Same regression on the active-mode hibernate path: `hibernate_after`
     %% is short enough that the conn hibernates during the idle gap and
     %% wakes via `recv_request_bytes_hib` when the second request arrives.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
@@ -663,7 +639,6 @@ keep_alive_reuse_after_idle_serves_second_request_hibernate_test() ->
     Sink ! stop.
 
 stray_msg_during_read_request_is_ignored_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_silent_sink_with_send_log(Self, Tag),
@@ -683,7 +658,6 @@ stray_msg_during_read_request_is_ignored_test() ->
     Sink ! stop.
 
 shoot_fires_accept_paired_with_conn_close_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     attach_telemetry(Tag, [
@@ -713,7 +687,6 @@ middleware_pipeline_runs_when_listener_has_middlewares_test() ->
     %% The middleware sets a marker into the request body via a
     %% no-op continuation. Asserts the response still lands and the
     %% middleware ran (echo handler reflects the body).
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Body = ~"mw-marker",
@@ -746,7 +719,6 @@ middleware_pipeline_runs_when_listener_has_middlewares_test() ->
     Sink ! stop.
 
 handler_crash_writes_500_and_fires_request_exception_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     attach_telemetry(Tag, [
@@ -782,7 +754,6 @@ interim_buffered_response_writes_500_test() ->
     %% A handler returning a buffered 1xx status is a misuse (RFC 9110
     %% §15.2): the conn loop rejects it with 500 rather than put an invalid
     %% interim status on the wire as the final response.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_once(
@@ -805,7 +776,6 @@ interim_buffered_response_writes_500_test() ->
     Sink ! stop.
 
 post_body_echoes_via_auto_mode_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Body = ~"hello-body",
@@ -838,7 +808,6 @@ post_body_echoes_via_auto_mode_test() ->
     Sink ! stop.
 
 oversized_body_writes_413_and_fires_request_rejected_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     attach_telemetry(Tag, [[roadrunner, request, rejected]]),
@@ -876,7 +845,6 @@ body_recv_timeout_writes_408_test() ->
     %% deadline, and that is what read_body reports as
     %% {error, request_timeout} → 408 + exit. Hence the short
     %% request_timeout — otherwise the test waits out the default.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n\r\n",
@@ -906,7 +874,6 @@ body_recv_timeout_writes_408_test() ->
     Sink ! stop.
 
 body_slow_client_exits_silently_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n\r\n",
@@ -933,7 +900,6 @@ body_slow_client_exits_silently_test() ->
 body_recv_error_writes_400_test() ->
     %% Generic recv error mid-body (not timeout, not slow_client) maps
     %% to a 400.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n\r\n",
@@ -963,7 +929,6 @@ manual_mode_dispatches_with_body_reader_test() ->
     %% returning 200 ok. Use `Connection: close` so the conn closes
     %% after the single request rather than looping back keep-alive
     %% (which the manual handler doesn't disable on its own).
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nContent-Length: 5\r\n\r\n",
@@ -991,7 +956,6 @@ manual_mode_dispatches_with_body_reader_test() ->
 manual_mode_bad_framing_writes_400_test() ->
     %% Non-chunked Transfer-Encoding rejected by `body_framing/1` →
     %% 400 + exit, before the handler is invoked.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: gzip\r\n\r\n",
@@ -1015,7 +979,6 @@ manual_mode_bad_framing_writes_400_test() ->
 
 not_found_writes_404_test() ->
     %% Router dispatch with no matching route → 404.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     %% Publish an empty route table under the listener name so
@@ -1046,7 +1009,6 @@ method_not_allowed_writes_405_test() ->
     %% Router dispatch where the path matches but the method isn't in the
     %% route's allowlist → 405 with a comma-joined, sorted Allow header,
     %% emitted before any pipeline runs.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Listener = mna405,
@@ -1087,7 +1049,6 @@ two_pipelined_requests_in_one_packet_serve_both_test() ->
     %% `Connection: close`) lets keep-alive engage. The second
     %% request closes via the test's `max_keep_alive_requests := 2`
     %% cap so the conn exits cleanly without a third iteration.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Both =
@@ -1117,7 +1078,6 @@ pipelined_responses_coalesce_into_one_send_test() ->
     %% while the loop spins on `buffered` and reach the wire as ONE
     %% send when the loop is about to block for the next request — the
     %% coalescing observable is the send COUNT, not just the bytes.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
@@ -1147,7 +1107,6 @@ manual_mode_bodyless_pipelined_requests_coalesce_test() ->
     %% for a bodyless one its framing is `none`, so the pre-drain flush
     %% is skipped and the pipelined batch stays coalesced: both
     %% responses in one send.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Req = ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n",
@@ -1175,7 +1134,6 @@ pipelined_response_precedes_error_for_malformed_followup_test() ->
     %% A valid request pipelined ahead of garbage: the queued 200 must
     %% flush BEFORE the 400 hits the wire, so the client attributes
     %% each response to the right request.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1205,7 +1163,6 @@ keep_alive_max_cap_closes_after_max_test() ->
     %% `max_keep_alive_requests := 1` — the single served request hits
     %% the cap and the conn closes (no second iteration even though
     %% keep-alive is otherwise eligible).
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Both =
@@ -1229,7 +1186,6 @@ manual_mode_drain_failure_closes_cleanly_test() ->
     %% then has to consume the body_reader's unread bytes — when the
     %% recv in that drain returns `{error, closed}`, drain_body returns
     %% `{error, _}` and the conn must exit cleanly without crashing.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Headers = ~"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 100\r\n\r\n",
@@ -1266,7 +1222,6 @@ manual_mode_pipelined_leftover_uses_manual_drain_test() ->
     %% req has `body_reader` set) and feed ManualLeftover to the next
     %% iteration's read_request_phase. Covers the manual-mode clause
     %% of pipelined_leftover/3.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Req1 = ~"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello",
@@ -1301,7 +1256,6 @@ keep_alive_idle_timeout_silently_closes_test() ->
     %% Uses the `roadrunner_keepalive_handler` (no `Connection: close`)
     %% so keep-alive engages — otherwise the hello handler would
     %% close after request 1 and we'd never enter `phase=keep_alive`.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1332,7 +1286,6 @@ hibernate_after_fires_during_keep_alive_idle_test() ->
     %% enter `process_info(Pid, status) =:= waiting` AND show a
     %% drastically reduced `total_heap_size` after hibernation. We
     %% poll for status=waiting + heap < 5000 words.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1368,7 +1321,6 @@ hibernate_after_fires_during_keep_alive_idle_test() ->
 
 hibernate_path_handles_close_test() ->
     %% Coverage: the hibernate path's ClosedTag clause.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1392,7 +1344,6 @@ hibernate_path_handles_close_test() ->
     Sink ! stop.
 
 hibernate_path_handles_tcp_error_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1419,7 +1370,6 @@ hibernate_path_handles_deadline_fired_test() ->
     %% With short keep_alive_timeout AND hibernate_after, the
     %% deadline timer fires before hibernation does — covers the
     %% `{?MODULE, deadline_fired}` clause.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1442,7 +1392,6 @@ hibernate_path_handles_deadline_fired_test() ->
     Sink ! stop.
 
 hibernate_path_drops_stray_messages_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1468,7 +1417,6 @@ hibernate_path_drops_stray_messages_test() ->
     Sink ! stop.
 
 request_start_and_stop_pair_with_shared_request_id_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     attach_telemetry(Tag, [
@@ -1497,7 +1445,6 @@ head_method_buffered_response_omits_body_test() ->
     %% path in conn_loop pattern-matches on `method := ~"HEAD"` and
     %% forces the body to `~""`. Headers (including content-length)
     %% stay as-is so the framing matches what GET would have returned.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1518,7 +1465,6 @@ head_method_buffered_response_omits_body_test() ->
     Sink ! stop.
 
 stream_response_writes_chunked_body_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1543,7 +1489,6 @@ stream_response_writes_chunked_body_test() ->
     Sink ! stop.
 
 loop_response_runs_until_stop_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1574,7 +1519,6 @@ loop_response_runs_until_stop_test() ->
     Sink ! stop.
 
 sendfile_response_writes_head_then_body_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Path = filename:join(["/tmp", "rr_conn_loop_sendfile.txt"]),
@@ -1608,7 +1552,6 @@ sendfile_response_writes_head_then_body_test() ->
 sendfile_response_skips_body_for_head_method_test() ->
     %% RFC 9110 §9.3.2 — HEAD must not include a message body.
     %% Covers the `~"HEAD"` branch of dispatch_response/4's sendfile clause.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Path = filename:join(["/tmp", "rr_conn_loop_sendfile_head.txt"]),
@@ -1646,7 +1589,6 @@ sendfile_at_keep_alive_ceiling_signals_close_test() ->
     %% carry `Connection: close`, even though the client never asked to
     %% close. Mirrors the buffered ceiling case: `ensure_close_signaled/3`
     %% routes both shapes through `with_close_if_last/3`.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Path = filename:join(["/tmp", "rr_conn_loop_sendfile_ceiling.txt"]),
@@ -1689,7 +1631,6 @@ sendfile_dispatch_closes_socket_on_error_test() ->
     %% a missing path: `roadrunner_transport:sendfile/4` returns
     %% `{error, enoent}` from `file:open/2`, exercising the same
     %% close-on-error path a short_write would take in production.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_once(
@@ -1724,7 +1665,6 @@ websocket_conn_hibernates_forwards_drain_and_closes_test() ->
     %% `{roadrunner_drain, _}` broadcast to the session, and once the
     %% session ends (a close frame injected through the fake socket) the
     %% conn wakes, runs the websocket finishing path, and exits normal.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_ws_sink(Self, Tag, <<
@@ -1775,7 +1715,6 @@ pipelined_response_flushes_once_before_ws_upgrade_test() ->
     %% A GET pipelined ahead of a WS upgrade: the queued 200 must reach
     %% the wire exactly once, BEFORE the 101 — and never again from a
     %% stale accumulator when the conn finishes after the session.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_ws_sink(Self, Tag, <<
@@ -1824,7 +1763,6 @@ websocket_dispatch_invokes_session_run_test() ->
     %% and returns `rejected`. We're covering the dispatch_response
     %% websocket clause — a full handshake test lives above and in the
     %% WS suite.
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1848,7 +1786,6 @@ websocket_dispatch_invokes_session_run_test() ->
     Sink ! stop.
 
 slot_released_after_parse_exit_test() ->
-    ensure_pg(),
     Self = self(),
     Tag = make_ref(),
     Sink = spawn_active_sink_with_send_log(
@@ -1868,15 +1805,6 @@ slot_released_after_parse_exit_test() ->
     Sink ! stop.
 
 %% --- helpers ---
-
-ensure_pg() ->
-    case whereis(pg) of
-        undefined ->
-            {ok, _} = pg:start_link(),
-            ok;
-        _ ->
-            ok
-    end.
 
 fake_opts(ListenerName) ->
     #{

--- a/test/roadrunner_conn_tests.erl
+++ b/test/roadrunner_conn_tests.erl
@@ -1694,48 +1694,49 @@ consume_state_next_chunk_bad_chunk_test() ->
         roadrunner_conn:consume_body_reader(State, next_chunk)
     ).
 
-join_drain_group_undefined_listener_test() ->
-    ?assertEqual(ok, roadrunner_conn:join_drain_group(undefined, true)),
-    ?assertEqual(ok, roadrunner_conn:join_drain_group(undefined, false)).
+register_for_drain_registers_self_test() ->
+    Table = ets:new(register_for_drain, [set, public]),
+    ?assertEqual(ok, roadrunner_conn:register_for_drain(#{drain_table => Table})),
+    ?assertEqual([{self()}], ets:tab2list(Table)),
+    ?assertEqual(ok, roadrunner_conn:unregister_for_drain(#{drain_table => Table})),
+    ?assertEqual([], ets:tab2list(Table)).
 
-join_drain_group_disabled_skips_pg_test() ->
-    %% `false` short-circuits without touching pg, even when a real
-    %% listener name is supplied. Verifies the opt-out path callers
-    %% use to skip per-conn pg overhead on short-lived workloads.
-    ?assertEqual(ok, roadrunner_conn:join_drain_group(some_listener, false)).
+register_for_drain_disabled_skips_registry_test() ->
+    %% `graceful_drain => false` short-circuits without touching the
+    %% registry — the opt-out callers use on short-lived workloads.
+    Table = ets:new(register_for_drain_disabled, [set, public]),
+    ?assertEqual(
+        ok, roadrunner_conn:register_for_drain(#{graceful_drain => false, drain_table => Table})
+    ),
+    ?assertEqual([], ets:tab2list(Table)).
 
-join_drain_group_for_undefined_listener_test() ->
-    %% `join_drain_group_for/2` joins on behalf of another pid (used by
-    %% roadrunner_ws_session). `undefined` listener short-circuits.
-    ?assertEqual(ok, roadrunner_conn:join_drain_group_for(self(), undefined)).
+register_for_drain_without_registry_is_noop_test() ->
+    %% Hand-built proto_opts (tests) carry no table: nothing to register or
+    %% unregister.
+    ?assertEqual(ok, roadrunner_conn:register_for_drain(#{})),
+    ?assertEqual(ok, roadrunner_conn:unregister_for_drain(#{})).
 
-join_drain_group_for_without_pg_scope_test() ->
-    %% Without the `pg` scope (test harness skips the supervision
-    %% tree), the join is silently skipped. Caller never crashes.
-    case whereis(pg) of
-        undefined ->
-            ?assertEqual(ok, roadrunner_conn:join_drain_group_for(self(), some_listener));
-        _ ->
-            %% Scope is running — join then leave so the test doesn't
-            %% pollute other suites' membership.
-            ok = roadrunner_conn:join_drain_group_for(self(), some_listener),
-            ok = pg:leave({roadrunner_drain, some_listener}, self())
-    end.
-
-join_drain_group_for_joins_pid_when_pg_scope_running_test() ->
-    %% pg-running branch of `join_drain_group_for/2`: the helper calls
-    %% `pg:join` and the caller's pid lands in the listener's drain
-    %% group. Start pg explicitly so the test is deterministic
-    %% regardless of sibling-test sequencing.
-    _ =
-        case whereis(pg) of
-            undefined -> {ok, _} = pg:start_link();
-            _ -> ok
+unregister_for_drain_after_listener_gone_is_noop_test() ->
+    %% The listener owns the table and `stop/1` does not wait for conns, so
+    %% a conn outliving its listener leaves a table that no longer exists.
+    Self = self(),
+    Owner = spawn(fun() ->
+        Table = ets:new(orphaned_registry, [set, public]),
+        Self ! {table, Table},
+        receive
+            stop -> ok
+        end
+    end),
+    Table =
+        receive
+            {table, T} -> T
         end,
-    Listener = join_drain_group_for_joins_pid_when_pg_scope_running,
-    ok = roadrunner_conn:join_drain_group_for(self(), Listener),
-    ?assert(lists:member(self(), pg:get_members({roadrunner_drain, Listener}))),
-    ok = pg:leave({roadrunner_drain, Listener}, self()).
+    MRef = monitor(process, Owner),
+    Owner ! stop,
+    receive
+        {'DOWN', MRef, process, Owner, _} -> ok
+    end,
+    ?assertEqual(ok, roadrunner_conn:unregister_for_drain(#{drain_table => Table})).
 
 consume_state_next_chunk_for_content_length_drains_fully_test() ->
     %% Non-chunked framing: `next_chunk` drains the full body in one

--- a/test/roadrunner_drain_handler.erl
+++ b/test/roadrunner_drain_handler.erl
@@ -3,7 +3,7 @@
 Test fixture — `{loop, ...}` handler that signals "started" by
 pushing a chunk, then waits for `{roadrunner_drain, _}` and stops
 cleanly. Used to verify `roadrunner_listener:drain/2` reaches in-flight
-loops via the per-listener `pg` group.
+loops via the per-listener drain registry.
 """.
 
 -behaviour(roadrunner_handler).

--- a/test/roadrunner_h2_overload_tests.erl
+++ b/test/roadrunner_h2_overload_tests.erl
@@ -162,13 +162,13 @@ await_ping_ack(Sock, Buf) ->
     end.
 
 conn_pid(Name) ->
-    [Pid] = pg:get_members({roadrunner_drain, Name}),
+    ProtoOpts = element(4, sys:get_state(whereis(Name))),
+    [{Pid}] = ets:tab2list(maps:get(drain_table, ProtoOpts)),
     Pid.
 
 %% --- harness ---
 
 start_listener(Name, OverloadMode) ->
-    _ = ensure_pg(),
     %% Each test runs in its own process, so the previous one's
     %% registration may still be settling. Take the name rather than
     %% racing for it.
@@ -186,12 +186,6 @@ start_listener(Name, OverloadMode) ->
         overload_mode => OverloadMode
     }),
     {Name, roadrunner_listener:port(Name)}.
-
-ensure_pg() ->
-    case whereis(pg) of
-        undefined -> pg:start_link();
-        Pid -> {ok, Pid}
-    end.
 
 expect_handler() ->
     receive

--- a/test/roadrunner_h3_listener_pool_tests.erl
+++ b/test/roadrunner_h3_listener_pool_tests.erl
@@ -51,7 +51,6 @@ valid_listeners_opt_lets_listener_boot() ->
     %% non-default pool wiring: boot a listener with a tuned `{http3, _}`
     %% entry. It comes up clean and stops clean.
     {ok, _} = application:ensure_all_started(ssl),
-    ensure_pg(),
     Name = list_to_atom(
         "h3_pool_test_valid_" ++ integer_to_list(erlang:unique_integer([positive]))
     ),
@@ -68,7 +67,6 @@ custom_max_streams_bidi_threads_into_proto_opts() ->
     %% proto_opts key the QUIC pool reads when advertising the peer's
     %% bidirectional-stream cap in the transport parameters.
     {ok, _} = application:ensure_all_started(ssl),
-    ensure_pg(),
     Name = list_to_atom(
         "h3_max_streams_bidi_test_" ++ integer_to_list(erlang:unique_integer([positive]))
     ),
@@ -82,12 +80,3 @@ custom_max_streams_bidi_threads_into_proto_opts() ->
     ProtoOpts = element(4, State),
     ?assertEqual(256, maps:get(http3_max_streams_bidi, ProtoOpts)),
     ok = roadrunner_listener:stop(Name).
-
-ensure_pg() ->
-    case whereis(pg) of
-        undefined ->
-            {ok, _} = pg:start_link(),
-            ok;
-        _ ->
-            ok
-    end.

--- a/test/roadrunner_http3_SUITE.erl
+++ b/test/roadrunner_http3_SUITE.erl
@@ -167,29 +167,7 @@ all() ->
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
     {ok, _} = application:ensure_all_started(ssl),
-    %% Start the default `pg` scope standalone (the drain group lives
-    %% there) rather than the whole roadrunner app, so this suite
-    %% coexists with others that started pg in the shared CT node.
-    ok = ensure_pg_started(),
     Config.
-
-ensure_pg_started() ->
-    %% Start the default `pg` scope unlinked so it survives this
-    %% transient `init_per_suite` process (a plain `pg:start_link/0`
-    %% would link it here and it would die before the testcases run,
-    %% leaving the drain group empty).
-    case whereis(pg) of
-        undefined ->
-            case pg:start_link() of
-                {ok, Pid} ->
-                    _ = unlink(Pid),
-                    ok;
-                {error, {already_started, _}} ->
-                    ok
-            end;
-        _ ->
-            ok
-    end.
 
 end_per_suite(_Config) ->
     ok.
@@ -1041,7 +1019,7 @@ max_concurrent_requests_queue_stale_grant(_Config) ->
     Conn = connect(roadrunner_listener:port(Name)),
     try
         ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/"))),
-        [ConnPid] = pg:get_members({roadrunner_drain, Name}),
+        [ConnPid] = drain_members(Name),
         ConnPid ! {roadrunner_slot, 999, granted},
         ConnPid ! {roadrunner_slot, 999, timeout},
         %% The connection carries on serving as if nothing happened.
@@ -1318,8 +1296,8 @@ drain(Config) ->
     Name = ?config(listener, Config),
     Conn = connect(?config(port, Config)),
     ?assertEqual({200, ~"ok"}, status_body(get(Conn, ~"/"))),
-    %% The h3 conn loop joined the listener's drain group.
-    ?assertMatch([_ | _], pg:get_members({roadrunner_drain, Name})),
+    %% The h3 conn loop registered in the listener's drain registry.
+    ?assertMatch([_ | _], drain_members(Name)),
     %% With no request in flight, draining sends a GOAWAY and closes the
     %% idle connection cleanly, so the listener drains before the
     %% deadline (exercises the conn-loop drain branch + clean close).
@@ -1341,7 +1319,7 @@ refuse_request_during_drain(Config) ->
     timer:sleep(20),
     %% Drive the conn loop's drain directly — the same message the
     %% listener broadcasts (its synchronous `drain/2` would block here).
-    [LoopPid] = pg:get_members({roadrunner_drain, Name}),
+    [LoopPid] = drain_members(Name),
     LoopPid ! {roadrunner_drain, erlang:monotonic_time(millisecond) + 5000},
     timer:sleep(20),
     %% A request opened after the GOAWAY is rejected.
@@ -1574,3 +1552,9 @@ ll_decode(Bytes) ->
             _ -> <<>>
         end,
     {Status, Body}.
+
+%% Pids registered in the listener's drain registry, read straight out of
+%% the listener state (`#state{proto_opts = #{drain_table := Table}}`).
+drain_members(Name) ->
+    ProtoOpts = element(4, sys:get_state(whereis(Name))),
+    [Pid || {Pid} <- ets:tab2list(maps:get(drain_table, ProtoOpts))].

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -163,14 +163,16 @@ listener_honors_recv_buffer_opt_test() ->
 %% notify_drain/2 (soft drain — broadcast without stopping the listener)
 %% =============================================================================
 
-notify_drain_reaches_pg_members_test() ->
-    %% Self-join the drain group so the broadcast reaches this process,
-    %% then call notify_drain and assert the message lands.
-    ok = ensure_pg_started(),
+notify_drain_reaches_registered_members_test() ->
+    %% Register this process in a running listener's drain registry so
+    %% the broadcast reaches it, then call notify_drain and assert the
+    %% message lands.
     Name = listener_test_notify_drain,
-    Group = {roadrunner_drain, Name},
-    ok = pg:join(Group, self()),
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0, routes => roadrunner_hello_handler
+    }),
     try
+        ok = roadrunner_listener:register_for_drain(Name, self()),
         Deadline = erlang:monotonic_time(millisecond) + 30000,
         ok = roadrunner_listener:notify_drain(Name, Deadline),
         receive
@@ -179,18 +181,31 @@ notify_drain_reaches_pg_members_test() ->
             ?assert(false)
         end
     after
-        ok = pg:leave(Group, self())
+        ok = roadrunner_listener:stop(Name)
     end.
 
 notify_drain_with_no_members_is_noop_test() ->
-    %% Empty group — just confirms the call returns ok and doesn't crash.
-    ok = ensure_pg_started(),
+    %% Empty registry — just confirms the call returns ok and doesn't crash.
+    Name = listener_test_notify_drain_empty,
+    {ok, _} = roadrunner_listener:start_link(Name, #{
+        port => 0, routes => roadrunner_hello_handler
+    }),
     ?assertEqual(
-        ok,
+        ok, roadrunner_listener:notify_drain(Name, erlang:monotonic_time(millisecond) + 30000)
+    ),
+    ok = roadrunner_listener:stop(Name).
+
+notify_drain_on_unknown_listener_exits_test() ->
+    %% Like any call into a listener that is not running.
+    ?assertExit(
+        {noproc, _},
         roadrunner_listener:notify_drain(
-            listener_test_notify_drain_empty,
-            erlang:monotonic_time(millisecond) + 30000
+            listener_test_notify_drain_missing, erlang:monotonic_time(millisecond) + 30000
         )
+    ),
+    ?assertExit(
+        {noproc, _},
+        roadrunner_listener:register_for_drain(listener_test_notify_drain_missing, self())
     ).
 
 %% =============================================================================
@@ -198,12 +213,11 @@ notify_drain_with_no_members_is_noop_test() ->
 %% =============================================================================
 
 slot_reconciliation_releases_sustained_orphan_slots_test() ->
-    %% With reconciliation enabled, an orphaned slot (counter > pg
-    %% members for two consecutive ticks) is reaped — simulates
+    %% With reconciliation enabled, an orphaned slot (counter > live
+    %% registered conns for two consecutive ticks) is reaped — simulates
     %% `kill`-bypasses-`terminate` recovery. Also asserts the
     %% `[roadrunner, listener, slots_reconciled]` telemetry event fires
     %% with the released count.
-    ok = ensure_pg_started(),
     {ok, _} = application:ensure_all_started(telemetry),
     Self = self(),
     HandlerId = make_ref(),
@@ -227,7 +241,7 @@ slot_reconciliation_releases_sustained_orphan_slots_test() ->
         ProtoOpts = element(4, State),
         Counter = maps:get(client_counter, ProtoOpts),
         ?assertEqual(0, counters:get(Counter, 1)),
-        %% Plant 3 orphan slots — bumped without a corresponding pg join.
+        %% Plant 3 orphan slots — bumped without a corresponding registration.
         ok = counters:add(Counter, 1, 3),
         ?assertEqual(3, counters:get(Counter, 1)),
         %% First tick at 30ms records prev_diff=3; second tick at 60ms
@@ -245,10 +259,11 @@ slot_reconciliation_releases_sustained_orphan_slots_test() ->
         telemetry:detach(HandlerId)
     end.
 
-slot_reconciliation_only_reaps_excess_over_pg_members_test() ->
-    %% Counter > pg members → only the diff is orphan; pg members
-    %% themselves represent live conns and must NOT be touched.
-    ok = ensure_pg_started(),
+slot_reconciliation_only_reaps_excess_over_live_members_test() ->
+    %% Counter > live members → only the diff is orphan; registered live
+    %% conns must NOT be touched, and a registered pid that has since
+    %% died counts for nothing (its slot is exactly what the reaper is
+    %% for).
     Name = listener_test_reap_partial,
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
         port => 0,
@@ -259,26 +274,33 @@ slot_reconciliation_only_reaps_excess_over_pg_members_test() ->
     State = sys:get_state(ListenerPid),
     ProtoOpts = element(4, State),
     Counter = maps:get(client_counter, ProtoOpts),
-    %% Plant 2 fake "live conn" pids in the drain group + bump
-    %% counter to 5. Diff = 5 - 2 = 3 orphans. After two ticks the
-    %% reaper should release 3, leaving counter at 2 (the live ones).
+    %% Plant 2 fake "live conn" pids in the registry, plus one that is
+    %% registered but already dead, and bump the counter to 5. Live diff
+    %% = 5 - 2 = 3 orphans. After two ticks the reaper should release 3,
+    %% leaving counter at 2 (the live ones), and drop the dead row.
     Stub1 = spawn(fun() ->
-        pg:join({roadrunner_drain, Name}, self()),
         receive
             stop -> ok
         end
     end),
     Stub2 = spawn(fun() ->
-        pg:join({roadrunner_drain, Name}, self()),
         receive
             stop -> ok
         end
     end),
-    %% Wait briefly for both joins to register.
-    timer:sleep(20),
+    ok = roadrunner_listener:register_for_drain(Name, Stub1),
+    ok = roadrunner_listener:register_for_drain(Name, Stub2),
+    Dead = spawn(fun() -> ok end),
+    DeadRef = monitor(process, Dead),
+    receive
+        {'DOWN', DeadRef, process, Dead, _} -> ok
+    end,
+    ok = roadrunner_listener:register_for_drain(Name, Dead),
     ok = counters:add(Counter, 1, 5),
     timer:sleep(200),
     ?assertEqual(2, counters:get(Counter, 1)),
+    Table = maps:get(drain_table, ProtoOpts),
+    ?assertEqual(lists:sort([{Stub1}, {Stub2}]), lists:sort(ets:tab2list(Table))),
     Stub1 ! stop,
     Stub2 ! stop,
     ok = roadrunner_listener:stop(Name).
@@ -733,7 +755,6 @@ listener_drops_unknown_info_message_test() ->
     ok = roadrunner_listener:stop(Name).
 
 slot_reconciliation_disabled_by_default_test() ->
-    ok = ensure_pg_started(),
     Name = listener_test_no_reap,
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
         port => 0, routes => roadrunner_hello_handler
@@ -867,7 +888,6 @@ drain(Sock) ->
 %% =============================================================================
 
 overload_mode_rejects_bad_config_test() ->
-    ok = ensure_pg_started(),
     Base = #{port => 0, routes => roadrunner_hello_handler, max_concurrent_requests => 4},
     %% Validation runs in `init/1`, so a bad opt comes back as a start
     %% error rather than an exception in the caller.
@@ -905,7 +925,6 @@ overload_mode_rejects_bad_config_test() ->
 %% `request_timeout` and `max_queued` from the ceiling, so the feature is
 %% usable without inventing numbers.
 overload_mode_queue_derives_its_knobs_test() ->
-    ok = ensure_pg_started(),
     Name = overload_queue_derived,
     {ok, _} = roadrunner_listener:start_link(Name, #{
         port => 0,
@@ -922,7 +941,6 @@ overload_mode_queue_derives_its_knobs_test() ->
     ok = roadrunner_listener:stop(Name).
 
 overload_mode_queue_starts_a_listener_test() ->
-    ok = ensure_pg_started(),
     Name = overload_queue_ok,
     {ok, _} = roadrunner_listener:start_link(Name, #{
         port => 0,
@@ -946,7 +964,6 @@ overload_mode_queue_starts_a_listener_test() ->
 drain_with_no_active_conns_returns_immediately_test_() ->
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_drain_idle,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0, routes => roadrunner_hello_handler
@@ -964,7 +981,6 @@ drain_with_no_active_conns_returns_immediately_test_() ->
 drain_waits_for_in_flight_loop_to_close_test_() ->
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_drain_loop,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -992,7 +1008,6 @@ drain_waits_for_in_flight_loop_to_close_test_() ->
 drain_timeout_kills_unresponsive_conns_test_() ->
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_drain_kill,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -1019,7 +1034,6 @@ drain_timeout_kills_unresponsive_conns_test_() ->
 drain_closes_conn_stalled_mid_body_test_() ->
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_drain_body,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -1063,7 +1077,6 @@ drain_closes_conn_stalled_mid_body_test_() ->
 drain_closes_keep_alive_conn_after_in_flight_request_test_() ->
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_drain_ka,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0, routes => roadrunner_drain_pause_handler
@@ -1082,12 +1095,12 @@ drain_closes_keep_alive_conn_after_in_flight_request_test_() ->
                 %% message in its mailbox and closes without trying
                 %% to read a second keep-alive request.
                 ok = gen_tcp:send(Sock, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
-                %% Brief warm-up so the conn has joined the `pg` drain
-                %% group before drain queries members. The acceptor
+                %% Brief warm-up so the conn has registered in the drain
+                %% registry before drain queries members. The acceptor
                 %% bumps the live-clients counter before spawning the
                 %% conn; without this sleep, drain can observe
-                %% counter=1 / pg=empty on a slow scheduler and time
-                %% out before the handler's 150ms sleep finishes.
+                %% counter=1 / registry=empty on a slow scheduler and
+                %% time out before the handler's 150ms sleep finishes.
                 timer:sleep(20),
                 Self = self(),
                 spawn_link(fun() ->
@@ -1161,7 +1174,6 @@ unreachable_route_stops_the_listener_from_starting_test_() ->
 reload_routes_swaps_dispatch_table_test_() ->
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_reload,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -1191,7 +1203,6 @@ reload_routes_refuses_an_unworkable_table_test_() ->
     %% table already published, so the running one is left exactly as it was.
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_reload_reject,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -1234,7 +1245,6 @@ reload_routes_rebakes_listener_middlewares_test_() ->
     %% middlewares on reloaded routes.
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_reload_listener_mws,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0,
@@ -1395,7 +1405,6 @@ drain_close(Sock, Acc) ->
 status_returns_phase_test_() ->
     {setup,
         fun() ->
-            ok = ensure_pg_started(),
             Name = listener_test_status,
             {ok, _} = roadrunner_listener:start_link(Name, #{
                 port => 0, routes => roadrunner_hello_handler
@@ -1413,15 +1422,6 @@ status_returns_phase_test_() ->
                 ?assertEqual(accepting, roadrunner_listener:status(Name))
             end}
         end}.
-
-ensure_pg_started() ->
-    case whereis(pg) of
-        undefined ->
-            {ok, _} = pg:start_link(),
-            ok;
-        _ ->
-            ok
-    end.
 
 %% gen_server replies to `drain/2` *before* `terminate/2` finishes, so
 %% there's a brief window where `whereis/1` still returns the pid even

--- a/test/roadrunner_proxy_protocol_tests.erl
+++ b/test/roadrunner_proxy_protocol_tests.erl
@@ -204,8 +204,8 @@ proxy_request(Header, Request) ->
     end).
 
 %% Stand up a real listener directly (no app start/stop, mirroring
-%% roadrunner_compress_tests) so concurrent test modules don't race on the
-%% shared `pg` scope.
+%% roadrunner_compress_tests) so concurrent test modules don't race on
+%% the application's start and stop.
 with_listener(Fun) ->
     Name = list_to_atom("proxy_it_" ++ integer_to_list(erlang:unique_integer([positive]))),
     {ok, _} = roadrunner_listener:start_link(Name, #{

--- a/test/roadrunner_quic_listener_SUITE.erl
+++ b/test/roadrunner_quic_listener_SUITE.erl
@@ -56,9 +56,6 @@ all() ->
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
     {ok, _} = application:ensure_all_started(ssl),
-    %% The default `pg` scope hosts a connection owner's drain group; start it
-    %% unlinked so it outlives this transient process.
-    ok = ensure_pg_started(),
     Config.
 
 end_per_suite(_Config) ->
@@ -405,17 +402,3 @@ cert_key() ->
     {cert, CertDer} = lists:keyfind(cert, 1, Opts),
     {key, {KeyType, KeyDer}} = lists:keyfind(key, 1, Opts),
     {[CertDer], public_key:der_decode(KeyType, KeyDer)}.
-
-ensure_pg_started() ->
-    case whereis(pg) of
-        undefined ->
-            case pg:start_link() of
-                {ok, Pid} ->
-                    _ = unlink(Pid),
-                    ok;
-                {error, {already_started, _}} ->
-                    ok
-            end;
-        _ ->
-            ok
-    end.

--- a/test/roadrunner_quic_listener_sup_SUITE.erl
+++ b/test/roadrunner_quic_listener_sup_SUITE.erl
@@ -36,9 +36,6 @@ all() ->
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
     {ok, _} = application:ensure_all_started(ssl),
-    %% The default `pg` scope hosts a connection owner's drain group; start it
-    %% unlinked so it outlives this transient process.
-    ok = ensure_pg_started(),
     Config.
 
 end_per_suite(_Config) ->
@@ -166,17 +163,3 @@ cert_key() ->
     {cert, CertDer} = lists:keyfind(cert, 1, Opts),
     {key, {KeyType, KeyDer}} = lists:keyfind(key, 1, Opts),
     {CertDer, [], public_key:der_decode(KeyType, KeyDer)}.
-
-ensure_pg_started() ->
-    case whereis(pg) of
-        undefined ->
-            case pg:start_link() of
-                {ok, Pid} ->
-                    _ = unlink(Pid),
-                    ok;
-                {error, {already_started, _}} ->
-                    ok
-            end;
-        _ ->
-            ok
-    end.

--- a/test/roadrunner_quic_test_h3_SUITE.erl
+++ b/test/roadrunner_quic_test_h3_SUITE.erl
@@ -17,10 +17,7 @@ all() ->
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
     {ok, _} = application:ensure_all_started(ssl),
-    %% The h3 listener's drain group lives in the default `pg` scope; start it
-    %% unlinked so it outlives this transient process. Neither the native
-    %% server nor the native client needs the `quic` app.
-    ok = ensure_pg_started(),
+    %% Neither the native server nor the native client needs the `quic` app.
     Config.
 
 end_per_suite(_Config) ->
@@ -64,17 +61,3 @@ native_client_post(Config) ->
 %% =============================================================================
 %% Helpers
 %% =============================================================================
-
-ensure_pg_started() ->
-    case whereis(pg) of
-        undefined ->
-            case pg:start_link() of
-                {ok, Pid} ->
-                    _ = unlink(Pid),
-                    ok;
-                {error, {already_started, _}} ->
-                    ok
-            end;
-        _ ->
-            ok
-    end.

--- a/test/roadrunner_telemetry_tests.erl
+++ b/test/roadrunner_telemetry_tests.erl
@@ -109,10 +109,6 @@ request_rejected_event_fires_on_bad_request_line_test() ->
     %% `[roadrunner, request, rejected]` with the parser's reason atom so
     %% ops tooling can track protocol-attack-shaped traffic.
     {ok, _} = application:ensure_all_started(telemetry),
-    case whereis(pg) of
-        undefined -> {ok, _} = pg:start_link();
-        _ -> ok
-    end,
     HandlerId = attach([[roadrunner, request, rejected]]),
     try
         Self = self(),


### PR DESCRIPTION
# Description

Connections register for drain in a per-listener ETS table instead of joining one `pg` scope: `roadrunner_conn:register_for_drain/1` is a lock-free insert at conn start, `unregister_for_drain/1` the delete on every exit path, and `roadrunner_listener:drain/2`, `notify_drain/2` and the slot reconciler read the table. Under a connect burst 512 simultaneous `pg:join` calls queued 3 to 4 ms behind the scope process; the inserts take 6 to 16 µs each. The supervisor no longer starts the default `pg` scope, the by-name entry points (`notify_drain/2`, the new `roadrunner_listener:register_for_drain/2`) are calls into the listener and exit with `noproc` when it is not running, and the reconciler now also drops the rows of killed connections; the `slots_reconciled` metadata key `pg_count_bounded` is now `live_conns_bounded`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
