### PR TITLE
Document quieting ssl alert logs and note the conn_close reason gap

### DIFF
--- a/docs/resource_limits.md
+++ b/docs/resource_limits.md
@@ -249,3 +249,34 @@ interactive and embedded mode alike. If you run roadrunner outside a
 release (a plain shell, an escript, a container that boots `erl`
 directly), expect the first requests after each restart to be slower,
 and send some traffic before putting the node into rotation.
+
+## TLS alert logging on internet-facing ports
+
+`ssl` logs every alert it raises or receives as a notice-level report,
+"TLS server: In state hello ... generated SERVER ALERT: Fatal - Unexpected
+Message" being the common shape. A TLS port reachable from the internet
+raises one for every scanner and misdirected client that connects and
+sends something other than a ClientHello, so the log fills with them.
+
+Roadrunner reports each failed handshake itself as
+`[roadrunner, listener, accept_error]` with a `{handshake, Reason}` reason
+that carries the alert text, so a deployment that consumes that event
+already has the information and can silence the duplicate through the
+listener's `tls` opts:
+
+```erlang
+roadrunner:start_listener(edge, #{
+    port => 443,
+    tls => [{certfile, Cert}, {keyfile, Key}, {log_level, warning}],
+    routes => Routes
+}).
+```
+
+Roadrunner leaves the level at `ssl`'s default on purpose. The same
+setting also hides alerts raised after the handshake (a bad record from a
+buggy client, a renegotiation attempt), which the connection does not
+report anywhere else yet: it closes, and `conn_close` carries no reason.
+Until it does, `ssl`'s notice is the only trace of those, and a
+deployment that has not attached telemetry handlers would otherwise see
+nothing about TLS trouble at all. Quiet it when you consume the event;
+keep it while the log is what you read.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,6 +242,28 @@ lot of them.
 
 ## Other
 
+### Carry the close reason in `conn_close` telemetry
+
+**What:** `[roadrunner, listener, conn_close]` says that a connection
+ended, not why. The recv paths drop the transport's reason on the way
+to `exit_normal`, so a peer closing, a `request_timeout`, a slow-client
+cut-off, a drain and a TLS alert after the handshake all look the same
+to a telemetry consumer, and for the TLS alert `ssl`'s own notice log is
+the only trace. Thread a `reason` through the exit paths of the h1, h2
+and h3 loops into the event metadata: `normal`, `peer_closed`,
+`request_timeout`, `keep_alive_timeout`, `slow_client`, `drained`, or
+`{transport, Reason}` with the transport's term (`{tls_alert, {Desc,
+Text}}` included). Once it lands, lowering `ssl`'s alert `log_level` by
+default becomes a lossless change and can be revisited.
+
+**Why deferred:** surfaced while deciding whether to quiet `ssl`'s
+alert logging by default; the mute alone would have removed the only
+trace of post-handshake alerts, and the reason belongs in the event on
+its own merits, which is a change across every exit path rather than a
+rider on a log setting.
+
+**Scope:** medium.
+
 ### Connection-process memory tuning follow-ups
 
 **What:** The `handler_spawn` listener opt already exposes the full


### PR DESCRIPTION
# Description

`ssl` logs a notice for every alert, so an internet-facing TLS port produces one report per scanner probe. Rather than lowering `ssl`'s `log_level` in the hardened defaults (#228, closed), which would also have hidden alerts raised after the handshake that roadrunner does not report anywhere else, this documents the trade-off in `docs/resource_limits.md` with the one-line `tls` setting for deployments that already consume `[roadrunner, listener, accept_error]`, and adds a roadmap entry to carry the close reason in `conn_close` telemetry, after which quiet-by-default becomes a lossless change.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/roadrunner/blob/main/CONTRIBUTING.md)
