### PR TITLE
Report a PROXY header that cannot be read as an accept error

### DIFF
--- a/src/roadrunner_conn_loop.erl
+++ b/src/roadrunner_conn_loop.erl
@@ -206,12 +206,18 @@ awaiting_shoot(Socket0, ProtoOpts, ListenerName) ->
                         {error, {handshake, _} = Reason} ->
                             handshake_failed(ProtoOpts, ListenerName, Reason)
                     end;
-                close ->
+                {close, Reason} ->
                     %% Malformed/absent PROXY header on a proxy_protocol
-                    %% listener (a misconfigured upstream). No accept telemetry
+                    %% listener, or a peer gone before sending one: a
+                    %% misconfigured upstream, or a direct client on a port
+                    %% meant for the balancer. Report it the way a failed
+                    %% handshake is reported, so it is visible rather than a
+                    %% silent close, then release the slot. No accept telemetry
                     %% has fired yet (it pairs with the real peer in serve/5),
-                    %% so release the slot and close silently, like the
-                    %% pre-`shoot` drain path below.
+                    %% so no conn_close either.
+                    ok = roadrunner_telemetry:listener_accept_error(#{
+                        listener_name => ListenerName, reason => {proxy_protocol, Reason}
+                    }),
                     exit_clean(Socket0, ProtoOpts, undefined, undefined, ListenerName, 0, normal)
             end;
         {roadrunner_drain, _Deadline} ->
@@ -339,8 +345,9 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
 
 %% Read and strip a PROXY-protocol header when the listener enabled it. Returns
 %% `{ok, Peer, Leftover}` — the real client peer on a PROXY command, the OS peer
-%% on a LOCAL/UNKNOWN one — or `close` on a malformed header or read error. With
-%% the opt off the OS peer passes straight through and no bytes are read.
+%% on a LOCAL/UNKNOWN one — or `{close, Reason}` on a malformed header or read
+%% error, with the parser's or the transport's reason. With the opt off the OS
+%% peer passes straight through and no bytes are read.
 %%
 %% On a TLS listener (`tls_upgrade` set) the header is followed by the
 %% ClientHello, and bytes read past the header cannot be handed back to `ssl`,
@@ -350,7 +357,7 @@ serve(Socket, ProtoOpts, ListenerName, Peer, Buffered) ->
     roadrunner_transport:socket(),
     roadrunner_conn:proto_opts(),
     {inet:ip_address(), inet:port_number()} | undefined
-) -> {ok, {inet:ip_address(), inet:port_number()} | undefined, binary()} | close.
+) -> {ok, {inet:ip_address(), inet:port_number()} | undefined, binary()} | {close, term()}.
 proxy_protocol_stage(_Socket, #{proxy_protocol := false}, OsPeer) ->
     {ok, OsPeer, <<>>};
 proxy_protocol_stage(
@@ -363,7 +370,7 @@ proxy_protocol_stage(
     case read_proxy_header_exact(Socket, Timeout) of
         {ok, Peer, <<>>} -> {ok, Peer, <<>>};
         {local, <<>>} -> {ok, OsPeer, <<>>};
-        {error, _Reason} -> close
+        {error, Reason} -> {close, Reason}
     end;
 proxy_protocol_stage(Socket, #{proxy_protocol := true} = ProtoOpts, OsPeer) ->
     read_proxy_header(Socket, ProtoOpts, OsPeer, <<>>).
@@ -444,7 +451,7 @@ read_proxy_v1_line(Socket, Timeout) ->
     roadrunner_conn:proto_opts(),
     {inet:ip_address(), inet:port_number()} | undefined,
     binary()
-) -> {ok, {inet:ip_address(), inet:port_number()} | undefined, binary()} | close.
+) -> {ok, {inet:ip_address(), inet:port_number()} | undefined, binary()} | {close, term()}.
 read_proxy_header(Socket, #{request_timeout := Timeout} = ProtoOpts, OsPeer, Acc) ->
     case roadrunner_transport:recv(Socket, 0, Timeout) of
         {ok, Bytes} ->
@@ -453,10 +460,10 @@ read_proxy_header(Socket, #{request_timeout := Timeout} = ProtoOpts, OsPeer, Acc
                 {ok, Peer, Rest} -> {ok, Peer, Rest};
                 {local, Rest} -> {ok, OsPeer, Rest};
                 more -> read_proxy_header(Socket, ProtoOpts, OsPeer, Buf);
-                {error, _Reason} -> close
+                {error, Reason} -> {close, Reason}
             end;
-        {error, _} ->
-            close
+        {error, Reason} ->
+            {close, Reason}
     end.
 
 %% True iff the TLS handshake negotiated `h2`. Plain TCP and TLS

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -330,8 +330,11 @@ ops-tuning rationale.
     %% listener the header is read from the plain socket before the TLS
     %% handshake: the listener accepts plain TCP and upgrades each connection
     %% once the header is in. TCP-only: rejected on an HTTP/3-only listener.
-    %% Trust it only behind a balancer that always prepends the header
-    %% (otherwise a direct peer can spoof its IP).
+    %% A connection whose header is missing or malformed is closed and
+    %% reported as `[roadrunner, listener, accept_error]` with a
+    %% `{proxy_protocol, Reason}` reason. Trust it only behind a balancer
+    %% that always prepends the header (otherwise a direct peer can spoof its
+    %% IP).
     proxy_protocol => boolean(),
     %% Opt in to a per-peer request-rate guard keyed on the client IP. A map
     %% `#{rate := pos_integer()}` (requests allowed per `period`, required) with

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -79,11 +79,15 @@
 %% - `[roadrunner, listener, accept_error]` — fired when an acceptor's
 %%   `accept/1` returns any error other than the listen socket closing
 %%   (the acceptor keeps accepting instead of exiting), and when a
-%%   connection process fails its TLS handshake. Told apart by
-%%   `reason`: per-connection failures (`econnaborted`, or
+%%   connection process fails its TLS handshake or cannot read the
+%%   PROXY header a `proxy_protocol` listener expects. Told apart by
+%%   `reason`: per-connection failures (`econnaborted`;
 %%   `{handshake, HsReason}` for a failed TLS handshake — routine noise
-%%   on an internet-facing TLS port, reported by the connection that ran
-%%   it) cost nothing beyond that connection; resource errors
+%%   on an internet-facing TLS port; `{proxy_protocol, Reason}` for a
+%%   missing or malformed header, which points at a misconfigured
+%%   balancer or a direct client on a port meant for one; both reported
+%%   by the connection that hit them) cost nothing beyond that
+%%   connection; resource errors
 %%   (`emfile`/`enfile`/`system_limit` descriptor exhaustion, usually
 %%   `max_clients` above the OS `ulimit -n`) make the acceptor retry
 %%   after a short back-off. A sustained stream of descriptor-exhaustion
@@ -333,13 +337,15 @@ fails with anything other than the listen socket closing — a
 per-connection failure (`econnaborted`) or descriptor exhaustion
 (`emfile`/`enfile`/`system_limit`, typically `max_clients` sitting above
 the OS `ulimit -n`) — and when a connection process fails its TLS
-handshake (`{handshake, _}`). The acceptor reports its own failures
-here and keeps accepting rather than exiting (immediately for
+handshake (`{handshake, _}`) or cannot read the PROXY header a
+`proxy_protocol` listener expects (`{proxy_protocol, _}`, with the
+parser's or the transport's reason). The acceptor reports its own
+failures here and keeps accepting rather than exiting (immediately for
 per-connection failures, after a short back-off for resource errors),
 so a sustained stream of descriptor-exhaustion reasons is the signal
 to raise `ulimit -n`. `Metadata` should include `listener_name` and
-`reason` (the accept or handshake error). Carries no `peer`: there is
-no served connection to name.
+`reason` (the accept, handshake or PROXY-header error). Carries no
+`peer`: there is no served connection to name.
 """.
 -spec listener_accept_error(map()) -> ok.
 listener_accept_error(Metadata) ->

--- a/test/roadrunner_proxy_protocol_tests.erl
+++ b/test/roadrunner_proxy_protocol_tests.erl
@@ -193,9 +193,12 @@ malformed_closes_test() ->
     with_listener(fun(Port) ->
         {ok, S} = connect(Port),
         %% A raw request (no PROXY header) on a proxy_protocol listener is a
-        %% misconfigured upstream — the connection closes with no response.
+        %% misconfigured upstream — the connection closes with no response,
+        %% and the close is reported rather than silent.
+        HandlerId = attach_accept_error(),
         ok = gen_tcp:send(S, <<"GET / HTTP/1.1\r\nHost: x\r\n\r\n">>),
         ?assertEqual(<<>>, recv_response(S, <<>>)),
+        ?assertEqual({proxy_protocol, not_proxy_header}, await_accept_error(HandlerId)),
         gen_tcp:close(S)
     end).
 
@@ -203,13 +206,40 @@ recv_error_closes_test() ->
     with_listener(fun(Port) ->
         {ok, S} = connect(Port),
         %% Half-close (FIN) before sending any PROXY header: the server's first
-        %% recv returns {error, closed}, so the connection closes with no reply.
+        %% recv returns {error, closed}, so the connection closes with no reply
+        %% and the transport's reason is what gets reported.
+        HandlerId = attach_accept_error(),
         ok = gen_tcp:shutdown(S, write),
         ?assertEqual(<<>>, recv_response(S, <<>>)),
+        ?assertEqual({proxy_protocol, closed}, await_accept_error(HandlerId)),
         gen_tcp:close(S)
     end).
 
 %% --- helpers ---
+
+%% Forward `[roadrunner, listener, accept_error]` to the test process.
+attach_accept_error() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    HandlerId = {?MODULE, make_ref()},
+    ok = telemetry:attach(
+        HandlerId,
+        [roadrunner, listener, accept_error],
+        fun(_Event, _Measure, Meta, _Cfg) -> Self ! {accept_error, Meta} end,
+        undefined
+    ),
+    HandlerId.
+
+%% The reason of the next accept_error, detaching the handler either way.
+await_accept_error(HandlerId) ->
+    try
+        receive
+            {accept_error, #{reason := Reason}} -> Reason
+        after 5000 -> error(no_accept_error)
+        end
+    after
+        telemetry:detach(HandlerId)
+    end.
 
 proxy_request(Header, Request) ->
     with_listener(fun(Port) ->

--- a/test/roadrunner_proxy_protocol_tls_SUITE.erl
+++ b/test/roadrunner_proxy_protocol_tls_SUITE.erl
@@ -114,17 +114,15 @@ h2_alpn_negotiates_after_the_header(_Config) ->
 missing_header_closes_without_handshake(_Config) ->
     %% A raw ClientHello-less request on a PROXY listener is a misconfigured
     %% upstream: the connection closes before any TLS is attempted, so the
-    %% peer sees plain EOF and no alert.
+    %% peer sees plain EOF and no alert, and the close is reported with the
+    %% parser's reason.
     Port = start_listener(#{}),
     {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
     ok = gen_tcp:send(Tcp, ~"GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
     ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
     ok = gen_tcp:close(Tcp),
-    ok = wait_for_active_clients(0),
-    receive
-        {accept_error, _} -> error(accept_error_for_missing_header)
-    after 0 -> ok
-    end.
+    ?assertEqual({proxy_protocol, not_proxy_header}, await_accept_error()),
+    ok = wait_for_active_clients(0).
 
 overlong_v1_header_closes(_Config) ->
     %% A v1 line that runs past the spec's 107 bytes without a CRLF.
@@ -132,7 +130,9 @@ overlong_v1_header_closes(_Config) ->
     {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
     ok = gen_tcp:send(Tcp, <<"PROXY ", (binary:copy(~"x", 120))/binary>>),
     ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
-    ok = gen_tcp:close(Tcp).
+    ok = gen_tcp:close(Tcp),
+    %% `line` packet mode fails the read at the bound with `emsgsize`.
+    ?assertEqual({proxy_protocol, emsgsize}, await_accept_error()).
 
 v1_line_without_cr_closes(_Config) ->
     %% The spec's line ends in CRLF; a bare LF is read as a line but is not a
@@ -141,28 +141,26 @@ v1_line_without_cr_closes(_Config) ->
     {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
     ok = gen_tcp:send(Tcp, ~"PROXY UNKNOWN\n"),
     ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
-    ok = gen_tcp:close(Tcp).
+    ok = gen_tcp:close(Tcp),
+    ?assertEqual({proxy_protocol, v1_malformed}, await_accept_error()).
 
 silence_before_header_times_out(_Config) ->
     %% The header read shares `tls_handshake_timeout`, so a peer that connects
     %% and sends nothing is cut off on the same schedule as one that never
-    %% sends a ClientHello. A missing header is a setup failure, not a
-    %% handshake failure, so it closes silently.
+    %% sends a ClientHello, and reported with the transport's `timeout`.
     Port = start_listener(#{tls_handshake_timeout => 200}),
     {ok, Tcp} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 1000),
     T0 = erlang:monotonic_time(millisecond),
     ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
     ?assert(erlang:monotonic_time(millisecond) - T0 < 2000),
     ok = gen_tcp:close(Tcp),
-    ok = wait_for_active_clients(0),
-    receive
-        {accept_error, _} -> error(accept_error_for_missing_header)
-    after 0 -> ok
-    end.
+    ?assertEqual({proxy_protocol, timeout}, await_accept_error()),
+    ok = wait_for_active_clients(0).
 
 peer_gone_mid_header_closes(_Config) ->
     %% The peer disconnects with the header half sent, once inside a v1 line
-    %% and once inside a v2 prefix: both reads fail and the conn closes.
+    %% and once inside a v2 prefix: both reads fail with `closed`, the conn
+    %% closes and reports it.
     Port = start_listener(#{}),
     lists:foreach(
         fun(Partial) ->
@@ -170,7 +168,8 @@ peer_gone_mid_header_closes(_Config) ->
             ok = gen_tcp:send(Tcp, Partial),
             ok = gen_tcp:shutdown(Tcp, write),
             ?assertEqual({error, closed}, gen_tcp:recv(Tcp, 0, 5000)),
-            ok = gen_tcp:close(Tcp)
+            ok = gen_tcp:close(Tcp),
+            ?assertEqual({proxy_protocol, closed}, await_accept_error())
         end,
         [~"PROXY TCP4 192.168", <<?V2_SIG, 16#21>>]
     ),
@@ -216,6 +215,13 @@ silence_after_header_times_out(_Config) ->
     end.
 
 %% --- helpers ---
+
+%% The reason of the next accept_error the per-case telemetry handler forwards.
+await_accept_error() ->
+    receive
+        {accept_error, #{reason := Reason}} -> Reason
+    after 5000 -> error(no_accept_error)
+    end.
 
 start_listener(Extra) ->
     {ok, _} = roadrunner_listener:start_link(


### PR DESCRIPTION
# Description

On a `proxy_protocol` listener a missing or malformed PROXY header, or a peer gone before sending one, closed the connection silently, so a misconfigured balancer or a direct client on a port meant for one left no trace. The connection now reports it as `[roadrunner, listener, accept_error]` with a `{proxy_protocol, Reason}` reason carrying the parser's or the transport's reason (`not_proxy_header`, `v1_malformed`, `emsgsize`, `closed`, `timeout`), the same event a failed TLS handshake uses. Plain and TLS listeners alike; the existing eunit and CT cases now assert the reported reason.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
