### PR TITLE
Refresh the TLS handshake throughput numbers in the comparison docs

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -28,10 +28,9 @@ shift, relative ordering tends to hold.
 
 Roadrunner beats cowboy on most common scenarios by +30–80 % req/s
 with proportionally lower p50 / p99. The exceptions are
-connection-storm-shape scenarios (open-conn / close-conn dominates)
-and the h2 `tls_handshake_throughput` case — those tie or slightly
-lose. Vs elli, roadrunner ties or wins on simple GETs (`hello`,
-`echo`, `json`) within a few percent, with elli still slightly
+connection-storm-shape scenarios (open-conn / close-conn dominates),
+which tie within variance. Vs elli, roadrunner ties or wins on simple
+GETs (`hello`, `echo`, `json`) within a few percent, with elli still slightly
 ahead on bandwidth-bound `large_response`. Roadrunner beats elli
 outright wherever the workload needs a feature elli doesn't ship —
 pipelining, gzip, body streaming, h2, WebSocket, router, native
@@ -82,11 +81,15 @@ needs any of these, elli isn't on the table.
 | `streaming_response`       |        62 k   |        61 k   |
 
 Multi-stream and basic-req h2 line up with the h1 picture — large
-wins on bigger headers/bodies, smaller wins on the simple paths. The
-one documented cowboy-wins case is `tls_handshake_throughput`
-(fresh-TLS-conn-per-request, runnable ad-hoc via
-`./scripts/bench.escript --scenarios tls_handshake_throughput`),
-explained in
+wins on bigger headers/bodies, smaller wins on the simple paths.
+`tls_handshake_throughput` (fresh-TLS-conn-per-request, runnable
+ad-hoc via `./scripts/bench.escript --scenarios
+tls_handshake_throughput`) used to be the one documented cowboy-wins
+case while the handshake ran inside the acceptor pool. With the
+handshake in the connection process it measures 2.9-3.0 k
+handshakes/s to cowboy's 2.7-2.9 k on the same box (three interleaved
+runs, 2026-09-06), 18-21 % above the previous roadrunner figure. The
+history is in
 [`conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md).
 
 ## Latency — p50 / p99 (lower = better)
@@ -134,9 +137,10 @@ Requires Docker and a compiled test profile. See
 ## Reading the numbers honestly
 
 - **vs cowboy: roadrunner wins on most scenarios** by 25–60 % on
-  req/s with proportionally lower p50 / p99. The exception is
-  `tls_handshake_throughput` (h2), where cowboy edges roadrunner
-  on fresh-TLS-conn-per-request workloads (documented in
+  req/s with proportionally lower p50 / p99. `tls_handshake_throughput`
+  (h2) was the exception while the handshake ran inside the acceptor
+  pool; with the handshake in the connection process it lands about
+  5 % ahead of cowboy (the history is in
   [`conn_lifecycle_investigation.md`](https://github.com/arizona-framework/roadrunner/blob/main/docs/conn_lifecycle_investigation.md)).
   Connection-storm-shape scenarios (in the full results) tie
   within variance.

--- a/docs/resource_results.md
+++ b/docs/resource_results.md
@@ -70,8 +70,15 @@ for the full per-scenario throughput grid see
 | `headers_heavy` | cowboy | 81 k | 163 MB | 80 MB | 1647 % |
 | `multi_stream_h2` | roadrunner | 325 k | 251 MB | 131 MB | 1382 % |
 | `multi_stream_h2` | cowboy | 297 k | 270 MB | 113 MB | 1439 % |
-| `tls_handshake_throughput` | cowboy | 2.9 k | 198 MB | 84 MB | 1214 % |
-| `tls_handshake_throughput` | roadrunner | 2.4 k | 145 MB | 63 MB | 927 % |
+| `tls_handshake_throughput` | roadrunner | 3.0 k | 132 MB | 61 MB | 774 % |
+| `tls_handshake_throughput` | cowboy | 2.8 k | 125 MB | 59 MB | 769 % |
+
+The two `tls_handshake_throughput` rows were re-measured on 2026-09-06
+(medians of three interleaved runs) after the TLS handshake moved from
+the acceptor into the connection process, with the servers pinned to 16
+threads, so their `cpu%` ceiling is ~1600 % rather than the ~2400 % of
+the rows above. Before that change the same scenario read 2.4 k for
+roadrunner and 2.9 k for cowboy.
 
 ## Patterns observed
 
@@ -87,10 +94,11 @@ for the full per-scenario throughput grid see
   the headline).
 - **`multi_stream_h2`** (h2): 7 % less RSS than cowboy with 9 %
   more throughput. The h2 hot path is more efficient end-to-end.
-- **`tls_handshake_throughput`** (h2): roadrunner uses 27 % less
-  RSS and 24 % less CPU than cowboy on this scenario, **but**
-  cowboy still wins 22 % on throughput — the per-handshake
-  serialization is the bottleneck, not resources.
+- **`tls_handshake_throughput`** (h2): about 5 % more handshakes per
+  second than cowboy at the same CPU and within 7 MB of RSS, now that
+  the acceptor pool no longer serializes handshakes. Before the
+  handshake moved into the connection process, cowboy led this
+  scenario by 22 %.
 
 ### Where roadrunner pays a tax
 


### PR DESCRIPTION
# Description

`docs/comparison.md` and `docs/resource_results.md` still described `tls_handshake_throughput` as the one scenario cowboy wins (2.9 k vs 2.4 k handshakes/s). Re-measured after #223 moved the TLS handshake into the connection process, same laptop, three interleaved runs: pre-#223 code 2386-2467 handshakes/s, `main` 2860-2915, cowboy 2755-2870, so the prose is updated and the two table rows re-measured with a note on why their `cpu%` column is not comparable with the rest of the table.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
