### PR TITLE
Reap orphaned connection slots by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,11 +414,12 @@ type, with per-key defaults and tuning rationale. Beyond `port`,
   to in-flight conns, polls until idle or deadline, then
   `exit(Pid, shutdown)` for stragglers.
 - **Status**: `roadrunner_listener:status/1` returns `accepting | draining`.
-- **Slot reconciliation**: Optional `slot_reconciliation => #{interval => N}`
-  listener opt: a periodic reaper that compares `client_counter` against the
-  live registered conns and releases slots orphaned by `kill`-style exits. Off by
-  default; enable in production where you can't trust every exit path to run
-  `terminate/3` (`kill` signals, OOM kills, supervisor brutal-kill).
+- **Slot reconciliation**: a periodic reaper that compares `client_counter`
+  against the live registered conns and releases slots orphaned by
+  `kill`-style exits (`kill` signals, OOM kills, supervisor brutal-kill),
+  on by default every 60 s; tune with `slot_reconciliation => #{interval => N}`
+  or turn it off with `slot_reconciliation => disabled`. Off on
+  `graceful_drain => false` listeners, which keep no registry.
 
 ## Documentation
 

--- a/src/roadrunner_conn.erl
+++ b/src/roadrunner_conn.erl
@@ -330,9 +330,9 @@ skips the cleanup funnel, so the slot is **leaked** for the lifetime
 of the listener process. This is bounded:
 `max_clients` accepted connections each leak at most one slot
 under killing, and the listener restart resets the counter. If
-leaks become a real concern under chaos-test conditions, the optional
-`slot_reconciliation` reaper compares the registered conns still alive
-against the live counter and reconciles the difference.
+leaks become a real concern under chaos-test conditions, the
+`slot_reconciliation` reaper (on by default) compares the registered
+conns still alive against the live counter and reconciles the difference.
 """.
 -spec try_acquire_slot(proto_opts()) -> boolean().
 try_acquire_slot(#{client_counter := Ref, max_clients := Max}) ->

--- a/src/roadrunner_listener.erl
+++ b/src/roadrunner_listener.erl
@@ -48,6 +48,12 @@ All duration and interval values in `opts()` are in milliseconds —
 %% covers slow real clients.
 -define(DEFAULT_TLS_HANDSHAKE_TIMEOUT, 5000).
 -define(DEFAULT_KEEP_ALIVE_TIMEOUT, 60000).
+%% A conn killed outright (`exit(Pid, kill)`, a `max_heap_size` kill) skips
+%% its exit path and leaks a slot and a drain-registry row for the life of
+%% the listener; only the reaper gives them back, so it runs by default.
+%% One tick a minute costs at most one `is_process_alive` per registered
+%% conn, and an orphan is reaped within two ticks.
+-define(DEFAULT_SLOT_RECONCILIATION_INTERVAL, 60000).
 -define(DEFAULT_NUM_ACCEPTORS, 10).
 -define(DEFAULT_MAX_KEEP_ALIVE, 1000).
 -define(DEFAULT_MAX_CLIENTS, 16384).
@@ -223,10 +229,12 @@ Optional middleware and timing knobs (durations in milliseconds):
 - `body_buffering` — `auto` (default; framework reads the full
   body before invoking the handler) or `manual` (handler calls
   `roadrunner_req:read_body/1,2`).
-- `slot_reconciliation` — `disabled` (default) or
-  `#{interval := Ms}` to periodically reap slots orphaned by
-  brutal-kill exits, and with them the killed conns' rows in the
-  drain registry.
+- `slot_reconciliation` — `#{interval := Ms}` (default 60000) for the
+  periodic reaper that releases slots orphaned by brutal-kill exits,
+  and with them the killed conns' rows in the drain registry, or
+  `disabled` to turn it off. A `graceful_drain => false` listener keeps
+  no registry to compare against, so the reaper is off there; asking
+  for both is a configuration conflict.
 - `graceful_drain` — opt out of the per-conn drain registry
   (`true` default; `false` trades drain notification for a little
   less per-conn work on short-lived workloads).
@@ -617,7 +625,7 @@ WebSocket session tunables (under `ws` in the listener opts).
     port :: inet:port_number(),
     proto_opts :: roadrunner_conn:proto_opts(),
     phase = accepting :: accepting | draining | stopped,
-    %% Slot reconciliation (off by default). When enabled, a periodic
+    %% Slot reconciliation (on by default, every 60 s). A periodic
     %% timer compares `client_counter` against the live registered conns
     %% and releases slots that have been orphaned by `kill`-style exits
     %% (which bypass `terminate/3`). `prev_diff` tracks the previous
@@ -1019,15 +1027,34 @@ first_pem_entry(File) ->
     [{Type, Der, not_encrypted} | _] = public_key:pem_decode(Pem),
     {Type, Der}.
 
+%% `graceful_drain => false` leaves no registry to compare the counter
+%% against: every live conn would look like an orphan and lose its slot. So
+%% the reaper is off on such a listener, and asking for it explicitly there
+%% is a conflict rather than a silent no-op.
 -spec setup_reconciliation(opts()) ->
     disabled | #{interval := pos_integer(), prev_diff := non_neg_integer()}.
+setup_reconciliation(#{graceful_drain := false, slot_reconciliation := Explicit}) when
+    Explicit =/= disabled
+->
+    error({listener_opt_conflict, slot_reconciliation, Explicit, no_drain_registry});
+setup_reconciliation(#{graceful_drain := false}) ->
+    disabled;
+setup_reconciliation(#{slot_reconciliation := disabled}) ->
+    disabled;
 setup_reconciliation(#{slot_reconciliation := #{interval := IntervalMs}}) when
     is_integer(IntervalMs), IntervalMs > 0
 ->
-    erlang:send_after(IntervalMs, self(), reconcile_slots),
-    #{interval => IntervalMs, prev_diff => 0};
+    arm_reconciliation(IntervalMs);
+setup_reconciliation(#{slot_reconciliation := Other}) ->
+    error({invalid_listener_opt, slot_reconciliation, Other});
 setup_reconciliation(_Opts) ->
-    disabled.
+    arm_reconciliation(?DEFAULT_SLOT_RECONCILIATION_INTERVAL).
+
+-spec arm_reconciliation(pos_integer()) ->
+    #{interval := pos_integer(), prev_diff := non_neg_integer()}.
+arm_reconciliation(IntervalMs) ->
+    _ = erlang:send_after(IntervalMs, self(), reconcile_slots),
+    #{interval => IntervalMs, prev_diff => 0}.
 
 %% Arm the periodic per-peer rate-limit bucket sweep when the guard is on. Like
 %% `setup_reconciliation`, the `erlang:send_after` timer auto-cancels when the

--- a/src/roadrunner_telemetry.erl
+++ b/src/roadrunner_telemetry.erl
@@ -388,7 +388,7 @@ request_throttled(Metadata) ->
     ok.
 
 -doc """
-Emit `[roadrunner, listener, slots_reconciled]` when the optional
+Emit `[roadrunner, listener, slots_reconciled]` when the
 `slot_reconciliation` reaper releases orphan slots that the
 `kill`-bypasses-`terminate` path left behind. `Metadata` should
 include `listener_name`, `released` (count), `counter_was` (value

--- a/test/roadrunner_listener_tests.erl
+++ b/test/roadrunner_listener_tests.erl
@@ -736,7 +736,7 @@ slot_reconciliation_disabled_drops_reconcile_slots_message_test() ->
     %% dropped — gen_server stays alive.
     Name = listener_test_disabled_reap,
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
-        port => 0, routes => roadrunner_hello_handler
+        port => 0, slot_reconciliation => disabled, routes => roadrunner_hello_handler
     }),
     ListenerPid ! reconcile_slots,
     %% Process must still answer port/1.
@@ -754,12 +754,24 @@ listener_drops_unknown_info_message_test() ->
     ?assert(roadrunner_listener:port(Name) > 0),
     ok = roadrunner_listener:stop(Name).
 
-slot_reconciliation_disabled_by_default_test() ->
-    Name = listener_test_no_reap,
+slot_reconciliation_on_by_default_test() ->
+    %% Nothing but the reaper gives a killed conn's slot back, so it is armed
+    %% without being asked, at the one-minute default.
+    Name = listener_test_default_reap,
     {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
         port => 0, routes => roadrunner_hello_handler
     }),
+    %% {state, LSocket, Port, ProtoOpts, Phase, Reconciliation, Quic}
+    ?assertEqual(#{interval => 60000, prev_diff => 0}, element(6, sys:get_state(ListenerPid))),
+    ok = roadrunner_listener:stop(Name).
+
+slot_reconciliation_disabled_keeps_orphans_test() ->
+    Name = listener_test_no_reap,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0, slot_reconciliation => disabled, routes => roadrunner_hello_handler
+    }),
     State = sys:get_state(ListenerPid),
+    ?assertEqual(disabled, element(6, State)),
     ProtoOpts = element(4, State),
     Counter = maps:get(client_counter, ProtoOpts),
     %% Plant orphan slots; without reconciliation they stay forever.
@@ -767,6 +779,48 @@ slot_reconciliation_disabled_by_default_test() ->
     timer:sleep(100),
     ?assertEqual(3, counters:get(Counter, 1)),
     ok = roadrunner_listener:stop(Name).
+
+graceful_drain_off_disables_slot_reconciliation_test() ->
+    %% Without a drain registry every live conn would read as an orphan, so
+    %% the default reaper stays off on such a listener.
+    Name = listener_test_no_registry_no_reap,
+    {ok, ListenerPid} = roadrunner_listener:start_link(Name, #{
+        port => 0, graceful_drain => false, routes => roadrunner_hello_handler
+    }),
+    ?assertEqual(disabled, element(6, sys:get_state(ListenerPid))),
+    ok = roadrunner_listener:stop(Name).
+
+slot_reconciliation_without_registry_is_a_conflict_test() ->
+    %% Asking for the reaper on a listener that keeps no registry would
+    %% release live slots; refuse the combination outright.
+    process_flag(trap_exit, true),
+    R = roadrunner_listener:start_link(listener_test_reap_conflict, #{
+        port => 0,
+        graceful_drain => false,
+        slot_reconciliation => #{interval => 30},
+        routes => roadrunner_hello_handler
+    }),
+    ?assertMatch(
+        {error, {
+            {listener_opt_conflict, slot_reconciliation, #{interval := 30}, no_drain_registry},
+            _Stack
+        }},
+        R
+    ).
+
+listener_rejects_invalid_slot_reconciliation_test() ->
+    %% Anything but `disabled` or `#{interval := PosInt}` is a configuration
+    %% error, not a silent fallback to the default.
+    process_flag(trap_exit, true),
+    lists:foreach(
+        fun(Bad) ->
+            R = roadrunner_listener:start_link(listener_test_reap_invalid, #{
+                port => 0, slot_reconciliation => Bad, routes => roadrunner_hello_handler
+            }),
+            ?assertMatch({error, {{invalid_listener_opt, slot_reconciliation, Bad}, _Stack}}, R)
+        end,
+        [#{interval => 0}, #{interval => -5}, #{interval => fast}, enabled, 60000]
+    ).
 
 listener_info_initial_zero_test() ->
     Name = listener_test_info_init,


### PR DESCRIPTION
# Description

A connection killed outright (`exit(Pid, kill)`, a `max_heap_size` kill from `handler_spawn`, a brutal supervisor shutdown) skips its exit path and leaks one `max_clients` slot and one drain-registry row for the life of the listener, and only the `slot_reconciliation` reaper gives them back. It now runs by default every 60 s instead of waiting to be configured; one tick costs at most one `is_process_alive` per registered connection and it only logs or emits `slots_reconciled` when it actually releases something. `slot_reconciliation => disabled` turns it off. A `graceful_drain => false` listener keeps no registry to compare against, so the reaper stays off there and asking for it explicitly is rejected as `{listener_opt_conflict, slot_reconciliation, _, no_drain_registry}`; an invalid value is rejected as `{invalid_listener_opt, slot_reconciliation, _}` instead of silently falling back.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
