### PR TITLE
Start telemetry in the conn loop tests' attach helper

### DIFF
--- a/test/roadrunner_conn_loop_tests.erl
+++ b/test/roadrunner_conn_loop_tests.erl
@@ -2158,6 +2158,10 @@ drain_then_wait(Pid) ->
     end.
 
 attach_telemetry(Tag, EventNames) ->
+    %% Started here rather than assumed: run alone, this module used to fail
+    %% six tests with `noproc` on `telemetry_handler_table` because only an
+    %% earlier module in the run had started the telemetry app.
+    {ok, _} = application:ensure_all_started(telemetry),
     Self = self(),
     [
         telemetry:attach(


### PR DESCRIPTION
# Description

`roadrunner_conn_loop_tests` assumed the telemetry app was already running, so run on its own the module failed six tests with `noproc` on `telemetry_handler_table`; only an earlier module in the full run had started it. The attach helper now starts telemetry itself, and the module passes alone.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
