### PR TITLE
Read the PROXY header before the TLS handshake on TLS listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   `keep_alive_timeout`, `min_bytes_per_second`, `max_keep_alive_requests`,
   `rate_limit` (opt-in per-peer request-rate guard)
 - **Real client IP**: `proxy_protocol` (read the PROXY-protocol header an
-  L4 balancer prepends, so `roadrunner_req:peer/1` is the real client)
+  L4 balancer prepends, on plain and TLS listeners alike, so
+  `roadrunner_req:peer/1` is the real client)
 - **Bind address**: `ip` (restrict a listener to a specific local
   interface, e.g. `{127,0,0,1}` for loopback-only; default binds all
   interfaces)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,22 +242,6 @@ lot of them.
 
 ## Other
 
-### PROXY protocol on TLS listeners reads the header after the handshake
-
-**What:** `proxy_protocol => true` is accepted on TLS listeners, but the
-conn reads the PROXY header only after the TLS handshake, from the
-decrypted stream. An L4 balancer prepends that header in plaintext before
-the ClientHello, so on TLS the handshake sees the header instead of a
-hello and fails. The header has to be read from the raw TCP socket
-first. With the handshake now running in the conn process at `shoot`,
-the two stages sit next to each other and can simply be swapped.
-
-**Why deferred:** surfaced while auditing the handshake move; no
-listener in the test suite combines the two options, and the swap wants
-a fixture that speaks PROXY-then-TLS.
-
-**Scope:** small.
-
 ### Connection-process memory tuning follow-ups
 
 **What:** The `handler_spawn` listener opt already exposes the full

--- a/rebar.config
+++ b/rebar.config
@@ -92,6 +92,7 @@
         {"test/roadrunner_http2_flow_control_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_http3_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_tls_handshake_SUITE.erl", unnecessary_function_arguments},
+        {"test/roadrunner_proxy_protocol_tls_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_socket_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_test_conn_SUITE.erl", unnecessary_function_arguments},
         {"test/roadrunner_quic_test_h3_SUITE.erl", unnecessary_function_arguments},

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -175,6 +175,12 @@ deadline in milliseconds.
     %% the request peer is the real client. TCP-only; the listener rejects it on
     %% an HTTP/3-only listener.
     proxy_protocol => boolean(),
+    %% TLS options for a TLS listener that also reads the PROXY protocol: it
+    %% accepts plain TCP (the header comes before any TLS bytes) and the conn
+    %% upgrades each socket with these once the header is in. Absent on every
+    %% other listener; a TLS listener without the PROXY protocol handshakes
+    %% the socket `ssl:listen` accepted.
+    tls_upgrade => [ssl:tls_server_option()],
     %% Enabled protocols as a flat atom list in user-supplied (ALPN
     %% preference) order. On plain TCP with `[http2]`,
     %% `roadrunner_conn_loop:awaiting_shoot/3` routes straight to the

--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -187,51 +187,32 @@ init_loop(Parent, Socket, ProtoOpts) ->
 awaiting_shoot(Socket0, ProtoOpts, ListenerName) ->
     receive
         shoot ->
-            %% Socket ownership has just transferred from the acceptor. On a
-            %% TLS listener the socket arrives pre-handshake: the handshake
-            %% runs here, in the connection it belongs to, so a slow or
-            %% silent peer costs only this process and never parks an
-            %% acceptor (see `roadrunner_transport:handshake/2`). Plain TCP
-            %% passes straight through.
-            #{tls_handshake_timeout := HsTimeout} = ProtoOpts,
-            ok = label_handshake(Socket0, ListenerName),
-            case roadrunner_transport:handshake(Socket0, HsTimeout) of
-                {ok, Socket} ->
-                    %% If the listener enabled the PROXY protocol, read and
-                    %% strip the header an L4 balancer prepended so we serve
-                    %% the real client peer; otherwise the OS peer passes
-                    %% through unchanged.
-                    OsPeer = roadrunner_conn:peer(Socket),
-                    case proxy_protocol_stage(Socket, ProtoOpts, OsPeer) of
-                        {ok, Peer, Buffered} ->
+            %% Socket ownership has just transferred from the acceptor. Three
+            %% things happen before the first request is read, in this order.
+            %% If the listener enabled the PROXY protocol, the header an L4
+            %% balancer prepended is read off the raw stream first, because it
+            %% arrives in plaintext before any TLS bytes. Then, on a TLS
+            %% listener, the handshake runs here, in the connection it belongs
+            %% to, so a slow or silent peer costs only this process and never
+            %% parks an acceptor (see `roadrunner_transport:handshake/2,3`);
+            %% plain TCP passes straight through. Then the peer is served.
+            OsPeer = roadrunner_conn:peer(Socket0),
+            case proxy_protocol_stage(Socket0, ProtoOpts, OsPeer) of
+                {ok, Peer, Buffered} ->
+                    ok = label_handshake(Socket0, ProtoOpts, ListenerName),
+                    case tls_handshake(Socket0, ProtoOpts) of
+                        {ok, Socket} ->
                             serve(Socket, ProtoOpts, ListenerName, Peer, Buffered);
-                        close ->
-                            %% Malformed/absent PROXY header on a proxy_protocol
-                            %% listener (a misconfigured upstream). No accept
-                            %% telemetry has fired yet (it pairs with the real
-                            %% peer in serve/5), so release the slot and close
-                            %% silently, like the pre-`shoot` drain path below.
-                            exit_clean(
-                                Socket, ProtoOpts, undefined, undefined, ListenerName, 0, normal
-                            )
+                        {error, {handshake, _} = Reason} ->
+                            handshake_failed(ProtoOpts, ListenerName, Reason)
                     end;
-                {error, {handshake, _} = Reason} ->
-                    %% A garbage ClientHello, a TLS alert, a peer gone
-                    %% mid-handshake, or the `tls_handshake_timeout` bound —
-                    %% routine noise on an internet-facing TLS port. Surface
-                    %% it as the same accept_error event the acceptor pool
-                    %% emits for its own failures, then release the slot. No
-                    %% accept telemetry has fired (it pairs with the peer in
-                    %% serve/5), so no conn_close either. The socket is not
-                    %% closed here: `handshake/2` already closed a timed-out
-                    %% one, and on any other failure `ssl` tore the
-                    %% connection down itself.
-                    ok = roadrunner_telemetry:listener_accept_error(#{
-                        listener_name => ListenerName, reason => Reason
-                    }),
-                    ok = roadrunner_conn:unregister_for_drain(ProtoOpts),
-                    ok = roadrunner_conn:release_slot(ProtoOpts),
-                    exit(normal)
+                close ->
+                    %% Malformed/absent PROXY header on a proxy_protocol
+                    %% listener (a misconfigured upstream). No accept telemetry
+                    %% has fired yet (it pairs with the real peer in serve/5),
+                    %% so release the slot and close silently, like the
+                    %% pre-`shoot` drain path below.
+                    exit_clean(Socket0, ProtoOpts, undefined, undefined, ListenerName, 0, normal)
             end;
         {roadrunner_drain, _Deadline} ->
             %% Drain before `shoot` — no telemetry was fired yet (accept
@@ -245,16 +226,46 @@ awaiting_shoot(Socket0, ProtoOpts, ListenerName) ->
             awaiting_shoot(Socket0, ProtoOpts, ListenerName)
     end.
 
+%% A TLS listener behind a PROXY-protocol balancer accepts plain TCP and
+%% carries the TLS options in `tls_upgrade`; every other TLS listener hands
+%% out a pre-handshake `ssl` socket. Plain TCP passes through unchanged.
+-spec tls_handshake(roadrunner_transport:socket(), roadrunner_conn:proto_opts()) ->
+    {ok, roadrunner_transport:socket()} | {error, {handshake, term()}}.
+tls_handshake(Socket, #{tls_upgrade := TlsOpts, tls_handshake_timeout := HsTimeout}) ->
+    roadrunner_transport:handshake(Socket, TlsOpts, HsTimeout);
+tls_handshake(Socket, #{tls_handshake_timeout := HsTimeout}) ->
+    roadrunner_transport:handshake(Socket, HsTimeout).
+
+-spec handshake_failed(roadrunner_conn:proto_opts(), atom(), {handshake, term()}) -> no_return().
+handshake_failed(ProtoOpts, ListenerName, Reason) ->
+    %% A garbage ClientHello, a TLS alert, a peer gone mid-handshake, or the
+    %% `tls_handshake_timeout` bound — routine noise on an internet-facing
+    %% TLS port. Surface it as the same accept_error event the acceptor pool
+    %% emits for its own failures, then release the slot. No accept
+    %% telemetry has fired (it pairs with the peer in serve/5), so no
+    %% conn_close either. The socket is not closed here: `handshake/2`
+    %% already closed a timed-out one, and on any other failure (every
+    %% failure, for the `handshake/3` upgrade) `ssl` tore the connection
+    %% down itself.
+    ok = roadrunner_telemetry:listener_accept_error(#{
+        listener_name => ListenerName, reason => Reason
+    }),
+    ok = roadrunner_conn:unregister_for_drain(ProtoOpts),
+    ok = roadrunner_conn:release_slot(ProtoOpts),
+    exit(normal).
+
 %% The handshake is the one pre-serve phase that can block for a while (up
 %% to `tls_handshake_timeout` on a silent peer), so a TLS conn is relabelled
 %% for its duration; `refine_conn_label/2` takes over once the peer is being
-%% served. Plain TCP has no handshake and keeps the `awaiting_shoot` label
-%% until then.
--spec label_handshake(roadrunner_transport:socket(), atom()) -> ok.
-label_handshake(Socket, ListenerName) ->
-    case roadrunner_conn:scheme(Socket) of
-        https -> proc_lib:set_label({roadrunner_conn, tls_handshake, ListenerName});
-        http -> ok
+%% served. A TLS conn is either a pre-handshake `ssl` socket or, behind a
+%% PROXY-protocol balancer, a plain socket about to be upgraded. Plain TCP
+%% has no handshake and keeps the `awaiting_shoot` label until then.
+-spec label_handshake(roadrunner_transport:socket(), roadrunner_conn:proto_opts(), atom()) ->
+    ok.
+label_handshake(Socket, ProtoOpts, ListenerName) ->
+    case is_map_key(tls_upgrade, ProtoOpts) orelse roadrunner_conn:scheme(Socket) =:= https of
+        true -> proc_lib:set_label({roadrunner_conn, tls_handshake, ListenerName});
+        false -> ok
     end.
 
 %% Begin serving a connection once the peer is settled (the real client when
@@ -330,22 +341,104 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
 %% `{ok, Peer, Leftover}` — the real client peer on a PROXY command, the OS peer
 %% on a LOCAL/UNKNOWN one — or `close` on a malformed header or read error. With
 %% the opt off the OS peer passes straight through and no bytes are read.
+%%
+%% On a TLS listener (`tls_upgrade` set) the header is followed by the
+%% ClientHello, and bytes read past the header cannot be handed back to `ssl`,
+%% so the header is read exactly and `Leftover` is always empty. On plain TCP
+%% whatever arrived with the header is kept as the start of the first request.
 -spec proxy_protocol_stage(
     roadrunner_transport:socket(),
     roadrunner_conn:proto_opts(),
     {inet:ip_address(), inet:port_number()} | undefined
 ) -> {ok, {inet:ip_address(), inet:port_number()} | undefined, binary()} | close.
-proxy_protocol_stage(Socket, #{proxy_protocol := ProxyProto} = ProtoOpts, OsPeer) ->
-    case ProxyProto of
-        false -> {ok, OsPeer, <<>>};
-        true -> read_proxy_header(Socket, ProtoOpts, OsPeer, <<>>)
+proxy_protocol_stage(_Socket, #{proxy_protocol := false}, OsPeer) ->
+    {ok, OsPeer, <<>>};
+proxy_protocol_stage(
+    Socket, #{proxy_protocol := true, tls_upgrade := _, tls_handshake_timeout := Timeout}, OsPeer
+) ->
+    %% The header read is connection setup like the handshake that follows
+    %% it, so it shares the handshake bound rather than `request_timeout`:
+    %% a peer that connects and sends nothing holds its slot no longer here
+    %% than on a TLS listener without the PROXY protocol.
+    case read_proxy_header_exact(Socket, Timeout) of
+        {ok, Peer, <<>>} -> {ok, Peer, <<>>};
+        {local, <<>>} -> {ok, OsPeer, <<>>};
+        {error, _Reason} -> close
+    end;
+proxy_protocol_stage(Socket, #{proxy_protocol := true} = ProtoOpts, OsPeer) ->
+    read_proxy_header(Socket, ProtoOpts, OsPeer, <<>>).
+
+%% A v1 header (CRLF included) never exceeds 107 bytes (HAProxy spec §2.1).
+-define(PROXY_V1_MAX, 107).
+
+%% Exact read for the TLS case. Six bytes tell v1 (`PROXY `) from v2 (the
+%% first six bytes of its signature); a v2 prefix then declares the length of
+%% the rest, while a v1 line is read in one call with the socket in `line`
+%% packet mode, bounded at the spec's 107 bytes.
+-spec read_proxy_header_exact(roadrunner_transport:socket(), timeout()) ->
+    {ok, {inet:ip_address(), inet:port_number()}, binary()}
+    | {local, binary()}
+    | more
+    | {error, term()}.
+read_proxy_header_exact(Socket, Timeout) ->
+    maybe
+        {ok, Head} ?= roadrunner_transport:recv(Socket, 6, Timeout),
+        {ok, Header} ?= read_proxy_header_rest(Head, Socket, Timeout),
+        roadrunner_proxy_protocol:parse(Header)
     end.
 
-%% The socket is passive at this phase, so read synchronously, accumulating
-%% until `roadrunner_proxy_protocol:parse/1` decides. The parser bounds the
-%% header size (v1 107 bytes, v2 by its declared length), so `Acc` cannot grow
-%% without bound, and each recv carries the per-request timeout against a
-%% dribbling sender.
+-spec read_proxy_header_rest(binary(), roadrunner_transport:socket(), timeout()) ->
+    {ok, binary()} | {error, term()}.
+read_proxy_header_rest(~"PROXY ", Socket, Timeout) ->
+    read_proxy_v1_line(Socket, Timeout);
+read_proxy_header_rest(Head, Socket, Timeout) ->
+    maybe
+        {ok, Rest} ?= roadrunner_transport:recv(Socket, 10, Timeout),
+        Prefix = <<Head/binary, Rest/binary>>,
+        {ok, Len} ?= roadrunner_proxy_protocol:v2_body_length(Prefix),
+        {ok, Body} ?= recv_exact(Socket, Len, Timeout),
+        {ok, <<Prefix/binary, Body/binary>>}
+    end.
+
+%% `recv(_, 0, _)` would return whatever is buffered, which here could be the
+%% first bytes of the ClientHello; a header with no address block has nothing
+%% more to read.
+-spec recv_exact(roadrunner_transport:socket(), non_neg_integer(), timeout()) ->
+    {ok, binary()} | {error, term()}.
+recv_exact(_Socket, 0, _Timeout) ->
+    {ok, <<>>};
+recv_exact(Socket, Len, Timeout) ->
+    roadrunner_transport:recv(Socket, Len, Timeout).
+
+%% The rest of a v1 line after `PROXY `, up to and including its LF, in one
+%% read: `{packet, line}` makes the driver stop at the newline, so the
+%% ClientHello behind it stays buffered for the upgrade, and `packet_size`
+%% caps the line at the spec's bound (a longer one fails with `emsgsize`).
+%% Raw mode is restored either way; on a failure the conn closes anyway.
+-spec read_proxy_v1_line(roadrunner_transport:socket(), timeout()) ->
+    {ok, binary()} | {error, term()}.
+read_proxy_v1_line(Socket, Timeout) ->
+    ok = roadrunner_transport:setopts(Socket, [{packet, line}, {packet_size, ?PROXY_V1_MAX - 6}]),
+    Result = roadrunner_transport:recv(Socket, 0, Timeout),
+    ok = roadrunner_transport:setopts(Socket, [{packet, raw}, {packet_size, 0}]),
+    case Result of
+        {ok, Line} when
+            byte_size(Line) >= 2, binary_part(Line, byte_size(Line) - 2, 2) =:= ~"\r\n"
+        ->
+            {ok, <<"PROXY ", Line/binary>>};
+        {ok, _LfOnly} ->
+            %% The spec's line ends in CRLF; a bare LF is not a header.
+            {error, v1_malformed};
+        {error, _} = E ->
+            E
+    end.
+
+%% Plain TCP: the socket is passive at this phase, so read synchronously,
+%% accumulating until `roadrunner_proxy_protocol:parse/1` decides. The parser
+%% bounds the header size (v1 107 bytes, v2 by its declared length), so `Acc`
+%% cannot grow without bound, and each recv carries the per-request timeout
+%% against a dribbling sender. Over-reading is fine here: leftover bytes are
+%% the start of the first request and are threaded into its parse.
 -spec read_proxy_header(
     roadrunner_transport:socket(),
     roadrunner_conn:proto_opts(),

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -131,7 +131,9 @@ Optional middleware and timing knobs (durations in milliseconds):
   acceptor, so a slow or silent peer never blocks other connections
   from being accepted; one that exceeds the bound is closed and
   reported as a per-connection `{handshake, timeout}` accept error,
-  releasing its `max_clients` slot. Default 5 s.
+  releasing its `max_clients` slot. On a TLS listener that also reads
+  the PROXY protocol, the same bound covers the header read that
+  precedes the handshake. Default 5 s.
 - `keep_alive_timeout` — idle timeout between requests on a
   keep-alive conn. Default 60 s.
 - `num_acceptors` — size of the acceptor pool. Default 10.
@@ -324,9 +326,12 @@ ops-tuning rationale.
     graceful_drain => boolean(),
     %% Opt in to the PROXY protocol (HAProxy v1 text / v2 binary). When `true`,
     %% the connection reads and strips the header an L4 balancer prepends before
-    %% the first byte, so `roadrunner_req:peer/1` is the real client. TCP-only:
-    %% rejected on an HTTP/3-only listener. Trust it only behind a balancer that
-    %% always prepends the header (otherwise a direct peer can spoof its IP).
+    %% the first byte, so `roadrunner_req:peer/1` is the real client. On a TLS
+    %% listener the header is read from the plain socket before the TLS
+    %% handshake: the listener accepts plain TCP and upgrades each connection
+    %% once the header is in. TCP-only: rejected on an HTTP/3-only listener.
+    %% Trust it only behind a balancer that always prepends the header
+    %% (otherwise a direct peer can spoof its IP).
     proxy_protocol => boolean(),
     %% Opt in to a per-peer request-rate guard keyed on the client IP. A map
     %% `#{rate := pos_integer()}` (requests allowed per `period`, required) with
@@ -1060,6 +1065,12 @@ listener_name() ->
 -spec open_listen_socket(
     inet:port_number(), opts(), [http1 | http2, ...]
 ) -> {ok, roadrunner_transport:socket()} | {error, term()}.
+open_listen_socket(Port, #{tls := _, proxy_protocol := true} = Opts, _Protocols) ->
+    %% TLS behind a PROXY-protocol balancer: the header arrives in plaintext
+    %% before the ClientHello, so the listen socket is plain TCP and the conn
+    %% reads the header off the raw stream, then upgrades the socket with the
+    %% `tls_upgrade` options carried in proto_opts (`maybe_tls_upgrade/3`).
+    roadrunner_transport:listen(Port, base_listen_opts(Opts));
 open_listen_socket(Port, #{tls := UserTlsOpts} = Opts, Protocols) ->
     %% TLS path — caller supplies cert/key. ALPN is derived from the
     %% normalized `protocols` list (`http2` → `~"h2"`, `http1` →
@@ -1154,10 +1165,6 @@ spawn_acceptors_loop(LSocket, ProtoOpts, I, N) ->
     {ok, _Pid} = roadrunner_acceptor:start_link(LSocket, ProtoOpts, I),
     spawn_acceptors_loop(LSocket, ProtoOpts, I + 1, N).
 
-%% Validate the opt-in `proxy_protocol` listener opt. It is a TCP-stream
-%% feature (an L4 balancer prepends the header before the first byte), so it
-%% conflicts with an HTTP/3-only (UDP) listener; on a mixed `[http1, http3]`
-%% listener the TCP side honors it and h3 ignores it.
 %% Queue mode only means something when there is a ceiling to queue
 %% behind, so asking for it without `max_concurrent_requests` is a
 %% configuration error rather than a silent no-op.
@@ -1203,6 +1210,28 @@ setup_overload({queue, #{max_queued := MaxQueued, timeout := Timeout}}, Max, Cou
     {ok, Pid} = roadrunner_overload_queue:start_link(Max, Counter, MaxQueued),
     {queue, Pid, roadrunner_overload_queue:waiters_ref(Pid), Timeout}.
 
+%% A TLS listener that also reads the PROXY protocol cannot hand its
+%% sockets out through `ssl:listen`: the header arrives in plaintext before
+%% the ClientHello and has to come off the raw socket first. Such a
+%% listener accepts plain TCP (`open_listen_socket/3`) and the connection
+%% process upgrades each socket with these options once the header is in
+%% (`roadrunner_conn_loop:awaiting_shoot/3`). Every other listener leaves
+%% the key out, so the `ssl:listen` path is untouched.
+-spec maybe_tls_upgrade(
+    roadrunner_conn:proto_opts(), opts(), [http1 | http2 | http3, ...]
+) -> roadrunner_conn:proto_opts().
+maybe_tls_upgrade(#{proxy_protocol := true} = ProtoOpts, #{tls := UserTlsOpts}, Protocols) ->
+    TcpProtocols = [P || P <- Protocols, P =/= http3],
+    ProtoOpts#{tls_upgrade => roadrunner_transport:build_tls_opts(TcpProtocols, UserTlsOpts)};
+maybe_tls_upgrade(ProtoOpts, _Opts, _Protocols) ->
+    ProtoOpts.
+
+%% Validate the opt-in `proxy_protocol` listener opt. It is a TCP-stream
+%% feature (an L4 balancer prepends the header before the first byte), so it
+%% conflicts with an HTTP/3-only (UDP) listener; on a mixed `[http1, http3]`
+%% listener the TCP side honors it and h3 ignores it. On a TLS listener the
+%% header precedes the ClientHello, which is why such a listener accepts
+%% plain TCP and upgrades per connection (`maybe_tls_upgrade/3`).
 -spec validate_proxy_protocol(term(), [http1 | http2 | http3, ...]) -> boolean().
 validate_proxy_protocol(false, _Protocols) ->
     false;
@@ -1328,6 +1357,7 @@ build_proto_opts(Opts, ListenerName) ->
         }),
         ProtoFlats
     ),
+    WithTlsUpgrade = maybe_tls_upgrade(Base, Opts, Protocols),
     WithHibernate =
         %% Optional `hibernate_after` — `roadrunner_conn_loop` reads it
         %% from proto_opts and routes the recv path through
@@ -1338,9 +1368,9 @@ build_proto_opts(Opts, ListenerName) ->
         %% conns where the heap-shrink win dominates.
         case Opts of
             #{hibernate_after := Ms} when is_integer(Ms), Ms > 0 ->
-                Base#{hibernate_after => Ms};
+                WithTlsUpgrade#{hibernate_after => Ms};
             #{} ->
-                Base
+                WithTlsUpgrade
         end,
     %% Optional `rate_check_interval` — the rate-check timer
     %% interval inside `reading_request`. Default 1000ms; ops can

--- a/src/roadrunner_proxy_protocol.erl
+++ b/src/roadrunner_proxy_protocol.erl
@@ -26,7 +26,7 @@
 %% address-family/transport byte, a 16-bit address-block length, then the
 %% addresses (and optional TLVs, which we skip).
 
--export([parse/1]).
+-export([parse/1, v2_body_length/1]).
 
 -on_load(init_patterns/0).
 
@@ -62,6 +62,18 @@ parse(Bin) ->
         true -> more;
         false -> {error, not_proxy_header}
     end.
+
+-doc """
+Length of the address block a 16-byte v2 header prefix declares, for a
+caller that must not read past the header and so fetches exactly the
+rest (`{ok, 0}` when there is no address block). `{error,
+not_proxy_header}` if the prefix does not open with the v2 signature.
+""".
+-spec v2_body_length(binary()) -> {ok, non_neg_integer()} | {error, not_proxy_header}.
+v2_body_length(<<?V2_SIG, _VerCmd, _FamTrans, Len:16>>) ->
+    {ok, Len};
+v2_body_length(_) ->
+    {error, not_proxy_header}.
 
 %% =============================================================================
 %% v1 (text)

--- a/src/roadrunner_transport.erl
+++ b/src/roadrunner_transport.erl
@@ -44,6 +44,7 @@
     listen_tls/2,
     accept/1,
     handshake/2,
+    handshake/3,
     controlling_process/2,
     recv/3,
     send/2,
@@ -82,7 +83,8 @@ the `ssl` application is started (typically `application:ensure_all_started(ssl)
 
 `Opts` is the list passed to `ssl:listen/2` — `cert`, `key`/`keyfile`,
 `cacerts`, etc. Performs the TCP listen + TLS context bind in one call;
-each `accept/2` then runs the per-connection handshake.
+each socket `accept/1` hands out then completes its handshake in its
+connection process via `handshake/2`.
 """.
 -spec listen_tls(inet:port_number(), [ssl:tls_server_option() | gen_tcp:listen_option()]) ->
     {ok, socket()} | {error, term()}.
@@ -147,6 +149,26 @@ handshake({ssl, Pre}, HandshakeTimeout) ->
     end;
 handshake(Socket, _HandshakeTimeout) ->
     {ok, Socket}.
+
+-doc """
+Upgrade a plain TCP socket from `accept/1` to TLS with a server-side
+handshake, bounded by `HandshakeTimeout` ms. This is the path a TLS
+listener with `proxy_protocol => true` takes: it listens on plain TCP so
+the connection process can read the PROXY header off the raw stream
+first, then upgrades with the listener's TLS options (`TlsOpts`, as
+`build_tls_opts/2` produces them).
+
+Failures come back as `{error, {handshake, Reason}}` like `handshake/2`.
+Unlike the pre-accepted form, `ssl` closes the TCP socket itself on
+every failure here, `timeout` included, so nothing is left to close.
+""".
+-spec handshake(socket(), [ssl:tls_server_option()], timeout()) ->
+    {ok, socket()} | {error, {handshake, term()}}.
+handshake({gen_tcp, S}, TlsOpts, HandshakeTimeout) ->
+    case ssl:handshake(S, TlsOpts, HandshakeTimeout) of
+        {ok, Ssl} -> {ok, {ssl, Ssl}};
+        {error, HsReason} -> {error, {handshake, HsReason}}
+    end.
 
 -doc "Hand the controlling process for the underlying socket.".
 -spec controlling_process(socket(), pid()) -> ok | {error, term()}.

--- a/test/roadrunner_acceptor_tests.erl
+++ b/test/roadrunner_acceptor_tests.erl
@@ -194,6 +194,7 @@ acceptor_hands_tls_sockets_off_before_the_handshake_test() ->
         #{
             listener_name => acceptor_test_tls_noise,
             tls_handshake_timeout => 5000,
+            proxy_protocol => false,
             client_counter => Counter,
             max_clients => 10,
             graceful_drain => false,

--- a/test/roadrunner_proxy_protocol_tests.erl
+++ b/test/roadrunner_proxy_protocol_tests.erl
@@ -143,6 +143,23 @@ partial_v2_signature_is_more_test() ->
 not_a_proxy_header_test() ->
     ?assertEqual({error, not_proxy_header}, ?M:parse(<<"GET / HTTP/1.1\r\n">>)).
 
+v2_body_length_reads_the_declared_length_test() ->
+    Hdr = v2(2, 1, 1, 1, <<203, 0, 113, 9, 10, 0, 0, 1, 5000:16, 443:16>>),
+    <<Prefix:16/binary, _/binary>> = Hdr,
+    ?assertEqual({ok, 12}, roadrunner_proxy_protocol:v2_body_length(Prefix)),
+    <<Empty:16/binary>> = v2(2, 0, 0, 0, <<>>),
+    ?assertEqual({ok, 0}, roadrunner_proxy_protocol:v2_body_length(Empty)).
+
+v2_body_length_rejects_other_prefixes_test() ->
+    ?assertEqual(
+        {error, not_proxy_header},
+        roadrunner_proxy_protocol:v2_body_length(<<"PROXY TCP4 1.2.3.4 5">>)
+    ),
+    ?assertEqual(
+        {error, not_proxy_header},
+        roadrunner_proxy_protocol:v2_body_length(<<"GET / HTTP/1.1\r\n">>)
+    ).
+
 %% --- end-to-end: a real listener with proxy_protocol => true overrides the
 %% request peer with the address the PROXY header reports ---
 

--- a/test/roadrunner_proxy_protocol_tls_SUITE.erl
+++ b/test/roadrunner_proxy_protocol_tls_SUITE.erl
@@ -1,0 +1,276 @@
+-module(roadrunner_proxy_protocol_tls_SUITE).
+-moduledoc """
+PROXY protocol in front of TLS.
+
+An L4 balancer prepends its PROXY header in plaintext before the
+ClientHello, so a TLS listener with `proxy_protocol => true` accepts
+plain TCP, reads exactly the header, and only then upgrades the socket
+to TLS. Drives a real listener with clients that speak PROXY-then-TLS
+and checks the served peer, the exact-read bounds, and every failure
+path between the header and the handshake.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([suite/0, all/0, init_per_testcase/2, end_per_testcase/2]).
+-export([
+    v2_header_then_tls_reports_client_peer/1,
+    v1_header_then_tls_reports_client_peer/1,
+    v1_unknown_then_tls_keeps_os_peer/1,
+    v2_header_split_across_segments/1,
+    v2_local_without_address_block_keeps_os_peer/1,
+    h2_alpn_negotiates_after_the_header/1,
+    missing_header_closes_without_handshake/1,
+    overlong_v1_header_closes/1,
+    v1_line_without_cr_closes/1,
+    silence_before_header_times_out/1,
+    peer_gone_mid_header_closes/1,
+    garbage_after_header_fails_handshake/1,
+    silence_after_header_times_out/1
+]).
+
+-define(V2_SIG, 16#0D, 16#0A, 16#0D, 16#0A, 16#00, 16#0D, 16#0A, 16#51, 16#55, 16#49, 16#54, 16#0A).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [
+        v2_header_then_tls_reports_client_peer,
+        v1_header_then_tls_reports_client_peer,
+        v1_unknown_then_tls_keeps_os_peer,
+        v2_header_split_across_segments,
+        v2_local_without_address_block_keeps_os_peer,
+        h2_alpn_negotiates_after_the_header,
+        missing_header_closes_without_handshake,
+        overlong_v1_header_closes,
+        v1_line_without_cr_closes,
+        silence_before_header_times_out,
+        peer_gone_mid_header_closes,
+        garbage_after_header_fails_handshake,
+        silence_after_header_times_out
+    ].
+
+init_per_testcase(Case, Config) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    HandlerId = {?MODULE, Case},
+    ok = telemetry:attach_many(
+        HandlerId,
+        [[roadrunner, listener, accept], [roadrunner, listener, accept_error]],
+        fun(Event, _Measure, Meta, _Cfg) -> Self ! {lists:last(Event), Meta} end,
+        undefined
+    ),
+    [{handler_id, HandlerId} | Config].
+
+end_per_testcase(_Case, Config) ->
+    ok = telemetry:detach(?config(handler_id, Config)),
+    ok = roadrunner_listener:stop(?MODULE).
+
+v2_header_then_tls_reports_client_peer(_Config) ->
+    Port = start_listener(#{}),
+    Hdr = v2(16#21, 16#11, <<203, 0, 113, 9, 10, 0, 0, 1, 5000:16, 443:16>>),
+    ?assertEqual(~"203.0.113.9", peer_through(Port, [Hdr])),
+    ok = wait_for_active_clients(0).
+
+v1_header_then_tls_reports_client_peer(_Config) ->
+    Port = start_listener(#{}),
+    ?assertEqual(
+        ~"192.168.0.7",
+        peer_through(Port, [~"PROXY TCP4 192.168.0.7 10.0.0.1 5000 443\r\n"])
+    ).
+
+v1_unknown_then_tls_keeps_os_peer(_Config) ->
+    Port = start_listener(#{}),
+    ?assertEqual(~"127.0.0.1", peer_through(Port, [~"PROXY UNKNOWN\r\n"])).
+
+v2_header_split_across_segments(_Config) ->
+    %% The exact reads wait for the rest of the header rather than deciding
+    %% on a partial one.
+    Port = start_listener(#{}),
+    <<First:10/binary, Second/binary>> =
+        v2(16#21, 16#11, <<198, 51, 100, 23, 10, 0, 0, 1, 40000:16, 443:16>>),
+    ?assertEqual(~"198.51.100.23", peer_through(Port, [First, Second])).
+
+v2_local_without_address_block_keeps_os_peer(_Config) ->
+    %% LOCAL command, AF_UNSPEC, zero-length address block: nothing to read
+    %% past the 16-byte prefix, and the OS peer stands.
+    Port = start_listener(#{}),
+    ?assertEqual(~"127.0.0.1", peer_through(Port, [v2(16#20, 16#00, <<>>)])).
+
+h2_alpn_negotiates_after_the_header(_Config) ->
+    %% The upgrade carries the listener's ALPN list like `ssl:listen` does.
+    Port = start_listener(#{protocols => [http2, http1]}),
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Tcp, v2(16#21, 16#11, <<203, 0, 113, 9, 10, 0, 0, 1, 5000:16, 443:16>>)),
+    {ok, Tls} = ssl:connect(
+        Tcp, client_opts() ++ [{alpn_advertised_protocols, [~"h2"]}], 5000
+    ),
+    ?assertEqual({ok, ~"h2"}, ssl:negotiated_protocol(Tls)),
+    ok = ssl:close(Tls).
+
+missing_header_closes_without_handshake(_Config) ->
+    %% A raw ClientHello-less request on a PROXY listener is a misconfigured
+    %% upstream: the connection closes before any TLS is attempted, so the
+    %% peer sees plain EOF and no alert.
+    Port = start_listener(#{}),
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Tcp, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
+    ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
+    ok = gen_tcp:close(Tcp),
+    ok = wait_for_active_clients(0),
+    receive
+        {accept_error, _} -> error(accept_error_for_missing_header)
+    after 0 -> ok
+    end.
+
+overlong_v1_header_closes(_Config) ->
+    %% A v1 line that runs past the spec's 107 bytes without a CRLF.
+    Port = start_listener(#{}),
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Tcp, <<"PROXY ", (binary:copy(~"x", 120))/binary>>),
+    ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
+    ok = gen_tcp:close(Tcp).
+
+v1_line_without_cr_closes(_Config) ->
+    %% The spec's line ends in CRLF; a bare LF is read as a line but is not a
+    %% header, and the connection closes before any TLS is attempted.
+    Port = start_listener(#{}),
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Tcp, ~"PROXY UNKNOWN\n"),
+    ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
+    ok = gen_tcp:close(Tcp).
+
+silence_before_header_times_out(_Config) ->
+    %% The header read shares `tls_handshake_timeout`, so a peer that connects
+    %% and sends nothing is cut off on the same schedule as one that never
+    %% sends a ClientHello. A missing header is a setup failure, not a
+    %% handshake failure, so it closes silently.
+    Port = start_listener(#{tls_handshake_timeout => 200}),
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    T0 = erlang:monotonic_time(millisecond),
+    ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
+    ?assert(erlang:monotonic_time(millisecond) - T0 < 2000),
+    ok = gen_tcp:close(Tcp),
+    ok = wait_for_active_clients(0),
+    receive
+        {accept_error, _} -> error(accept_error_for_missing_header)
+    after 0 -> ok
+    end.
+
+peer_gone_mid_header_closes(_Config) ->
+    %% The peer disconnects with the header half sent, once inside a v1 line
+    %% and once inside a v2 prefix: both reads fail and the conn closes.
+    Port = start_listener(#{}),
+    lists:foreach(
+        fun(Partial) ->
+            {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+            ok = gen_tcp:send(Tcp, Partial),
+            ok = gen_tcp:shutdown(Tcp, write),
+            ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
+            ok = gen_tcp:close(Tcp)
+        end,
+        [~"PROXY TCP4 192.168", <<?V2_SIG, 16#21>>]
+    ),
+    ok = wait_for_active_clients(0).
+
+garbage_after_header_fails_handshake(_Config) ->
+    %% A good header followed by plain HTTP instead of a ClientHello: the
+    %% upgrade fails and is reported like any other failed handshake.
+    Port = start_listener(#{}),
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Tcp, [
+        v2(16#21, 16#11, <<203, 0, 113, 9, 10, 0, 0, 1, 5000:16, 443:16>>),
+        ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
+    ]),
+    receive
+        {accept_error, Meta} ->
+            ?assertEqual(?MODULE, maps:get(listener_name, Meta)),
+            ?assertMatch({handshake, _}, maps:get(reason, Meta))
+    after 5000 ->
+        error(no_handshake_accept_error)
+    end,
+    ok = gen_tcp:close(Tcp),
+    ok = wait_for_active_clients(0).
+
+silence_after_header_times_out(_Config) ->
+    %% Header, then nothing: `tls_handshake_timeout` cuts the upgrade off,
+    %% the peer sees the socket go away, and nothing was ever accepted.
+    Port = start_listener(#{tls_handshake_timeout => 200}),
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    ok = gen_tcp:send(Tcp, ~"PROXY TCP4 192.168.0.7 10.0.0.1 5000 443\r\n"),
+    receive
+        {accept_error, Meta} ->
+            ?assertEqual({handshake, timeout}, maps:get(reason, Meta))
+    after 5000 ->
+        error(no_handshake_timeout)
+    end,
+    ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
+    ok = gen_tcp:close(Tcp),
+    ok = wait_for_active_clients(0),
+    receive
+        {accept, _} -> error(accept_fired_for_unhandshaken_peer)
+    after 0 -> ok
+    end.
+
+%% --- helpers ---
+
+start_listener(Extra) ->
+    {ok, _} = roadrunner_listener:start_link(
+        ?MODULE,
+        Extra#{
+            port => 0,
+            tls => roadrunner_test_certs:server_opts(),
+            proxy_protocol => true,
+            routes => roadrunner_proxy_peer_handler
+        }
+    ),
+    roadrunner_listener:port(?MODULE).
+
+client_opts() ->
+    [{verify, verify_none} | roadrunner_test_certs:client_opts()] ++ [binary, {active, false}].
+
+%% Send the header pieces on a plain socket, upgrade it to TLS, and ask the
+%% peer-echo handler which client address the server saw.
+peer_through(Port, HeaderPieces) ->
+    {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
+    lists:foreach(fun(Piece) -> ok = gen_tcp:send(Tcp, Piece) end, HeaderPieces),
+    {ok, Tls} = ssl:connect(Tcp, client_opts(), 5000),
+    ok = ssl:send(Tls, ~"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+    Reply = recv_until_closed(Tls, <<>>),
+    ok = ssl:close(Tls),
+    [_Headers, Body] = binary:split(Reply, ~"\r\n\r\n"),
+    Body.
+
+%% The peer handler answers with `connection: close`, so read to EOF.
+recv_until_closed(Tls, Acc) ->
+    case ssl:recv(Tls, 0, 5000) of
+        {ok, Data} -> recv_until_closed(Tls, <<Acc/binary, Data/binary>>);
+        {error, closed} -> Acc
+    end.
+
+%% A v2 header: signature, version/command byte, family/transport byte, the
+%% address block's length and the block itself.
+v2(VerCmd, FamTrans, Body) ->
+    <<?V2_SIG, VerCmd, FamTrans, (byte_size(Body)):16, Body/binary>>.
+
+%% Slot release happens after the telemetry event or the close the peer
+%% observes, so poll the counter until it settles.
+wait_for_active_clients(N) ->
+    wait_for_active_clients(N, erlang:monotonic_time(millisecond) + 5000).
+
+wait_for_active_clients(N, Deadline) ->
+    case roadrunner_listener:info(?MODULE) of
+        #{active_clients := N} ->
+            ok;
+        #{active_clients := Other} ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                true ->
+                    timer:sleep(10),
+                    wait_for_active_clients(N, Deadline);
+                false ->
+                    error({active_clients, Other, expected, N})
+            end
+    end.


### PR DESCRIPTION
# Description

`proxy_protocol => true` on a TLS listener could not work: an L4 balancer sends its PROXY header in plaintext before the ClientHello, and the conn only read it after the TLS handshake, so the handshake saw the header instead of a hello and every connection failed. Such a listener now accepts plain TCP, reads exactly the header off the raw socket (a v2 prefix declares its length, a v1 line is read in one call in `line` packet mode, bounded at the spec's 107 bytes), then upgrades with `ssl:handshake/3` using the listener's TLS options, so `roadrunner_req:peer/1` behind AWS NLB or HAProxy with the PROXY protocol is the real client. The header read shares `tls_handshake_timeout`. TLS listeners without the option keep the `ssl:listen` path untouched, and the upgrade costs the same per connection (2.3 ms vs 2.4 ms, RSA-2048 dominated).

The new `roadrunner_proxy_protocol_tls_SUITE` speaks PROXY v1 and v2 then TLS, including h2 ALPN, a header split across segments, and every failure between the header and the handshake.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
